### PR TITLE
Make E2E tests less flaky

### DIFF
--- a/cypress/e2e/ifc-model/load-sample-model.cy.js
+++ b/cypress/e2e/ifc-model/load-sample-model.cy.js
@@ -1,22 +1,22 @@
 describe('sample models', () => {
   context('when no model is loaded', () => {
-    it('should display tooltip when hovering', () => {
+    beforeEach(() => {
       cy.setCookie('isFirstTime', 'false')
       cy.visit('/')
+      cy.get('#viewer-container').get('canvas').should('be.visible')
+    })
+
+    it('should display tooltip when hovering', () => {
       cy.get('form').findByRole('button', {name: /Open IFC/, timeout: 5000}).realHover()
       cy.findByRole('tooltip').contains('Open IFC')
     })
 
     it('should display the sample models dialog', () => {
-      cy.setCookie('isFirstTime', 'false')
-      cy.visit('/')
-      cy.findByRole('dialog')
       cy.get('form').findByRole('button', {name: /Open IFC/, timeout: 5000}).realClick()
+      cy.findByRole('dialog').contains('Sample Projects')
     })
 
     it('should load the Momentum model when selected', () => {
-      cy.setCookie('isFirstTime', 'false')
-      cy.visit('/')
       cy.get('form').findByRole('button', {name: /Open IFC/, timeout: 5000}).realClick()
       cy.findByRole('button', {name: /Sample Projects/}).realClick()
       cy.findByRole('listbox').within(() => {

--- a/cypress/e2e/ifc-model/load-sample-model.cy.js
+++ b/cypress/e2e/ifc-model/load-sample-model.cy.js
@@ -3,27 +3,28 @@ describe('sample models', () => {
     it('should display tooltip when hovering', () => {
       cy.setCookie('isFirstTime', 'false')
       cy.visit('/')
-      cy.get('form').findByRole('button', {name: /Open IFC/}).realHover()
+      cy.get('form').findByRole('button', {name: /Open IFC/, timeout: 5000}).realHover()
       cy.findByRole('tooltip').contains('Open IFC')
     })
 
     it('should display the sample models dialog', () => {
       cy.setCookie('isFirstTime', 'false')
       cy.visit('/')
-      cy.get('form').findByRole('button', {name: /Open IFC/}).realClick()
       cy.findByRole('dialog')
+      cy.get('form').findByRole('button', {name: /Open IFC/, timeout: 5000}).realClick()
     })
 
     it('should load the Momentum model when selected', () => {
       cy.setCookie('isFirstTime', 'false')
       cy.visit('/')
-      cy.get('form').findByRole('button', {name: /Open IFC/}).realClick()
+      cy.get('form').findByRole('button', {name: /Open IFC/, timeout: 5000}).realClick()
       cy.findByRole('button', {name: /Sample Projects/}).realClick()
       cy.findByRole('listbox').within(() => {
         cy.findByRole('option', {name: /Momentum/}).realClick()
       })
+      cy.findByRole('listbox').should('not.exist')
       cy.findByRole('tree', {label: /IFC Navigator/})
-      cy.findByText('Momentum / KNIK v3', {timeout: 10000})
+      cy.findByText('Momentum / KNIK v3', {timeout: 5000})
     })
   })
 })


### PR DESCRIPTION
This PR introduces some longer timeouts for finding elements that are asynchronously loaded (specifically, those that rely on ifc.js for loading models).