### PR TITLE
Perform proper URL rewriting when Git Redirector is in use

### DIFF
--- a/config/common.js
+++ b/config/common.js
@@ -44,7 +44,7 @@ export const build = {
     'process.env.SENTRY_DSN': JSON.stringify(process.env.SENTRY_DSN || null),
     'process.env.SENTRY_ENVIRONMENT': JSON.stringify(process.env.SENTRY_ENVIRONMENT || process.env.NODE_ENV),
     'process.env.DISABLE_MOCK_SERVICE_WORKER': JSON.stringify(process.env.DISABLE_MOCK_SERVICE_WORKER),
-    'process.env.RAW_GIT_PROXY_URL': JSON.stringify(process.env.RAW_GIT_PROXY_URL || 'raw.githubusercontent.com'),
+    'process.env.RAW_GIT_PROXY_URL': JSON.stringify(process.env.RAW_GIT_PROXY_URL || 'https://raw.githubusercontent.com'),
   },
   plugins: [
     progress(),

--- a/src/Containers/CadView.jsx
+++ b/src/Containers/CadView.jsx
@@ -764,7 +764,23 @@ export const getFinalURL = async (url, accessToken) => {
   switch (u.host.toLowerCase()) {
     case 'github.com':
       if (!accessToken) {
-        u.host = process.env.RAW_GIT_PROXY_URL || 'raw.githubusercontent.com'
+        const proxyURL = new URL(process.env.RAW_GIT_PROXY_URL || 'https://raw.githubusercontent.com')
+
+        // Replace the protocol, host, and hostname in the target
+        u.protocol = proxyURL.protocol
+        u.host = proxyURL.host
+        u.hostname = proxyURL.hostname
+
+        // If the port is specified, replace it in the target URL
+        if (proxyURL.port) {
+          u.port = proxyURL.port
+        }
+
+        // If there's a path, *and* it's not just the root, then prepend it to the target URL
+        if (proxyURL.pathname && proxyURL.pathname !== '/') {
+          u.pathname = proxyURL.pathname + u.pathname
+        }
+
         return u.toString()
       }
 

--- a/src/Containers/CadView.test.jsx
+++ b/src/Containers/CadView.test.jsx
@@ -345,7 +345,8 @@ describe('With environment variables', () => {
 
   it('getFinalURL', async () => {
     expect(await getFinalURL('https://github.com/')).toStrictEqual('https://raw.githubusercontent.com/')
-    process.env.RAW_GIT_PROXY_URL = 'rawgit.bldrs.dev'
+
+    process.env.RAW_GIT_PROXY_URL = 'https://rawgit.bldrs.dev'
     expect(await getFinalURL('https://github.com/')).toStrictEqual('https://rawgit.bldrs.dev/')
   })
 })


### PR DESCRIPTION
When an IFC load request is being fulfilled, there's a small piece of logic that will rewrite the URL based on if it's a request to GitHub **and** the Share user is *not* logged in. Previously, the rewrite target was static: `raw.githubusercontent.com` but that logic was changed with #716.

In creating that issue (and the subsequent code review), I neglected to clarify that the entire URL should be modified appropriately as opposed to the bad logic of only replacing the host name of the target URL.

This PR fixes that logic to do the correct URL rewriting. This did not affect any users in production because it was never enabled (via setting the environment variable).