### PR TITLE
Disable recording of screenshots and videos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@
 .DS_Store
 .vscode
 *.log
+
+cypress/videos
+cypress/screenshots

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -7,5 +7,7 @@ module.exports = defineConfig({
     setupNodeEvents(on, config) {
       // implement node event listeners here
     },
+    screenshotOnRunFailure: false,
+    video: false,
   },
 })

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -1,4 +1,5 @@
-const { defineConfig } = require("cypress");
+const {defineConfig} = require('cypress')
+
 
 module.exports = defineConfig({
   e2e: {
@@ -7,4 +8,4 @@ module.exports = defineConfig({
       // implement node event listeners here
     },
   },
-});
+})


### PR DESCRIPTION
By default, the Cypress test runner will unconditionally record a video of each test being executed and take a screenshot of the browser of failed test runs.

This is useful when investigating test failures in your local development environment but not needed when being executed by a GitHub action because these videos and/or screenshots are being discarded, so it is a waste of time and money to let Cypress execute them as GitHub Actions are finite and not free.