### PR TITLE
Toggle scene size when drawer expanded; desktop only.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bldrs",
-  "version": "1.0.0-r384",
+  "version": "1.0.0-r385",
   "main": "src/index.jsx",
   "homepage": "https://github.com/bldrs-ai/Share",
   "bugs": {

--- a/src/Components/SideDrawer.jsx
+++ b/src/Components/SideDrawer.jsx
@@ -120,13 +120,16 @@ export default function SideDrawerWrapper() {
 }
 
 
+export const SIDE_DRAWER_WIDTH = '31em'
+
+
 const useStyles = makeStyles((props) => (preprocessMediaQuery(MOBILE_WIDTH, {
   drawer: {
     '::-webkit-scrollbar': {
       display: 'none',
     },
     '& > .MuiPaper-root': {
-      'width': '31em',
+      'width': SIDE_DRAWER_WIDTH,
       // This lets the h1 in ItemProperties use 1em padding but have
       // its mid-line align with the text in SearchBar
       'padding': '4px 1em',

--- a/src/Containers/CadView.jsx
+++ b/src/Containers/CadView.jsx
@@ -10,7 +10,7 @@ import Logo from '../Components/Logo'
 import NavPanel from '../Components/NavPanel'
 import OperationsGroup from '../Components/OperationsGroup'
 import SearchBar from '../Components/SearchBar'
-import SideDrawerWrapper from '../Components/SideDrawer'
+import SideDrawerWrapper, {SIDE_DRAWER_WIDTH} from '../Components/SideDrawer'
 import SnackBarMessage from '../Components/SnackbarMessage'
 import {hasValidUrlParams as urlHasCameraParams} from '../Components/CameraControl'
 import {navToDefault} from '../Share'
@@ -114,14 +114,14 @@ export default function CadView({
     setShowNavPanel(false)
     setShowSearchBar(false)
     const theme = colorModeContext.getTheme()
-    const intializedViewer = initViewer(
+    const initializedViewer = initViewer(
         pathPrefix,
         (theme &&
-        theme.palette &&
-        theme.palette.background &&
-        theme.palette.background.paper) || '0xabcdef')
-    setViewer(intializedViewer)
-    setViewerStore(intializedViewer)
+         theme.palette &&
+         theme.palette.background &&
+         theme.palette.background.paper) || '0xabcdef')
+    setViewer(initializedViewer)
+    setViewerStore(initializedViewer)
     debug().log('CadView#onModelPath, done setting new viewer')
   }
 
@@ -135,6 +135,23 @@ export default function CadView({
     addThemeListener()
     await loadIfc(modelPath.gitpath || (installPrefix + modelPath.filepath))
   }
+
+
+  // Shrink the scene viewer when drawer is open.  This recenters the
+  // view in the new shrunk canvas, which preserves what the user is
+  // looking at.
+  // TODO(pablo): add render testing
+  useEffect(() => {
+    if (viewer) {
+      if (isDrawerOpen) {
+        viewer.container.style.width = `calc(100% - ${SIDE_DRAWER_WIDTH})`
+      } else {
+        viewer.container.style.width = '100%'
+      }
+      viewer.context.resize()
+    }
+  }, [isDrawerOpen, viewer])
+
 
   const setAlertMessage = (msg) =>
     setAlert(<Alert onCloseCb={() => navToDefault(navigate, appPrefix)} message={msg}/>)
@@ -422,9 +439,10 @@ export default function CadView({
 
 
 /**
- * @param {string} pathPrefix e.g. /share/v/p
+ * @param {string} pathPrefix E.g. /share/v/p
  * @param {string} backgroundColorStr CSS str like '#abcdef'
- * @return {Object} IfcViewerAPI viewer
+ * @return {Object} IfcViewerAPI viewer, width a .container property
+ *     referencing its container.
  */
 function initViewer(pathPrefix, backgroundColorStr = '#abcdef') {
   debug().log('CadView#initViewer: pathPrefix: ', pathPrefix, backgroundColorStr)
@@ -459,6 +477,9 @@ function initViewer(pathPrefix, backgroundColorStr = '#abcdef') {
     }
   }
 
+  // window.addEventListener('resize', () => {v.context.resize()})
+
+  v.container = container
   return v
 }
 

--- a/src/Containers/CadView.jsx
+++ b/src/Containers/CadView.jsx
@@ -3,7 +3,8 @@ import {useNavigate, useSearchParams} from 'react-router-dom'
 import {Color} from 'three'
 import {IfcViewerAPI} from 'web-ifc-viewer'
 import {makeStyles} from '@mui/styles'
-import {ColorModeContext} from '../Context/ColorMode'
+import SearchIndex from './SearchIndex'
+import {navToDefault} from '../Share'
 import Alert from '../Components/Alert'
 import BaseGroup from '../Components/BaseGroup'
 import Logo from '../Components/Logo'
@@ -12,14 +13,14 @@ import OperationsGroup from '../Components/OperationsGroup'
 import SearchBar from '../Components/SearchBar'
 import SideDrawerWrapper, {SIDE_DRAWER_WIDTH} from '../Components/SideDrawer'
 import SnackBarMessage from '../Components/SnackbarMessage'
+import {useIsMobile} from '../Components/Hooks'
 import {hasValidUrlParams as urlHasCameraParams} from '../Components/CameraControl'
-import {navToDefault} from '../Share'
+import {ColorModeContext} from '../Context/ColorMode'
 import * as Privacy from '../privacy/Privacy'
 import useStore from '../store/useStore'
 import debug from '../utils/debug'
 import {assertDefined} from '../utils/assert'
 import {computeElementPath, setupLookupAndParentLinks} from '../utils/TreeUtils'
-import SearchIndex from './SearchIndex.js'
 
 
 /**
@@ -137,20 +138,17 @@ export default function CadView({
   }
 
 
+  const isMobile = useIsMobile()
   // Shrink the scene viewer when drawer is open.  This recenters the
   // view in the new shrunk canvas, which preserves what the user is
   // looking at.
   // TODO(pablo): add render testing
   useEffect(() => {
-    if (viewer) {
-      if (isDrawerOpen) {
-        viewer.container.style.width = `calc(100% - ${SIDE_DRAWER_WIDTH})`
-      } else {
-        viewer.container.style.width = '100%'
-      }
+    if (viewer && !isMobile) {
+      viewer.container.style.width = isDrawerOpen ? `calc(100% - ${SIDE_DRAWER_WIDTH})` : '100%'
       viewer.context.resize()
     }
-  }, [isDrawerOpen, viewer])
+  }, [isDrawerOpen, isMobile, viewer])
 
 
   const setAlertMessage = (msg) =>


### PR DESCRIPTION
I don't think we had an issue filed for this, but it came up in discussion.. now that the drawer is bigger the content is obscured.  This gives the same centered view when drawer is open or closed.

Desktop only.