### PR TITLE
Restore live-reloading.  Fix 404 bounce handler!

### DIFF
--- a/config/common.js
+++ b/config/common.js
@@ -1,4 +1,3 @@
-import {cleanPlugin} from 'esbuild-clean-plugin'
 import copyStaticFiles from 'esbuild-copy-static-files'
 import progress from 'esbuild-plugin-progress'
 import svgrPlugin from 'esbuild-plugin-svgr'
@@ -38,7 +37,6 @@ export const build = {
   logLevel: 'info',
   plugins: [
     progress(),
-    cleanPlugin(),
     svgrPlugin(),
     copyStaticFiles({
       src: assetsDir,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bldrs",
-  "version": "1.0.0-r403",
+  "version": "1.0.0-r433",
   "main": "src/index.jsx",
   "homepage": "https://github.com/bldrs-ai/Share",
   "bugs": {


### PR DESCRIPTION
This fixes the live-reload bug.

I bisected it down to cleanPlugin.  No idea why that was causing trouble.  Maybe related, there's no contents in the docs directory.. esbuild keeps the build in memory.

ALSO..... Fixed the 404 bounce to work locally.  Not sure this ever worked before :(. I hadn't set the proxy up right.

We can finally reload any URL no problem!