### PR TITLE
fix individual note sharing

### DIFF
--- a/src/Components/notes/Notes.jsx
+++ b/src/Components/notes/Notes.jsx
@@ -16,7 +16,6 @@ export const NOTE_PREFIX = 'i'
 export default function Notes() {
   const classes = useStyles()
   const selectedNoteId = useStore((state) => state.selectedNoteId)
-  const setSelectedNoteId = useStore((state) => state.setSelectedNoteId)
   const notes = useStore((state) => state.notes)
   const setNotes = useStore((state) => state.setNotes)
   const comments = useStore((state) => state.comments)
@@ -93,10 +92,6 @@ export default function Notes() {
 
     if (selectedNoteId !== null) {
       fetchComments(filteredNote)
-    }
-    // This address bug #314 by clearing selected issue when new model is loaded
-    if (!filteredNote) {
-      setSelectedNoteId(null)
     }
     // this useEffect runs everytime notes are fetched to enable fetching the comments when the platform is open
     // using the link

--- a/src/Components/notes/Notes.test.jsx
+++ b/src/Components/notes/Notes.test.jsx
@@ -64,7 +64,7 @@ describe('IssueControl', () => {
           <Notes/>
         </ShareMock>)
 
-    const expectedText = 'Local issue 2'
+    const expectedText = 'Local issue - some text is here to test - Id:1257156364'
     expect(await findByText(expectedText)).toBeVisible()
   })
 


### PR DESCRIPTION
This PR fixes individual note sharing via permalink, this https://deploy-preview-528--bldrs-share.netlify.app/share/v/p/index.ifc#c:-111.37,14.94,90.63,-43.48,15.73,-4.34::i:1493510953 should open to an individual note.