### PR TITLE
Remove network fonts.

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3,20 +3,13 @@
 
 <head>
   <meta charset="utf-8" />
-  <meta name="description" content="Build every thing together: Collab and Share 3d models online" />
-  <meta name="keywords" content="ifc, ifc viewer, cad viewer, share ifc, share model, open source" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <meta name="theme-color" content="#000000" />
+  <meta name="description" content="Build every thing together: Collab and Share 3d models online"/>
+  <meta name="keywords" content="ifc, ifc viewer, cad viewer, share ifc, share model, open source"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1"/>
+  <meta name="theme-color" content="#000000"/>
   <meta name="viewport"
     content="width=device-width, user-scalable=no, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0">
-  <link rel="icon" href="/favicon.ico" />
-  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&amp;display=swap" />
-  <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons" />
-  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@100;300;400&amp;display=swap" />
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@100;200;300;400;500;600&amp;display=swap"
-    rel="stylesheet">
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link rel="icon" href="/favicon.ico"/>
   <title>bldrs.ai</title>
   <!-- Start Single Page Apps for GitHub Pages -->
   <script type="text/javascript">
@@ -39,7 +32,7 @@
 <body>
   <noscript>You need to enable JavaScript to run this app.</noscript>
   <div id="root"></div>
-  <script>
+  <script type="application/javascript">
     const loader = document.createElement('script')
     const pathPrefix = window.location.pathname.startsWith('/Share') ? '/Share' : ''
     loader.setAttribute('src', pathPrefix + '/index.js')


### PR DESCRIPTION
I had a draft (https://github.com/bldrs-ai/Share/pull/825) setup for this change, but it got out of sync.

I don't see any significant diffs in fonts and the network load for them makes me sad.  We can revisit later if we want to use something visually distinct.

Using screens from Nick and I just testing on it.  

Draft PR on Mac:
![image](https://github.com/bldrs-ai/Share/assets/2480879/2c11b807-8488-4d70-83fc-249ecf39d2f1)

Draft PR on Windows:
![image](https://github.com/bldrs-ai/Share/assets/2480879/529b7965-1460-4bb2-a843-cc6fbffdeb45)

Prod win:
![image](https://github.com/bldrs-ai/Share/assets/2480879/d35a2f2c-91c3-4c0b-96cb-827f7e8e1c79)

Prod Mac:
![image](https://github.com/bldrs-ai/Share/assets/2480879/93953626-cdbd-4c8d-b0a8-3b5436a8a2de)
