### PR TITLE
Refine Cypress tests

### DIFF
--- a/cypress/e2e/ifc-model/load-sample-model.cy.js
+++ b/cypress/e2e/ifc-model/load-sample-model.cy.js
@@ -4,26 +4,29 @@ describe('sample models', () => {
       cy.setCookie('isFirstTime', 'false')
       cy.visit('/')
       cy.get('#viewer-container').get('canvas').should('be.visible')
+
+      // Wait up to 15 seconds for IFC to finish loading
+      cy.get('[data-model-ready="true"]', {timeout: 15000}).should('exist')
     })
 
     it('should display tooltip when hovering', () => {
-      cy.get('form').findByRole('button', {name: /Open IFC/, timeout: 5000}).realHover()
+      cy.findByRole('button', {name: 'Open IFC'}).realHover()
       cy.findByRole('tooltip').contains('Open IFC')
     })
 
     it('should display the sample models dialog', () => {
-      cy.get('form').findByRole('button', {name: /Open IFC/, timeout: 5000}).realClick()
+      cy.findByRole('button', {name: 'Open IFC'}).realClick()
       cy.findByRole('dialog').contains('Sample Projects')
     })
 
     it('should load the Momentum model when selected', () => {
-      cy.get('form').findByRole('button', {name: /Open IFC/, timeout: 5000}).realClick()
-      cy.findByRole('button', {name: /Sample Projects/}).realClick()
+      cy.findByRole('button', {name: 'Open IFC'}).realClick()
+      cy.findByLabelText('Sample Projects').realClick()
       cy.findByRole('listbox').within(() => {
-        cy.findByRole('option', {name: /Momentum/}).realClick()
+        cy.findByRole('option', {name: 'Momentum'}).realClick()
       })
       cy.findByRole('listbox').should('not.exist')
-      cy.findByRole('tree', {label: /IFC Navigator/})
+      cy.findByRole('tree', {label: 'IFC Navigator'})
       cy.findByText('Momentum / KNIK v3', {timeout: 5000})
     })
   })

--- a/src/Components/OpenModelControl.jsx
+++ b/src/Components/OpenModelControl.jsx
@@ -36,7 +36,7 @@ export default function OpenModelControl({fileOpen}) {
               setIsDialogDisplayed(true)
             }}
             color='primary'
-            value={'something'}
+            value={'Open IFC'}
           >
             <OpenIcon/>
           </ToggleButton>

--- a/src/Containers/CadView.jsx
+++ b/src/Containers/CadView.jsx
@@ -76,6 +76,7 @@ export default function CadView({
   const setSelectedElements = useStore((state) => state.setSelectedElements)
   const setViewerStore = useStore((state) => state.setViewerStore)
   const snackMessage = useStore((state) => state.snackMessage)
+  const [modelReady, setModelReady] = useState(false)
 
 
   /* eslint-disable react-hooks/exhaustive-deps */
@@ -147,6 +148,9 @@ export default function CadView({
       debug().warn('CadView#onViewer, viewer is null')
       return
     }
+
+    setModelReady(false)
+
     // define mesh colors for selected and preselected element
     const preselectMat = new MeshLambertMaterial({
       transparent: true,
@@ -168,6 +172,8 @@ export default function CadView({
     const tmpModelRef = await loadIfc(pathToLoad)
     await onModel(tmpModelRef)
     selectElementBasedOnFilepath(pathToLoad)
+
+    setModelReady(true)
   }
 
 
@@ -451,7 +457,7 @@ export default function CadView({
 
 
   return (
-    <div className={classes.root}>
+    <div className={classes.root} data-model-ready={modelReady}>
       <div className={classes.view} id='viewer-container'></div>
       <div className={classes.menusWrapper}>
         <SnackBarMessage


### PR DESCRIPTION
The Cypress test suite periodically encounters failures due to the tests firing before the IFC model is loaded. The load time is variable according to how quickly the browser loads the WASM **and** the model.

There is currently no attribute or callback to indicate that the model is ready for user interaction, so this PR attempts to introduce a state variable that acts as that indicator then refactors the Cypress test suite, specifically the model tests, to rely on said indicator.