### PR TITLE
Tests: Introduce CadView.test.jsx.

### DIFF
--- a/__mocks__/web-ifc-viewer.js
+++ b/__mocks__/web-ifc-viewer.js
@@ -1,0 +1,25 @@
+const ifcjsMock = jest.createMockFromModule('web-ifc-viewer')
+export default ifcjsMock
+
+const constructorMock = ifcjsMock.IfcViewerAPI
+// Not sure why this is required, but otherwise these internal fields
+// are not present in the instantiated IfcViewerAPI.
+const impl = {
+  IFC: {
+    context: {
+      ifcCamera: {
+        cameraControls: {},
+      },
+    },
+    setWasmPath: jest.fn(),
+    loadIfcUrl: jest.fn(),
+  },
+  clipper: {
+    active: false,
+  },
+  context: {
+    resize: jest.fn(),
+  },
+}
+constructorMock.mockImplementation(() => impl)
+export {constructorMock as IfcViewerAPI}

--- a/src/Containers/CadView.test.jsx
+++ b/src/Containers/CadView.test.jsx
@@ -1,0 +1,48 @@
+import React from 'react'
+import {render} from '@testing-library/react'
+import CadView from './CadView'
+import ShareMock from '../ShareMock'
+
+
+jest.mock('web-ifc-viewer')
+
+import {IfcViewerAPI} from 'web-ifc-viewer'
+
+
+const ifcObj = {
+  IFC: {
+    context: {
+      ifcCamera: {
+        cameraControls: {},
+      },
+    },
+    setWasmPath: jest.fn(),
+    loadIfcUrl: jest.fn(),
+  },
+  clipper: {
+    active: false,
+  },
+  context: {
+    resize: jest.fn(),
+  },
+}
+IfcViewerAPI.mockImplementation(() => ifcObj)
+
+
+describe('CadView', () => {
+  it('renders with mock IfcViewerAPI', () => {
+    // Mock IfcViewerApi is in $repo/__mocks__/web-ifc-viewer.js
+    const modelPath = {
+      gitPath: '',
+    }
+    render(
+        <ShareMock>
+          <CadView
+            installPrefix={''}
+            appPrefix={''}
+            pathPrefix={''}
+            modelPath={modelPath}
+          />
+        </ShareMock>)
+  })
+})

--- a/src/Containers/CadView.test.jsx
+++ b/src/Containers/CadView.test.jsx
@@ -1,36 +1,14 @@
 import React from 'react'
-import {render} from '@testing-library/react'
+import {render, screen, waitFor} from '@testing-library/react'
 import CadView from './CadView'
 import ShareMock from '../ShareMock'
 
 
+jest.mock('three')
 jest.mock('web-ifc-viewer')
 
-import {IfcViewerAPI} from 'web-ifc-viewer'
-
-
-const ifcObj = {
-  IFC: {
-    context: {
-      ifcCamera: {
-        cameraControls: {},
-      },
-    },
-    setWasmPath: jest.fn(),
-    loadIfcUrl: jest.fn(),
-  },
-  clipper: {
-    active: false,
-  },
-  context: {
-    resize: jest.fn(),
-  },
-}
-IfcViewerAPI.mockImplementation(() => ifcObj)
-
-
 describe('CadView', () => {
-  it('renders with mock IfcViewerAPI', () => {
+  it('renders with mock IfcViewerAPI', async () => {
     // Mock IfcViewerApi is in $repo/__mocks__/web-ifc-viewer.js
     const modelPath = {
       gitPath: '',
@@ -44,5 +22,8 @@ describe('CadView', () => {
             modelPath={modelPath}
           />
         </ShareMock>)
+    // Necessary to wait for some of the component to render to avoid
+    // act() warningings from testing-library.
+    await waitFor(() => screen.getByTitle(/Bldrs: 1.0.0/i))
   })
 })

--- a/src/Containers/CadView.test.jsx
+++ b/src/Containers/CadView.test.jsx
@@ -4,7 +4,11 @@ import CadView from './CadView'
 import ShareMock from '../ShareMock'
 
 
+// TODO(pablo): This mock suppresses "WARNING: Multiple instances of
+// Three.js being imported", but why is it being included if
+// web-ifc-viewer is being mocked?
 jest.mock('three')
+
 jest.mock('web-ifc-viewer')
 
 describe('CadView', () => {


### PR DESCRIPTION
This PR introduces CadView test, using a global mock for IFC.js's web-ifc-viewer module.

It also demonstrates a waitFor assert on some of the rendered content such that the test doesn't trigger the react "use act" warning.  Specifically I'm waiting on the title attribute in the logo's DOM tag.  Running without this waitFor shows a warning for CadView.jsx#L196, which is in the loading callback for the viewer.  I'm confused, as this modifies the page after the Bldrs logo is rendered.  But works for now.  Hopefully we'll get clarity on this.