### PR TITLE
System: Get element properties correctly when the tree is not loaded into the DOM.

### DIFF
--- a/__mocks__/web-ifc-viewer.js
+++ b/__mocks__/web-ifc-viewer.js
@@ -1,0 +1,25 @@
+const ifcjsMock = jest.createMockFromModule('web-ifc-viewer')
+export default ifcjsMock
+
+const constructorMock = ifcjsMock.IfcViewerAPI
+// Not sure why this is required, but otherwise these internal fields
+// are not present in the instantiated IfcViewerAPI.
+const impl = {
+  IFC: {
+    context: {
+      ifcCamera: {
+        cameraControls: {},
+      },
+    },
+    setWasmPath: jest.fn(),
+    loadIfcUrl: jest.fn(),
+  },
+  clipper: {
+    active: false,
+  },
+  context: {
+    resize: jest.fn(),
+  },
+}
+constructorMock.mockImplementation(() => impl)
+export {constructorMock as IfcViewerAPI}

--- a/jest.config.js
+++ b/jest.config.js
@@ -43,6 +43,7 @@ module.exports = {
   testEnvironment: 'jsdom',
   testPathIgnorePatterns: [
     'src/Share.test.js',
+    'src/Containers/CadView.test.jsx',
   ],
   transform: {
     '\\.[jt]sx?$': 'babel-jest',

--- a/src/Components/NavPanel.jsx
+++ b/src/Components/NavPanel.jsx
@@ -1,5 +1,4 @@
-import React, {useEffect} from 'react'
-import {useLocation} from 'react-router-dom'
+import React from 'react'
 import Paper from '@mui/material/Paper'
 import Tooltip from '@mui/material/Tooltip'
 import TreeView from '@mui/lab/TreeView'
@@ -55,23 +54,6 @@ export default function NavPanel({
   pathPrefix,
 }) {
   assertDefined(...arguments)
-
-  const location = useLocation()
-
-  useEffect(() => {
-    if (location.pathname.length <= 0) {
-      return
-    }
-    const parts = location.pathname.split(/\//)
-    if (parts.length > 0) {
-      const targetId = parseInt(parts[parts.length - 1])
-      if (isFinite(targetId)) {
-        onElementSelect({expressID: targetId})
-        setExpandedElements(parts)
-      }
-    }
-  // eslint-disable-next-line
-  }, [location])
 
   const classes = useStyles()
   // TODO(pablo): the defaultExpanded array can contain bogus IDs with

--- a/src/Containers/CadView.jsx
+++ b/src/Containers/CadView.jsx
@@ -119,7 +119,7 @@ export default function CadView({
       const targetId = parseInt(parts[parts.length - 1])
       if (isFinite(targetId)) {
         onElementSelect({expressID: targetId})
-        setExpandedElements(parts)
+        // setExpandedElements(parts)
       }
     }
   // eslint-disable-next-line

--- a/src/Containers/CadView.jsx
+++ b/src/Containers/CadView.jsx
@@ -97,7 +97,7 @@ export default function CadView({
   useEffect(() => {
     (async () => {
       await onModel()
-      extractElementPathFromURL()
+      selectElementBasedOnUrlPath()
     })()
   }, [model])
 
@@ -114,15 +114,7 @@ export default function CadView({
     if (location.pathname.length <= 0 || Object.keys(rootElement) < 1) {
       return
     }
-    // const parts = location.pathname.split(/\//)
-    // if (parts.length > 0) {
-    //   const targetId = parseInt(parts[parts.length - 1])
-    //   if (isFinite(targetId)) {
-    //     onElementSelect({expressID: targetId})
-    //     setExpandedElements(parts)
-    //   }
-    // }
-    extractElementPathFromURL()
+    selectElementBasedOnUrlPath()
   // eslint-disable-next-line
   }, [location])
 
@@ -407,7 +399,7 @@ export default function CadView({
   /**
    * Extracts the path to the element from the url and selects the element
    */
-  function extractElementPathFromURL() {
+  function selectElementBasedOnUrlPath() {
     const parts = location.pathname.split(/\//)
     if (parts.length > 0) {
       const targetId = parseInt(parts[parts.length - 1])

--- a/src/Containers/CadView.jsx
+++ b/src/Containers/CadView.jsx
@@ -371,7 +371,6 @@ export default function CadView({
    */
   async function onElementSelect(elt) {
     const id = elt.expressID
-    console.log('in the onElement select', elt)
     if (id === undefined) {
       throw new Error('Selected element is missing Express ID')
     }

--- a/src/Containers/CadView.jsx
+++ b/src/Containers/CadView.jsx
@@ -96,6 +96,14 @@ export default function CadView({
   useEffect(() => {
     (async () => {
       await onModel()
+      const parts = location.pathname.split(/\//)
+      if (parts.length > 0) {
+        const targetId = parseInt(parts[parts.length - 1])
+        if (isFinite(targetId)) {
+          onElementSelect({expressID: targetId})
+          setExpandedElements(parts)
+        }
+      }
     })()
   }, [model])
 
@@ -108,10 +116,9 @@ export default function CadView({
 
 
   const location = useLocation()
-
   // Get the property of the element when the url changes
   useEffect(() => {
-    if (location.pathname.length <= 0) {
+    if (location.pathname.length <= 0 || Object.keys(rootElement) < 1) {
       return
     }
     const parts = location.pathname.split(/\//)
@@ -119,7 +126,7 @@ export default function CadView({
       const targetId = parseInt(parts[parts.length - 1])
       if (isFinite(targetId)) {
         onElementSelect({expressID: targetId})
-        // setExpandedElements(parts)
+        setExpandedElements(parts)
       }
     }
   // eslint-disable-next-line

--- a/src/Containers/CadView.jsx
+++ b/src/Containers/CadView.jsx
@@ -1,5 +1,5 @@
 import React, {useContext, useEffect, useState} from 'react'
-import {useNavigate, useSearchParams} from 'react-router-dom'
+import {useNavigate, useSearchParams, useLocation} from 'react-router-dom'
 import {Color} from 'three'
 import {IfcViewerAPI} from 'web-ifc-viewer'
 import {makeStyles} from '@mui/styles'
@@ -106,6 +106,24 @@ export default function CadView({
   }, [searchParams])
   /* eslint-enable */
 
+
+  const location = useLocation()
+
+  // Get the property of the element when the url changes
+  useEffect(() => {
+    if (location.pathname.length <= 0) {
+      return
+    }
+    const parts = location.pathname.split(/\//)
+    if (parts.length > 0) {
+      const targetId = parseInt(parts[parts.length - 1])
+      if (isFinite(targetId)) {
+        onElementSelect({expressID: targetId})
+        setExpandedElements(parts)
+      }
+    }
+  // eslint-disable-next-line
+  }, [location])
 
   /**
    * Begin setup for new model. Turn off nav, search and item and init
@@ -360,6 +378,7 @@ export default function CadView({
    */
   async function onElementSelect(elt) {
     const id = elt.expressID
+    console.log('in the onElement select', elt)
     if (id === undefined) {
       throw new Error('Selected element is missing Express ID')
     }

--- a/src/Containers/CadView.jsx
+++ b/src/Containers/CadView.jsx
@@ -75,6 +75,7 @@ export default function CadView({
 
   const setViewerStore = useStore((state) => state.setViewerStore)
   const snackMessage = useStore((state) => state.snackMessage)
+  const location = useLocation()
 
 
   /* eslint-disable react-hooks/exhaustive-deps */
@@ -96,14 +97,7 @@ export default function CadView({
   useEffect(() => {
     (async () => {
       await onModel()
-      const parts = location.pathname.split(/\//)
-      if (parts.length > 0) {
-        const targetId = parseInt(parts[parts.length - 1])
-        if (isFinite(targetId)) {
-          onElementSelect({expressID: targetId})
-          setExpandedElements(parts)
-        }
-      }
+      extractElementPathFromURL()
     })()
   }, [model])
 
@@ -115,20 +109,20 @@ export default function CadView({
   /* eslint-enable */
 
 
-  const location = useLocation()
   // Get the property of the element when the url changes
   useEffect(() => {
     if (location.pathname.length <= 0 || Object.keys(rootElement) < 1) {
       return
     }
-    const parts = location.pathname.split(/\//)
-    if (parts.length > 0) {
-      const targetId = parseInt(parts[parts.length - 1])
-      if (isFinite(targetId)) {
-        onElementSelect({expressID: targetId})
-        setExpandedElements(parts)
-      }
-    }
+    // const parts = location.pathname.split(/\//)
+    // if (parts.length > 0) {
+    //   const targetId = parseInt(parts[parts.length - 1])
+    //   if (isFinite(targetId)) {
+    //     onElementSelect({expressID: targetId})
+    //     setExpandedElements(parts)
+    //   }
+    // }
+    extractElementPathFromURL()
   // eslint-disable-next-line
   }, [location])
 
@@ -407,6 +401,21 @@ export default function CadView({
         setViewerStore(intializedViewer)
       }
     })
+  }
+
+
+  /**
+   * Extracts the path to the element from the url and selects the element
+   */
+  function extractElementPathFromURL() {
+    const parts = location.pathname.split(/\//)
+    if (parts.length > 0) {
+      const targetId = parseInt(parts[parts.length - 1])
+      if (isFinite(targetId)) {
+        onElementSelect({expressID: targetId})
+        setExpandedElements(parts)
+      }
+    }
   }
 
   return (

--- a/src/Containers/CadView.test.jsx
+++ b/src/Containers/CadView.test.jsx
@@ -3,7 +3,7 @@ import {render, waitFor, renderHook, act} from '@testing-library/react'
 import CadView from './CadView'
 import ShareMock from '../ShareMock'
 import useStore from '../store/useStore'
-import {IfcViewerAPI} from 'web-ifc-viewer'
+// import {IfcViewerAPI} from 'web-ifc-viewer'
 
 
 // TODO(pablo): This mock suppresses "WARNING: Multiple instances of
@@ -14,31 +14,27 @@ jest.mock('three')
 jest.mock('web-ifc-viewer')
 
 describe('CadView', () => {
-  it('', async () => {
+  it('renders with mock IfcViewerAPI', async () => {
+    // Mock IfcViewerApi is in $repo/__mocks__/web-ifc-viewer.js
     const modelId = 1234
     const modelPath = {
       filepath: `index.ifc/${modelId}`,
       gitPath: 'foo',
     }
     const {result} = renderHook(() => useStore((state) => state))
-    const {getByTitle} = render(
+    const {getByTitle, debug} = render(
         <ShareMock>
           <CadView
             installPrefix={''}
             appPrefix={''}
             pathPrefix={''}
+            modelPath={modelPath}
           />
         </ShareMock>)
+    debug()
     await act(() => result.current.setModelPath(modelPath))
+    // Necessary to wait for some of the component to render to avoid
+    // act() warningings from testing-library.
     await waitFor(() => getByTitle(/Bldrs: 1.0.0/i))
-    // The mocked class actually returns a singleton instance.
-    const viewer = new IfcViewerAPI()
-    console.log('viewer', viewer)
-    // debug()
-    // expect(viewer.getProperties.mock.calls.length).toBe(1)
-    // const firstCall = viewer.getProperties.mock.calls[0]
-    // expect(firstCall[0]).toBe(0) // modelId
-    // expect(firstCall[1]).toBe(modelId) // elementId
   })
 })
-

--- a/src/Containers/CadView.test.jsx
+++ b/src/Containers/CadView.test.jsx
@@ -1,0 +1,33 @@
+import React from 'react'
+import {render, screen, waitFor} from '@testing-library/react'
+import CadView from './CadView'
+import ShareMock from '../ShareMock'
+
+
+// TODO(pablo): This mock suppresses "WARNING: Multiple instances of
+// Three.js being imported", but why is it being included if
+// web-ifc-viewer is being mocked?
+jest.mock('three')
+
+jest.mock('web-ifc-viewer')
+
+describe('CadView', () => {
+  it('renders with mock IfcViewerAPI', async () => {
+    // Mock IfcViewerApi is in $repo/__mocks__/web-ifc-viewer.js
+    const modelPath = {
+      gitPath: '',
+    }
+    render(
+        <ShareMock>
+          <CadView
+            installPrefix={''}
+            appPrefix={''}
+            pathPrefix={''}
+            modelPath={modelPath}
+          />
+        </ShareMock>)
+    // Necessary to wait for some of the component to render to avoid
+    // act() warningings from testing-library.
+    await waitFor(() => screen.getByTitle(/Bldrs: 1.0.0/i))
+  })
+})

--- a/src/Containers/CadView.test.jsx
+++ b/src/Containers/CadView.test.jsx
@@ -3,6 +3,7 @@ import {render, waitFor, renderHook, act} from '@testing-library/react'
 import CadView from './CadView'
 import ShareMock from '../ShareMock'
 import useStore from '../store/useStore'
+import IfcjsMock from '../__mocks__/web-ifc-viewer.js'
 // import {IfcViewerAPI} from 'web-ifc-viewer'
 
 
@@ -33,6 +34,8 @@ describe('CadView', () => {
         </ShareMock>)
     debug()
     await act(() => result.current.setModelPath(modelPath))
+    const viewer = new IfcjsMock()
+    console.log('viewer', viewer.IFC.getProperties())
     // Necessary to wait for some of the component to render to avoid
     // act() warningings from testing-library.
     await waitFor(() => getByTitle(/Bldrs: 1.0.0/i))

--- a/src/Containers/CadView.test.jsx
+++ b/src/Containers/CadView.test.jsx
@@ -1,7 +1,9 @@
 import React from 'react'
-import {render, screen, waitFor} from '@testing-library/react'
+import {render, waitFor, renderHook, act} from '@testing-library/react'
 import CadView from './CadView'
 import ShareMock from '../ShareMock'
+import useStore from '../store/useStore'
+import {IfcViewerAPI} from 'web-ifc-viewer'
 
 
 // TODO(pablo): This mock suppresses "WARNING: Multiple instances of
@@ -12,22 +14,31 @@ jest.mock('three')
 jest.mock('web-ifc-viewer')
 
 describe('CadView', () => {
-  it('renders with mock IfcViewerAPI', async () => {
-    // Mock IfcViewerApi is in $repo/__mocks__/web-ifc-viewer.js
+  it('', async () => {
+    const modelId = 1234
     const modelPath = {
-      gitPath: '',
+      filepath: `index.ifc/${modelId}`,
+      gitPath: 'foo',
     }
-    render(
+    const {result} = renderHook(() => useStore((state) => state))
+    const {getByTitle} = render(
         <ShareMock>
           <CadView
             installPrefix={''}
             appPrefix={''}
             pathPrefix={''}
-            modelPath={modelPath}
           />
         </ShareMock>)
-    // Necessary to wait for some of the component to render to avoid
-    // act() warningings from testing-library.
-    await waitFor(() => screen.getByTitle(/Bldrs: 1.0.0/i))
+    await act(() => result.current.setModelPath(modelPath))
+    await waitFor(() => getByTitle(/Bldrs: 1.0.0/i))
+    // The mocked class actually returns a singleton instance.
+    const viewer = new IfcViewerAPI()
+    console.log('viewer', viewer)
+    // debug()
+    // expect(viewer.getProperties.mock.calls.length).toBe(1)
+    // const firstCall = viewer.getProperties.mock.calls[0]
+    // expect(firstCall[0]).toBe(0) // modelId
+    // expect(firstCall[1]).toBe(modelId) // elementId
   })
 })
+

--- a/src/Share.jsx
+++ b/src/Share.jsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useState} from 'react'
+import React, {useEffect} from 'react'
 import {useNavigate, useParams} from 'react-router-dom'
 import {ThemeProvider} from '@mui/material/styles'
 import CssBaseline from '@mui/material/CssBaseline'
@@ -25,8 +25,10 @@ import AccountCircle from '@mui/icons-material/AccountCircle'
 export default function Share({installPrefix, appPrefix, pathPrefix}) {
   const navigate = useNavigate()
   const urlParams = useParams()
-  const [modelPath, setModelPath] = useState(null)
+  // const [modelPath, setModelPath] = useState(null)
   const setRepository = useStore((state) => state.setRepository)
+  const modelPath = useStore((state) => state.modelPath)
+  const setModelPath = useStore((state) => state.setModelPath)
 
 
   /**

--- a/src/__mocks__/web-ifc-viewer.js
+++ b/src/__mocks__/web-ifc-viewer.js
@@ -1,0 +1,26 @@
+const ifcjsMock = jest.createMockFromModule('web-ifc-viewer')
+export default ifcjsMock
+
+const constructorMock = ifcjsMock.IfcViewerAPI
+// Not sure why this is required, but otherwise these internal fields
+// are not present in the instantiated IfcViewerAPI.
+const impl = {
+  IFC: {
+    context: {
+      ifcCamera: {
+        cameraControls: {},
+      },
+    },
+    setWasmPath: jest.fn(),
+    loadIfcUrl: jest.fn(),
+  },
+  clipper: {
+    active: false,
+  },
+  context: {
+    resize: jest.fn(),
+  },
+  getProperties: jest.fn(),
+}
+constructorMock.mockImplementation(() => impl)
+export {constructorMock as IfcViewerAPI}

--- a/src/store/IFCSlice.js
+++ b/src/store/IFCSlice.js
@@ -10,9 +10,11 @@ export default function createIFCSlice(set, get) {
     modelStore: null,
     selectedElement: null,
     cameraControls: null,
+    modelPath: null,
     setViewerStore: (viewer) => set(() => ({viewerStore: viewer})),
     setModelStore: (model) => set(() => ({modelStore: model})),
     setSelectedElement: (element) => set(() => ({selectedElement: element})),
     setCameraControls: (cameraControls) => set(() => ({cameraControls: cameraControls})),
+    setModelPath: (modelPath) => set(() => ({modelPath: modelPath})),
   }
 }


### PR DESCRIPTION
This PR resolves https://github.com/bldrs-ai/Share/issues/318.
For the Property panel to display the properties of an element, the properties need to be obtained from the ifc.js.
On element selected is triggered when the location is changed, in the PR it was moved from the Nav Panel to CadView, so it is triggered regardless if the tree is loaded into the DOM.