### PR TITLE
Ignore code coverage results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 .vscode
 .idea
 *.log
+/coverage
 
 cypress/videos
 cypress/screenshots


### PR DESCRIPTION
This PR adds a new VCS ignore pattern that prevents code coverage results from being committed to the repository.