### PR TITLE
react18: fix render warnings in tests.

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
     "@testing-library/dom": "^8.17.1",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.3.0",
-    "@testing-library/react-hooks": "^8.0.1",
     "babel-jest": "^28.1.3",
     "babel-loader": "^8.2.5",
     "esbuild": "^0.14.54",

--- a/src/Components/IssuesControl.test.jsx
+++ b/src/Components/IssuesControl.test.jsx
@@ -1,6 +1,5 @@
 import React from 'react'
-import {render, screen} from '@testing-library/react'
-import {act, renderHook} from '@testing-library/react-hooks'
+import {act, render, renderHook, screen} from '@testing-library/react'
 import ShareMock from '../ShareMock'
 import useStore from '../store/useStore'
 import {IssuesNavBar, Issues} from './IssuesControl'

--- a/src/Components/ItemProperties.test.jsx
+++ b/src/Components/ItemProperties.test.jsx
@@ -1,6 +1,5 @@
 import React from 'react'
-import {render, screen, waitFor} from '@testing-library/react'
-import {act, renderHook} from '@testing-library/react-hooks'
+import {act, render, renderHook, screen, waitFor} from '@testing-library/react'
 import ShareMock from '../ShareMock'
 import {MockModel} from '../utils/IfcMock.test'
 import useStore from '../store/useStore'

--- a/src/Components/SideDrawer.test.jsx
+++ b/src/Components/SideDrawer.test.jsx
@@ -1,6 +1,5 @@
 import React from 'react'
-import {render, screen, waitFor} from '@testing-library/react'
-import {act, renderHook} from '@testing-library/react-hooks'
+import {act, render, renderHook, screen, waitFor} from '@testing-library/react'
 import useStore from '../store/useStore'
 import ShareMock from '../ShareMock'
 import SideDrawerWrapper from './SideDrawer'

--- a/src/store/useStore.test.js
+++ b/src/store/useStore.test.js
@@ -1,4 +1,4 @@
-import {act, renderHook} from '@testing-library/react-hooks'
+import {act, renderHook} from '@testing-library/react'
 import useStore from './useStore'
 
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3427,14 +3427,6 @@
     lodash "^4.17.15"
     redent "^3.0.0"
 
-"@testing-library/react-hooks@^8.0.1":
-  version "8.0.1"
-  resolved "https://registry.yarnpkg.com/@testing-library/react-hooks/-/react-hooks-8.0.1.tgz#0924bbd5b55e0c0c0502d1754657ada66947ca12"
-  integrity sha512-Aqhl2IVmLt8IovEVarNDFuJDVWVvhnr9/GCU6UUnrYXwgDFF9h2L2o2P9KBni1AST5sT6riAyoukFLyjQUgD/g==
-  dependencies:
-    "@babel/runtime" "^7.12.5"
-    react-error-boundary "^3.1.0"
-
 "@testing-library/react@^13.3.0":
   version "13.3.0"
   resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-13.3.0.tgz#bf298bfbc5589326bbcc8052b211f3bb097a97c5"
@@ -11452,13 +11444,6 @@ react-element-to-jsx-string@^14.3.4:
     "@base2/pretty-print-object" "1.0.1"
     is-plain-object "5.0.0"
     react-is "17.0.2"
-
-react-error-boundary@^3.1.0:
-  version "3.1.4"
-  resolved "https://registry.yarnpkg.com/react-error-boundary/-/react-error-boundary-3.1.4.tgz#255db92b23197108757a888b01e5b729919abde0"
-  integrity sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==
-  dependencies:
-    "@babel/runtime" "^7.12.5"
 
 react-inspector@^2.3.1:
   version "2.3.1"


### PR DESCRIPTION
Warnings like below were being caused by @testling-library/react-hooks not being adapted to react18, which we upgraded to in #299.  Instead, those methods have now been merged into @testing-library/react and we now use them from there.  Also removed the old library.

```
console.error
      Warning: ReactDOM.render is no longer supported in React 18. Use createRoot instead. Until you switch to the new API, your app will behave as if it's running React 17. Learn more: https://reactjs.org/link/switch-to-createroot
```
