### PR TITLE
Specify the environment value when relaying exceptions

### DIFF
--- a/config/common.js
+++ b/config/common.js
@@ -37,6 +37,7 @@ export const build = {
   logLevel: 'info',
   define: {
     'process.env.SENTRY_DSN': JSON.stringify(process.env.SENTRY_DSN || null),
+    'process.env.SENTRY_ENVIRONMENT': JSON.stringify(process.env.SENTRY_ENVIRONMENT || process.env.NODE_ENV),
   },
   plugins: [
     progress(),

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -17,6 +17,7 @@ import ApplicationError from './Components/ApplicationError'
 
 Sentry.init({
   dsn: process.env.SENTRY_DSN,
+  environment: process.env.SENTRY_ENVIRONMENT,
   integrations: [
     new BrowserTracing({
       routingInstrumentation: Sentry.reactRouterV6Instrumentation(


### PR DESCRIPTION
PR to explicitly set the environment value that is used for categorization within the Sentry project.

`esbuild` features logic[1] that forces the value of `NODE_ENV` to `production` when one bundles using its build API. This causes all errors from all environments to be tagged as `production` regardless if it's actually production.

This fix uses a different environment variable (whose value is conditionally set in Netlify) to inform the Sentry SDK of the environment we are currently operating in.

1: https://esbuild.github.io/api/#platform