### PR TITLE
Viewer: CutPlane: Created cut plane form normal and point 

### DIFF
--- a/__mocks__/web-ifc-viewer.js
+++ b/__mocks__/web-ifc-viewer.js
@@ -26,6 +26,9 @@ const impl = {
   },
   clipper: {
     active: false,
+    deleteAllPlanes: jest.fn(() => {
+      return 'cutPlane'
+    }),
   },
   container: {
     style: {},
@@ -46,6 +49,13 @@ constructorMock.mockImplementation(() => impl)
  */
 function __getIfcViewerAPIMockSingleton() {
   return impl
+}
+
+/**
+ * delete all planes mock fucntion
+ */
+function deleteAllPlanes() {
+  console.log('deletePlane ')
 }
 
 

--- a/__mocks__/web-ifc-viewer.js
+++ b/__mocks__/web-ifc-viewer.js
@@ -29,6 +29,9 @@ const impl = {
     deleteAllPlanes: jest.fn(() => {
       return 'cutPlane'
     }),
+    createFromNormalAndCoplanarPoint: jest.fn(() => {
+      return 'createFromNormalAndCoplanarPoint'
+    }),
   },
   container: {
     style: {},

--- a/__mocks__/web-ifc-viewer.js
+++ b/__mocks__/web-ifc-viewer.js
@@ -54,13 +54,6 @@ function __getIfcViewerAPIMockSingleton() {
   return impl
 }
 
-/**
- * delete all planes mock fucntion
- */
-function deleteAllPlanes() {
-  console.log('deletePlane ')
-}
-
 
 export {
   ifcjsMock as default,

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@mui/styles": "^5.9.2",
     "@octokit/rest": "^19.0.3",
     "clsx": "^1.2.1",
+    "@testing-library/react-hooks": "^8.0.1",
     "normalize.css": "^8.0.1",
     "prop-types": "^15.8.1",
     "react": "^18.2.0",

--- a/src/Components/CutPlaneMenu.jsx
+++ b/src/Components/CutPlaneMenu.jsx
@@ -14,8 +14,9 @@ import {addHashParams, getHashParams, removeHashParams} from '../utils/location'
 /**
  * BasicMenu used when there are several option behind UI button
  * show/hide from the right of the screen.
+ *
  * @param {Array} listOfOptions Title for the drawer
- * @return {Object} ItemPropertiesDrawer react component
+ * @return {object} ItemPropertiesDrawer react component
  */
 export default function CutPlaneMenu({listOfOptions, icon, title}) {
   const [anchorEl, setAnchorEl] = useState(null)

--- a/src/Components/CutPlaneMenu.jsx
+++ b/src/Components/CutPlaneMenu.jsx
@@ -1,0 +1,116 @@
+import React, {useState, useEffect} from 'react'
+import Menu from '@mui/material/Menu'
+import MenuItem from '@mui/material/MenuItem'
+import {makeStyles} from '@mui/styles'
+import {Vector3} from 'three'
+import {useLocation} from 'react-router-dom'
+import CutPlaneIcon from '../assets/2D_Icons/CutPlane.svg'
+import useStore from '../store/useStore'
+import {TooltipIconButton} from './Buttons'
+import {getModelCenter} from '../utils/cutPlane'
+import {addHashParams, getHashParams, removeHashParams} from '../utils/location'
+
+
+/**
+ * BasicMenu used when there are several option behind UI button
+ * show/hide from the right of the screen.
+ * @param {Array} listOfOptions Title for the drawer
+ * @return {Object} ItemPropertiesDrawer react component
+ */
+export default function CutPlaneMenu({listOfOptions, icon, title}) {
+  const [anchorEl, setAnchorEl] = useState(null)
+  const [cutPlaneDirection, setCutPlaneDirection] = useState('')
+  const open = Boolean(anchorEl)
+  const model = useStore((state) => state.modelStore)
+  const PLANE_PREFIX = 'p'
+  const classes = useStyles()
+
+  const handleClick = (event) => {
+    setAnchorEl(event.currentTarget)
+  }
+  const handleClose = () => {
+    setAnchorEl(null)
+  }
+  const viewer = useStore((state) => state.viewerStore)
+  const location = useLocation()
+
+  const createPlane = (normalDirection) => {
+    viewer.clipper.deleteAllPlanes()
+    const modelCenter = getModelCenter(model)
+    const planeHash = getHashParams(location, 'p')
+    if (normalDirection === cutPlaneDirection) {
+      viewer.clipper.deleteAllPlanes()
+      removeHashParams(window.location, PLANE_PREFIX)
+      setCutPlaneDirection('')
+      return
+    }
+    let normal
+    switch (normalDirection) {
+      case 'x':
+        normal = new Vector3(-1, 0, 0)
+        break
+      case 'y':
+        normal = new Vector3(0, -1, 0)
+        break
+      case 'z':
+        normal = new Vector3(0, 0, -1)
+        break
+      default:
+        normal = new Vector3(0, 1, 0)
+        break
+    }
+    if (!planeHash || planeHash !== normalDirection ) {
+      addHashParams(window.location, PLANE_PREFIX, {planeAxis: normalDirection})
+    }
+    setCutPlaneDirection(normalDirection)
+    return viewer.clipper.createFromNormalAndCoplanarPoint(normal, modelCenter)
+  }
+
+  useEffect(() => {
+    const planeHash = getHashParams(location, 'p')
+    if (planeHash && model && viewer) {
+      const planeDirection = planeHash.split(':')[1]
+      createPlane(planeDirection)
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [model])
+
+  return (
+    <div>
+      <TooltipIconButton
+        title={'Cut Planes'}
+        icon={<CutPlaneIcon/>}
+        onClick={handleClick}
+      />
+      <Menu
+        elevation={1}
+        id='basic-menu'
+        anchorEl={anchorEl}
+        open={open}
+        onClose={handleClose}
+        className={classes.root}
+        anchorOrigin={{vertical: 'top', horizontal: 'center'}}
+        transformOrigin={{vertical: 'top', horizontal: 'center'}}
+        PaperProps={{
+          style: {
+            left: '300px',
+            transform: 'translateX(-40px) translateY(-40px)',
+          },
+        }}
+      >
+        <MenuItem onClick={() => createPlane('x')} selected={cutPlaneDirection === 'x'}> X</MenuItem>
+        <MenuItem onClick={() => createPlane('y')} selected={cutPlaneDirection === 'y'}>Y</MenuItem>
+        <MenuItem onClick={() => createPlane('z')} selected={cutPlaneDirection === 'z'}>Z</MenuItem>
+      </Menu>
+    </div>
+  )
+}
+
+
+const useStyles = makeStyles({
+  root: {
+    '& .Mui-selected': {
+      border: '1px solid lightGray',
+    },
+  },
+})

--- a/src/Components/CutPlaneMenu.jsx
+++ b/src/Components/CutPlaneMenu.jsx
@@ -79,7 +79,7 @@ export default function CutPlaneMenu({listOfOptions, icon, title}) {
   return (
     <div>
       <TooltipIconButton
-        title={'Cut Planes'}
+        title={'Section'}
         icon={<CutPlaneIcon/>}
         onClick={handleClick}
       />

--- a/src/Components/CutPlaneMenu.test.jsx
+++ b/src/Components/CutPlaneMenu.test.jsx
@@ -1,0 +1,41 @@
+import React from 'react'
+import {render, fireEvent} from '@testing-library/react'
+import CutPlaneMenu from './CutPlaneMenu'
+import ShareMock from '../ShareMock'
+import {makeTestTree} from '../utils/TreeUtils.test'
+import {__getIfcViewerAPIMockSingleton} from 'web-ifc-viewer'
+
+
+describe('CutPlane', () => {
+  it('Section Button', () => {
+    const {getByTitle, debug} = render(<ShareMock><CutPlaneMenu/></ShareMock>)
+    debug()
+    expect(getByTitle('Section')).toBeInTheDocument()
+  })
+
+  it('Section Menu', () => {
+    const {getByTitle, getByText, debug} = render(<ShareMock><CutPlaneMenu/></ShareMock>)
+    const sectionButton = getByTitle('Section')
+    fireEvent.click(sectionButton)
+    debug()
+    expect(getByText('X')).toBeInTheDocument()
+    expect(getByText('Y')).toBeInTheDocument()
+    expect(getByText('Z')).toBeInTheDocument()
+  })
+
+  it('X Section', () => {
+    const {getByTitle, getByText, debug} = render(<ShareMock><CutPlaneMenu/></ShareMock>)
+    const sectionButton = getByTitle('Section')
+    fireEvent.click(sectionButton)
+    const xDirection = getByText('X')
+    fireEvent.click(xDirection)
+    const viewer = __getIfcViewerAPIMockSingleton()
+    const callDeletePlanes = viewer.clipper.deleteAllPlanes
+    console.log('callDeletePlanes', callDeletePlanes)
+    debug()
+    // expect(getByText('X')).toBeInTheDocument()
+    // expect(getByText('Y')).toBeInTheDocument()
+    // expect(getByText('Z')).toBeInTheDocument()
+  })
+})
+

--- a/src/Components/CutPlaneMenu.test.jsx
+++ b/src/Components/CutPlaneMenu.test.jsx
@@ -2,46 +2,58 @@ import React from 'react'
 import {act, fireEvent, render, renderHook} from '@testing-library/react'
 import CutPlaneMenu from './CutPlaneMenu'
 import ShareMock from '../ShareMock'
-import {makeTestTree} from '../utils/TreeUtils.test'
 import useStore from '../store/useStore'
 import {__getIfcViewerAPIMockSingleton} from 'web-ifc-viewer'
 
 
 describe('CutPlane', () => {
   it('Section Button', () => {
-    const {getByTitle, debug} = render(<ShareMock><CutPlaneMenu/></ShareMock>)
-    debug()
+    const {getByTitle} = render(<ShareMock><CutPlaneMenu/></ShareMock>)
     expect(getByTitle('Section')).toBeInTheDocument()
   })
 
   it('Section Menu', () => {
-    const {getByTitle, getByText, debug} = render(<ShareMock><CutPlaneMenu/></ShareMock>)
+    const {getByTitle, getByText} = render(<ShareMock><CutPlaneMenu/></ShareMock>)
     const sectionButton = getByTitle('Section')
     fireEvent.click(sectionButton)
-    debug()
     expect(getByText('X')).toBeInTheDocument()
     expect(getByText('Y')).toBeInTheDocument()
     expect(getByText('Z')).toBeInTheDocument()
   })
 
   it('X Section', async () => {
-    const {getByTitle, getByText, debug} = render(<ShareMock><CutPlaneMenu/></ShareMock>)
+    const {getByTitle, getByText} = render(<ShareMock><CutPlaneMenu/></ShareMock>)
     const sectionButton = getByTitle('Section')
     const {result} = renderHook(() => useStore((state) => state))
     const viewer = __getIfcViewerAPIMockSingleton()
     await act(() => {
       result.current.setViewerStore(viewer)
-      result.current.toggleIsPropertiesOn()
     })
     fireEvent.click(sectionButton)
     const xDirection = getByText('X')
     fireEvent.click(xDirection)
-    debug()
     const callDeletePlanes = viewer.clipper.deleteAllPlanes.mock.calls
-    console.log('callDeletePlanes', callDeletePlanes)
-    // expect(getByText('X')).toBeInTheDocument()
-    // expect(getByText('Y')).toBeInTheDocument()
-    // expect(getByText('Z')).toBeInTheDocument()
+    const callCreatePlanes = viewer.clipper.deleteAllPlanes.mock.calls
+    expect(callDeletePlanes.length).toBe(1)
+    expect(callCreatePlanes.length).toBe(1)
+  })
+
+  it('X Section in URL', async () => {
+    render(
+        <ShareMock
+          initialEntries={['/v/p/index.ifc#p:x']}
+        >
+          <CutPlaneMenu/>
+        </ShareMock>)
+    const {result} = renderHook(() => useStore((state) => state))
+    const viewer = __getIfcViewerAPIMockSingleton()
+    await act(() => {
+      result.current.setViewerStore(viewer)
+    })
+    const callDeletePlanes = viewer.clipper.deleteAllPlanes.mock.calls
+    const callCreatePlanes = viewer.clipper.deleteAllPlanes.mock.calls
+    expect(callDeletePlanes.length).toBe(1)
+    expect(callCreatePlanes.length).toBe(1)
   })
 })
 

--- a/src/Components/CutPlaneMenu.test.jsx
+++ b/src/Components/CutPlaneMenu.test.jsx
@@ -1,8 +1,9 @@
 import React from 'react'
-import {render, fireEvent} from '@testing-library/react'
+import {act, fireEvent, render, renderHook} from '@testing-library/react'
 import CutPlaneMenu from './CutPlaneMenu'
 import ShareMock from '../ShareMock'
 import {makeTestTree} from '../utils/TreeUtils.test'
+import useStore from '../store/useStore'
 import {__getIfcViewerAPIMockSingleton} from 'web-ifc-viewer'
 
 
@@ -23,16 +24,21 @@ describe('CutPlane', () => {
     expect(getByText('Z')).toBeInTheDocument()
   })
 
-  it('X Section', () => {
+  it('X Section', async () => {
     const {getByTitle, getByText, debug} = render(<ShareMock><CutPlaneMenu/></ShareMock>)
     const sectionButton = getByTitle('Section')
+    const {result} = renderHook(() => useStore((state) => state))
+    const viewer = __getIfcViewerAPIMockSingleton()
+    await act(() => {
+      result.current.setViewerStore(viewer)
+      result.current.toggleIsPropertiesOn()
+    })
     fireEvent.click(sectionButton)
     const xDirection = getByText('X')
     fireEvent.click(xDirection)
-    const viewer = __getIfcViewerAPIMockSingleton()
-    const callDeletePlanes = viewer.clipper.deleteAllPlanes
-    console.log('callDeletePlanes', callDeletePlanes)
     debug()
+    const callDeletePlanes = viewer.clipper.deleteAllPlanes.mock.calls
+    console.log('callDeletePlanes', callDeletePlanes)
     // expect(getByText('X')).toBeInTheDocument()
     // expect(getByText('Y')).toBeInTheDocument()
     // expect(getByText('Z')).toBeInTheDocument()

--- a/src/Components/ItemProperties.test.jsx
+++ b/src/Components/ItemProperties.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import {act, render, renderHook, screen, waitFor} from '@testing-library/react'
+import {act, render, screen, waitFor, renderHook} from '@testing-library/react'
 import ShareMock from '../ShareMock'
 import {MockModel} from '../utils/IfcMock.test'
 import useStore from '../store/useStore'

--- a/src/Components/OperationsGroup.jsx
+++ b/src/Components/OperationsGroup.jsx
@@ -1,15 +1,14 @@
 import React from 'react'
 import {makeStyles} from '@mui/styles'
+import useStore from '../store/useStore'
 import CameraControl from './CameraControl'
+import CutPlaneMenu from './CutPlaneMenu'
 import ShareControl from './ShareControl'
 import ShortcutsControl from './ShortcutsControl'
 import {TooltipIconButton} from './Buttons'
-import CutPlaneIcon from '../assets/2D_Icons/CutPlane.svg'
 import ClearIcon from '../assets/2D_Icons/Clear.svg'
 import MarkupIcon from '../assets/2D_Icons/Markup.svg'
 import ListIcon from '../assets/2D_Icons/List.svg'
-import {useIsMobile} from './Hooks'
-import useStore from '../store/useStore'
 
 
 /**
@@ -20,14 +19,15 @@ import useStore from '../store/useStore'
  * @param {Function} unSelectItem deselects currently selected element
  * @return {React.Component}
  */
-export default function OperationsGroup({viewer, unSelectItem}) {
+export default function OperationsGroup({unSelectItem}) {
   const turnCommentsOn = useStore((state) => state.turnCommentsOn)
   const toggleIsPropertiesOn = useStore((state) => state.toggleIsPropertiesOn)
   const openDrawer = useStore((state) => state.openDrawer)
   const selectedElement = useStore((state) => state.selectedElement)
   const isCommentsOn = useStore((state) => state.isCommentsOn)
-  const classes = useStyles({isCommentsOn: isCommentsOn})
+  const viewer = useStore((state) => state.viewerStore)
 
+  const classes = useStyles({isCommentsOn: isCommentsOn})
   const toggle = (panel) => {
     openDrawer()
     if (panel === 'Properties') {
@@ -37,6 +37,7 @@ export default function OperationsGroup({viewer, unSelectItem}) {
       turnCommentsOn()
     }
   }
+
 
   return (
     <div className={classes.container}>
@@ -58,18 +59,10 @@ export default function OperationsGroup({viewer, unSelectItem}) {
           /> :
           null
         }
-        {useIsMobile() ?
-          <TooltipIconButton
-            title="Section plane"
-            onClick={() => viewer.clipper.createPlane()}
-            icon={<CutPlaneIcon/>}
-          /> :
-          null
-        }
+        <CutPlaneMenu/>
         <TooltipIconButton title="Clear selection" onClick={unSelectItem} icon={<ClearIcon/>}/>
         <ShortcutsControl/>
       </div>
-      {/* Invisible */}
       <CameraControl viewer={viewer}/>
     </div>
   )

--- a/src/Components/SideDrawer.test.jsx
+++ b/src/Components/SideDrawer.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import {act, render, screen, waitFor, renderHook} from '@testing-library/react'
+import {act, render, renderHook} from '@testing-library/react'
 import useStore from '../store/useStore'
 import ShareMock from '../ShareMock'
 import SideDrawerWrapper from './SideDrawer'

--- a/src/Components/SideDrawer.test.jsx
+++ b/src/Components/SideDrawer.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import {act, render, renderHook} from '@testing-library/react'
+import {act, render, screen, waitFor, renderHook} from '@testing-library/react'
 import useStore from '../store/useStore'
 import ShareMock from '../ShareMock'
 import SideDrawerWrapper from './SideDrawer'

--- a/src/utils/cutPlane.js
+++ b/src/utils/cutPlane.js
@@ -1,0 +1,78 @@
+import {Box3, BufferAttribute, BufferGeometry, Mesh, Vector3} from 'three'
+
+
+/* eslint-disable no-magic-numbers */
+/**
+ * getSelectionAxisFromBoundingBox is the helper method for the cutplane logic
+ *
+ * @param {Object} boundingBox bouding box
+ * @return {Object}
+ */
+export function getSelectionAxisFromBoundingBox(boundingBox) {
+  return {
+    x: {
+      size: Math.abs( boundingBox.max.x - boundingBox.min.x),
+      center: (boundingBox.max.x + boundingBox.min.x) / 2,
+    },
+    y: {
+      size: Math.abs( boundingBox.max.y - boundingBox.min.y),
+      center: (boundingBox.max.y + boundingBox.min.y) / 2,
+    },
+    z: {
+      size: Math.abs(boundingBox.max.z - boundingBox.min.z ),
+      center: (boundingBox.max.z + boundingBox.min.z) / 2,
+    },
+  }
+}
+
+
+/**
+ * getModelCenter return the center of the model based on bounding box
+ *
+ * @param {Object} ifcModel bouding box
+ * @return {Object} centerCoordinates
+ */
+export function getModelCenter(ifcModel) {
+  return new Vector3(
+      (ifcModel?.geometry.boundingBox.max.x +
+        ifcModel?.geometry.boundingBox.min.x) /
+      2,
+      (ifcModel?.geometry.boundingBox.max.y +
+        ifcModel?.geometry.boundingBox.min.y) /
+      2,
+      (ifcModel?.geometry.boundingBox.max.z +
+        ifcModel?.geometry.boundingBox.min.z) /
+      2,
+  )
+}
+
+
+/**
+ * getElementBoundingBox creates a bounding box around the model
+ *
+ * @param {Object} selection seclected meshes
+ * @return {Object} boudingBox geometry
+ */
+export function getElementBoundingBox(selection) {
+  const geometry = new BufferGeometry()
+  const coordinates = []
+  const alreadySaved = new Set()
+  const position = selection.geometry.attributes['position']
+  const vertices = Float32Array.from(coordinates)
+  const mesh = new Mesh(geometry)
+  const boundingBox = new Box3()
+  geometry.setAttribute('position', new BufferAttribute(vertices, selection.geometry.index.count))
+  boundingBox.setFromObject(mesh)
+
+  for (let i = 0; i < selection.geometry.index.array.length; i++) {
+    if (!alreadySaved.has(selection.geometry.index.array[i])) {
+      coordinates.push(position.getX(selection.geometry.index.array[i]))
+      coordinates.push(position.getY(selection.geometry.index.array[i]))
+      coordinates.push(position.getZ(selection.geometry.index.array[i]))
+      alreadySaved.add(selection.geometry.index.array[i])
+    }
+  }
+
+  return boundingBox
+}
+

--- a/src/utils/cutPlane.js
+++ b/src/utils/cutPlane.js
@@ -5,8 +5,8 @@ import {Box3, BufferAttribute, BufferGeometry, Mesh, Vector3} from 'three'
 /**
  * getSelectionAxisFromBoundingBox is the helper method for the cutplane logic
  *
- * @param {Object} boundingBox bouding box
- * @return {Object}
+ * @param {object} boundingBox bouding box
+ * @return {object}
  */
 export function getSelectionAxisFromBoundingBox(boundingBox) {
   return {
@@ -29,8 +29,8 @@ export function getSelectionAxisFromBoundingBox(boundingBox) {
 /**
  * getModelCenter return the center of the model based on bounding box
  *
- * @param {Object} ifcModel bouding box
- * @return {Object} centerCoordinates
+ * @param {object} ifcModel bouding box
+ * @return {object} centerCoordinates
  */
 export function getModelCenter(ifcModel) {
   return new Vector3(
@@ -50,8 +50,8 @@ export function getModelCenter(ifcModel) {
 /**
  * getElementBoundingBox creates a bounding box around the model
  *
- * @param {Object} selection seclected meshes
- * @return {Object} boudingBox geometry
+ * @param {object} selection seclected meshes
+ * @return {object} boudingBox geometry
  */
 export function getElementBoundingBox(selection) {
   const geometry = new BufferGeometry()


### PR DESCRIPTION
This PR is addressing #153.
- Add a basic menu to the cut plane UI that allows the user to create a cut plane at the center of the model on one of the axes.
- Introduce plane hash URL(:p) parameter.
- At the moment only a single plane can be created which simplifies the issue of sharing the cut plane in the permalink.
- The menu buttons have a toggle state and can be deselected.
- deselecting the cut plane clears the URL parameter.

https://deploy-preview-332--bldrs-share.netlify.app/share/v/gh/Swiss-Property-AG/Portfolio/main/ASTRA.ifc#p:z::c:-3.98,12.13,-51.23,18.61,6.65,-8.62