### PR TITLE
fix: Support cutting-plane orientation based on surface normal

### DIFF
--- a/src/Containers/CadView.jsx
+++ b/src/Containers/CadView.jsx
@@ -526,6 +526,7 @@ function initViewer(pathPrefix, backgroundColorStr = '#abcdef') {
   // Path to web-ifc.wasm in serving directory.
   v.IFC.setWasmPath('./static/js/')
   v.clipper.active = true
+  v.clipper.orthogonalY = false;
 
   // Highlight items when hovering over them
   window.onmousemove = (event) => {


### PR DESCRIPTION
This PR solves #497 .

The issue is that the clipper component of the IFC viewer has a flag `orthogonalY` that controls whether to lock the cut plane normal vector to the y-axis if it exceeds a certain tolerance `toleranceOrthogonalY`. This flag default value is true, which was causing the issue.