### PR TITLE
Fix JSDoc lint error

### DIFF
--- a/src/FixtureContext.jsx
+++ b/src/FixtureContext.jsx
@@ -8,6 +8,7 @@ import Styles from './Styles'
 
 /**
  * Mirrors the context setup for Share.
+ *
  * @param {object} props
  * @return {React.Component}
  */


### PR DESCRIPTION
PR to address a lint error that was introduced in `ed226ff`.

This fixes the build and unblocks future PRs.