### PR TITLE
Clear element path on unselect

### DIFF
--- a/src/Components/CutPlaneMenu.jsx
+++ b/src/Components/CutPlaneMenu.jsx
@@ -18,9 +18,8 @@ import {addHashParams, getHashParams, removeHashParams} from '../utils/location'
  * @param {Array} listOfOptions Title for the drawer
  * @return {object} ItemPropertiesDrawer react component
  */
-export default function CutPlaneMenu({listOfOptions, icon, title}) {
+export default function CutPlaneMenu() {
   const [anchorEl, setAnchorEl] = useState(null)
-  const [cutPlaneDirection, setCutPlaneDirection] = useState('')
   const open = Boolean(anchorEl)
   const model = useStore((state) => state.modelStore)
   const PLANE_PREFIX = 'p'
@@ -33,6 +32,8 @@ export default function CutPlaneMenu({listOfOptions, icon, title}) {
     setAnchorEl(null)
   }
   const viewer = useStore((state) => state.viewerStore)
+  const cutPlaneDirection = useStore((state) => state.cutPlaneDirection)
+  const setCutPlaneDirection = useStore((state) => state.setCutPlaneDirection)
   const location = useLocation()
 
   const createPlane = (normalDirection) => {

--- a/src/Components/NavPanel.jsx
+++ b/src/Components/NavPanel.jsx
@@ -33,7 +33,6 @@ export default function NavPanel({
   // TODO(pablo): the defaultExpanded array can contain bogus IDs with
   // no error.  Not sure of a better way to pre-open the first few
   // nodes besides hardcoding.
-  console.log('selectedElements', selectedElements)
   return (
     <Paper className={classes.root} >
       <div className={classes.treeContainer}>

--- a/src/Components/NavPanel.jsx
+++ b/src/Components/NavPanel.jsx
@@ -1,38 +1,13 @@
 import React from 'react'
 import Paper from '@mui/material/Paper'
-import Tooltip from '@mui/material/Tooltip'
 import TreeView from '@mui/lab/TreeView'
-import IconButton from '@mui/material/IconButton'
 import {makeStyles} from '@mui/styles'
 import NavTree from './NavTree'
 import {assertDefined} from '../utils/assert'
 import NodeClosed from '../assets/2D_Icons/NodeClosed.svg'
 import NodeOpen from '../assets/2D_Icons/NodeOpened.svg'
-import Hamburger from '../assets/2D_Icons/Menu.svg'
+import useStore from '../store/useStore'
 
-
-/**
- * Navigation panel control is a button that toggles the visibility of nav panel
- *
- * @param {number} topOffset global offset defined in the cad view
- * @param {Function} onClickMenuCb callback passed from cad view
- * @return {object} The button react component
- */
-export function NavPanelControl({topOffset, onClickMenuCb}) {
-  const classes = useStyles({topOffset: topOffset})
-  return (
-    <div className={classes.toggleButton}>
-      <Tooltip title="Model Navigation" placement="bottom">
-        <IconButton onClick={() => {
-          onClickMenuCb()
-        }}
-        >
-          <Hamburger className={classes.treeIcon}/>
-        </IconButton>
-      </Tooltip>
-    </div>
-  )
-}
 
 /**
  * @param {object} model
@@ -47,7 +22,6 @@ export function NavPanelControl({topOffset, onClickMenuCb}) {
 export default function NavPanel({
   model,
   element,
-  selectedElements,
   defaultExpandedElements,
   expandedElements,
   setExpandedElements,
@@ -55,9 +29,11 @@ export default function NavPanel({
 }) {
   assertDefined(...arguments)
   const classes = useStyles()
+  const selectedElements = useStore((state) => state.selectedElements)
   // TODO(pablo): the defaultExpanded array can contain bogus IDs with
   // no error.  Not sure of a better way to pre-open the first few
   // nodes besides hardcoding.
+  console.log('selectedElements', selectedElements)
   return (
     <Paper className={classes.root} >
       <div className={classes.treeContainer}>

--- a/src/Containers/CadView.jsx
+++ b/src/Containers/CadView.jsx
@@ -56,7 +56,7 @@ export default function CadView({
   const [rootElement, setRootElement] = useState({})
   const [elementsById] = useState({})
   const [defaultExpandedElements, setDefaultExpandedElements] = useState([])
-  const [selectedElements, setSelectedElements] = useState([])
+  // const [selectedElements, setSelectedElements] = useState([])
   const [expandedElements, setExpandedElements] = useState([])
 
   // UI elts
@@ -76,6 +76,9 @@ export default function CadView({
 
   const setViewerStore = useStore((state) => state.setViewerStore)
   const snackMessage = useStore((state) => state.snackMessage)
+  const setSelectedElements = useStore((state) => state.setSelectedElements)
+  const selectedElements = useStore((state) => state.selectedElements)
+  console.log('selectedElements in cad view', selectedElements)
 
 
   /* eslint-disable react-hooks/exhaustive-deps */
@@ -341,7 +344,7 @@ export default function CadView({
 
   /** Unpick active scene elts and remove clip planes. */
   function unSelectItems() {
-    setSelectedElement({})
+    setSelectedElement(null)
     viewer.IFC.unpickIfcItems()
     viewer.clipper.deleteAllPlanes()
     const repoFilePath = modelPath.gitpath ? modelPath.getRepoPath() : modelPath.filepath
@@ -356,6 +359,7 @@ export default function CadView({
    * @param {Array} resultIDs Array of expressIDs
    */
   async function selectItemsInScene(resultIDs) {
+    console.log('selected elements in scene', resultIDs)
     setSelectedElements(resultIDs.map((id) => `${id}`))
     try {
       await viewer.pickIfcItemsByID(0, resultIDs, true)
@@ -458,7 +462,6 @@ export default function CadView({
           <NavPanel
             model={model}
             element={rootElement}
-            selectedElements={selectedElements}
             defaultExpandedElements={defaultExpandedElements}
             expandedElements={expandedElements}
             setExpandedElements={setExpandedElements}

--- a/src/Containers/CadView.jsx
+++ b/src/Containers/CadView.jsx
@@ -76,6 +76,7 @@ export default function CadView({
   const setViewerStore = useStore((state) => state.setViewerStore)
   const snackMessage = useStore((state) => state.snackMessage)
   const setSelectedElements = useStore((state) => state.setSelectedElements)
+  const setCutPlaneDirection = useStore((state) => state.setCutPlaneDirection)
 
 
   /* eslint-disable react-hooks/exhaustive-deps */
@@ -344,9 +345,10 @@ export default function CadView({
     setSelectedElement(null)
     viewer.IFC.unpickIfcItems()
     viewer.clipper.deleteAllPlanes()
+    setSelectedElements(null)
+    setCutPlaneDirection(null)
     const repoFilePath = modelPath.gitpath ? modelPath.getRepoPath() : modelPath.filepath
     navigate(`${pathPrefix}${repoFilePath}`)
-    setSelectedElements(null)
   }
 
 

--- a/src/Containers/CadView.jsx
+++ b/src/Containers/CadView.jsx
@@ -56,7 +56,6 @@ export default function CadView({
   const [rootElement, setRootElement] = useState({})
   const [elementsById] = useState({})
   const [defaultExpandedElements, setDefaultExpandedElements] = useState([])
-  // const [selectedElements, setSelectedElements] = useState([])
   const [expandedElements, setExpandedElements] = useState([])
 
   // UI elts
@@ -359,7 +358,6 @@ export default function CadView({
    * @param {Array} resultIDs Array of expressIDs
    */
   async function selectItemsInScene(resultIDs) {
-    console.log('selected elements in scene', resultIDs)
     setSelectedElements(resultIDs.map((id) => `${id}`))
     try {
       await viewer.pickIfcItemsByID(0, resultIDs, true)

--- a/src/Containers/CadView.jsx
+++ b/src/Containers/CadView.jsx
@@ -349,7 +349,7 @@ export default function CadView({
     viewer.clipper.deleteAllPlanes()
     const repoFilePath = modelPath.gitpath ? modelPath.getRepoPath() : modelPath.filepath
     navigate(`${pathPrefix}${repoFilePath}`)
-    setSelectedElements([])
+    setSelectedElements(null)
   }
 
 

--- a/src/Containers/CadView.jsx
+++ b/src/Containers/CadView.jsx
@@ -344,6 +344,9 @@ export default function CadView({
     setSelectedElement({})
     viewer.IFC.unpickIfcItems()
     viewer.clipper.deleteAllPlanes()
+    const repoFilePath = modelPath.gitpath ? modelPath.getRepoPath() : modelPath.filepath
+    navigate(`${pathPrefix}${repoFilePath}`)
+    setSelectedElements([])
   }
 
 

--- a/src/Containers/CadView.jsx
+++ b/src/Containers/CadView.jsx
@@ -76,8 +76,6 @@ export default function CadView({
   const setViewerStore = useStore((state) => state.setViewerStore)
   const snackMessage = useStore((state) => state.snackMessage)
   const setSelectedElements = useStore((state) => state.setSelectedElements)
-  const selectedElements = useStore((state) => state.selectedElements)
-  console.log('selectedElements in cad view', selectedElements)
 
 
   /* eslint-disable react-hooks/exhaustive-deps */

--- a/src/Containers/CadView.test.jsx
+++ b/src/Containers/CadView.test.jsx
@@ -78,8 +78,8 @@ describe('CadView', () => {
     viewer._loadedModel.ifcManager.getSpatialStructure.mockReturnValueOnce(testTree)
     const {result} = renderHook(() => useStore((state) => state))
     await act(() => {
-      // result.current.setSelectedElement(targetEltId)
-      // result.current.setSelectedElements([targetEltId])
+      result.current.setSelectedElement(targetEltId)
+      result.current.setSelectedElements([targetEltId])
       result.current.setCutPlaneDirection('y')
     })
     const {getByTitle} = render(

--- a/src/Containers/CadView.test.jsx
+++ b/src/Containers/CadView.test.jsx
@@ -13,7 +13,6 @@ describe('CadView', () => {
     jest.clearAllMocks()
   })
 
-
   it('renders with mock IfcViewerAPI', async () => {
     const modelPath = {
       filepath: `index.ifc`,
@@ -68,8 +67,7 @@ describe('CadView', () => {
     await actAsyncFlush()
   })
 
-
-  it('clear elements on unselect', async () => {
+  it('clear elements and planes on unselect', async () => {
     const testTree = makeTestTree()
     const targetEltId = testTree.children[0].expressID
     const modelPath = {
@@ -80,10 +78,11 @@ describe('CadView', () => {
     viewer._loadedModel.ifcManager.getSpatialStructure.mockReturnValueOnce(testTree)
     const {result} = renderHook(() => useStore((state) => state))
     await act(() => {
-      result.current.setSelectedElement(targetEltId)
-      result.current.setSelectedElements([targetEltId])
+      // result.current.setSelectedElement(targetEltId)
+      // result.current.setSelectedElements([targetEltId])
+      result.current.setCutPlaneDirection('y')
     })
-    const {debug, getByTitle} = render(
+    const {getByTitle} = render(
         <ShareMock>
           <CadView
             installPrefix={'/'}
@@ -92,13 +91,16 @@ describe('CadView', () => {
             modelPath={modelPath}
           />
         </ShareMock>)
-    debug()
     expect(getByTitle('Section')).toBeInTheDocument()
     const clearSelection = getByTitle('Clear selection')
-    fireEvent.click(clearSelection)
+    act(() => {
+      fireEvent.click(clearSelection)
+    })
     const callDeletePlanes = viewer.clipper.deleteAllPlanes.mock.calls
     expect(callDeletePlanes.length).toBe(1)
     expect(result.current.selectedElements).toBe(null)
     expect(result.current.selectedElement).toBe(null)
+    expect(result.current.cutPlaneDirection).toBe(null)
+    await actAsyncFlush()
   })
 })

--- a/src/store/IFCSlice.js
+++ b/src/store/IFCSlice.js
@@ -11,11 +11,13 @@ export default function createIFCSlice(set, get) {
     modelPath: null,
     modelStore: null,
     selectedElement: null,
+    selectedElements: [],
     cameraControls: null,
     setViewerStore: (viewer) => set(() => ({viewerStore: viewer})),
     setModelPath: (modelPath) => set(() => ({modelPath: modelPath})),
     setModelStore: (model) => set(() => ({modelStore: model})),
     setSelectedElement: (element) => set(() => ({selectedElement: element})),
+    setSelectedElements: (elements) => set(() => ({selectedElements: elements})),
     setCameraControls: (cameraControls) => set(() => ({cameraControls: cameraControls})),
   }
 }

--- a/src/store/UISlice.js
+++ b/src/store/UISlice.js
@@ -11,6 +11,7 @@ export default function createUISlice(set, get) {
     isPropertiesOn: false,
     isCommentsOn: false,
     snackMessage: null,
+    cutPlaneDirection: null,
     openDrawer: () => set(() => ({isDrawerOpen: true})),
     closeDrawer: () => set(() => ({isDrawerOpen: false})),
     toggleIsPropertiesOn: () => set((state) => ({isPropertiesOn: !state.isPropertiesOn})),
@@ -18,5 +19,6 @@ export default function createUISlice(set, get) {
     turnCommentsOn: () => set(() => ({isCommentsOn: true})),
     turnCommentsOff: () => set(() => ({isCommentsOn: false})),
     setSnackMessage: (message) => set(() => ({snackMessage: message})),
+    setCutPlaneDirection: (direction) => set(() => ({cutPlaneDirection: direction})),
   }
 }


### PR DESCRIPTION
This PR addresses #334
- clear the element path from the URL when the element is unselected
- clear the url hash parameters including camera and plane