### PR TITLE
Disable Cypress E2E tests on Windows

### DIFF
--- a/.github/workflows/end-to-end-tests.yml
+++ b/.github/workflows/end-to-end-tests.yml
@@ -55,25 +55,3 @@ jobs:
         with:
           browser: chrome
           start: node config/serve.js
-
-  run-cypress-on-windows:
-    runs-on: windows-latest
-    needs: install-cypress
-    steps:
-      - name: Checkout
-        id: checkout
-        uses: actions/checkout@v3
-
-      - name: Restore build artifacts
-        id: restore-artifacts
-        uses: actions/download-artifact@v3
-        with:
-          name: build
-          path: docs/
-
-      - name: E2E Tests on Google Chrome
-        id: e2e-on-google-chrome
-        uses: cypress-io/github-action@v5
-        with:
-          browser: chrome
-          start: node config/serve.js


### PR DESCRIPTION
The GitHub Actions runner on Windows struggles to install large NPM packages, specifically `material-design-icons`. This PR disables E2E tests from running on Windows for now.

For more information, see:
- https://stackoverflow.com/a/64275929
- https://github.com/yarnpkg/yarn/issues/6221
- https://github.com/yarnpkg/yarn/issues/8242
- https://github.com/yarnpkg/yarn/issues/8754
- https://discuss.circleci.com/t/yarn-install-is-failing-with-network-connection-issue-from-today/43196/4
- https://medium.com/@henkjan_47362/just-a-short-notice-for-whomever-is-searching-for-hours-like-i-did-a741d0cd167b