### PR TITLE
GitHub IFC Download Logic Refactor in UI

### DIFF
--- a/config/common.js
+++ b/config/common.js
@@ -44,6 +44,7 @@ export const build = {
     'process.env.SENTRY_DSN': JSON.stringify(process.env.SENTRY_DSN || null),
     'process.env.SENTRY_ENVIRONMENT': JSON.stringify(process.env.SENTRY_ENVIRONMENT || process.env.NODE_ENV),
     'process.env.DISABLE_MOCK_SERVICE_WORKER': JSON.stringify(process.env.DISABLE_MOCK_SERVICE_WORKER),
+    'process.env.RAW_GIT_PROXY_URL': JSON.stringify(process.env.RAW_GIT_PROXY_URL || 'raw.githubusercontent.com'),
   },
   plugins: [
     progress(),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bldrs",
-  "version": "1.0.0-r670",
+  "version": "1.0.0-r669",
   "main": "src/index.jsx",
   "license": "MIT",
   "homepage": "https://github.com/bldrs-ai/Share",

--- a/src/Containers/CadView.jsx
+++ b/src/Containers/CadView.jsx
@@ -755,16 +755,20 @@ const getGitHubDownloadURL = async (url, accessToken) => {
 }
 
 
-const getFinalURL = async (url, accessToken) => {
+export const getFinalURL = async (url, accessToken) => {
   const u = new URL(url)
+  debug().log('CadView#getFinalURL: url: ', url)
+  debug().log('CadView#getFinalURL: accessToken: ', accessToken)
+  debug().log('CadView#getFinalURL: process.env.RAW_GIT_PROXY_URL: ', process.env.RAW_GIT_PROXY_URL)
 
   switch (u.host.toLowerCase()) {
     case 'github.com':
-      if (accessToken === '') {
-        u.host = 'raw.githubusercontent.com'
+      if (!accessToken) {
+        u.host = process.env.RAW_GIT_PROXY_URL || 'raw.githubusercontent.com'
         return u.toString()
       }
 
+      debug().log('CadView#getFinalURL: calling getGitHubDownloadURL')
       return await getGitHubDownloadURL(url, accessToken)
 
     default:

--- a/src/Containers/CadView.test.jsx
+++ b/src/Containers/CadView.test.jsx
@@ -7,6 +7,7 @@ import useStore from '../store/useStore'
 import {actAsyncFlush} from '../utils/tests'
 import {makeTestTree} from '../utils/TreeUtils.test'
 import CadView, * as AllCadView from './CadView'
+import {getFinalURL} from './CadView'
 
 
 const mockedUseNavigate = jest.fn()
@@ -324,4 +325,27 @@ describe('CadView', () => {
     await actAsyncFlush()
   })
   */
+})
+
+
+describe('With environment variables', () => {
+  const OLD_ENV = process.env
+
+
+  beforeEach(() => {
+    jest.resetModules()
+    process.env = {...OLD_ENV}
+  })
+
+
+  afterAll(() => {
+    process.env = OLD_ENV
+  })
+
+
+  it('getFinalURL', async () => {
+    expect(await getFinalURL('https://github.com/')).toStrictEqual('https://raw.githubusercontent.com/')
+    process.env.RAW_GIT_PROXY_URL = 'rawgit.bldrs.dev'
+    expect(await getFinalURL('https://github.com/')).toStrictEqual('https://rawgit.bldrs.dev/')
+  })
 })


### PR DESCRIPTION
# GitHub IFC Download Logic Refactor in UI

## Background

Currently, a user can paste the URL for a GitHub-hosted IFC file into the search box utilizing either the browser URL (https://github.com/bldrs-ai/Share/blob/main/haus.ifc) or the direct download URL (https://raw.githubusercontent.com/bldrs-ai/Share/main/haus.ifc).

## Problem

If a non-logged in user tries to view a file that is located in a **public** GitHub repository which has large file support enabled (known as Git LFS), GitHub will not serve the file using the generic methods.

The standard, anonymous download logic of Share will attempt to download the file from `raw.githubusercontent.com` and due to LFS, this will fail to load the IFC which results in an error displayed to the user.

(Users who are logged in to the Share application via GitHub are not affected by this issue)

## Proposed Solution

I have developed an application proxy server that will be deployed at `https://rawgit.bldrs.dev`. This application will read the requested URL, perform the necessary interactions with the GitHub Download API and return a HTTP 302 redirect to the correct URL.

The web-ifc module will follow the redirect returned from the proxy to the correct location and allow Share to load and render the IFC.

In order to reach this state, the Share application will need to be modified to request download content from `rawgit.bldrs.dev` _instead_ of `raw.githubusercontent.com`.

## Requirements

* The hostname for the application proxy server will be read from an environment variable named `RAW_GIT_PROXY_URL`. If the environment variable is not present, its value should default to `raw.githubusercontent.com`. For a reference on how to introduce an environment variable to the project, please see `config/common.js`

* The `getFinalURL` function in `src/Containers/CadView.jsx` is modified to replace the hostname of unauthenticated requests with the value of the `RAW_GIT_PROXY_URL` environment variable.

* A new unit test is added for the `getFinalURL` function that exercises both code paths: when an access token is provided and when it is not.

## Acceptance Criteria

1. As a developer running the Share application locally, when I am _not_ logged into the application, I should be able to paste a GitHub browser URL into the search bar and upon submission, see the application make HTTP requests to `raw.githubusercontent.com` via my browser's Web Inspector ("Network" tab).

2. As a developer running the Share application locally, who has set the `RAW_GIT_PROXY_URL` environment variable to contain a value of `rawgit.bldrs.dev`, when I am _not_ logged into the application, I should be able to paste a GitHub browser URL into the search bar and upon submission, see the application make HTTP requests to `rawgit.bldrs.dev` via my browser's Web Inspector ("Network" tab).

3. As a developer running the Share application via a Netlify Deploy Preview link, when I am **successfully** logged into the application, I should be able to paste a GitHub browser URL into the search bar and upon submission, see the application make HTTP requests to `raw.githubusercontent.com` via my browser's Web Inspector ("Network" tab).