### PR TITLE
Update types for location

### DIFF
--- a/src/utils/location.js
+++ b/src/utils/location.js
@@ -1,4 +1,6 @@
+/** @type {Object<string, Function>} */
 const hashListeners = {}
+
 window.onhashchange = () => {
   for (const name in hashListeners) {
     if (Object.prototype.hasOwnProperty.call(hashListeners, name)) {
@@ -44,6 +46,7 @@ export function addHashParams(location, name, params, includeNames = false) {
     encodedParams += `${separator}${encodedParam}`
   }
   const sets = location.hash.substring(1).split('::')
+  /** @type {Object<string, string>} */
   const setMap = {}
   for (let i = 0; i < sets.length; i++) {
     const set = sets[i]

--- a/src/utils/location.js
+++ b/src/utils/location.js
@@ -28,9 +28,9 @@ export function addHashListener(name, onHashCb) {
  * Serialize the given paramObj and add it to the current
  * location.hash
  *
- * @param {object} location The window.location object
+ * @param {import('history').Location} location The window.location object
  * @param {string} name A unique name for the params
- * @param {object} params The parameters to encode
+ * @param {Object<string, any>} params The parameters to encode
  * @param {boolean} includeNames Whether or not to include the
  *   parameter names in the encoding, default is false.
  */
@@ -71,7 +71,7 @@ export function addHashParams(location, name, params, includeNames = false) {
 
 
 /**
- * @param {object} location
+ * @param {import('history').Location} location
  * @param {string} name prefix of the params to fetch
  * @return {string|undefined} The encoded params
  */
@@ -101,7 +101,7 @@ export function getHashParamsFromHashStr(hashStr, name) {
 /**
  * Removes the given named hash param.
  *
- * @param {object} location
+ * @param {import('history').Location} location
  * @param {string} name prefix of the params to fetch
  */
 export function removeHashParams(location, name) {

--- a/src/utils/location.js
+++ b/src/utils/location.js
@@ -11,7 +11,7 @@ window.onhashchange = () => {
 }
 
 
-// TODO(pablo): Ideally this would be hanled by react-router
+// TODO(pablo): Ideally this would be handled by react-router
 // location, but doesn't seem to be supported yet in v6.
 // See also https://stackoverflow.com/a/71210781/3630172
 /**

--- a/src/utils/location.test.js
+++ b/src/utils/location.test.js
@@ -24,82 +24,99 @@ const newTestLocation = () => ({
 })
 
 test('addHashParams', () => {
-  let loc
+  const loc = newTestLocation()
 
-  loc = {hash: ''}
+  loc.hash = ''
   addHashParams(loc, 'test', {a: 1})
   expect(loc.hash).toBe('test:1')
 
-  loc = {hash: '#'}
+  loc.hash = '#'
   addHashParams(loc, 'test', {a: 1})
   expect(loc.hash).toBe('test:1')
 
-  loc = {hash: '#'}
+  loc.hash = '#'
   addHashParams(loc, 'test', {a: 1}, true) // true: includeNames
   expect(loc.hash).toBe('test:a=1')
 
-  loc = {hash: '#test:a=0'}
+  loc.hash = '#test:a=0'
   addHashParams(loc, 'test', {a: 1}, true)
   expect(loc.hash).toBe('test:a=1')
 
-  loc = {hash: '#test:b=0'}
+  loc.hash = '#test:b=0'
   addHashParams(loc, 'test', {a: 1}, true)
   expect(loc.hash).toBe('test:a=1')
 })
 
 
 test('addHashParamsMultiple', () => {
-  let loc
-  loc = {hash: '#other:a=0::otter:b=3'}
+  const loc = newTestLocation()
+
+  loc.hash = '#other:a=0::otter:b=3'
   addHashParams(loc, 'test', {a: 1}, true)
   expect(loc.hash).toBe('other:a=0::otter:b=3::test:a=1')
 
-  loc = {hash: '#other:a=0::test:a=0::otter:b=3'}
+  loc.hash = '#other:a=0::test:a=0::otter:b=3'
   addHashParams(loc, 'test', {a: 1}, true)
   expect(loc.hash).toBe('other:a=0::test:a=1::otter:b=3')
 })
 
 
 test('addHashParams with tilde', () => {
-  const loc = {hash: '#other:a=0::otter:b=3'}
+  const loc = newTestLocation()
+  loc.hash = '#other:a=0::otter:b=3'
+
   addHashParams(loc, 'test', {a: 1}, true)
   expect(loc.hash).toBe('other:a=0::otter:b=3::test:a=1')
 })
 
 
-test('getHashParams', () => {
-  let loc
+describe('getHashParams', () => {
+  const loc = newTestLocation()
 
-  loc = {hash: '#a:1'}
-  expect(getHashParams(loc, 'a')).toBe('a:1')
+  it('', () => {
+    loc.hash = '#a:1'
+    expect(getHashParams(loc, 'a')).toBe('a:1')
+  })
 
-  loc = {hash: '#a:1::b:2'}
-  expect(getHashParams(loc, 'a')).toBe('a:1')
-  expect(getHashParams(loc, 'b')).toBe('b:2')
-  expect(getHashParams(loc, 'c')).toBe(undefined)
+  it('', () => {
+    loc.hash = '#a:1::b:2'
+    expect(getHashParams(loc, 'a')).toBe('a:1')
+    expect(getHashParams(loc, 'b')).toBe('b:2')
+    expect(getHashParams(loc, 'c')).toBe(undefined)
+  })
 })
 
 
-test('removeHashParams', () => {
-  let loc
+describe('removeHashParams', () => {
+  const loc = newTestLocation()
 
-  loc = {hash: '#'}
-  removeHashParams(loc, 'a')
-  expect(loc).toStrictEqual({hash: ''})
+  it('operates on an empty hash', () => {
+    loc.hash = ''
+    removeHashParams(loc, 'a')
+    expect(loc.hash).toStrictEqual('')
+  })
 
-  loc = {hash: '#a:1'}
-  removeHashParams(loc, 'a')
-  expect(loc).toStrictEqual({hash: ''})
+  it('removes the only hash parameter', () => {
+    loc.hash = '#a:1'
+    removeHashParams(loc, 'a')
+    expect(loc.hash).toStrictEqual('')
+  })
 
-  loc = {hash: '#a:1::b:2'}
-  removeHashParams(loc, 'a')
-  expect(loc).toStrictEqual({hash: 'b:2'})
+  it('removes the first of two hash parameters', () => {
+    loc.hash = '#a:1::b:2'
+    removeHashParams(loc, 'a')
+    expect(loc.hash).toStrictEqual('b:2')
+  })
 
-  loc = {hash: '#a:1::b:2'}
-  removeHashParams(loc, 'b')
-  expect(loc).toStrictEqual({hash: 'a:1'})
+  it('removes the second of two hash parameters', () => {
+    loc.hash = '#a:1::b:2'
+    removeHashParams(loc, 'b')
+    expect(loc.hash).toStrictEqual('a:1')
+  })
 
-  loc = {hash: '#a:1::b:2::c:3'}
-  removeHashParams(loc, 'b')
-  expect(loc).toStrictEqual({hash: 'a:1::c:3'})
+  it('removes the second of three hash parameters', () => {
+    loc.hash = '#a:1::b:2::c:3'
+    removeHashParams(loc, 'b')
+    expect(loc.hash).toStrictEqual('a:1::c:3')
+  })
 })

--- a/src/utils/location.test.js
+++ b/src/utils/location.test.js
@@ -5,6 +5,24 @@ import {
 } from './location'
 
 
+const newTestLocation = () => ({
+  host: 'localhost',
+  protocol: 'http:',
+  ancestorOrigins: [],
+  hash: '',
+  href: 'http://localhost/#',
+  hostname: 'localhost',
+  origin: 'http://localhost',
+  pathname: '/',
+  port: '',
+  search: '',
+  assign: () => undefined,
+  reload: () => undefined,
+  replace: () => undefined,
+  state: null,
+  key: '',
+})
+
 test('addHashParams', () => {
   let loc
 


### PR DESCRIPTION
PR to update the location handling functions to use the Location type.

This uses the type and shape from the history react-router package, since the native DOM type is immutable (which prevents instantiation for testing).

It's not a big deal since the input into these functions is the location object emitted from react-router.