### PR TITLE
Remove duplicate ESLint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -101,8 +101,7 @@ module.exports = {
     'require-await': 'error',
     'linebreak-style': ['error', 'unix'],
     'no-console': 'error',
-    'no-alert': 'error',
-    'no-debugger': 'error'
+    'no-debugger': 'error',
   },
   settings: {
     react: {


### PR DESCRIPTION
PR to remove a duplicated ESLint rule (`no-alert`) which was already set to the error level.