### PR TITLE
Use React Context API to avoid prop drilling

### DIFF
--- a/src/BaseRoutes.jsx
+++ b/src/BaseRoutes.jsx
@@ -28,13 +28,13 @@ import {usePaths} from './Paths'
 export default function BaseRoutes({testElt = null}) {
   const location = useLocation()
   const navigate = useNavigate()
-  const {installPrefix} = usePaths()
+  const {installPrefix, appPrefix} = usePaths()
 
   useEffect(() => {
     if (location.pathname === installPrefix ||
         location.pathname === (installPrefix + '/')) {
-      debug().log('BaseRoutes#useEffect[], forwarding to: ', installPrefix + '/share')
-      navigate(installPrefix + '/share')
+      debug().log('BaseRoutes#useEffect[], forwarding to: ', appPrefix)
+      navigate(appPrefix)
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])

--- a/src/BaseRoutes.jsx
+++ b/src/BaseRoutes.jsx
@@ -8,6 +8,7 @@ import {
 } from 'react-router-dom'
 import ShareRoutes from './ShareRoutes'
 import debug from './utils/debug'
+import {usePaths} from './Paths'
 
 
 /**
@@ -27,7 +28,7 @@ import debug from './utils/debug'
 export default function BaseRoutes({testElt = null}) {
   const location = useLocation()
   const navigate = useNavigate()
-  const installPrefix = window.location.pathname.startsWith('/Share') ? '/Share' : ''
+  const {installPrefix} = usePaths()
 
   useEffect(() => {
     if (location.pathname === installPrefix ||
@@ -46,9 +47,7 @@ export default function BaseRoutes({testElt = null}) {
           path="share/*"
           element={
             testElt ||
-              <ShareRoutes
-                installPrefix={installPrefix}
-                appPrefix={installPrefix + '/share'} />
+              <ShareRoutes />
           }/>
       </Route>
     </Routes>

--- a/src/BaseRoutes.test.jsx
+++ b/src/BaseRoutes.test.jsx
@@ -15,6 +15,8 @@ test('BaseRoutes', () => {
   const testLabel = 'Test node label'
   const {getByText} = render(
       <MockRoutes
-        contentElt={<BaseRoutes testElt={<>{testLabel}</>}/>}/>)
+        contentElt={<BaseRoutes testElt={<>{testLabel}</>}/>}
+      />,
+  )
   expect(getByText(testLabel)).toBeInTheDocument()
 })

--- a/src/BaseRoutesMock.test.jsx
+++ b/src/BaseRoutesMock.test.jsx
@@ -3,6 +3,7 @@ import {ThemeProvider} from '@mui/material/styles'
 import useTheme from './Theme'
 import {render} from '@testing-library/react'
 import {MemoryRouter, Routes, Route} from 'react-router-dom'
+import {PathsProvider} from './Paths'
 
 
 test('mockRoutes', () => {
@@ -12,7 +13,10 @@ test('mockRoutes', () => {
 })
 
 
-const ColorModeContext = createContext({toggleColorMode: () => {}})
+const ColorModeContext = createContext({
+  toggleColorMode: () => {
+  },
+})
 
 /**
  * @param {Object} contentElt React component
@@ -23,11 +27,13 @@ export function MockRoutes({contentElt}) {
   return (
     <ColorModeContext.Provider value={colorMode}>
       <ThemeProvider theme={theme}>
-        <MemoryRouter>
-          <Routes>
-            <Route path="/*" element={contentElt} />
-          </Routes>
-        </MemoryRouter>
+        <PathsProvider installPrefix={'/'} appPrefix={'share'}>
+          <MemoryRouter>
+            <Routes>
+              <Route path="/*" element={contentElt}/>
+            </Routes>
+          </MemoryRouter>
+        </PathsProvider>
       </ThemeProvider>
     </ColorModeContext.Provider>
   )

--- a/src/Containers/CadView.jsx
+++ b/src/Containers/CadView.jsx
@@ -19,6 +19,7 @@ import debug from '../utils/debug'
 import * as Privacy from '../privacy/Privacy'
 import {assertDefined} from '../utils/assert'
 import {computeElementPath, setupLookupAndParentLinks} from '../utils/TreeUtils'
+import {usePaths} from '../Paths'
 
 
 /**
@@ -35,13 +36,14 @@ let count = 0
  * @return {Object}
  */
 export default function CadView({
-  installPrefix,
-  appPrefix,
   pathPrefix,
   modelPath,
 }) {
   assertDefined(...arguments)
   debug().log('CadView#init: count: ', count++)
+
+  const {installPrefix, appPrefix} = usePaths()
+
   // React router
   const navigate = useNavigate()
   // TODO(pablo): Removing this setter leads to a very strange stack overflow

--- a/src/Paths.jsx
+++ b/src/Paths.jsx
@@ -1,0 +1,18 @@
+import React from 'react'
+
+
+const PathsContext = React.createContext({installPrefix: undefined, appPrefix: undefined})
+
+export const usePaths = () => {
+  const paths = React.useContext(PathsContext)
+
+  return paths
+}
+
+export const PathsProvider = ({installPrefix, appPrefix, children}) => {
+  return (
+    <PathsContext.Provider value={{installPrefix: installPrefix, appPrefix: appPrefix}}>
+      {children}
+    </PathsContext.Provider>
+  )
+}

--- a/src/Share.jsx
+++ b/src/Share.jsx
@@ -5,6 +5,7 @@ import CssBaseline from '@mui/material/CssBaseline'
 import CadView from './Containers/CadView'
 import useTheme from './Theme'
 import debug from './utils/debug'
+import {usePaths} from './Paths'
 import './index.css'
 // TODO: This isn't used.
 // If icons-material isn't imported somewhere, mui dies
@@ -20,10 +21,11 @@ import AccountCircle from '@mui/icons-material/AccountCircle'
  * @param {string} pathPrefix e.g. v/p for CadView, currently the only child.
  * @return {Object} The Share react component.
  */
-export default function Share({installPrefix, appPrefix, pathPrefix}) {
+export default function Share({pathPrefix}) {
   const navigate = useNavigate()
   const urlParams = useParams()
   const [modelPath, setModelPath] = useState(null)
+  const {installPrefix, appPrefix} = usePaths()
 
 
   /**
@@ -64,8 +66,6 @@ export default function Share({installPrefix, appPrefix, pathPrefix}) {
         <ColorModeContext.Provider value={colorMode}>
           <ThemeProvider theme={theme}>
             <CadView
-              installPrefix={installPrefix}
-              appPrefix={appPrefix}
               pathPrefix={pathPrefix}
               modelPath={modelPath}
             />

--- a/src/Share.test.jsx
+++ b/src/Share.test.jsx
@@ -11,7 +11,8 @@ beforeAll(() => {
   const window = {innerWidth: 800, innerHeight: 600}
   const canvasGL = new Canvas.Canvas(window.innerWidth, window.innerHeight)
   // mock function to avoid errors inside THREE.WebGlRenderer()
-  canvasGL.addEventListener = function(event, func, bind_) {}
+  canvasGL.addEventListener = function(event, func, bind_) {
+  }
   const mockRenderer = new THREE.WebGLRenderer({
     context: glContext,
     antialias: true,
@@ -36,10 +37,8 @@ import Share from './Share'
 test('Share', () => {
   const {getByText} = render(
       <MockRoutes
-        contentElt={
-          <Share
-            installPrefix={'/'}
-            appPrefix={'share'}
-            pathPrefix={'v/p'} />}/>)
+        contentElt={<Share pathPrefix={'v/p'}/>}
+      />,
+  )
   expect(getByText(/BLDRS/i)).toBeInTheDocument()
 })

--- a/src/ShareRoutes.jsx
+++ b/src/ShareRoutes.jsx
@@ -84,7 +84,7 @@ function Forward() {
   const {appPrefix} = usePaths()
 
   useEffect(() => {
-    if (location.pathname == appPrefix) {
+    if (location.pathname === appPrefix) {
       const dest = appPrefix + '/v/p'
       debug().log('ShareRoutes#useEffect[location]: forwarding to: ', dest)
       navigate(dest)

--- a/src/ShareRoutes.jsx
+++ b/src/ShareRoutes.jsx
@@ -9,6 +9,7 @@ import {
 import {assertDefined} from './utils/assert'
 import Share from './Share'
 import debug from './utils/debug'
+import {usePaths} from './Paths'
 
 
 /**
@@ -35,16 +36,16 @@ import debug from './utils/debug'
  *              ^... path to the component in BaseRoutes.jsx.
  * @return {Object}
  */
-export default function ShareRoutes({installPrefix, appPrefix}) {
+export default function ShareRoutes() {
+  const {appPrefix} = usePaths()
+
   return (
     <Routes>
-      <Route path='/' element={<Forward appPrefix={appPrefix} />}>
+      <Route path='/' element={<Forward />}>
         <Route
           path='v/new/*'
           element={
             <Share
-              installPrefix={installPrefix}
-              appPrefix={appPrefix}
               pathPrefix={appPrefix + '/v/new'}
             />
           }
@@ -53,8 +54,6 @@ export default function ShareRoutes({installPrefix, appPrefix}) {
           path='v/p/*'
           element={
             <Share
-              installPrefix={installPrefix}
-              appPrefix={appPrefix}
               pathPrefix={appPrefix + '/v/p'}
             />
           }
@@ -63,8 +62,6 @@ export default function ShareRoutes({installPrefix, appPrefix}) {
           path='v/gh/:org/:repo/:branch/*'
           element={
             <Share
-              installPrefix={installPrefix}
-              appPrefix={appPrefix}
               pathPrefix={appPrefix + '/v/gh'}
             />
           }
@@ -81,9 +78,10 @@ export default function ShareRoutes({installPrefix, appPrefix}) {
  * @param {string} appPrefix The install prefix, e.g. /share.
  * @return {Object}
  */
-function Forward({appPrefix}) {
+function Forward() {
   const location = useLocation()
   const navigate = useNavigate()
+  const {appPrefix} = usePaths()
 
   useEffect(() => {
     if (location.pathname == appPrefix) {

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -2,9 +2,15 @@ import React from 'react'
 import {render} from 'react-dom'
 import {BrowserRouter} from 'react-router-dom'
 import BaseRoutes from './BaseRoutes'
+import {PathsProvider} from './Paths'
 
+
+const installPrefix = window.location.pathname.startsWith('/Share') ? '/Share' : ''
+const appPrefix = installPrefix + '/share'
 
 render(
-    <BrowserRouter>
-      <BaseRoutes/>
-    </BrowserRouter>, document.getElementById('root'))
+    <PathsProvider installPrefix={installPrefix} appPrefix={appPrefix}>
+      <BrowserRouter>
+        <BaseRoutes/>
+      </BrowserRouter>
+    </PathsProvider>, document.getElementById('root'))


### PR DESCRIPTION
Prop drilling[1] is the act of passing a property through multiple layers of components when the intermediate layers don't necessarily need said property.

Rather than passing the install and application prefix properties through each layer repeatedly because something downstream might need it, this has been refactored to use the React Context API which allows consumers to select which property they need without the use of prop drilling.

There's probably room for improvement here by removing the `appPrefix` member and replacing it with something that is calculated from `installPrefix` when needed, but that can be evaluated at a separate time.

1: https://www.geeksforgeeks.org/what-is-prop-drilling-and-how-to-avoid-it/