### PR TITLE
Added workaround for canvas installation issue on M1 to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ Join the [Bldrs Discord](https://discord.gg/apWHfDtkJs).
 > yarn serve
 ```
 
-## Mac M1
-If you're on a shiny new M1, you need to install the `cairo` and `pango` libraries before running `yarn install`. You can do this with brew: `brew install cairo pango`. Otherwise, building `canvas` will cause an error. This should be fixed soon hopefully, see [this issue](https://github.com/Automattic/node-canvas/issues/2038) for more info.
+## Mac M1 (or other ARM CPUs)
+If you're on a shiny new M1, you need to install the `cairo` and `pango` libraries before running `yarn install`. You can do this with brew: `brew install cairo pango`. Otherwise, building `canvas` will cause an error. [See here](https://github.com/Automattic/node-canvas/wiki/Installation%3A-Mac-OS-X) for more info and troubleshooting with ARM CPUs and `canvas`.
 
 # Build & Include IFC files to publish
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ Join the [Bldrs Discord](https://discord.gg/apWHfDtkJs).
 > yarn serve
 ```
 
+## Mac M1
+If you're on a shiny new M1, you need to install the `cairo` and `pango` libraries before running `yarn install`. You can do this with brew: `brew install cairo pango`. Otherwise, building `canvas` will cause an error. This should be fixed soon hopefully, see [this issue](https://github.com/Automattic/node-canvas/issues/2038) for more info.
+
 # Build & Include IFC files to publish
 
 Build the static serving directory, including any of your IFC files


### PR DESCRIPTION
This PR adds instructios to the readme that helps Mac M1 users with node v16 to run `yarn install` without any errors.

The issue is related to `canvas` and you need to install `cairo` and `pango` (`brew install cairo pango`) before running `yarn install`. It then build `canvas` correctly without relying to download the missing libraries. See [the open issue here](https://github.com/Automattic/node-canvas/issues/2038) (probably good idea to follow it and see when this is fixed).

This closes issue #207 (see there for more background in this also)