### PR TITLE
Rollback camera-controls 1.38.2 -> 1.36.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bldrs",
-  "version": "1.0.911",
+  "version": "1.0.914",
   "main": "src/index.jsx",
   "license": "MIT",
   "homepage": "https://github.com/bldrs-ai/Share",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4692,9 +4692,9 @@ camelcase@^6.2.0:
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
 camera-controls@^1.33.1:
-  version "1.38.2"
-  resolved "https://registry.yarnpkg.com/camera-controls/-/camera-controls-1.38.2.tgz#3289013e6de05cee51dc98af87d3fc7c1a7df585"
-  integrity sha512-EfzbovxLssyWpJVG9uKcazSDDIEcd1hUsPhPF/OWWnICsKY9WbLY/2S4UPW73HHbvnVeR/Z9wsWaQKtANy/2Yg==
+  version "1.36.1"
+  resolved "https://registry.npmjs.org/camera-controls/-/camera-controls-1.36.1.tgz"
+  integrity sha512-muYZT4bgA9iR/lfZwM1TLM/GPttAlRM+fDCjg9qsmH4omDMefGF8/Q5QFkadRGCeCOTFESGYXcOhqV/tt4z6fQ==
 
 caniuse-lite@^1.0.30001400:
   version "1.0.30001441"


### PR DESCRIPTION
Oleg reported a problem from the hackathon with camera:

"Also camera is buggy - so when I show the sharing functionality sometimes the camera views are not going through from session to session"

Ironically, looks like it was the camera-controls update in https://github.com/bldrs-ai/Share/pull/993, which was to freeze our npms.  Lesson learned: don't change the yarn.lock file without lots of testing.