### PR TITLE
De-duplicate bundling efforts

### DIFF
--- a/config/common.js
+++ b/config/common.js
@@ -1,12 +1,20 @@
 import svgrPlugin from 'esbuild-plugin-svgr'
 import copyStaticFiles from 'esbuild-copy-static-files'
 import {cleanPlugin} from 'esbuild-clean-plugin'
+import {fileURLToPath} from 'url'
+import * as path from 'node:path'
+import * as process from 'node:process'
 
 
-const entry = 'src/index.jsx'
-const buildDir = 'docs'
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+
+const entryPoint = path.resolve(__dirname, '..', 'src', 'index.jsx')
+const assetsDir = path.resolve(__dirname, '..', 'public')
+const buildDir = path.resolve(__dirname, '..', 'dist')
+
 export const build = {
-  entryPoints: [entry],
+  entryPoints: [entryPoint],
   bundle: true,
   minify: true,
   // https://esbuild.github.io/api/#keep-names
@@ -30,7 +38,7 @@ export const build = {
     svgrPlugin(),
     cleanPlugin(),
     copyStaticFiles({
-      src: './public',
+      src: assetsDir,
       dest: buildDir,
     }),
   ],

--- a/config/common.js
+++ b/config/common.js
@@ -17,7 +17,7 @@ const buildDir = path.resolve(__dirname, '..', 'docs')
 export const build = {
   entryPoints: [entryPoint],
   bundle: true,
-  minify: true,
+  minify: process.env.NODE_ENV === 'production',
   // https://esbuild.github.io/api/#keep-names
   // We use code identifiers e.g. in ItemProperties for their names
   keepNames: true,

--- a/config/common.js
+++ b/config/common.js
@@ -1,6 +1,7 @@
 import svgrPlugin from 'esbuild-plugin-svgr'
 import copyStaticFiles from 'esbuild-copy-static-files'
 import {cleanPlugin} from 'esbuild-clean-plugin'
+import progress from 'esbuild-plugin-progress'
 import {fileURLToPath} from 'url'
 import * as path from 'node:path'
 import * as process from 'node:process'
@@ -36,6 +37,7 @@ export const build = {
   logLevel: 'info',
   plugins: [
     svgrPlugin(),
+    progress(),
     cleanPlugin(),
     copyStaticFiles({
       src: assetsDir,

--- a/config/common.js
+++ b/config/common.js
@@ -33,6 +33,7 @@ export const build = {
   outdir: buildDir,
   format: 'esm',
   sourcemap: true,
+  platform: 'browser',
   target: ['chrome58', 'firefox57', 'safari11', 'edge18'],
   logLevel: 'info',
   plugins: [

--- a/config/common.js
+++ b/config/common.js
@@ -1,4 +1,6 @@
 import svgrPlugin from 'esbuild-plugin-svgr'
+import copyStaticFiles from 'esbuild-copy-static-files'
+import {cleanPlugin} from 'esbuild-clean-plugin'
 
 
 const entry = 'src/index.jsx'
@@ -18,10 +20,18 @@ export const build = {
   //   https://esbuild.github.io/api/#chunk-names
   //   https://github.com/evanw/esbuild/issues/16
   splitting: false,
+  metafile: true,
   outdir: buildDir,
   format: 'esm',
   sourcemap: true,
   target: ['chrome58', 'firefox57', 'safari11', 'edge18'],
   logLevel: 'info',
-  plugins: [svgrPlugin()],
+  plugins: [
+    svgrPlugin(),
+    cleanPlugin(),
+    copyStaticFiles({
+      src: './public',
+      dest: buildDir,
+    }),
+  ],
 }

--- a/config/common.js
+++ b/config/common.js
@@ -1,7 +1,7 @@
-import svgrPlugin from 'esbuild-plugin-svgr'
-import copyStaticFiles from 'esbuild-copy-static-files'
 import {cleanPlugin} from 'esbuild-clean-plugin'
+import copyStaticFiles from 'esbuild-copy-static-files'
 import progress from 'esbuild-plugin-progress'
+import svgrPlugin from 'esbuild-plugin-svgr'
 import {fileURLToPath} from 'url'
 import * as path from 'node:path'
 import * as process from 'node:process'
@@ -36,9 +36,9 @@ export const build = {
   target: ['chrome58', 'firefox57', 'safari11', 'edge18'],
   logLevel: 'info',
   plugins: [
-    svgrPlugin(),
     progress(),
     cleanPlugin(),
+    svgrPlugin(),
     copyStaticFiles({
       src: assetsDir,
       dest: buildDir,

--- a/config/common.js
+++ b/config/common.js
@@ -11,7 +11,7 @@ const __dirname = path.dirname(__filename)
 
 const entryPoint = path.resolve(__dirname, '..', 'src', 'index.jsx')
 const assetsDir = path.resolve(__dirname, '..', 'public')
-const buildDir = path.resolve(__dirname, '..', 'dist')
+const buildDir = path.resolve(__dirname, '..', 'docs')
 
 export const build = {
   entryPoints: [entryPoint],

--- a/config/serve.js
+++ b/config/serve.js
@@ -4,31 +4,12 @@ import * as common from './common.js'
 
 
 const SERVE_PORT = 8080
+const HTTP_NOT_FOUND = 404
 
-esbuild.serve({
-  port: SERVE_PORT,
-  servedir: common.build.outdir,
-}, common.build).then((result) => {
-  // The result tells us where esbuild's local server is
-  const {host, port} = result
-
-  http.createServer((req, res) => {
-    const options = {
-      hostname: host,
-      port: port,
-      path: req.url,
-      method: req.method,
-      headers: req.headers,
-    }
-
-    // Forward each incoming request to esbuild
-    const proxyReq = http.request(options, (proxyRes) => {
-      // If esbuild returns "not found", send a custom 404 page
-      const HTTP_NOT_FOUND = 404
-      if (proxyRes.statusCode === HTTP_NOT_FOUND) {
-        res.writeHead(HTTP_NOT_FOUND, {'Content-Type': 'text/html'})
-        res.end(
-`<!DOCTYPE html>
+const serveNotFound = ((res) => {
+  res.writeHead(HTTP_NOT_FOUND, {'Content-Type': 'text/html'})
+  res.end(
+      `<!DOCTYPE html>
 <html>
   <head>
     <meta charset="utf-8">
@@ -53,13 +34,39 @@ esbuild.serve({
     Resource not found.  Redirecting...
   </body>
 </html>`)
-        return
-      }
+})
 
-      // Otherwise, forward the response from esbuild to the client
-      res.writeHead(proxyRes.statusCode, proxyRes.headers)
-      proxyRes.pipe(res, {end: true})
-    })
+const proxyRequestHandler = ((options, res) => http.request(options, (proxyRes) => {
+  // If esbuild returns "not found", send a custom 404 page
+  if (proxyRes.statusCode === HTTP_NOT_FOUND) {
+    serveNotFound(res)
+  }
+
+  // Otherwise, forward the response from esbuild to the client
+  res.writeHead(proxyRes.statusCode, proxyRes.headers)
+  proxyRes.pipe(res, {end: true})
+})
+)
+
+
+esbuild.serve({
+  port: SERVE_PORT,
+  servedir: common.build.outdir,
+}, {}).then((result) => {
+  // The result tells us where esbuild's local server is
+  const {host, port} = result
+
+  http.createServer((req, res) => {
+    const options = {
+      hostname: host,
+      port: port,
+      path: req.url,
+      method: req.method,
+      headers: req.headers,
+    }
+
+    // Forward each incoming request to esbuild
+    const proxyReq = proxyRequestHandler(options, res)
 
     // Forward the body of the request to esbuild
     req.pipe(proxyReq, {end: true})

--- a/package.json
+++ b/package.json
@@ -7,12 +7,10 @@
     "url": "https://github.com/bldrs-ai/Share/issues"
   },
   "scripts": {
-    "build": "yarn build-docs && yarn build-share && yarn build-storybook",
-    "build-docs": "yarn clean && shx cp -r public docs",
+    "build": "yarn build-share && yarn build-storybook",
     "build-storybook": "shx mkdir -p docs && build-storybook -o docs/sb",
-    "build-share": "yarn build-docs && yarn write-new-version && node config/build.js && yarn build-share-copy-web-asm",
+    "build-share": "yarn write-new-version && node config/build.js && yarn build-share-copy-web-asm",
     "build-share-copy-web-asm": "shx cp node_modules/web-ifc/*.wasm docs/static/js",
-    "clean": "shx rm -rf docs",
     "husky-init": "husky install",
     "lint": "yarn eslint src",
     "precommit": "yarn lint && yarn test",

--- a/package.json
+++ b/package.json
@@ -69,6 +69,8 @@
     "babel-jest": "^28.1.3",
     "babel-loader": "^8.2.5",
     "esbuild": "^0.15.5",
+    "esbuild-clean-plugin": "^1.0.0",
+    "esbuild-copy-static-files": "^0.1.0",
     "esbuild-plugin-svgr": "^1.0.1",
     "eslint": "^8.22.0",
     "eslint-config-google": "^0.14.0",

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "esbuild": "^0.15.5",
     "esbuild-clean-plugin": "^1.0.0",
     "esbuild-copy-static-files": "^0.1.0",
+    "esbuild-plugin-progress": "^1.0.1",
     "esbuild-plugin-svgr": "^1.0.1",
     "eslint": "^8.22.0",
     "eslint-config-google": "^0.14.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5782,6 +5782,20 @@ define-property@^2.0.2:
     is-descriptor "^1.0.2"
     isobject "^3.0.1"
 
+del@^6.0.0:
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/del/-/del-6.1.1.tgz#3b70314f1ec0aa325c6b14eb36b95786671edb7a"
+  integrity sha512-ua8BhapfP0JUJKC/zV9yHHDW/rDoDxP4Zhn3AkA6/xT6gY7jYXJiaeyBZznYVujhZZET+UgcbZiQ7sN3WqcImg==
+  dependencies:
+    globby "^11.0.1"
+    graceful-fs "^4.2.4"
+    is-glob "^4.0.1"
+    is-path-cwd "^2.2.0"
+    is-path-inside "^3.0.2"
+    p-map "^4.0.0"
+    rimraf "^3.0.2"
+    slash "^3.0.0"
+
 delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
@@ -6209,6 +6223,18 @@ esbuild-android-arm64@0.15.5:
   version "0.15.5"
   resolved "https://registry.yarnpkg.com/esbuild-android-arm64/-/esbuild-android-arm64-0.15.5.tgz#e301db818c5a67b786bf3bb7320e414ac0fcf193"
   integrity sha512-YyEkaQl08ze3cBzI/4Cm1S+rVh8HMOpCdq8B78JLbNFHhzi4NixVN93xDrHZLztlocEYqi45rHHCgA8kZFidFg==
+
+esbuild-clean-plugin@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/esbuild-clean-plugin/-/esbuild-clean-plugin-1.0.0.tgz#bf63199c8b471e043ffe9f6a7db279e728b5cba9"
+  integrity sha512-Omr+4j5Cm8hdMLhW734ksqzqTaNX55J7/7HBQTqz5n/B9ZCgnTAb6RKqTKBuUyNEuABURyzfZVK4mZ/tqO2BxQ==
+  dependencies:
+    del "^6.0.0"
+
+esbuild-copy-static-files@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/esbuild-copy-static-files/-/esbuild-copy-static-files-0.1.0.tgz#4bb4987b5b554d2fc122a45f077d74663b4dbcf0"
+  integrity sha512-KlpmYqANA1t2nZavEdItfcOjJC6wbHA21v35HJWN32DddGTWKNNGDKljUzbCPojmpD+wAw8/DXr5abJ4jFCE0w==
 
 esbuild-darwin-64@0.14.54:
   version "0.14.54"
@@ -7445,7 +7471,7 @@ globalthis@^1.0.0:
   dependencies:
     define-properties "^1.1.3"
 
-globby@^11.0.2, globby@^11.1.0:
+globby@^11.0.1, globby@^11.0.2, globby@^11.1.0:
   version "11.1.0"
   resolved "https://registry.yarnpkg.com/globby/-/globby-11.1.0.tgz#bd4be98bb042f83d796f7e3811991fbe82a0d34b"
   integrity sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==
@@ -8225,6 +8251,16 @@ is-object@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-object/-/is-object-1.0.2.tgz#a56552e1c665c9e950b4a025461da87e72f86fcf"
   integrity sha512-2rRIahhZr2UWb45fIOuvZGpFtz0TyOZLf32KxBbSoUCeZR495zCKlWUKKUByk3geS2eAs7ZAABt0Y/Rx0GiQGA==
+
+is-path-cwd@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/is-path-cwd/-/is-path-cwd-2.2.0.tgz#67d43b82664a7b5191fd9119127eb300048a9fdb"
+  integrity sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ==
+
+is-path-inside@^3.0.2:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-3.0.3.tgz#d231362e53a07ff2b0e0ea7fed049161ffd16283"
+  integrity sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==
 
 is-plain-obj@^2.0.0:
   version "2.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4119,6 +4119,11 @@ ansi-regex@^2.0.0:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
   integrity sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==
 
+ansi-regex@^4.1.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.1.tgz#164daac87ab2d6f6db3a29875e2d1766582dabed"
+  integrity sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==
+
 ansi-regex@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
@@ -5037,7 +5042,7 @@ ccount@^2.0.0:
   resolved "https://registry.yarnpkg.com/ccount/-/ccount-2.0.1.tgz#17a3bf82302e0870d6da43a01311a8bc02a3ecf5"
   integrity sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==
 
-chalk@^2.0.0, chalk@^2.4.1:
+chalk@^2.0.0, chalk@^2.0.1, chalk@^2.4.1, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
   integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
@@ -5186,6 +5191,18 @@ cli-boxes@^2.2.1:
   resolved "https://registry.yarnpkg.com/cli-boxes/-/cli-boxes-2.2.1.tgz#ddd5035d25094fce220e9cab40a45840a440318f"
   integrity sha512-y4coMcylgSCdVinjiDBuR8PCC2bLjyGTwEmPb9NHR/QaNU6EUOXcTY/s6VjGMD6ENSEaeQYHCY0GNGS5jfMwPw==
 
+cli-cursor@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-2.1.0.tgz#b35dac376479facc3e94747d41d0d0f5238ffcb5"
+  integrity sha512-8lgKz8LmCRYZZQDpRyT2m5rKJ08TnU4tR9FFFW2rxpxR1FzWi4PQ/NfyODchAatHaUgnSPVcx/R5w6NuTBzFiw==
+  dependencies:
+    restore-cursor "^2.0.0"
+
+cli-spinners@^2.0.0:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-2.7.0.tgz#f815fd30b5f9eaac02db604c7a231ed7cb2f797a"
+  integrity sha512-qu3pN8Y3qHNgE2AFweciB1IfMnmZ/fsNTEE+NOFjmGB2F/7rLhnhzppvpCnN4FovtP26k8lHyy9ptEbNwWFLzw==
+
 cli-table3@^0.6.1:
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/cli-table3/-/cli-table3-0.6.2.tgz#aaf5df9d8b5bf12634dc8b3040806a0c07120d2a"
@@ -5212,6 +5229,11 @@ clone-deep@^4.0.1:
     is-plain-object "^2.0.4"
     kind-of "^6.0.2"
     shallow-clone "^3.0.0"
+
+clone@^1.0.2:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
+  integrity sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==
 
 clsx@1.1.0:
   version "1.1.0"
@@ -5746,6 +5768,13 @@ default-browser-id@^1.0.4:
     bplist-parser "^0.1.0"
     meow "^3.1.0"
     untildify "^2.0.0"
+
+defaults@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/defaults/-/defaults-1.0.3.tgz#c656051e9817d9ff08ed881477f3fe4019f3ef7d"
+  integrity sha512-s82itHOnYrN0Ib8r+z7laQz3sdE+4FP3d9Q7VLO7U+KRT+CR0GsWuyHxzdAY82I7cXv0G/twrqomTJLOssO5HA==
+  dependencies:
+    clone "^1.0.2"
 
 define-lazy-prop@^2.0.0:
   version "2.0.0"
@@ -6387,6 +6416,13 @@ esbuild-openbsd-64@0.15.5:
   version "0.15.5"
   resolved "https://registry.yarnpkg.com/esbuild-openbsd-64/-/esbuild-openbsd-64-0.15.5.tgz#26705b61961d525d79a772232e8b8f211fdbb035"
   integrity sha512-2mMFfkLk3oPWfopA9Plj4hyhqHNuGyp5KQyTT9Rc8hFd8wAn5ZrbJg+gNcLMo2yzf8Uiu0RT6G9B15YN9WQyMA==
+
+esbuild-plugin-progress@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/esbuild-plugin-progress/-/esbuild-plugin-progress-1.0.1.tgz#18c80754de55a2c1bc1af1fc293df4228ae3d10e"
+  integrity sha512-uIHEeZ6N4BWAFq+FKoL+8w71wy62c/UssUm9iIGEeEFyqfFwCFove8rkVYd2zYkW0f8Z2JXbvkxhaQ3iAfXFAg==
+  dependencies:
+    ora "3.4.0"
 
 esbuild-plugin-svgr@^1.0.1:
   version "1.0.1"
@@ -9349,6 +9385,13 @@ lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
+log-symbols@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-2.2.0.tgz#5740e1c5d6f0dfda4ad9323b5332107ef6b4c40a"
+  integrity sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==
+  dependencies:
+    chalk "^2.0.1"
+
 longest-streak@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/longest-streak/-/longest-streak-3.0.1.tgz#c97315b7afa0e7d9525db9a5a2953651432bdc5d"
@@ -10040,6 +10083,11 @@ mime@^2.4.4:
   resolved "https://registry.yarnpkg.com/mime/-/mime-2.6.0.tgz#a2a682a95cd4d0cb1d6257e28f83da7e35800367"
   integrity sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==
 
+mimic-fn@^1.0.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.2.0.tgz#820c86a39334640e99516928bd03fca88057d022"
+  integrity sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==
+
 mimic-fn@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
@@ -10505,6 +10553,13 @@ once@^1.3.0, once@^1.3.1, once@^1.4.0:
   dependencies:
     wrappy "1"
 
+onetime@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/onetime/-/onetime-2.0.1.tgz#067428230fd67443b2794b22bba528b6867962d4"
+  integrity sha512-oyyPpiMaKARvvcgip+JV+7zci5L8D1W9RZIz2l1o08AM3pfspitVWnPt3mzHcBPp12oYMTy0pqrFs/C+m3EwsQ==
+  dependencies:
+    mimic-fn "^1.0.0"
+
 onetime@^5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/onetime/-/onetime-5.1.2.tgz#d0e96ebb56b07476df1dd9c4806e5237985ca45e"
@@ -10552,6 +10607,18 @@ optionator@^0.9.1:
     prelude-ls "^1.2.1"
     type-check "^0.4.0"
     word-wrap "^1.2.3"
+
+ora@3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/ora/-/ora-3.4.0.tgz#bf0752491059a3ef3ed4c85097531de9fdbcd318"
+  integrity sha512-eNwHudNbO1folBP3JsZ19v9azXWtQZjICdr3Q0TDPIaeBQ3mXLrh54wM+er0+hSp+dWKf+Z8KM58CYzEyIYxYg==
+  dependencies:
+    chalk "^2.4.2"
+    cli-cursor "^2.1.0"
+    cli-spinners "^2.0.0"
+    log-symbols "^2.2.0"
+    strip-ansi "^5.2.0"
+    wcwidth "^1.0.1"
 
 os-browserify@^0.3.0:
   version "0.3.0"
@@ -11771,6 +11838,14 @@ resolve@^2.0.0-next.3:
     path-parse "^1.0.7"
     supports-preserve-symlinks-flag "^1.0.0"
 
+restore-cursor@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-2.0.0.tgz#9f7ee287f82fd326d4fd162923d62129eee0dfaf"
+  integrity sha512-6IzJLuGi4+R14vwagDHX+JrXmPVtPpn4mffDJ1UdR7/Edm87fl6yi8mMBIVvFtJaNTUvjughmW4hwLhRG7gC1Q==
+  dependencies:
+    onetime "^2.0.0"
+    signal-exit "^3.0.2"
+
 ret@~0.1.10:
   version "0.1.15"
   resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
@@ -12448,6 +12523,13 @@ strip-ansi@^3.0.1:
   integrity sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==
   dependencies:
     ansi-regex "^2.0.0"
+
+strip-ansi@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-5.2.0.tgz#8c9a536feb6afc962bdfa5b104a5091c1ad9c0ae"
+  integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
+  dependencies:
+    ansi-regex "^4.1.0"
 
 strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
@@ -13402,6 +13484,13 @@ watchpack@^2.2.0, watchpack@^2.4.0:
   dependencies:
     glob-to-regexp "^0.4.1"
     graceful-fs "^4.1.2"
+
+wcwidth@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/wcwidth/-/wcwidth-1.0.1.tgz#f0b0dcf915bc5ff1528afadb2c0e17b532da2fe8"
+  integrity sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==
+  dependencies:
+    defaults "^1.0.3"
 
 web-ifc-three@^0.0.118:
   version "0.0.118"


### PR DESCRIPTION
Currently, there are some actions that are undertaken for building the project that duplicate esbuild plugin functionality.

This PR adds and configures said plugins, then removes the corresponding actions that were previously performed externally.