### PR TITLE
Bug: Property window  is cropped

### DIFF
--- a/src/Components/ItemProperties.jsx
+++ b/src/Components/ItemProperties.jsx
@@ -422,9 +422,11 @@ const useStyles = makeStyles((theme) => ({
   psetsList: {
     padding: '0px',
     margin: 0,
-    height: '370px',
+    minHeight: '370px',
+    height: '100%',
     overflow: 'scroll',
     width: '100%',
+    flexGrow: 1,
   },
   section: {
     'listStyle': 'none',

--- a/src/Components/SideDrawer.jsx
+++ b/src/Components/SideDrawer.jsx
@@ -162,7 +162,7 @@ const useStyles = makeStyles((props) => (preprocessMediaQuery(MOBILE_WIDTH, {
     },
   },
   content: {
-    'overflow': 'hidden',
+    'overflow': 'scroll',
     'height': '95%',
     'marginTop': '20px',
     'display': 'flex',
@@ -187,7 +187,7 @@ const useStyles = makeStyles((props) => (preprocessMediaQuery(MOBILE_WIDTH, {
     borderRadius: '5px',
     overflow: 'hidden',
     display: (p) => p.isPropertiesOn ? '' : 'none',
-    height: (p) => p.isCommentsOn ? '50%' : '1200px',
+    height: (p) => p.isCommentsOn ? '50%' : '98%',
   },
   divider: {
     height: '1px',

--- a/src/Components/SideDrawerPanels.jsx
+++ b/src/Components/SideDrawerPanels.jsx
@@ -49,7 +49,7 @@ export function PropertiesPanel() {
           </div>
         }
       />
-      <div className={classes.contentContainer}>
+      <div className={classes.contentContainerProperties}>
         {selectedElement ? <ItemProperties/> : null}
       </div>
     </>
@@ -62,7 +62,7 @@ export const NotesPanel = () => {
   return (
     <>
       <IssuesNavBar/>
-      <div className={classes.contentContainer}>
+      <div className={classes.contentContainerNotes}>
         <Issues/>
       </div>
     </>
@@ -89,13 +89,21 @@ const useStyles = makeStyles((theme) => ({
     paddingLeft: '2px',
     alignItems: 'center',
   },
-  contentContainer: {
+  contentContainerProperties: {
     marginTop: '4px',
     display: 'flex',
     flexDirection: 'column',
     alignItems: 'center',
     height: '100%',
     overflow: 'scroll',
+  },
+  contentContainerNotes: {
+    marginTop: '4px',
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    height: '100%',
+    overflow: 'auto',
   },
   controls: {
     height: '100%',


### PR DESCRIPTION
This PR is addressing #342.
Fixed by setting the properties container of the property panel to 98 %percent of the height.

<img width="1388" alt="image" src="https://user-images.githubusercontent.com/3433606/186665182-746d1e5e-8ca5-4d90-bbc9-0143bf4447ab.png">
