### PR TITLE
view-100: clear camera on mouse wheel and touchmove

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bldrs",
-  "version": "1.0.972",
+  "version": "1.0.971",
   "main": "src/index.jsx",
   "license": "MIT",
   "homepage": "https://github.com/bldrs-ai/Share",

--- a/src/Components/CameraControl.jsx
+++ b/src/Components/CameraControl.jsx
@@ -69,8 +69,11 @@ function onLoad(location, cameraControls, viewer) {
 
     canvas.removeEventListener('mousemove', onMouseMove)
     canvas.addEventListener('mousemove', onMouseMove)
+    canvas.addEventListener('touchmove', removeCameraUrlParams)
+    canvas.addEventListener('wheel', removeCameraUrlParams)
 
     canvas.removeEventListener('mouseup', onMouseUp)
+    canvas.removeEventListener('touchend', onMouseUp)
     canvas.addEventListener('mouseup', onMouseUp)
   }
 }


### PR DESCRIPTION
If model is zoomed or touchmove'd (phone), then without a clear of camera, adding a cutplane, or actually any hash state, will reset model position to camera hash state.

So add clear callbacks for those events.

Can't test these in cypress (same issue as rotation).  Testing locally and on deploy.