### PR TITLE
FIX: enhancing IFC isolator perf. by  applying BVH trees when creating the hiding/isolation subsets

### DIFF
--- a/src/Infrastructure/IfcIsolator.js
+++ b/src/Infrastructure/IfcIsolator.js
@@ -124,6 +124,7 @@ export default class IfcIsolator {
       modelID: 0,
       scene: this.context.getScene(),
       ids: includedIds,
+      applyBVH: true,
       removePrevious: true,
       customID: this.subsetCustomId,
     })
@@ -142,6 +143,7 @@ export default class IfcIsolator {
       modelID: 0,
       scene: this.context.getScene(),
       ids: includedIds,
+      applyBVH: true,
       removePrevious: true,
       customID: this.subsetCustomId,
     })
@@ -297,6 +299,7 @@ export default class IfcIsolator {
         modelID: 0,
         scene: this.context.getScene(),
         ids: hidden,
+        applyBVH: true,
         removePrevious: true,
         customID: this.revealSubsetCustomId,
         material: this.hiddenMaterial,


### PR DESCRIPTION
This PR is a performance enhancement on the IfcIsolator. Applying BVH trees for the created geometry subsets seems to help with navigating the model (after applying isolation or hiding) seamlessly with the previously encountered lags.