### PR TITLE
Hide nav panel by toggling css display property.

### DIFF
--- a/src/Components/NavPanel.jsx
+++ b/src/Components/NavPanel.jsx
@@ -53,6 +53,7 @@ export default function NavPanel({
   onElementSelect,
   setExpandedElements,
   pathPrefix,
+  displayNavPanel,
 }) {
   assertDefined(...arguments)
 
@@ -73,7 +74,7 @@ export default function NavPanel({
   // eslint-disable-next-line
   }, [location])
 
-  const classes = useStyles()
+  const classes = useStyles({displayNavPanel: displayNavPanel})
   // TODO(pablo): the defaultExpanded array can contain bogus IDs with
   // no error.  Not sure of a better way to pre-open the first few
   // nodes besides hardcoding.
@@ -111,6 +112,7 @@ export default function NavPanel({
 
 const useStyles = makeStyles({
   root: {
+    'display': (props) => props.displayNavPanel ? 'block' : 'none',
     'position': 'absolute',
     'top': '94px',
     'left': '20px',

--- a/src/Components/SearchBar.jsx
+++ b/src/Components/SearchBar.jsx
@@ -7,7 +7,7 @@ import {
 import InputBase from '@mui/material/InputBase'
 import Paper from '@mui/material/Paper'
 import {makeStyles} from '@mui/styles'
-import {TooltipToggleButton, FormButton} from './Buttons'
+import {TooltipToggleButton, FormButton, TooltipIconButton} from './Buttons'
 import debug from '../utils/debug'
 import {
   looksLikeLink,
@@ -90,7 +90,7 @@ export default function SearchBar({onClickMenuCb, showNavPanel}) {
   return (
     <div>
       <Paper component='form' className={classes.root} onSubmit={onSubmit}>
-        <TooltipToggleButton
+        <TooltipIconButton
           placement='bottom'
           title='Toggle tree view'
           onClick={onClickMenuCb}

--- a/src/Containers/CadView.jsx
+++ b/src/Containers/CadView.jsx
@@ -241,6 +241,7 @@ export default function CadView({
     rootElt.LongName = rootProps.LongName
     setRootElement(rootElt)
     setNavPanelReady(true)
+    setDisplayNavPanel(true)
   }
 
 

--- a/src/Containers/CadView.jsx
+++ b/src/Containers/CadView.jsx
@@ -60,7 +60,8 @@ export default function CadView({
   // UI elts
   const colorModeContext = useContext(ColorModeContext)
   const classes = useStyles()
-  const [showNavPanel, setShowNavPanel] = useState(false)
+  const [navPanelReady, setNavPanelReady] = useState(false)
+  const [displayNavPanel, setDisplayNavPanel] = useState(false)
   const [showSearchBar, setShowSearchBar] = useState(false)
   const [alert, setAlert] = useState(null)
   const [isLoading, setIsLoading] = useState(false)
@@ -111,7 +112,7 @@ export default function CadView({
    * new viewer.
    */
   function onModelPath() {
-    setShowNavPanel(false)
+    setNavPanelReady(false)
     setShowSearchBar(false)
     const theme = colorModeContext.getTheme()
     const intializedViewer = initViewer(
@@ -239,7 +240,7 @@ export default function CadView({
     rootElt.Name = rootProps.Name
     rootElt.LongName = rootProps.LongName
     setRootElement(rootElt)
-    setShowNavPanel(true)
+    setNavPanelReady(true)
   }
 
 
@@ -380,13 +381,11 @@ export default function CadView({
         <div className={classes.search}>
           {showSearchBar && (
             <SearchBar
-              onClickMenuCb={() => setShowNavPanel(!showNavPanel)}
-              showNavPanel={showNavPanel}
-              isOpen={showNavPanel}
+              onClickMenuCb={() => setDisplayNavPanel(!displayNavPanel)}
             />
           )}
         </div>
-        {showNavPanel &&
+        {navPanelReady &&
           <NavPanel
             model={model}
             element={rootElement}
@@ -395,6 +394,7 @@ export default function CadView({
             expandedElements={expandedElements}
             onElementSelect={onElementSelect}
             setExpandedElements={setExpandedElements}
+            displayNavPanel={displayNavPanel}
             pathPrefix={
               pathPrefix + (modelPath.gitpath ? modelPath.getRepoPath() : modelPath.filepath)
             }


### PR DESCRIPTION
This PR resolves [#318](https://github.com/bldrs-ai/Share/issues/318).
For the Property panel to display the properties of an element, the tree needs to be loaded into the scene.
Changed the tree toggle logic to control the CSS display property as opposed to subtracting the navpanel component from the scene.