### PR TITLE
Upgrade Conway Dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bldrs",
-  "version": "1.0.0-r749",
+  "version": "1.0.0-r747",
   "main": "src/index.jsx",
   "license": "MIT",
   "homepage": "https://github.com/bldrs-ai/Share",
@@ -13,7 +13,7 @@
     "build-webifc": "yarn clean && yarn build-share-webifc && yarn build-cosmos",
     "build-cosmos": "shx rm -rf docs/cosmos; shx mkdir -p docs ; cosmos-export --config .cosmos.config.json && shx mv cosmos-export docs/cosmos",
     "build-share": "yarn write-new-version && node tools/esbuild/build.js && shx mkdir -p docs/static/js",
-    "build-share-conway": "USE_WEBIFC_SHIM=true yarn build-share && yarn build-share-copy-wasm-conway",
+    "build-share-conway": "USE_WEBIFC_SHIM=true yarn build-share",
     "build-share-webifc": "USE_WEBIFC_SHIM=false yarn build-share && yarn build-share-copy-wasm-webifc",
     "build-share-copy-wasm-webifc": "shx cp node_modules/web-ifc/*.wasm docs/static/js",
     "build-share-copy-wasm-conway": "shx cp node_modules/bldrs-conway/compiled/dependencies/conway-geom/Dist/*.wasm docs/static/js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4543,7 +4543,7 @@ bl@^4.1.0:
 
 bldrs-conway@./bldrs-conway-v0.0.1.tgz:
   version "0.0.1"
-  resolved "./bldrs-conway-v0.0.1.tgz#e2ca4d12524b0130bdc6ab2c4af65a838b693e37"
+  resolved "./bldrs-conway-v0.0.1.tgz#fb515339a20d717d414936f39d629bd64f06cda9"
   dependencies:
     buffer "^6.0.3"
     gl-matrix "^3.4.3"


### PR DESCRIPTION
This PR upgrades the Conway Dependency to latest main. It addresses permissive parsing for nullable references. 

It also removes the copying of wasm modules for the Conway shim since that is no longer needed.