### PR TITLE
Support personal GitHub API token for local development

### DIFF
--- a/config/common.js
+++ b/config/common.js
@@ -39,6 +39,7 @@ export const build = {
     'process.env.OAUTH2_CLIENT_ID': JSON.stringify(process.env.OAUTH2_CLIENT_ID),
     'process.env.OAUTH2_REDIRECT_URI': JSON.stringify(process.env.OAUTH2_REDIRECT_URI || null),
     'process.env.AUTH0_DOMAIN': JSON.stringify(process.env.AUTH0_DOMAIN),
+    'process.env.GITHUB_API_TOKEN': JSON.stringify(process.env.GITHUB_API_TOKEN),
     'process.env.GITHUB_BASE_URL': JSON.stringify(process.env.GITHUB_BASE_URL || 'https://api.github.com'),
     'process.env.SENTRY_DSN': JSON.stringify(process.env.SENTRY_DSN || null),
     'process.env.SENTRY_ENVIRONMENT': JSON.stringify(process.env.SENTRY_ENVIRONMENT || process.env.NODE_ENV),

--- a/src/BaseRoutes.jsx
+++ b/src/BaseRoutes.jsx
@@ -49,7 +49,9 @@ export default function BaseRoutes({testElt = null}) {
       navigation(targetURL)
     }
 
-    if (!isLoading && isAuthenticated) {
+    if (process.env.NODE_ENV === 'development' && process.env.GITHUB_API_TOKEN) {
+      setAccessToken(process.env.GITHUB_API_TOKEN)
+    } else if (!isLoading && isAuthenticated) {
       getAccessTokenSilently({
         authorizationParams: {
           audience: 'https://api.github.com/',


### PR DESCRIPTION
PR to allow one to bypass Auth0 and the OAuth proxy in favor of using their personal GitHub API token to make protected calls.

The value of the `GITHUB_API_TOKEN` environment variable will be picked up in development only, if the variable is set.