### PR TITLE
Graceful handling of note loading failure

### DIFF
--- a/src/Components/ApplicationError.jsx
+++ b/src/Components/ApplicationError.jsx
@@ -20,11 +20,12 @@ const ApplicationError = () => {
         We&apos;re not quite sure what went wrong.
       </Typography>
 
-      <Typography>
-        Not to worry. You can <a href={'/'}>click here to start a new session</a>.
+      <Typography sx={{pb: 2, lineHeight: 1.75}}>
+        Not to worry.<br/>
+        You can <a href="/">click here to start a new session</a>.
       </Typography>
 
-      <Logo/>
+      <a href="/"><Logo/></a>
     </Box>
   )
 }

--- a/src/Components/Notes/Notes.jsx
+++ b/src/Components/Notes/Notes.jsx
@@ -1,6 +1,7 @@
 import React, {useEffect, useState} from 'react'
 import Paper from '@mui/material/Paper'
 import {useAuth0} from '@auth0/auth0-react'
+import * as Sentry from '@sentry/react'
 import debug from '../../utils/debug'
 import useStore from '../../store/useStore'
 import {getIssues, getIssueComments} from '../../utils/GitHub'
@@ -30,6 +31,14 @@ export default function Notes() {
   const drawer = useStore((state) => state.drawer)
   const accessToken = useStore((state) => state.accessToken)
   const [hasError, setHasError] = useState(false)
+  const handleError = (err) => {
+    if (!err) {
+      return
+    }
+
+    Sentry.captureException(err)
+    setHasError(true)
+  }
 
 
   useEffect(() => {
@@ -68,7 +77,7 @@ export default function Notes() {
         setNotes(newNotes)
       } catch (e) {
         debug().warn('failed to fetch notes: ', e)
-        setHasError(true)
+        handleError(e)
       }
     })()
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -105,7 +114,7 @@ export default function Notes() {
         setComments(newComments)
       } catch (e) {
         debug().warn('failed to fetch comments: ', e)
-        setHasError(true)
+        handleError(e)
       }
     })()
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/Components/Notes/Notes.jsx
+++ b/src/Components/Notes/Notes.jsx
@@ -1,4 +1,4 @@
-import React, {useEffect} from 'react'
+import React, {useEffect, useState} from 'react'
 import Paper from '@mui/material/Paper'
 import {useAuth0} from '@auth0/auth0-react'
 import debug from '../../utils/debug'
@@ -8,6 +8,7 @@ import Loader from '../Loader'
 import NoContent from '../NoContent'
 import NoteCard from './NoteCard'
 import NoteCardCreate from './NoteCardCreate'
+import ApplicationError from '../ApplicationError'
 
 
 /** The prefix to use for the note ID within the URL hash. */
@@ -28,6 +29,7 @@ export default function Notes() {
   const repository = useStore((state) => state.repository)
   const drawer = useStore((state) => state.drawer)
   const accessToken = useStore((state) => state.accessToken)
+  const [hasError, setHasError] = useState(false)
 
 
   useEffect(() => {
@@ -66,6 +68,7 @@ export default function Notes() {
         setNotes(newNotes)
       } catch (e) {
         debug().warn('failed to fetch notes: ', e)
+        setHasError(true)
       }
     })()
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -102,6 +105,7 @@ export default function Notes() {
         setComments(newComments)
       } catch (e) {
         debug().warn('failed to fetch comments: ', e)
+        setHasError(true)
       }
     })()
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -115,7 +119,7 @@ export default function Notes() {
   }, [drawer, selectedNoteId])
 
 
-  return (
+  return hasError ? <ApplicationError/> : (
     <Paper
       elevation={0}
       square


### PR DESCRIPTION
If the application fails to load comments or notes, it will display a spinner in the sidebar that never stops.

This PR addresses that scenario by introducing logic to:
* render an application error component that gives the user the option to "restart"
* dispatches the error to the Sentry subsystem (which will forward it along, if it's configured in that given environment).