### PR TITLE
Tighten up local development environment identification

### DIFF
--- a/src/utils/network.js
+++ b/src/utils/network.js
@@ -5,12 +5,19 @@ import debug from './debug'
  * @return {boolean} True if running locally
  */
 export function isRunningLocally() {
-  const local = window.location.hostname == 'localhost' ||
-    window.location.hostname.startsWith('127.') ||
-        window.location.hostname.startsWith('192.')
+  const local = window.location.hostname === 'localhost' ||
+      window.location.hostname === '[::1]' ||
+      window.location.hostname.startsWith('10.') ||
+      window.location.hostname.startsWith('127.') ||
+      window.location.hostname.startsWith('169.254.') ||
+      window.location.hostname.match(/^172\.(1[6-9]|2[0-9]|3[0-1])/) ||
+      window.location.hostname.startsWith('192.168.') ||
+      window.location.hostname.endsWith('.local')
+
   if (local) {
     debug().warn('Network: site is being served locally')
     return true
   }
+
   return false
 }


### PR DESCRIPTION
PR to address:
* overly broad matching (`192.0.0.0/8` --> `192.168.0.0/16`)
* lack of a check for other RFC1918 private space (`10.0.0.0/8`, `172.16.0.0/12`)
* lack of a check for link local addressing (`169.254.0.0/16`, typically shows up when DHCP is requested but not available)
* lack of a check for IPv6 loopback address