### PR TITLE
Don't allow an anonymous user to request user organizations

### DIFF
--- a/src/Components/OpenModelControl.jsx
+++ b/src/Components/OpenModelControl.jsx
@@ -42,7 +42,10 @@ export default function OpenModelControl({fileOpen}) {
       setOrgNamesArray(orgNames)
       return orgs
     }
-    fetchOrganizations()
+
+    if (accessToken) {
+      fetchOrganizations()
+    }
   }, [accessToken, user])
 
 

--- a/src/__mocks__/api-handlers.js
+++ b/src/__mocks__/api-handlers.js
@@ -2,7 +2,7 @@ import {rest} from 'msw'
 import {
   MOCK_COMMENTS,
   MOCK_ISSUES,
-  MOCK_ORGANIZATION,
+  MOCK_ORGANIZATIONS,
   MOCK_REPOSITORY,
   MOCK_FILES,
 } from '../utils/GitHub'
@@ -190,9 +190,7 @@ export const handlers = [
 
     return res(
         ctx.status(httpOk),
-        ctx.json({
-          data: [MOCK_ORGANIZATION],
-        }),
+        ctx.json(MOCK_ORGANIZATIONS.data),
     )
   }),
 

--- a/src/__mocks__/api-handlers.js
+++ b/src/__mocks__/api-handlers.js
@@ -9,8 +9,9 @@ import {
 
 
 const httpOk = 200
-const httpNotFound = 404
 const httpCreated = 201
+const httpAuthorizationRequired = 401
+const httpNotFound = 404
 
 export const handlers = [
   rest.get('https://api.github.com/repos/:org/:repo/issues', (req, res, ctx) => {
@@ -175,6 +176,18 @@ export const handlers = [
   }),
 
   rest.get('https://api.github.com/user/orgs', (req, res, ctx) => {
+    const authHeader = req.headers.get('authorization')
+
+    if (!authHeader) {
+      return res(
+          ctx.status(httpAuthorizationRequired),
+          ctx.json({
+            message: 'Requires authentication',
+            documentation_url: 'https://docs.github.com/rest/reference/orgs#list-organizations-for-the-authenticated-user',
+          }),
+      )
+    }
+
     return res(
         ctx.status(httpOk),
         ctx.json({

--- a/src/utils/GitHub.js
+++ b/src/utils/GitHub.js
@@ -744,6 +744,12 @@ export const MOCK_ORGANIZATION = {
   description: 'Build. Every. Thing. Together.',
 }
 
+export const MOCK_ORGANIZATIONS = {
+  data: [
+    MOCK_ORGANIZATION,
+  ],
+}
+
 export const MOCK_REPOSITORY = {
   id: 337879836,
   node_id: 'MDEwOlJlcG9zaXRvcnkzMzc4Nzk4MzY=',

--- a/src/utils/GitHub.js
+++ b/src/utils/GitHub.js
@@ -183,12 +183,17 @@ export async function getDownloadURL(repository, path, ref = '', accessToken = '
  * @param {string} [accessToken]
  * @return {Promise} the list of organization
  */
-export async function getOrganizations(accessToken = '') {
+export async function getOrganizations(accessToken) {
+  if (!accessToken) {
+    throw new Error('GitHub access token is required for this call')
+  }
+
   const res = await octokit.request(`/user/orgs`, {
     headers: {
       authorization: `Bearer ${accessToken}`,
     },
   })
+
   return res.data
 }
 

--- a/src/utils/GitHub.test.js
+++ b/src/utils/GitHub.test.js
@@ -87,16 +87,19 @@ describe('GitHub', () => {
       expect(res.status).toEqual(httpOK)
     })
   })
+
   describe('get models from github', () => {
-    it('successfullly get organizations', async () => {
+    it('successfully get organizations', async () => {
       const res = await getOrganizations()
       expect(res.data).toEqual([MOCK_ORGANIZATION])
     })
-    it('successfullly get repositories', async () => {
+
+    it('successfully get repositories', async () => {
       const res = await getRepositories('bldrs-ai')
       expect(res.data).toEqual([MOCK_REPOSITORY])
     })
-    it('successfullly get files', async () => {
+
+    it('successfully get files', async () => {
       const res = await getFiles('Share', 'pablo-mayrgundter')
       expect(res.data).toEqual([MOCK_FILES])
     })

--- a/src/utils/GitHub.test.js
+++ b/src/utils/GitHub.test.js
@@ -8,7 +8,6 @@ import {
   getOrganizations,
   getRepositories,
   getFiles,
-  MOCK_ORGANIZATION,
   MOCK_REPOSITORY,
   MOCK_FILES,
 } from './GitHub'
@@ -89,11 +88,6 @@ describe('GitHub', () => {
   })
 
   describe('get models from github', () => {
-    it('successfully get organizations', async () => {
-      const res = await getOrganizations()
-      expect(res.data).toEqual([MOCK_ORGANIZATION])
-    })
-
     it('successfully get repositories', async () => {
       const res = await getRepositories('bldrs-ai')
       expect(res.data).toEqual([MOCK_REPOSITORY])
@@ -102,6 +96,21 @@ describe('GitHub', () => {
     it('successfully get files', async () => {
       const res = await getFiles('Share', 'pablo-mayrgundter')
       expect(res.data).toEqual([MOCK_FILES])
+    })
+  })
+
+  describe('getOrganizations', () => {
+    it('encounters an exception if no access token is provided', () => {
+      expect(async () => await getOrganizations())
+          .toThrowError('GitHub access token is required for this call')
+    })
+
+    it('receives a list of organizations', async () => {
+      const orgs = await getOrganizations()
+      expect(orgs).toHaveLength(1)
+
+      const org = orgs[0]
+      expect(org.login).toEqual('bldrs-ai')
     })
   })
 })

--- a/src/utils/GitHub.test.js
+++ b/src/utils/GitHub.test.js
@@ -106,7 +106,7 @@ describe('GitHub', () => {
     })
 
     it('receives a list of organizations', async () => {
-      const orgs = await getOrganizations()
+      const orgs = await getOrganizations('testtoken')
       expect(orgs).toHaveLength(1)
 
       const org = orgs[0]

--- a/src/utils/GitHub.test.js
+++ b/src/utils/GitHub.test.js
@@ -101,7 +101,7 @@ describe('GitHub', () => {
 
   describe('getOrganizations', () => {
     it('encounters an exception if no access token is provided', () => {
-      expect(async () => await getOrganizations())
+      expect(() => getOrganizations())
           .toThrowError('GitHub access token is required for this call')
     })
 

--- a/src/utils/GitHub.test.js
+++ b/src/utils/GitHub.test.js
@@ -101,7 +101,7 @@ describe('GitHub', () => {
 
   describe('getOrganizations', () => {
     it('encounters an exception if no access token is provided', () => {
-      expect(() => getOrganizations())
+      expect(() => getOrganizations()).rejects
           .toThrowError('GitHub access token is required for this call')
     })
 


### PR DESCRIPTION
When the application is loaded, it unconditionally requests a list of organizations from GitHub that the logged in user is a member of. This causes an exception to be thrown every time a non-logged-in user loads the page.

This PR adds logic to reject a request for a user's organizations if we're not logged in, fixes the shape of the mock object returned during testing, and separates the tests for `getOrganizations` into their own suite.