### PR TITLE
Remove confusing testId property

### DIFF
--- a/src/Components/Buttons.jsx
+++ b/src/Components/Buttons.jsx
@@ -14,7 +14,8 @@ import BackIcon from '../assets/icons/Back.svg'
 
 
 /**
- * An icon button with a tooltip.
+ * An icon button with a tooltip.  THe button will use a given buttonTestId or
+ * the tip title as the data-testid on the button.
  *
  * @property {string} title Tooltip text
  * @property {Function} onClick Callback
@@ -23,7 +24,7 @@ import BackIcon from '../assets/icons/Back.svg'
  * @property {boolean} [enabled] Whether the button can be clicked.  Default: true
  * @property {boolean} [selected] Selected state.  Default: false
  * @property {string} [size] Size enum: 'small', 'medium' or 'large'.  Default: 'medium'
- * @property {string} dataTestId Internal attribute for component testing.  Default: ''
+ * @property {string} [buttonTestId] Internal attribute for component testing.
  * @return {ReactElement}
  */
 export function TooltipIconButton({
@@ -37,7 +38,7 @@ export function TooltipIconButton({
   color,
   size,
   variant,
-  dataTestId,
+  buttonTestId,
 }) {
   assertDefined(title, onClick, icon, placement)
   const isMobile = useIsMobile()
@@ -63,7 +64,7 @@ export function TooltipIconButton({
         color={color}
         variant={variant}
         disabled={!enabled}
-        data-testid={dataTestId || title}
+        data-testid={buttonTestId || title}
         sx={{
           // TODO(pablo): couldn't figure how to set this in theme
           opacity: enabled ? '1.0' : '0.35',

--- a/src/Components/Buttons.test.jsx
+++ b/src/Components/Buttons.test.jsx
@@ -8,7 +8,7 @@ import QuestionIcon from '../assets/icons/Question.svg'
 
 describe('<TooltipIconButton />', () => {
   it('should render successfully', async () => {
-    const testId = 'test-button'
+    const buttonTestId = 'test-button'
     const rendered = render(
         <ThemeCtx>
           <TooltipIconButton
@@ -17,11 +17,11 @@ describe('<TooltipIconButton />', () => {
             onClick={() => {}}
             icon={<QuestionIcon/>}
             placement='top'
-            dataTestId={testId}
+            buttonTestId={buttonTestId}
           />
         </ThemeCtx>)
 
-    const button = rendered.getByTestId(testId)
+    const button = rendered.getByTestId(buttonTestId)
     fireEvent.mouseOver(button)
 
     const tooltip = await rendered.findByRole('tooltip')

--- a/src/Components/Open/.#OpenModelControl.test.jsx
+++ b/src/Components/Open/.#OpenModelControl.test.jsx
@@ -1,0 +1,1 @@
+pablo@air.local.27349

--- a/src/Components/Open/OpenModelControl.jsx
+++ b/src/Components/Open/OpenModelControl.jsx
@@ -183,7 +183,6 @@ function OpenModelDialog({
              selected={selectedOrgName}
              setSelected={selectOrg}
              data-testid='openOrganization'
-             testId='openOrganization'
            />
            <Selector
              label='Repository'
@@ -191,7 +190,6 @@ function OpenModelDialog({
              selected={selectedRepoName}
              setSelected={selectRepo}
              data-testid='openRepository'
-             testId='openRepository'
            />
            <Selector
              label='File'
@@ -199,7 +197,6 @@ function OpenModelDialog({
              selected={selectedFileName}
              setSelected={setSelectedFileName}
              data-testid='openFile'
-             testId='openFile'
            />
            {selectedFileName !== '' &&
             <Box sx={{textAlign: 'center', marginTop: '4px'}}>

--- a/src/Components/Open/SaveModelControl.jsx
+++ b/src/Components/Open/SaveModelControl.jsx
@@ -243,7 +243,6 @@ function SaveModelDialog({isDialogDisplayed, setIsDialogDisplayed, navigate, org
              selected={selectedRepoName}
              setSelected={selectRepo}
              data-testid='saveRepository'
-             testId='saveRepository'
            />
            <SelectorSeparator
              label={(currentPath === '') ? 'Folder' :
@@ -252,7 +251,6 @@ function SaveModelDialog({isDialogDisplayed, setIsDialogDisplayed, navigate, org
              selected={selectedFolderName}
              setSelected={selectFolder}
              data-testid='saveFolder'
-             testId='saveFolder'
            />
            {requestCreateFolder && (
              <div style={{display: 'flex', alignItems: 'center', marginBottom: '.5em'}}>
@@ -284,7 +282,6 @@ function SaveModelDialog({isDialogDisplayed, setIsDialogDisplayed, navigate, org
              onKeyDown={(e) => e.stopPropagation()}
              sx={{marginBottom: '.5em'}}
              data-testid='CreateFileId'
-             testId='CreateFileId'
            />
          </Stack>
         }

--- a/src/Components/Open/Selector.jsx
+++ b/src/Components/Open/Selector.jsx
@@ -11,7 +11,7 @@ import {handleBeforeUnload} from '../../utils/event'
  * @property {boolean} selected selected componet control the selected value of the component
  * @property {Function} setSelected callback to select the element
  * @property {Array} list list of element to populate select options
- * @property {string} [testId] id for testing
+ * @property {string} [data-testid] id for testing
  * @return {ReactElement}
  */
 export default function Selector({
@@ -20,7 +20,7 @@ export default function Selector({
   selected,
   setSelected,
   list,
-  testId = 'Selector',
+  ...props
 }) {
   const handleSelect = (e) => {
     window.removeEventListener('beforeunload', handleBeforeUnload)
@@ -37,7 +37,7 @@ export default function Selector({
       select
       size='small'
       sx={{width: '260px', marginBottom: '.5em'}}
-      data-testid={testId}
+      {...props}
     >
       {list.map((listMember, i) => {
         return (

--- a/src/Components/Open/SelectorSeparator.jsx
+++ b/src/Components/Open/SelectorSeparator.jsx
@@ -11,7 +11,7 @@ import {handleBeforeUnload} from '../../utils/event'
  * @property {boolean} selected selected componet control the selected value of the component
  * @property {Function} setSelected callback to select the element
  * @property {Array} list list of eleemnt to populate select options
- * @property {any} props
+ * @property {any} props For prop drilling to the TextField
  * @return {ReactElement}
  */
 export default function SelectorSeparator({

--- a/src/Components/Open/SelectorSeparator.jsx
+++ b/src/Components/Open/SelectorSeparator.jsx
@@ -11,7 +11,7 @@ import {handleBeforeUnload} from '../../utils/event'
  * @property {boolean} selected selected componet control the selected value of the component
  * @property {Function} setSelected callback to select the element
  * @property {Array} list list of eleemnt to populate select options
- * @property {string} testId id for testing
+ * @property {any} props
  * @return {ReactElement}
  */
 export default function SelectorSeparator({
@@ -20,7 +20,7 @@ export default function SelectorSeparator({
   selected,
   setSelected,
   list,
-  testId = 'SelectorSeparator',
+  ...props
 }) {
   const handleSelect = (e) => {
     window.removeEventListener('beforeunload', handleBeforeUnload)
@@ -35,7 +35,7 @@ export default function SelectorSeparator({
       label={label}
       select
       size='small'
-      data-testid={testId}
+      {...props}
     >
       {list.map((listMember, i) => {
         if (listMember.isSeparator) {

--- a/src/Components/SideDrawer/Panel.jsx
+++ b/src/Components/SideDrawer/Panel.jsx
@@ -17,11 +17,11 @@ import {useIsMobile} from '../Hooks'
  * @property {ReactElement} children Enclosed elements
  * @property {ReactElement} [action] Action component, for the top bar
  * @property {object} [sx] Passed to root Paper elt
- * @property {string} [testId] Set on the root Paper element
+ * @property {string} [paperTestId] Set on the root Paper element
  * @return {ReactElement}
  */
-export default function Panel({title, onCloseClick, children, action = null, sx = {}, testId = ''}) {
-  assertDefined(title, onCloseClick, children, testId)
+export default function Panel({title, onCloseClick, children, action = null, sx = {}, paperTestId = ''}) {
+  assertDefined(title, onCloseClick, children, paperTestId)
   const theme = useTheme()
   const isMobile = useIsMobile()
   return (
@@ -39,7 +39,7 @@ export default function Panel({title, onCloseClick, children, action = null, sx 
         },
         ...sx,
       }}
-      data-testid={testId}
+      data-testid={paperTestId}
     >
       <Stack
         direction='row'


### PR DESCRIPTION
We are using testing-library's special `data-testid` prop for finding elements in unit tests, as in https://testing-library.com/docs/queries/bytestid/

Over time a non-standard `testId` has crept into mixed usage.  Sometimes we were using it to pass the value for the data-testid in our new components, but then this was being confused with being a valid prop on a react component.

Testing-library seems to know about this as it emits the warning below if you do this.

This PR replaces this usage with the following cases.  testId for passing a props is now replaced by:
  - prop drilling of data-testid if value is just passed to a sole subcomponent
  - namedTestId if the id is targeted to one subcomponent in a complex case (e.g. as buttonTestId the Button in TooltipIconButton)

![image](https://github.com/bldrs-ai/Share/assets/2480879/366ceb65-75ce-4d92-a75e-201988e334d2)
