### PR TITLE
Let ESLint find files

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,6 +12,11 @@ module.exports = {
     'plugin:react-hooks/recommended',
     'plugin:jsx-a11y/recommended',
   ],
+  overrides: [
+    {
+      files: ['*.js', '*.mjs', '*.jsx'],
+    },
+  ],
   parser: '@babel/eslint-parser',
   parserOptions: {
     babelOptions: {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "copy-web-asm": "cp node_modules/web-ifc/*.wasm public/static/js",
     "build": "yarn copy-web-asm && yarn clean && yarn new-version && node config/build.js",
     "serve": "yarn build && node config/serve.js",
-    "lint": "yarn eslint `find src -name '*.jsx'` `find src -name '*.[m]js'`",
+    "lint": "yarn eslint src",
     "test": "jest",
     "precommit": "yarn lint && yarn test",
     "prepare": "husky install"


### PR DESCRIPTION
Rather than using a shell command to find the applicable files in the project, let ESLint perform the heavy lifting as part of its native feature set.