### PR TITLE
gha: remove percy from cypress run

### DIFF
--- a/.github/workflows/end-to-end-tests.yml
+++ b/.github/workflows/end-to-end-tests.yml
@@ -34,13 +34,8 @@ jobs:
           NODE_ENV: production
           SHARE_CONFIG: cypress
 
-      - name: Verify Percy CLI installation
-        run: yarn percy --version
-
       - name: Cypress run
         uses: cypress-io/github-action@v5
         with:
           browser: chrome
-          command: yarn percy exec -- cypress run
-        env:
-          PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
+          command: yarn cy


### PR DESCRIPTION
I was testing this setup and inadvertently checked it in.

Percy should be run locally only for now