### PR TITLE
fix: key down event (escape, a) highlighted elements deselection 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bldrs",
-  "version": "1.0.0-r659",
+  "version": "1.0.0-r614",
   "main": "src/index.jsx",
   "license": "MIT",
   "homepage": "https://github.com/bldrs-ai/Share",

--- a/src/Containers/CadView.jsx
+++ b/src/Containers/CadView.jsx
@@ -514,7 +514,7 @@ export default function CadView({
       }
       if (event.code === 'KeyA' ||
         event.code === 'Escape') {
-          selectItemsInScene([])
+        selectItemsInScene([])
       }
     }
   }

--- a/src/Containers/CadView.jsx
+++ b/src/Containers/CadView.jsx
@@ -514,7 +514,7 @@ export default function CadView({
       }
       if (event.code === 'KeyA' ||
         event.code === 'Escape') {
-        resetSelection()
+          selectItemsInScene([])
       }
     }
   }

--- a/src/Containers/CadView.test.jsx
+++ b/src/Containers/CadView.test.jsx
@@ -240,4 +240,35 @@ describe('CadView', () => {
     const setSelectionCalls = viewer.setSelection.mock.calls
     expect(setSelectionCalls).toEqual(expectedCall)
   })
+
+  it('can clear selection using Escape key', async () => {
+    const testTree = makeTestTree()
+    const selectedIdsAsString = ['0', '1']
+    const elementCount = 2
+    const modelPath = {
+      filepath: `index.ifc`,
+      gitpath: undefined,
+    }
+    const viewer = new IfcViewerAPIExtended()
+    viewer._loadedModel.ifcManager.getSpatialStructure.mockReturnValueOnce(testTree)
+    const {result} = renderHook(() => useStore((state) => state))
+    const {getByTitle} = render(
+        <ShareMock>
+          <CadView
+            installPrefix={'/'}
+            appPrefix={'/'}
+            pathPrefix={'/'}
+            modelPath={modelPath}
+          />
+        </ShareMock>)
+    await actAsyncFlush()
+    expect(getByTitle('Section')).toBeInTheDocument()
+    await act(() => {
+      result.current.setSelectedElements(selectedIdsAsString)
+    })
+    expect(result.current.selectedElements).toHaveLength(elementCount)
+    fireEvent.keyDown(getByTitle('Section'), {key: 'Escape', code: 'Escape', charCode: 27})
+    expect(result.current.selectedElements).toHaveLength(0)
+    await actAsyncFlush()
+  })
 })


### PR DESCRIPTION
This PR fixes issue regarding the deselection functionality using Escape and KeyA. The key down events was not working properly.
There are some limitations in how callback functions work where useState state is used. 