### PR TITLE
Disallow use of console, alert, and debugger

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -101,6 +101,9 @@ module.exports = {
     'jsdoc/require-param-type': 'off',
     'require-await': 'error',
     'linebreak-style': ['error', 'unix'],
+    'no-console': 'error',
+    'no-alert': 'error',
+    'no-debugger': 'error'
   },
   settings: {
     react: {

--- a/src/BaseRoutes.jsx
+++ b/src/BaseRoutes.jsx
@@ -63,8 +63,6 @@ export default function BaseRoutes({testElt = null}) {
         if (err.error !== 'login_required') {
           throw err
         }
-
-        console.log(err.error)
       })
     }
   }, [basePath, installPrefix, location, navigation, getAccessTokenSilently, isAuthenticated, isLoading, setAccessToken])

--- a/src/Components/SearchBar.jsx
+++ b/src/Components/SearchBar.jsx
@@ -66,7 +66,6 @@ export default function SearchBar({fileOpen}) {
         window.removeEventListener('beforeunload', handleBeforeUnload)
         navigate(modelPath, {replace: true})
       } catch (e) {
-        console.error(e)
         setError(`Please enter a valid url. Click on the LINK icon to learn more.`)
       }
       return

--- a/src/Containers/CadView.jsx
+++ b/src/Containers/CadView.jsx
@@ -275,7 +275,7 @@ export default function CadView({
           }
         },
         (error) => {
-          console.warn('CadView#loadIfc$onError', error)
+          debug().log('CadView#loadIfc$onError: ', error)
           // TODO(pablo): error modal.
           setIsLoading(false)
           setAlertMessage(`Could not load file: ${filepath}`)

--- a/src/Infrastructure/IfcViewerAPIExtended.js
+++ b/src/Infrastructure/IfcViewerAPIExtended.js
@@ -2,6 +2,7 @@ import {IfcViewerAPI} from 'web-ifc-viewer'
 import IfcHighlighter from './IfcHighlighter'
 import IfcViewsManager from './IfcElementsStyleManager'
 import IfcCustomViewSettings from './IfcCustomViewSettings'
+import debug from './utils/debug'
 
 
 const viewParameter = (new URLSearchParams(window.location.search)).get('view')?.toLowerCase() ?? 'default'
@@ -84,7 +85,7 @@ export class IfcViewerAPIExtended extends IfcViewerAPI {
         await this.pickIfcItemsByID(modelID, this._selectedExpressIds, focusSelection, true)
         this.highlighter.setHighlighted(this.IFC.selector.selection.meshes)
       } catch (e) {
-        console.error(e)
+        debug().log('IfcViewerAPIExtended#setSelection$onError: ', e)
       }
     } else {
       this.highlighter.setHighlighted(null)

--- a/src/Share.jsx
+++ b/src/Share.jsx
@@ -68,7 +68,7 @@ export default function Share({installPrefix, appPrefix, pathPrefix}) {
       debug().log('Setting default repo pablo-mayrgundter/Share')
       setRepository('pablo-mayrgundter', 'Share')
     } else {
-      console.warn('No repository set for project!', pathPrefix)
+      debug().log('No repository set for project!, ', pathPrefix)
     }
   }, [appPrefix, installPrefix, modelPath, pathPrefix, setRepository, urlParams, setModelPath])
 

--- a/src/WidgetApi/ApiConnection.js
+++ b/src/WidgetApi/ApiConnection.js
@@ -16,14 +16,14 @@ class AbstractApiConnection {
    * starts the api.
    */
   start() {
-    console.warn('start() is not implemented')
+    throw new Error('start() is not implemented')
   }
 
   /**
    * stops the api.
    */
   stop() {
-    console.warn('stop() is not implemented')
+    throw new Error('stop() is not implemented')
   }
 
   /**
@@ -33,7 +33,7 @@ class AbstractApiConnection {
    * @param {object} data
    */
   send(eventName, data) {
-    console.warn('send() is not implemented')
+    throw new Error('send() is not implemented')
   }
 
   /**
@@ -42,7 +42,7 @@ class AbstractApiConnection {
    * @param {string[]} capabilities
    */
   requestCapabilities(capabilities) {
-    console.warn('requestCapabilities() is not implemented')
+    throw new Error('requestCapabilities() is not implemented')
   }
 
   /**

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -39,6 +39,7 @@ if (process.env.DISABLE_MOCK_SERVICE_WORKER !== 'true') {
   worker.start({
     onUnhandledRequest(req) {
       if (req.url.host === 'api.github.com') {
+        // eslint-disable-next-line no-console
         console.error(`Found an unhandled ${req.method} request to ${req.url}`)
       }
     },

--- a/src/utils/version.mjs
+++ b/src/utils/version.mjs
@@ -23,4 +23,4 @@ pkgJson.version = `${version}-r${__versionString__}`
 const pkgJsonStr = JSON.stringify(pkgJson, null, '  ')
 
 // Outputs to console for capture by file redirect in the calling script.
-console.log(pkgJsonStr)
+console.log(pkgJsonStr) // eslint-disable-line no-console


### PR DESCRIPTION
PR to add ESLint rules that will loudly complain if one attempts to use `console.*`, `alert()`, or `debugger;`.

@aozien In `src/Infrastructure/IfcViewerAPIExtended.js`, can you confirm whether you want the debug logging of the error to remain, or has the code reached a level of maturity where that line can be removed?

@pablo-mayrgundter In `src/Share.jsx`, when no repository is set, do we still need that warning/debugging statement or can that be eliminated?