### PR TITLE
Move tests for <Issues>

### DIFF
--- a/src/Components/SideDrawer.test.jsx
+++ b/src/Components/SideDrawer.test.jsx
@@ -36,38 +36,4 @@ describe('SideDrawer', () => {
       result.current.toggleIsPropertiesOn()
     })
   })
-
-  it('issues id in url', async () => {
-    const {result} = renderHook(() => useStore((state) => state))
-    const extractedIssueId = '1257156364'
-    const {findByText} = render(<ShareMock><SideDrawerWrapper/></ShareMock>)
-    await act(() => {
-      result.current.setSelectedIssueId(Number(extractedIssueId))
-      result.current.turnCommentsOn()
-      result.current.openDrawer()
-    })
-    expect(await findByText('Local issue - some text is here to test - Id:1257156364')).toBeVisible()
-    // reset the store
-    await act(() => {
-      result.current.setSelectedIssueId(null)
-      result.current.turnCommentsOff()
-    })
-  })
-
-  it('opened via URL', async () => {
-    const {result} = renderHook(() => useStore((state) => state))
-    const {getByText} = render(
-        <ShareMock
-          initialEntries={['/v/p/index.ifc#i:2::c:-26.91,28.84,112.47,-22,16.21,-3.48']}
-        >
-          <SideDrawerWrapper/>
-        </ShareMock>)
-    expect(await getByText('Local issue 2')).toBeInTheDocument()
-
-    // reset the store
-    await act(() => {
-      result.current.setSelectedElement({})
-      result.current.turnCommentsOff()
-    })
-  })
 })

--- a/src/Components/issues/Issues.test.jsx
+++ b/src/Components/issues/Issues.test.jsx
@@ -45,6 +45,29 @@ describe('IssueControl', () => {
     expect(await getByText('open_workspace')).toBeVisible()
   })
 
+  it('Issue rendered based on selected issue ID', async () => {
+    const {result} = renderHook(() => useStore((state) => state))
+    const extractedIssueId = '1257156364'
+    const {findByText} = render(<ShareMock><Issues/></ShareMock>)
+
+    await act(() => {
+      result.current.setSelectedIssueId(Number(extractedIssueId))
+    })
+
+    const expectedText = 'Local issue - some text is here to test - Id:1257156364'
+    expect(await findByText(expectedText)).toBeVisible()
+  })
+
+  it('Issue rendered based on issue ID in URL', async () => {
+    const {findByText} = render(
+        <ShareMock initialEntries={['/v/p/index.ifc#i:2::c:-26.91,28.84,112.47,-22,16.21,-3.48']}>
+          <Issues/>
+        </ShareMock>)
+
+    const expectedText = 'Local issue 2'
+    expect(await findByText(expectedText)).toBeVisible()
+  })
+
   // XXX: Should this be split into two different tests?
   it('test Loader is present if issues are null, and removed when issues set', async () => {
     // Set up handler to return an empty set of issues


### PR DESCRIPTION
PR to refactor and relocate tests for the `<Issues>` component alongside the component's other unit tests.