### PR TITLE
Flesh out Auth0 user mock

### DIFF
--- a/src/__mocks__/authentication.js
+++ b/src/__mocks__/authentication.js
@@ -6,6 +6,7 @@ jest.mock('@auth0/auth0-react')
 
 const mockGitHubUser = {
   name: 'Unit Testing',
+  nickname: 'testing',
   picture: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAAAAACPAi4CAAAAwUlEQVR42u3VLQvCUBTGcT/LX6vMjyAIliVhYLELmgSzRbALA0EUVix' +
       'GQUEmFkG2riiO813EF+5Y8040nSed54ZfOOGegnyZggIKKKCAAj8DpnBOW4WhSINM3P8D8eGRBQTPIbYGXglhnXMHCihgD8zhlDaHkS2whMiUpIhvC0QQmLKBlS0gVTwzt' +
       '3Fu1sAEBu9xTLqCzwFpgetvj/tZE7wkB3Dtms+nc5EcgEjYq5VLTr2/yzxaAHqZFFBAAQXy5g5KPEV7KOa7LAAAAABJRU5ErkJggg==',

--- a/src/__mocks__/authentication.js
+++ b/src/__mocks__/authentication.js
@@ -13,6 +13,7 @@ const mockGitHubUser = {
   email: 'testing@example.com',
   email_verified: true,
   sub: 'github|1234567',
+  updated_at: '2023-02-22T17:07:29.123Z',
 }
 
 export const mockedUseAuth0 = jest.mocked(useAuth0, true)

--- a/src/__mocks__/authentication.js
+++ b/src/__mocks__/authentication.js
@@ -12,7 +12,7 @@ const mockGitHubUser = {
       '3Fu1sAEBu9xTLqCzwFpgetvj/tZE7wkB3Dtms+nc5EcgEjYq5VLTr2/yzxaAHqZFFBAAQXy5g5KPEV7KOa7LAAAAABJRU5ErkJggg==',
   email: 'testing@example.com',
   email_verified: true,
-  sub: '',
+  sub: 'github|1234567',
 }
 
 export const mockedUseAuth0 = jest.mocked(useAuth0, true)


### PR DESCRIPTION
When the initial Auth0 mock user object was created, I specified the bare minimum field set in order to test my UI component.

As additional work progresses this object should be fleshed out to reflect all fields that are returned by Auth0 to support future development.

This PR brings the object to that expected level.