### PR TITLE
Overriding IfcElements render colors on loading file

### DIFF
--- a/__mocks__/web-ifc-viewer.js
+++ b/__mocks__/web-ifc-viewer.js
@@ -58,6 +58,11 @@ const impl = {
         material: null,
       },
     },
+    loader: {
+      ifcManager: {
+        parser: {},
+      },
+    },
   },
   clipper: {
     active: false,
@@ -88,6 +93,7 @@ const impl = {
   }),
   setSelection: jest.fn(),
   pickIfcItemsByID: jest.fn(),
+  loadIfcUrl: jest.fn(jest.fn(() => loadedModel)),
 }
 const constructorMock = ifcjsMock.IfcViewerAPI
 constructorMock.mockImplementation(() => impl)

--- a/src/Containers/CadView.jsx
+++ b/src/Containers/CadView.jsx
@@ -251,7 +251,7 @@ export default function CadView({
     setIsLoading(true)
 
     const ifcURL = (uploadedFile || filepath.indexOf('/') === 0) ? filepath : await getFinalURL(filepath, accessToken)
-    const loadedModel = await viewer.IFC.loadIfcUrl(
+    const loadedModel = await viewer.loadIfcUrl(
         ifcURL,
         !urlHasCameraParams(), // fitToFrame
         (progressEvent) => {

--- a/src/Infrastructure/IfcColor.js
+++ b/src/Infrastructure/IfcColor.js
@@ -1,0 +1,14 @@
+/**
+ * create an ifc color object
+ *
+ * @param {number} r the red component of the color as a fraction between 0 and 1
+ * @param {number} g the green component of the color as a fraction between 0 and 1
+ * @param {number} b the blue component of the color as a fraction between 0 and 1
+ * @param {number} o the opacity component of the color as a fraction between 0 and 1
+ */
+export default function IfcColor(r = 0, g = 0, b = 0, o = 1) {
+  this.x = r
+  this.y = g
+  this.z = b
+  this.w = o
+}

--- a/src/Infrastructure/IfcCustomViewSettings.js
+++ b/src/Infrastructure/IfcCustomViewSettings.js
@@ -1,0 +1,18 @@
+import IfcColor from './IfcColor'
+
+
+/**
+ * Object containig the coloring settings
+ *
+ * @param {IfcColor} defaultColor the color to be used if the id wasn't found in the provided map,
+ * if undefined the original element color will be used instead
+ * @param {object} idsToColorMap an object containing pairs of {[expressId]:[IfcColor]} to be used for those elements
+ */
+export default function IfcCustomViewSettings(defaultColor, idsToColorMap = {}) {
+  this.defaultColor = defaultColor
+  this.idsToColorMap = idsToColorMap
+
+  this.getElementColor = (expressId) => {
+    return this.idsToColorMap[expressId] ? this.idsToColorMap[expressId] : this.defaultColor
+  }
+}

--- a/src/Infrastructure/IfcElementsStyleManager.js
+++ b/src/Infrastructure/IfcElementsStyleManager.js
@@ -1,6 +1,7 @@
 import IfcCustomViewSettings from './IfcCustomViewSettings'
 
 
+/* eslint-disable jsdoc/no-undefined-types */
 /**
  *  Overrides the default render functionality in the viewer
  * and adds a postprocessing effect (outlining selected elements)
@@ -27,6 +28,7 @@ export default class IfcElementsStyleManager {
     this.parser._overrideStyles = settings ? settings : new IfcCustomViewSettings()
   }
 }
+
 
 /* eslint-disable no-invalid-this */
 /**

--- a/src/Infrastructure/IfcElementsStyleManager.js
+++ b/src/Infrastructure/IfcElementsStyleManager.js
@@ -1,3 +1,6 @@
+import IfcCustomViewSettings from './IfcCustomViewSettings'
+
+
 /**
  *  Overrides the default render functionality in the viewer
  * and adds a postprocessing effect (outlining selected elements)
@@ -18,10 +21,10 @@ export default class IfcElementsStyleManager {
   /**
    * Applys view settings to the next load call
    *
-   * @param {object} settings an object containing expressId:IfcColor pairs
+   * @param {IfcCustomViewSettings} settings an object containing expressId:IfcColor pairs
    */
   setViewSettings(settings) {
-    this.parser._overrideStyles = settings
+    this.parser._overrideStyles = settings ? settings : new IfcCustomViewSettings()
   }
 }
 
@@ -45,7 +48,7 @@ function newStreamMeshFunction(parser) {
       const placedGeometry = placedGeometries.get(i)
       const itemMesh = this.getPlacedGeometry(modelID, mesh.expressID, placedGeometry)
       const geom = itemMesh.geometry.applyMatrix4(itemMesh.matrix)
-      const overrideStyle = this._overrideStyles[mesh.expressID]
+      const overrideStyle = this._overrideStyles.getElementColor(mesh.expressID)
       const color = overrideStyle !== undefined ? overrideStyle : placedGeometry.color
       this.storeGeometryByMaterial(color, geom)
     }

--- a/src/Infrastructure/IfcElementsStyleManager.js
+++ b/src/Infrastructure/IfcElementsStyleManager.js
@@ -1,0 +1,55 @@
+/**
+ *  Overrides the default render functionality in the viewer
+ * and adds a postprocessing effect (outlining selected elements)
+ */
+export default class IfcElementsStyleManager {
+  /**
+   * constructs new class
+   *
+   * @param {IfcParser} the parser of the viewer
+   */
+  constructor(parser) {
+    this.parser = parser
+    parser._overrideStyles = {}
+    parser.streamMesh = newStreamMeshFunction(parser)
+  }
+
+
+  /**
+   * Applys view settings to the next load call
+   *
+   * @param {object} settings an object containing expressId:IfcColor pairs
+   */
+  setViewSettings(settings) {
+    this.parser._overrideStyles = settings
+  }
+}
+
+/* eslint-disable no-invalid-this */
+/**
+ * Returns a new stream mesh function that uses
+ * the custom coloring provided
+ *
+ * @param {IfcParser} parser
+ * @return {Function} the new render function
+ */
+function newStreamMeshFunction(parser) {
+  /**
+   * Overrides the default stream function in the ifc parser
+   *
+   */
+  function streamMesh(modelID, mesh) {
+    const placedGeometries = mesh.geometries
+    const size = placedGeometries.size()
+    for (let i = 0; i < size; i++) {
+      const placedGeometry = placedGeometries.get(i)
+      const itemMesh = this.getPlacedGeometry(modelID, mesh.expressID, placedGeometry)
+      const geom = itemMesh.geometry.applyMatrix4(itemMesh.matrix)
+      const overrideStyle = this._overrideStyles[mesh.expressID]
+      const color = overrideStyle !== undefined ? overrideStyle : placedGeometry.color
+      this.storeGeometryByMaterial(color, geom)
+    }
+  }
+
+  return streamMesh.bind(parser)
+}

--- a/src/Infrastructure/IfcViewerAPIExtended.js
+++ b/src/Infrastructure/IfcViewerAPIExtended.js
@@ -1,6 +1,9 @@
 import {IfcViewerAPI} from 'web-ifc-viewer'
 import IfcHighlighter from './IfcHighlighter'
 import IfcViewsManager from './IfcElementsStyleManager'
+import IfcCustomViewSettings from './IfcCustomViewSettings'
+
+
 /**
  * Extending the original IFCViewerFunctionality
  */
@@ -13,6 +16,22 @@ export class IfcViewerAPIExtended extends IfcViewerAPI {
     super(options)
     this.highlighter = new IfcHighlighter(this.context)
     this.viewsManager = new IfcViewsManager(this.IFC.loader.ifcManager.parser)
+  }
+
+
+  /**
+  * Loads the given IFC in the current scene.
+  *
+  * @param {string} url IFC as URL.
+  * @param {boolean} fitToFrame (optional) if true, brings the perspectiveCamera to the loaded IFC.
+  * @param {(event: ProgressEvent) => void} onProgress (optional) a callback function to report on downloading progress
+  * @param {(err: any) => any} onError (optional) a callback function to report on loading errors
+  * @param {IfcCustomViewSettings} customViewSettings (optional) override the ifc elements file colors
+  * @returns {IfcModel} ifcModel object
+  */
+  async loadIfcUrl(url, fitToFrame, onProgress, onError, customViewSettings) {
+    this.viewsManager.setViewSettings(customViewSettings)
+    return await this.IFC.loadIfcUrl(url, fitToFrame, onProgress, onError)
   }
   /**
    * Gets the expressId of the element that the mouse is pointing at
@@ -32,12 +51,15 @@ export class IfcViewerAPIExtended extends IfcViewerAPI {
     const id = ifcManager.loader.ifcManager.getExpressId(mesh.geometry, found.faceIndex)
     return {modelID: mesh.modelID, id}
   }
+
+
   /**
    * gets a copy of the current selected expressIds in the scene
    *
    * @return {number[]} the selected express ids in the scene
    */
   getSelectedIds = () => [...this._selectedExpressIds]
+
 
   /**
    * sets the current selected expressIds in the scene

--- a/src/Infrastructure/IfcViewerAPIExtended.js
+++ b/src/Infrastructure/IfcViewerAPIExtended.js
@@ -1,6 +1,6 @@
 import {IfcViewerAPI} from 'web-ifc-viewer'
 import IfcHighlighter from './IfcHighlighter'
-
+import IfcViewsManager from './IfcElementsStyleManager'
 /**
  * Extending the original IFCViewerFunctionality
  */
@@ -12,6 +12,7 @@ export class IfcViewerAPIExtended extends IfcViewerAPI {
   constructor(options) {
     super(options)
     this.highlighter = new IfcHighlighter(this.context)
+    this.viewsManager = new IfcViewsManager(this.IFC.loader.ifcManager.parser)
   }
   /**
    * Gets the expressId of the element that the mouse is pointing at

--- a/src/Infrastructure/IfcViewerAPIExtended.js
+++ b/src/Infrastructure/IfcViewerAPIExtended.js
@@ -4,6 +4,7 @@ import IfcViewsManager from './IfcElementsStyleManager'
 import IfcCustomViewSettings from './IfcCustomViewSettings'
 
 
+/* eslint-disable jsdoc/no-undefined-types */
 /**
  * Extending the original IFCViewerFunctionality
  */
@@ -20,15 +21,15 @@ export class IfcViewerAPIExtended extends IfcViewerAPI {
 
 
   /**
-  * Loads the given IFC in the current scene.
-  *
-  * @param {string} url IFC as URL.
-  * @param {boolean} fitToFrame (optional) if true, brings the perspectiveCamera to the loaded IFC.
-  * @param {(event: ProgressEvent) => void} onProgress (optional) a callback function to report on downloading progress
-  * @param {(err: any) => any} onError (optional) a callback function to report on loading errors
-  * @param {IfcCustomViewSettings} customViewSettings (optional) override the ifc elements file colors
-  * @returns {IfcModel} ifcModel object
-  */
+   * Loads the given IFC in the current scene.
+   *
+   * @param {string} url IFC as URL.
+   * @param {boolean} fitToFrame (optional) if true, brings the perspectiveCamera to the loaded IFC.
+   * @param {Function(event)} onProgress (optional) a callback function to report on downloading progress
+   * @param {Function} onError (optional) a callback function to report on loading errors
+   * @param {IfcCustomViewSettings} customViewSettings (optional) override the ifc elements file colors
+   * @return {IfcModel} ifcModel object
+   */
   async loadIfcUrl(url, fitToFrame, onProgress, onError, customViewSettings) {
     this.viewsManager.setViewSettings(customViewSettings)
     return await this.IFC.loadIfcUrl(url, fitToFrame, onProgress, onError)


### PR DESCRIPTION
### The Idea
This is an alternative more of a static approach for colorizing single IfcElements at an early stage of file loading, without having to rely on the ifc-viewer subset functionality.

The viewer.loadIfcUrl now takes an extra parameter where you can specify options for overloading the loaded elements colors.

### The view-options is an object that contains
1. a map of key-value pair for elements and their colors.
2. a default color to be used for element as a fallback
3. if both failed, it will use the element's original color.

**This PR should be the first step of achieving the 'smart views' like functionality
The second step is to create the view-rules compiler**

Eventually those view settings will be the result of compiling the view-rules against the loaded model, 

for example having a view-rule  

> type:Wall set color:red; type:Slab set color:#0000FF;

will first be executed on the model file in the compiler that creates the viewOptions object to be passed to the viewer


![image](https://user-images.githubusercontent.com/17034318/218286838-31a6b1b2-cb25-4c7e-80df-60d2da1845f1.png)
![image](https://user-images.githubusercontent.com/17034318/218286596-35388543-90cd-4580-bb0d-c50e3bce6862.png)
