### PR TITLE
Add partial opacity background to OperationsGroup to enhance contrast…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bldrs",
-  "version": "1.0.0-r643",
+  "version": "1.0.0-r644",
   "main": "src/index.jsx",
   "license": "MIT",
   "homepage": "https://github.com/bldrs-ai/Share",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bldrs",
-  "version": "1.0.0-r641",
+  "version": "1.0.0-r643",
   "main": "src/index.jsx",
   "license": "MIT",
   "homepage": "https://github.com/bldrs-ai/Share",

--- a/src/Components/BranchesControl.jsx
+++ b/src/Components/BranchesControl.jsx
@@ -1,8 +1,9 @@
 import React, {useEffect, useState} from 'react'
 import {useNavigate} from 'react-router-dom'
-import TextField from '@mui/material/TextField'
+import Box from '@mui/material/Box'
 import MenuItem from '@mui/material/MenuItem'
 import Paper from '@mui/material/Paper'
+import TextField from '@mui/material/TextField'
 import Typography from '@mui/material/Typography'
 import useTheme from '@mui/styles/useTheme'
 import debug from '../utils/debug'
@@ -71,7 +72,7 @@ export default function Branches() {
 
 
   return (
-    <>
+    <Box sx={{width: '100%'}}>
       {branches.length > 1 && modelPath.repo !== undefined &&
         <Paper elevation={0} variant='control'
           sx={{
@@ -81,7 +82,7 @@ export default function Branches() {
         >
           <TextField
             sx={{
-              'width': '300px',
+              'width': '100%',
               '& .MuiOutlinedInput-input': {
                 color: theme.palette.primary.contrastText,
               },
@@ -134,6 +135,6 @@ export default function Branches() {
           </TextField>
         </Paper>
       }
-    </>
+    </Box>
   )
 }

--- a/src/Components/InputBar.jsx
+++ b/src/Components/InputBar.jsx
@@ -24,16 +24,8 @@ export default function InputBar({startAdorment, onSubmit}) {
     <Box>
       <Paper component='form' sx={{
         'display': 'flex',
-        'minWidth': '200px',
-        'width': '288px',
-        'maxWidth': '400px',
         'alignItems': 'center',
         'padding': '2px 2px 2px 2px',
-        '@media (max-width: 900px)': {
-          minWidth: '300px',
-          width: '300px',
-          maxWidth: '300px',
-        },
         '& .MuiInputBase-root': {
           flex: 1,
         },
@@ -50,11 +42,14 @@ export default function InputBar({startAdorment, onSubmit}) {
         >
           {startAdorment}
         </Box>
-        <Divider sx={{
-          height: '36px',
-          alignSelf: 'center',
-          margin: '0px 10px 0px 0px',
-        }} orientation="vertical" flexItem
+        <Divider
+          sx={{
+            height: '36px',
+            alignSelf: 'center',
+            margin: '0px 10px 0px 0px',
+          }}
+          orientation='vertical'
+          flexItem
         />
         <InputBase
           inputRef={searchInputRef}

--- a/src/Components/NavPanel.jsx
+++ b/src/Components/NavPanel.jsx
@@ -41,14 +41,13 @@ export default function NavPanel({
       sx={{
         'marginTop': '14px',
         'overflow': 'auto',
-        'width': '300px',
+        'width': '100%',
         'opacity': .8,
         'justifyContent': 'space-around',
         'alignItems': 'center',
         'maxHeight': '400px',
         '@media (max-width: 900px)': {
           maxHeight: '150px',
-          width: '300px',
           top: '86px',
         },
       }}

--- a/src/Components/OperationsGroup.jsx
+++ b/src/Components/OperationsGroup.jsx
@@ -61,12 +61,17 @@ export default function OperationsGroup({deselectItems}) {
   const theme = useTheme()
   const separatorOpacity = 0.1
   const separatorColor = hexToRgba(assertDefined(theme.palette.primary.contrastText), separatorOpacity)
+  // When the model has dark/black colors, then the icons (also dark)
+  // disappear. This keeps them visible.
+  const bgOpacity = 0.2
+  const bgColor = hexToRgba(assertDefined(theme.palette.scene.background), bgOpacity)
   return (
     <Box
       sx={{
         'display': 'flex',
         'flexDirection': 'column',
-        'margin': '1em 1em 0 0',
+        'padding': '1em',
+        'backgroundColor': `${bgColor}`,
         '@media (max-width: 900px)': {
           margin: '1em 0.5em 0 0',
         },

--- a/src/Components/OperationsGroup.jsx
+++ b/src/Components/OperationsGroup.jsx
@@ -70,10 +70,10 @@ export default function OperationsGroup({deselectItems}) {
       sx={{
         'display': 'flex',
         'flexDirection': 'column',
-        'padding': '1em',
         'backgroundColor': `${bgColor}`,
+        'padding': '1em',
         '@media (max-width: 900px)': {
-          margin: '1em 0.5em 0 0',
+          padding: '1em 0.5em',
         },
         '.MuiButtonGroup-root + .MuiButtonGroup-root': {
           marginTop: '0.5em',

--- a/src/Components/SearchBar.jsx
+++ b/src/Components/SearchBar.jsx
@@ -6,9 +6,9 @@ import Paper from '@mui/material/Paper'
 import useTheme from '@mui/styles/useTheme'
 import {looksLikeLink, githubUrlOrPathToSharePath} from '../ShareRoutes'
 import debug from '../utils/debug'
+import {handleBeforeUnload} from '../utils/event'
 import OpenModelControl from './OpenModelControl'
 import {TooltipIconButton} from './Buttons'
-import {handleBeforeUnload} from '../utils/event'
 import ClearIcon from '../assets/icons/Clear.svg'
 
 
@@ -28,8 +28,8 @@ export default function SearchBar({fileOpen}) {
   const searchInputRef = useRef(null)
   // input length is dynamically calculated in order to fit the input string into the Text input
   const widthPerChar = 6.5
-  const padding = 130
-  const calculatedInputWidth = (Number(inputText.length) * widthPerChar) + padding
+  const minWidthPx = 125
+  const widthPx = (Number(inputText.length) * widthPerChar) + minWidthPx
   // it is passed into the styles as a property the input width needs to change when the query exceeds the minWidth
   // TODO(oleg): find a cleaner way to achieve this
   const theme = useTheme()
@@ -87,8 +87,12 @@ export default function SearchBar({fileOpen}) {
   }
 
 
+  // The container and paper are set to 100% width to fill the
+  // container SearchBar shares with NavPanel.  This is an easier way
+  // to have them share the same width, which is now set in the parent
+  // container (CadView).
   return (
-    <Box>
+    <Box sx={{width: '100%'}}>
       <Paper
         component='form'
         onSubmit={onSubmit}
@@ -96,17 +100,14 @@ export default function SearchBar({fileOpen}) {
         variant='control'
         sx={{
           'display': 'flex',
-          'minWidth': '300px',
-          'width': `${calculatedInputWidth}px`,
+          'minWidth': '100%',
+          'width': `${widthPx}px`,
           'height': '56px',
-          'maxWidth': '700px',
           'alignItems': 'center',
           'opacity': .8,
-          'padding': '2px 6px 2px 6px',
+          'padding': '2px 6px',
           '@media (max-width: 900px)': {
-            minWidth: '300px',
-            width: '300px',
-            maxWidth: '300px',
+            width: '100%',
           },
           '& .MuiInputBase-root': {
             flex: 1,

--- a/src/Containers/CadView.jsx
+++ b/src/Containers/CadView.jsx
@@ -6,6 +6,7 @@ import useTheme from '@mui/styles/useTheme'
 import {navToDefault} from '../Share'
 import Alert from '../Components/Alert'
 import BranchesControl from '../Components/BranchesControl'
+import {useWindowDimensions} from '../Components/Hooks'
 import Logo from '../Components/Logo'
 import NavPanel from '../Components/NavPanel'
 import SearchBar from '../Components/SearchBar'
@@ -545,6 +546,11 @@ export default function CadView({
   }
 
 
+  const windowDimensions = useWindowDimensions()
+  const spacingBetweenSearchAndOpsGroupPx = 20
+  const operationsGroupWidthPx = 60
+  const searchAndNavWidthPx = windowDimensions.width - (operationsGroupWidthPx + spacingBetweenSearchAndOpsGroupPx)
+  const searchAndNavMaxWidthPx = 300
   return (
     <Box
       sx={{
@@ -578,14 +584,19 @@ export default function CadView({
       />
       {showSearchBar && (
         <Box sx={{
-          position: 'absolute',
-          top: `1em`,
-          left: '1em',
-          display: 'flex',
-          flexDirection: 'column',
-          justifyContent: 'flex-start',
-          alignItems: 'flex-start',
-          maxHeight: '95%',
+          'position': 'absolute',
+          'top': `1em`,
+          'left': '1em',
+          'display': 'flex',
+          'flexDirection': 'column',
+          'justifyContent': 'flex-start',
+          'alignItems': 'flex-start',
+          'maxHeight': '95%',
+          'width': '275px',
+          '@media (max-width: 900px)': {
+            width: `${searchAndNavWidthPx}px`,
+            maxWidth: `${searchAndNavMaxWidthPx}px`,
+          },
         }}
         >
           {isSearchBarVisible &&


### PR DESCRIPTION
… when button icons and mode have same color.

With (this PR) and without (prod):

<img width="459" alt="image" src="https://user-images.githubusercontent.com/2480879/223613933-fa53d563-32a4-43d4-950b-fa27d5a87355.png">

<img width="507" alt="image" src="https://user-images.githubusercontent.com/2480879/223614049-ee1315dc-535f-45ff-b2f3-7457cbb2b7e2.png">
