### PR TITLE
Fix #1101

### DIFF
--- a/cypress/e2e/notes-100/share-a-note.cy.js
+++ b/cypress/e2e/notes-100/share-a-note.cy.js
@@ -1,31 +1,55 @@
-import {waitForModel, homepageSetup, setCookieAndVisitHome} from '../../support/utils'
+import '@percy/cypress'
+import {
+  homepageSetup,
+  setIsReturningUser,
+  visitHomepageWaitForModel,
+} from '../../support/utils'
 
 
-describe('share-a-note', () => {
-  context('Open the model and access the list of notes', () => {
+/** @see https://github.com/bldrs-ai/Share/issues/1071 */
+describe('notes-100: Share a note', () => {
+  beforeEach(homepageSetup)
+
+  context('Visit model', () => {
     beforeEach(() => {
-      homepageSetup()
+      setIsReturningUser()
+      visitHomepageWaitForModel()
     })
 
-    it('check that clipboard is activated when a note is shared', () => {
-      setCookieAndVisitHome()
-      waitForModel()
-
-      cy.get('[data-testid="control-button-notes"]').click()
-      cy.get('[data-testid="panelTitle"]').contains('NOTES')
-      cy.get(':nth-child(1) > .MuiPaper-root > [data-testid="card-body"] > .MuiCardContent-root').contains('Test Issue body').click()
-      cy.get('.MuiCardHeader-title').contains('Local issue 2')
-
-      cy.window().then((win) => {
-        cy.spy(win.navigator.clipboard, 'writeText').as('clipboardSpy')
+    context('Open notes, select first', () => {
+      beforeEach(() => {
+        cy.get('[data-testid="control-button-notes"]').click()
+        cy.get('[data-testid="panelTitle"]').contains('NOTES')
+        cy.get(':nth-child(1) > .MuiPaper-root > [data-testid="card-body"] > .MuiCardContent-root')
+          .contains('Test Issue body')
+          .click()
+        cy.get('.MuiCardHeader-title').contains('Local issue 2')
       })
 
-      cy.get('.MuiCardActions-root > [data-testid="Share"] > .icon-share').click()
+      context('Click share in note footer', () => {
+        beforeEach(() => {
+          cy.window().then((win) => {
+            cy.stub(win.navigator.clipboard, 'writeText').as('clipboardSpy')
+              .resolves()
+          })
+          cy.get('.MuiCardActions-root > [data-testid="Share"] > .icon-share').click()
+          cy.get('@clipboardSpy').should('have.been.calledOnce')
+        })
 
-      // Now, verify that the clipboardSpy was called
-      cy.get('@clipboardSpy').should('have.been.calledOnce')
+        it('SnackBar informs link copied - Screen', () => {
+          cy.get('.MuiSnackbarContent-message > .css-1xhj18k').contains('The url path is copied to the clipboard')
+          cy.percySnapshot()
+        })
 
-      cy.get('.MuiSnackbarContent-message > .css-1xhj18k').contains('The url path is copied to the clipboard')
+        it('Link has model path, issue id, current camera', () => {
+          cy.get('@clipboardSpy').then((stub) => {
+            const clipboardText = stub.getCall(0).args[0] // Retrieve the first argument of the first call
+            const url = new URL(clipboardText)
+            expect(url.pathname).to.eq('/share/v/p/index.ifc')
+            expect(url.hash).to.eq('#c:-26.91,28.84,112.47,-22,16.21,-3.48;i:2')
+          })
+        })
+      })
     })
   })
 })

--- a/src/Components/Notes/NoteCard.jsx
+++ b/src/Components/Notes/NoteCard.jsx
@@ -1,5 +1,4 @@
 import React, {ReactElement, useState, useEffect} from 'react'
-import {useLocation} from 'react-router'
 import ReactMarkdown from 'react-markdown'
 import {useAuth0} from '@auth0/auth0-react'
 import Avatar from '@mui/material/Avatar'
@@ -74,7 +73,6 @@ export default function NoteCard({
   const [editBody, setEditBody] = useState(body)
 
   const {user} = useAuth0()
-  const location = useLocation()
 
   const embeddedCameraParams = findUrls(body)
       .filter((url) => {
@@ -125,10 +123,8 @@ export default function NoteCard({
 
   /** Copies location which contains the issue id, camera position and selected element path */
   function shareIssue() {
-    navigator.clipboard.writeText(location)
-    setSnackMessage('The url path is copied to the clipboard')
-    const pauseTimeMs = 5000
-    setTimeout(() => setSnackMessage(null), pauseTimeMs)
+    navigator.clipboard.writeText(window.location.href)
+    setSnackMessage({text: 'The url path is copied to the clipboard', autoDismiss: true})
   }
 
 

--- a/src/Components/Notes/NotesControl.jsx
+++ b/src/Components/Notes/NotesControl.jsx
@@ -66,7 +66,7 @@ export default function NotesControl() {
         setNotes(newNotes)
         toggleIsLoadingNotes()
       } catch (e) {
-        setSnackMessage('Notes: Cannot fetch from GitHub')
+        setSnackMessage({text: 'Notes: Cannot fetch from GitHub', autoDismiss: true})
       }
     })()
     // TODO(pablo):

--- a/src/Containers/AlertDialogAndSnackbar.jsx
+++ b/src/Containers/AlertDialogAndSnackbar.jsx
@@ -6,6 +6,7 @@ import Stack from '@mui/material/Stack'
 import AlertDialog from '../Components/AlertDialog'
 import {navToDefault} from '../Share'
 import useStore from '../store/useStore'
+import {assert} from '../utils/assert'
 import CloseIcon from '@mui/icons-material/Close'
 
 
@@ -17,12 +18,30 @@ export default function AlertAndSnackbar() {
   const setSnackMessage = useStore((state) => state.setSnackMessage)
 
   const [isSnackOpen, setIsSnackOpen] = useState(false)
+  const [text, setText] = useState(null)
+  const [duration, setDuration] = useState(null)
 
   const navigate = useNavigate()
 
 
   useEffect(() => {
-    setIsSnackOpen(snackMessage !== null)
+    if (snackMessage === null) {
+      setIsSnackOpen(false)
+      return
+    }
+    if (typeof snackMessage === 'string') {
+      setText(snackMessage)
+      setDuration(null)
+    } else {
+      assert(typeof snackMessage.text === 'string' && snackMessage.text.length > 0,
+             'snackMessage.text must be valid string')
+      assert(typeof snackMessage.autoDismiss === 'boolean' && snackMessage.autoDismiss,
+             'snackMessage.autoDismiss must be true')
+      setText(snackMessage.text)
+      const dismissTimeMs = 5000
+      setDuration(dismissTimeMs)
+    }
+    setIsSnackOpen(true)
   }, [snackMessage, setIsSnackOpen])
 
 
@@ -36,11 +55,12 @@ export default function AlertAndSnackbar() {
       />
       <Snackbar
         anchorOrigin={{vertical: 'bottom', horizontal: 'center'}}
+        autoHideDuration={duration}
         open={isSnackOpen}
         onClose={(event, reason) => setIsSnackOpen(false)}
         message={
           <Stack direction='row'>
-            {snackMessage}
+            {text}
             <IconButton onClick={() => setIsSnackOpen(false)}><CloseIcon className='icon-share'/></IconButton>
           </Stack>
         }


### PR DESCRIPTION
- @OlegMoshkovich it was as you said, link text needed to be passed instead of Location object
- Use MUI's autodismiss instead of handling it ourselves (see https://mui.com/material-ui/react-snackbar/#automatic-dismiss)
- Reworked the UX https://github.com/bldrs-ai/Share/issues/1071 and e2e test to match.
  - Punted on Screenshot for disappearing snack.. probably want to make that a configurable value to speedup our tests in general
- share-a-note.cy.js: Use a stub instead of spy: I was getting a permissions check on cypress locally, asking for permission to copy to clipboard.  Not granting caused a fail and so also concerned we'd maybe see that in GHA.  Stub lets us do same checks, but replaces the actual call to system clipboard and avoids the permission issue.

https://percy.io/8fe2b2f1/share/builds/33669933