### PR TITLE
Correct improper usage of async/await

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -83,6 +83,7 @@ module.exports = {
     'func-call-spacing': ['error', 'never'],
     'no-multiple-empty-lines': ['error', {max: 2, maxEOF: 1}],
     'react/jsx-closing-bracket-location': 'error',
+    'require-await': 'error',
   },
   settings: {
     react: {

--- a/src/Components/ItemProperties.test.jsx
+++ b/src/Components/ItemProperties.test.jsx
@@ -9,10 +9,8 @@ import ItemProperties from './ItemProperties'
 test('ItemProperties for single element', async () => {
   const testLabel = 10
   const {result} = renderHook(() => useStore((state) => state))
-  act(() => {
+  await act(() => {
     result.current.setSelectedElement({expressID: 10})
-  })
-  act(() => {
     result.current.setModelStore(new MockModel)
   })
 

--- a/src/Components/SideDrawer.test.jsx
+++ b/src/Components/SideDrawer.test.jsx
@@ -7,7 +7,7 @@ import SideDrawerWrapper from './SideDrawer'
 
 test('side drawer notes', async () => {
   const {result} = renderHook(() => useStore((state) => state))
-  act(() => {
+  await act(() => {
     result.current.turnCommentsOn()
     result.current.openDrawer()
   })
@@ -16,7 +16,7 @@ test('side drawer notes', async () => {
     expect(screen.getByText('Notes')).toBeInTheDocument()
   })
   // reset the store
-  act(() => {
+  await act(() => {
     result.current.turnCommentsOff()
   })
 })
@@ -24,7 +24,7 @@ test('side drawer notes', async () => {
 
 test('side drawer properties', async () => {
   const {result} = renderHook(() => useStore((state) => state))
-  act(() => {
+  await act(() => {
     result.current.toggleIsPropertiesOn()
     result.current.openDrawer()
   })
@@ -33,7 +33,7 @@ test('side drawer properties', async () => {
     expect(screen.getByText('Properties')).toBeInTheDocument()
   })
   // reset the store
-  act(() => {
+  await act(() => {
     result.current.setSelectedElement({})
     result.current.toggleIsPropertiesOn()
   })
@@ -43,7 +43,7 @@ test('side drawer properties', async () => {
 test('side drawer - issues id in url', async () => {
   const {result} = renderHook(() => useStore((state) => state))
   const extractedCommentId = '1257156364'
-  act(() => {
+  await act(() => {
     result.current.setSelectedIssueId(Number(extractedCommentId))
     result.current.turnCommentsOn()
     result.current.openDrawer()
@@ -53,7 +53,7 @@ test('side drawer - issues id in url', async () => {
     expect(screen.getByText('BLDRS-LOCAL_MODE-ID:1257156364')).toBeInTheDocument()
   })
   // reset the store
-  act(() => {
+  await act(() => {
     result.current.setSelectedElement({})
     result.current.turnCommentsOff()
   })
@@ -74,7 +74,7 @@ test('side drawer - opened via URL', async () => {
   })
 
   // reset the store
-  act(() => {
+  await act(() => {
     result.current.setSelectedElement({})
     result.current.turnCommentsOff()
   })

--- a/src/Containers/CadView.jsx
+++ b/src/Containers/CadView.jsx
@@ -311,7 +311,7 @@ export default function CadView({
   /**
    * Select items in model when they are double-clicked.
    */
-  async function setDoubleClickListener() {
+  function setDoubleClickListener() {
     window.ondblclick = async (event) => {
       if (event.target && event.target.tagName === 'CANVAS') {
         const item = await viewer.IFC.pickIfcItem(true)

--- a/src/Containers/CadView.jsx
+++ b/src/Containers/CadView.jsx
@@ -363,7 +363,7 @@ export default function CadView({
     if (id === undefined) {
       throw new Error('Selected element is missing Express ID')
     }
-    selectItems([id])
+    await selectItems([id])
     const props = await viewer.getProperties(0, elt.expressID)
     setSelectedElement(props)
 

--- a/src/utils/GitHub.js
+++ b/src/utils/GitHub.js
@@ -92,14 +92,17 @@ export async function getComment(repository, issueId, commentId) {
 async function getGitHub(repository, path, args) {
   assertDefined(repository.orgName)
   assertDefined(repository.name)
+
   debug().log('Dispatching GitHub request for repo:', repository)
-  return await octokit.request(`GET /repos/{org}/{repo}/${path}`, {
+  const res = await octokit.request(`GET /repos/{org}/{repo}/${path}`, {
     ...{
       org: repository.orgName,
       repo: repository.name,
     },
     ...args,
   })
+
+  return res
 }
 
 export const MOCK_ISSUE = {


### PR DESCRIPTION
Within the test suites, `await` is needed to ensure that the environment is properly set up before performing our assertions.

Within the code base:
* Functions were declared as `async`, but did not contain any asynchronous execution
* Asynchronous functions were being executed without resolving the promise (or otherwise awaiting for the result)
* The result of an asynchronous function was being directly returned with `return await` which would obscure a stack trace.