### PR TITLE
Cad: Generalize src/* IFC references to prepare for .obj support.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -54,7 +54,6 @@ module.exports = {
     'default-case': 'error',
     'default-param-last': ['error'],
     'eqeqeq': ['error', 'always'],
-    'no-alert': 'error',
     'no-empty-function': 'error',
     'no-eq-null': 'error',
     'no-eval': 'error',

--- a/jest.config.js
+++ b/jest.config.js
@@ -43,9 +43,7 @@ const esModules = [
 module.exports = {
   verbose: false,
   testEnvironment: 'jsdom',
-  testPathIgnorePatterns: [
-    'src/Share.test.js',
-  ],
+  testPathIgnorePatterns: [],
   transform: {
     '\\.[jt]sx?$': 'babel-jest',
     '^.+\\.svg$': '<rootDir>/svgTransform.js',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "bldrs",
   "version": "1.0.0-r675",
+  "version": "1.0.0-r658",
   "main": "src/index.jsx",
   "license": "MIT",
   "homepage": "https://github.com/bldrs-ai/Share",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "name": "bldrs",
-  "version": "1.0.0-r675",
-  "version": "1.0.0-r658",
+  "version": "1.0.0-r682",
   "main": "src/index.jsx",
   "license": "MIT",
   "homepage": "https://github.com/bldrs-ai/Share",

--- a/src/BaseRoutes.jsx
+++ b/src/BaseRoutes.jsx
@@ -18,7 +18,7 @@ const SentryRoutes = Sentry.withSentryReactRouterV6Routing(Routes)
  *
  * which when fully expanded becomes:
  *
- *   http://host/share/v/p/indec.ifc
+ *   http://host/share/v/p/index.ifc
  *   http://host/share/v/gh/bldrs-ai/Share/main/public/index.ifc
  *
  * @see https://github.com/bldrs-ai/Share/wiki/Design#ifc-scene-load

--- a/src/Filetype.js
+++ b/src/Filetype.js
@@ -1,7 +1,6 @@
-export const supportedTypes = ['ifc', 'obj']
-
-
+// Only differ by the leading '.'
 const fileTypeRegex = new RegExp(/(?:ifc|obj)/i)
+const fileSuffixRegex = new RegExp(/\.(?:ifc|obj)/i)
 
 
 /**
@@ -9,7 +8,7 @@ const fileTypeRegex = new RegExp(/(?:ifc|obj)/i)
  * @return {boolean} Is supported
  */
 export function isExtensionSupported(ext) {
-  return ext.match(fileTypeRegex)
+  return ext.match(fileTypeRegex) !== null
 }
 
 
@@ -27,17 +26,18 @@ export function pathSuffixSupported(pathWithSuffix) {
 
 
 /**
+ * e.g. for foo.ifc/bar => {parts: ['foo', '/bar'], extension: '.ifc'}
+ *
  * @param {string} filepath
- * @return {Array.<Array.<string>>}
+ * @return {Array.<Array.<string>>} {parts, extension}
  */
 export function splitAroundExtension(filepath) {
-  const splitRegex = /\.(?:ifc|obj)/i
-  const match = fileTypeRegex.exec(filepath)
+  const match = fileSuffixRegex.exec(filepath)
   if (!match) {
     throw new FilenameParseError('Filepath must contain ".(ifc|obj)" (case-insensitive)')
   }
-  const parts = filepath.split(splitRegex)
-  return {parts, match}
+  const parts = filepath.split(fileSuffixRegex)
+  return {parts, extension: match[0]}
 }
 
 

--- a/src/Filetype.js
+++ b/src/Filetype.js
@@ -1,6 +1,16 @@
-// Only differ by the leading '.'
-const fileTypeRegex = new RegExp(/(?:ifc|obj)/i)
-const fileSuffixRegex = new RegExp(/\.(?:ifc|obj)/i)
+export const supportedTypes = ['ifc']
+
+
+/** Make a non-capturing group of a choice of filetypes. */
+const typeRegexStr = `(?:${supportedTypes.join('|')})`
+
+
+/** */
+const filetypeRegex = new RegExp(typeRegexStr, 'i')
+
+
+/** Prepend it with a '.' to make a file suffix*/
+const fileSuffixRegex = new RegExp(`\\.${typeRegexStr}`, 'i')
 
 
 /**
@@ -8,7 +18,7 @@ const fileSuffixRegex = new RegExp(/\.(?:ifc|obj)/i)
  * @return {boolean} Is supported
  */
 export function isExtensionSupported(ext) {
-  return ext.match(fileTypeRegex) !== null
+  return ext.match(filetypeRegex) !== null
 }
 
 

--- a/src/Filetype.js
+++ b/src/Filetype.js
@@ -36,15 +36,13 @@ export function pathSuffixSupported(pathWithSuffix) {
 
 
 /**
- * e.g. for foo.ifc/bar => {parts: ['foo', '/bar'], extension: '.ifc'}
- *
  * @param {string} filepath
- * @return {Array.<Array.<string>>} {parts, extension}
+ * @return {{parts: Array.<string>, extension: string}}
  */
 export function splitAroundExtension(filepath) {
   const match = fileSuffixRegex.exec(filepath)
   if (!match) {
-    throw new FilenameParseError('Filepath must contain ".(ifc|obj)" (case-insensitive)')
+    throw new FilenameParseError(`Filepath must contain ".${typeRegexStr}" (case-insensitive)`)
   }
   const parts = filepath.split(fileSuffixRegex)
   return {parts, extension: match[0]}

--- a/src/Filetype.test.js
+++ b/src/Filetype.test.js
@@ -2,14 +2,14 @@ import {
   isExtensionSupported,
   pathSuffixSupported,
   splitAroundExtension,
+  supportedTypes,
 } from './Filetype'
 
 
 describe('Filetype', () => {
-  const supportedFiletypes = ['ifc', 'obj']
   const unsupportedFiletypes = ['arff', 'zip']
   it('supports only known extensions', () => {
-    for (const ext of supportedFiletypes) {
+    for (const ext of supportedTypes) {
       expect(isExtensionSupported(ext)).toBe(true)
       const path = `foo/bar/baz.${ext}`
       expect(pathSuffixSupported(path)).toBe(true)
@@ -23,7 +23,7 @@ describe('Filetype', () => {
 
 
   it('splitAroundExtension', () => {
-    for (const ext of supportedFiletypes) {
+    for (const ext of supportedTypes) {
       const {parts, extension} = splitAroundExtension(`asdf.${ext}/blah`)
       expect(parts).toStrictEqual(['asdf', '/blah'])
       expect(extension).toStrictEqual(`.${ext}`)

--- a/src/Filetype.test.js
+++ b/src/Filetype.test.js
@@ -1,4 +1,5 @@
 import {
+  FilenameParseError,
   isExtensionSupported,
   pathSuffixSupported,
   splitAroundExtension,
@@ -28,5 +29,8 @@ describe('Filetype', () => {
       expect(parts).toStrictEqual(['asdf', '/blah'])
       expect(extension).toStrictEqual(`.${ext}`)
     }
+    expect(() => {
+      splitAroundExtension(`asdf.obj/blah`)
+    }).toThrow(FilenameParseError)
   })
 })

--- a/src/Filetype.test.js
+++ b/src/Filetype.test.js
@@ -1,0 +1,32 @@
+import {
+  isExtensionSupported,
+  pathSuffixSupported,
+  splitAroundExtension,
+} from './Filetype'
+
+
+describe('Filetype', () => {
+  const supportedFiletypes = ['ifc', 'obj']
+  const unsupportedFiletypes = ['arff', 'zip']
+  it('supports only known extensions', () => {
+    for (const ext of supportedFiletypes) {
+      expect(isExtensionSupported(ext)).toBe(true)
+      const path = `foo/bar/baz.${ext}`
+      expect(pathSuffixSupported(path)).toBe(true)
+    }
+    for (const ext of unsupportedFiletypes) {
+      expect(isExtensionSupported(ext)).toBe(false)
+      const path = `foo/bar/baz.${ext}`
+      expect(pathSuffixSupported(path)).toBe(false)
+    }
+  })
+
+
+  it('splitAroundExtension', () => {
+    for (const ext of supportedFiletypes) {
+      const {parts, extension} = splitAroundExtension(`asdf.${ext}/blah`)
+      expect(parts).toStrictEqual(['asdf', '/blah'])
+      expect(extension).toStrictEqual(`.${ext}`)
+    }
+  })
+})

--- a/src/MimeType.js
+++ b/src/MimeType.js
@@ -1,0 +1,38 @@
+export const supportedTypes = ['ifc', 'obj']
+
+
+/**
+ * @param {string} ext
+ * @return {boolean} Is supported
+ */
+export function isExtensionSupported(ext) {
+  return ext.match(/(?:ifc|obj)/i)
+}
+
+
+/**
+ * @param {string} strWithSuffix
+ * @return {boolean} Is supported
+ */
+export function pathSuffixSupported(pathWithSuffix) {
+  const lastDotNdx = pathWithSuffix.lastIndexOf('.')
+  if (lastDotNdx === -1) {
+    return false
+  }
+  return isExtensionSupported(pathWithSuffix.substring(lastDotNdx + 1))
+}
+
+
+/**
+ * @param {string} filepath
+ * @return {Array.<string>}
+ */
+export function splitAroundExtension(filepath) {
+  const splitRegex = /\.(?:ifc|obj)/i
+  const match = splitRegex.exec(filepath)
+  if (!match) {
+    throw new Error('Filepath must contain ".(ifc|obj)" (case-insensitive)')
+  }
+  const parts = filepath.split(splitRegex)
+  return {parts, match}
+}

--- a/src/MimeType.js
+++ b/src/MimeType.js
@@ -1,12 +1,15 @@
 export const supportedTypes = ['ifc', 'obj']
 
 
+const fileTypeRegex = new RegExp(/(?:ifc|obj)/i)
+
+
 /**
  * @param {string} ext
  * @return {boolean} Is supported
  */
 export function isExtensionSupported(ext) {
-  return ext.match(/(?:ifc|obj)/i)
+  return ext.match(fileTypeRegex)
 }
 
 
@@ -25,14 +28,24 @@ export function pathSuffixSupported(pathWithSuffix) {
 
 /**
  * @param {string} filepath
- * @return {Array.<string>}
+ * @return {Array.<Array.<string>>}
  */
 export function splitAroundExtension(filepath) {
   const splitRegex = /\.(?:ifc|obj)/i
-  const match = splitRegex.exec(filepath)
+  const match = fileTypeRegex.exec(filepath)
   if (!match) {
-    throw new Error('Filepath must contain ".(ifc|obj)" (case-insensitive)')
+    throw new FilenameParseError('Filepath must contain ".(ifc|obj)" (case-insensitive)')
   }
   const parts = filepath.split(splitRegex)
   return {parts, match}
+}
+
+
+/** Custom error for better catch in UI. */
+export class FilenameParseError extends Error {
+  /** @param {string} msg */
+  constructor(msg) {
+    super(msg)
+    this.name = 'FilenameParseError'
+  }
 }

--- a/src/Share.jsx
+++ b/src/Share.jsx
@@ -2,7 +2,6 @@ import React, {useEffect, useMemo, useRef} from 'react'
 import {useNavigate, useParams} from 'react-router-dom'
 import CssBaseline from '@mui/material/CssBaseline'
 import {ThemeProvider} from '@mui/material/styles'
-import Styles from './Styles'
 import {CAMERA_PREFIX} from './Components/CameraControl'
 import CadView, {searchIndex} from './Containers/CadView'
 import WidgetApi from './WidgetApi/WidgetApi'
@@ -11,6 +10,8 @@ import useShareTheme from './theme/Theme'
 import debug from './utils/debug'
 import {navWith} from './utils/navigate'
 import {handleBeforeUnload} from './utils/event'
+import {splitAroundExtension} from './MimeType'
+import Styles from './Styles'
 
 
 /**
@@ -120,7 +121,14 @@ export function navToDefault(navigate, appPrefix) {
  *
  * @param {string} installPrefix e.g. /share
  * @param {string} pathPrefix e.g. /share/v/p
- * @param {object} urlParams e.g. .../:org/:repo/:branch/*
+ * @param {object} urlParams e.g.:
+ *     .../:org/:repo/:branch/ with .../a/b/c/d
+ *   becomes:
+ *     {
+ *       '*': 'a/b/c/d',
+ *       'org': 'a',
+ *       ...
+ *     }
  * @return {object}
  */
 export function getModelPath(installPrefix, pathPrefix, urlParams) {
@@ -130,12 +138,7 @@ export function getModelPath(installPrefix, pathPrefix, urlParams) {
   if (filepath === '') {
     return null
   }
-  const splitRegex = /\.ifc/i
-  const match = splitRegex.exec(filepath)
-  if (!match) {
-    throw new Error('Filepath must contain ".ifc" (case-insensitive)')
-  }
-  const parts = filepath.split(splitRegex)
+  const {parts, match} = splitAroundExtension(filepath)
   filepath = `/${parts[0]}${match[0]}`
   if (pathPrefix.endsWith('new') || pathPrefix.endsWith('/p')) {
     // * param is defined in ../Share.jsx, e.g.:

--- a/src/Share.jsx
+++ b/src/Share.jsx
@@ -136,9 +136,18 @@ export function getModelPath(installPrefix, pathPrefix, urlParams) {
   let m = null
   let filepath = urlParams['*']
   if (filepath === '') {
+    alert(`Must provide a filepath`)
     return null
   }
-  const {parts, extension} = splitAroundExtension(filepath)
+  let parts
+  let extension
+  try {
+    ({parts, extension} = splitAroundExtension(filepath))
+  } catch (e) {
+    alert(`Unsupported filetype: ${filepath}`)
+    debug().error(e)
+    return null
+  }
   filepath = `/${parts[0]}${extension}`
   if (pathPrefix.endsWith('new') || pathPrefix.endsWith('/p')) {
     // * param is defined in ../Share.jsx, e.g.:

--- a/src/Share.jsx
+++ b/src/Share.jsx
@@ -10,7 +10,7 @@ import useShareTheme from './theme/Theme'
 import debug from './utils/debug'
 import {navWith} from './utils/navigate'
 import {handleBeforeUnload} from './utils/event'
-import {splitAroundExtension} from './MimeType'
+import {splitAroundExtension} from './Filetype'
 import Styles from './Styles'
 
 
@@ -138,8 +138,8 @@ export function getModelPath(installPrefix, pathPrefix, urlParams) {
   if (filepath === '') {
     return null
   }
-  const {parts, match} = splitAroundExtension(filepath)
-  filepath = `/${parts[0]}${match[0]}`
+  const {parts, extension} = splitAroundExtension(filepath)
+  filepath = `/${parts[0]}${extension}`
   if (pathPrefix.endsWith('new') || pathPrefix.endsWith('/p')) {
     // * param is defined in ../Share.jsx, e.g.:
     //   /v/p/*.  It should be only the filename.

--- a/src/Share.jsx
+++ b/src/Share.jsx
@@ -136,7 +136,6 @@ export function getModelPath(installPrefix, pathPrefix, urlParams) {
   let m = null
   let filepath = urlParams['*']
   if (filepath === '') {
-    alert(`Must provide a filepath`)
     return null
   }
   let parts

--- a/src/Share.test.jsx
+++ b/src/Share.test.jsx
@@ -18,15 +18,16 @@ describe('Share', () => {
 
 
   it('getModelPath parses mixed-case ifc filepaths', () => {
-    [
+    for (const ext of [
       'ifc', 'Ifc', 'IFC', 'IfC', 'iFc', 'IFc',
       'obj', 'Obj', 'OBJ', 'ObJ', 'oBj', 'OBj',
-    ].forEach((ext) => {
-      expect(getModelPath('/share', '/share/v/p', {'*': `as_${ext}df.${ext}/1234`})).toStrictEqual({
+    ]) {
+      const inPath = `as_${ext}df.${ext}/1234`
+      expect(getModelPath('/share', '/share/v/p', {'*': inPath})).toStrictEqual({
         filepath: `/as_${ext}df.${ext}`,
         eltPath: '/1234',
       })
-    })
+    }
   })
 })
 

--- a/src/Share.test.jsx
+++ b/src/Share.test.jsx
@@ -10,17 +10,12 @@ describe('Share', () => {
       filepath: '/as_Ifcdf.ifc',
       eltPath: '/1234',
     })
-    expect(getModelPath('/share', '/share/v/p', {'*': 'as_Ifcdf.obj/1234'})).toStrictEqual({
-      filepath: '/as_Ifcdf.obj',
-      eltPath: '/1234',
-    })
   })
 
 
   it('getModelPath parses mixed-case ifc filepaths', () => {
     for (const ext of [
       'ifc', 'Ifc', 'IFC', 'IfC', 'iFc', 'IFc',
-      'obj', 'Obj', 'OBJ', 'ObJ', 'oBj', 'OBj',
     ]) {
       const inPath = `as_${ext}df.${ext}/1234`
       expect(getModelPath('/share', '/share/v/p', {'*': inPath})).toStrictEqual({

--- a/src/Share.test.jsx
+++ b/src/Share.test.jsx
@@ -1,21 +1,29 @@
 import {getModelPath} from './Share'
 
 
+jest.mock('three')
+
+
 describe('Share', () => {
-  it('getModelPath parses ifc filepaths', () => {
-    const urlParams = {'*': 'as_Ifcdf.ifc/1234'}
-    expect(getModelPath('/share', '/share/v/p', urlParams)).toStrictEqual({
+  it('getModelPath parses ifc and obj filepaths', () => {
+    expect(getModelPath('/share', '/share/v/p', {'*': 'as_Ifcdf.ifc/1234'})).toStrictEqual({
       filepath: '/as_Ifcdf.ifc',
+      eltPath: '/1234',
+    })
+    expect(getModelPath('/share', '/share/v/p', {'*': 'as_Ifcdf.obj/1234'})).toStrictEqual({
+      filepath: '/as_Ifcdf.obj',
       eltPath: '/1234',
     })
   })
 
 
   it('getModelPath parses mixed-case ifc filepaths', () => {
-    ['ifc', 'Ifc', 'IFC', 'IfC', 'iFc', 'IFc'].forEach((ext) => {
-      const urlParams = {'*': `as_Ifcdf.${ext}/1234`}
-      expect(getModelPath('/share', '/share/v/p', urlParams)).toStrictEqual({
-        filepath: `/as_Ifcdf.${ext}`,
+    [
+      'ifc', 'Ifc', 'IFC', 'IfC', 'iFc', 'IFc',
+      'obj', 'Obj', 'OBJ', 'ObJ', 'oBj', 'OBj',
+    ].forEach((ext) => {
+      expect(getModelPath('/share', '/share/v/p', {'*': `as_${ext}df.${ext}/1234`})).toStrictEqual({
+        filepath: `/as_${ext}df.${ext}`,
         eltPath: '/1234',
       })
     })

--- a/src/ShareRoutes.jsx
+++ b/src/ShareRoutes.jsx
@@ -6,18 +6,19 @@ import {
   useLocation,
   useNavigate,
 } from 'react-router-dom'
-import {assertDefined} from './utils/assert'
-import Share from './Share'
 import debug from './utils/debug'
+import {assertDefined} from './utils/assert'
 import {handleBeforeUnload} from './utils/event'
+import Share from './Share'
+import {pathSuffixSupported} from './MimeType'
 
 
 /**
  * For URL design see: https://github.com/bldrs-ai/Share/wiki/URL-Structure
  *
  * A new model path will cause a new instance of CadView to be
- * instantiated, including a new IFC.js viewer.  Thus, each model has
- * its own IFC.js/three.js context.
+ * instantiated.  CadView will invoke the model loader and creates a
+ * THREE.Scene.  This scene is currently not re-used
  *
  * For example, a first page load of:
  *
@@ -110,7 +111,7 @@ function Forward({appPrefix}) {
  */
 export function looksLikeLink(input) {
   assertDefined(input)
-  return input.toLowerCase().endsWith('.ifc') && (
+  return pathSuffixSupported(input) && (
     input.startsWith('http') ||
       input.startsWith('/') ||
       input.startsWith('bldrs') ||
@@ -170,9 +171,11 @@ const pathParts = [
 ]
 
 
+// TODO(pablo): this is pretty ad-hoc.  Could be unified with MimeType
+// parsing.
 /**
- * Matches strings like '/org/repo/branch/dir1/dir2/file.ifc' with
- * an optional host prefix.
+ * Matches strings like '/org/repo/branch/dir1/dir2/file.(ifc|obj)'
+ * with an optional host prefix.
  */
 const re = new RegExp(`^/${pathParts.join('/')}$`)
 

--- a/src/ShareRoutes.jsx
+++ b/src/ShareRoutes.jsx
@@ -10,7 +10,7 @@ import debug from './utils/debug'
 import {assertDefined} from './utils/assert'
 import {handleBeforeUnload} from './utils/event'
 import Share from './Share'
-import {pathSuffixSupported} from './MimeType'
+import {pathSuffixSupported} from './Filetype'
 
 
 /**

--- a/src/ShareRoutes.test.jsx
+++ b/src/ShareRoutes.test.jsx
@@ -2,7 +2,7 @@ import {
   looksLikeLink,
   trimToPath,
   githubUrlOrPathToSharePath} from './ShareRoutes'
-import {supportedTypes} from './MimeType'
+import {supportedTypes} from './Filetype'
 
 
 jest.mock('three')

--- a/src/ShareRoutes.test.jsx
+++ b/src/ShareRoutes.test.jsx
@@ -2,16 +2,19 @@ import {
   looksLikeLink,
   trimToPath,
   githubUrlOrPathToSharePath} from './ShareRoutes'
+import {supportedTypes} from './MimeType'
 
 
 jest.mock('three')
 
 
+// All paths here are .ifc but tests should use these as a template to
+// replace with all supporte suffixes.
 const path = '/org/repo/branch/file.ifc'
 const pathAbc = '/org/repo/branch/a/b/c/file.ifc'
 const pathBlob = '/org/repo/blob/branch/file.ifc'
 const pathBlobAbc = '/org/repo/blob/branch/a/b/c/file.ifc'
-const tests = [
+const testTemplates = [
   {s: 'http://www.github.com/org/repo/blob/branch/file.ifc', out: pathBlob},
   {s: 'http://github.com/org/repo/blob/branch/file.ifc', out: pathBlob},
   {s: 'http://www.github.com/org/repo/blob/branch/a/b/c/file.ifc', out: pathBlobAbc},
@@ -31,6 +34,29 @@ const tests = [
   {s: '/org/repo/blob/branch/a/b/c/file.ifc', out: pathBlobAbc},
   {s: '/org/repo/branch/a/b/c/file.ifc', out: pathAbc},
 ]
+
+
+/**
+ * Replace the tests above by using them a template for paths with
+ * different filetypes.
+ *
+ * @return {Array.<object>}
+ */
+function expandTestTemplates() {
+  const replaced = []
+  for (const test of testTemplates) {
+    for (const ext of supportedTypes) {
+      const subIn = test.s.replace(/.ifc/, `.${ext}`)
+      const subOut = test.out.replace(/.ifc/, `.${ext}`)
+      replaced.push({s: subIn, out: subOut})
+    }
+  }
+  // .ifc is one of the supported types, so don't need append original array
+  return replaced
+}
+
+// This is the actual array of tests used for the tests below.
+const tests = expandTestTemplates()
 
 
 describe('ShareRoutes', () => {


### PR DESCRIPTION
Plan of attack here is to de-IFC-ize things as much as possible then push down the IfcLoader into either a subclass of CadView, or a hook or something.

I'm leaving "IFC" in comments when there's full path examples and to minimize change, but this could change here too if it's jarring.