### PR TITLE
Fix all-tests break introduced in #633 by always requiring canvas.

### DIFF
--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -9,6 +9,12 @@ import {disableDebug} from './utils/debug'
 import {server} from './__mocks__/server'
 
 
+// TODO(pablo): this is somehow implicitly referenced in all tests,
+// but wasn't included when we added it in #633.  This is a quick fixup.
+// eslint-disable-next-line
+import {Canvas} from 'canvas'
+
+
 disableDebug()
 
 


### PR DESCRIPTION
Mainly for Ron to review since it was our work that broke it.

Ron, please run `yarn husky-init` in your fork.  This will setup a presubmit check that ensures `yarn lint` and `yarn test` are passing before commit completes.

Ogali, guess you're right! Here's an example of PR that was submitted with all tests broken.
