### PR TITLE
Fix private branches

### DIFF
--- a/src/Components/BranchesControl.jsx
+++ b/src/Components/BranchesControl.jsx
@@ -57,7 +57,7 @@ export default function Branches() {
     if (branches.length === 0 && modelPath.repo !== undefined) {
       fetchBranches()
     }
-  }, [repository, branches.length, modelPath.branch, modelPath.filepath, modelPath.org, modelPath.repo])
+  }, [accessToken, repository, branches.length, modelPath.branch, modelPath.filepath, modelPath.org, modelPath.repo])
 
 
   const handleSelect = (event) => {

--- a/src/Components/BranchesControl.jsx
+++ b/src/Components/BranchesControl.jsx
@@ -24,6 +24,7 @@ export default function Branches() {
   const [versionPaths, setVersionPaths] = useState([])
   const [selected, setSelected] = useState(0)
   const modelPath = useStore((state) => state.modelPath)
+  const accessToken = useStore((state) => state.accessToken)
   const theme = useTheme()
 
 
@@ -34,7 +35,7 @@ export default function Branches() {
     }
     const fetchBranches = async () => {
       try {
-        const branchesData = await getBranches(repository)
+        const branchesData = await getBranches(repository, accessToken)
         const versionPathsTemp = []
         if (branchesData.data.length > 0) {
           setBranches(branchesData.data)

--- a/src/utils/GitHub.js
+++ b/src/utils/GitHub.js
@@ -60,8 +60,17 @@ export async function getIssue(repository, issueId, accessToken = '') {
  * @param {object} repository
  * @return {object} the branches.
  */
-export async function getBranches(repository) {
-  const branches = await getGitHub(repository, 'branches')
+export async function getBranches(repository, accessToken = '') {
+  const args = {}
+
+  if (accessToken.length > 0) {
+    args.headers = {
+      authorization: `Bearer ${accessToken}`,
+      ...args.headers,
+    }
+  }
+
+  const branches = await getGitHub(repository, 'branches', args)
   debug().log('GitHub: branches: ', branches)
   return branches
 }


### PR DESCRIPTION
Currently, branch functionality is not available when reading assets from a private repository because the access token is not transmitted along with the request.

This PR adds that missing logic in order to restore functionality.