### PR TITLE
Explicit build control via environment variables

### DIFF
--- a/config/build.js
+++ b/config/build.js
@@ -8,7 +8,7 @@ esbuild
     .build(common.build)
     .then((result) => {
       // Remove development resources from non-development builds
-      if (process.env.NODE_ENV !== 'development' && process.env.NODE_ENV !== 'test') {
+      if (process.env.DISABLE_MOCK_SERVICE_WORKER === 'true') {
         unlink(join(common.buildDir, 'mockServiceWorker.js'), (err) => console.log(err))
       }
 

--- a/config/common.js
+++ b/config/common.js
@@ -43,6 +43,7 @@ export const build = {
     'process.env.GITHUB_BASE_URL': JSON.stringify(process.env.GITHUB_BASE_URL || 'https://api.github.com'),
     'process.env.SENTRY_DSN': JSON.stringify(process.env.SENTRY_DSN || null),
     'process.env.SENTRY_ENVIRONMENT': JSON.stringify(process.env.SENTRY_ENVIRONMENT || process.env.NODE_ENV),
+    'process.env.DISABLE_MOCK_SERVICE_WORKER': JSON.stringify(process.env.DISABLE_MOCK_SERVICE_WORKER),
   },
   plugins: [
     progress(),

--- a/config/common.js
+++ b/config/common.js
@@ -16,7 +16,7 @@ export const buildDir = path.resolve(__dirname, '..', 'docs')
 export const build = {
   entryPoints: [entryPoint],
   bundle: true,
-  minify: false, // process.env.NODE_ENV === 'production',
+  minify: process.env.MINIFY_BUILD === 'true',
   // https://esbuild.github.io/api/#keep-names
   // We use code identifiers e.g. in ItemProperties for their names
   keepNames: true,

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -33,7 +33,7 @@ Sentry.init({
   tracesSampleRate: 1.0,
 })
 
-if (process.env.NODE_ENV === 'development' || process.env.NODE_ENV === 'test') {
+if (process.env.DISABLE_MOCK_SERVICE_WORKER !== 'true') {
   const {worker} = require('./__mocks__/browser')
   worker.start({
     onUnhandledRequest(req) {


### PR DESCRIPTION
Originally, there was logic that would enable or disable different parts of the build depending on the value of the `NODE_ENV` environment variable.

However, using this variable is fraught with problems due to the nature of the tooling combination that interprets its values in different ways[1][2].

This PR introduces dedicated environment variables for controlling specific behavior when the build is being performed.

This goes along with the necessary configuration changes within Netlify to effect the build as desired.

1: https://seanconnolly.dev/dont-be-fooled-by-node-env
2: https://docs.netlify.com/configure-builds/manage-dependencies/#node-js-environment