### PR TITLE
Fix property set scrolling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bldrs",
-  "version": "1.0.0-r389",
+  "version": "1.0.0-r384",
   "main": "src/index.jsx",
   "homepage": "https://github.com/bldrs-ai/Share",
   "bugs": {

--- a/src/Components/ItemProperties.jsx
+++ b/src/Components/ItemProperties.jsx
@@ -422,11 +422,16 @@ const useStyles = makeStyles((theme) => ({
   psetsList: {
     padding: '0px',
     margin: 0,
-    minHeight: '400px',
+    height: '370px',
+    overflow: 'scroll',
+    width: '100%',
   },
   section: {
-    listStyle: 'none',
-    maxWidth: '400px',
+    'listStyle': 'none',
+    'width': '94%',
+    '@media (max-width: 900px)': {
+      width: '93%',
+    },
   },
   noElement: {
     maxWidth: '240px',

--- a/src/Components/MobileDrawer.jsx
+++ b/src/Components/MobileDrawer.jsx
@@ -15,7 +15,7 @@ import MarkupIcon from '../assets/2D_Icons/Markup.svg'
  * @return {Object} React component
  */
 export default function MobileDrawer({content}) {
-  const [open, setOpen] = useState(false)
+  const [open, setOpen] = useState(true)
   const toggleDrawer = () => setOpen(!open)
   const classes = useStyles({isOpen: open})
   const closeDrawer = useStore((state) => state.closeDrawer)


### PR DESCRIPTION
- This pr addresses scrolling for the psets, previously the psets in the expanded view did not scroll all the way.
- Change mobile drawer to full height when it is initially opened.