### PR TITLE
Fix 1130-select-element-doesnt-open-nav

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bldrs",
-  "version": "1.0.984",
+  "version": "1.0.985",
   "main": "src/index.jsx",
   "license": "MIT",
   "homepage": "https://github.com/bldrs-ai/Share",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bldrs",
-  "version": "1.0.983",
+  "version": "1.0.984",
   "main": "src/index.jsx",
   "license": "MIT",
   "homepage": "https://github.com/bldrs-ai/Share",

--- a/src/Components/NavTree/NavTreeControl.jsx
+++ b/src/Components/NavTree/NavTreeControl.jsx
@@ -1,4 +1,4 @@
-import React, {ReactElement} from 'react'
+import React, {ReactElement, useEffect, useState} from 'react'
 import useStore from '../../store/useStore'
 import {ControlButtonWithHashState} from '../Buttons'
 import TreeIcon from '../../assets/icons/Tree.svg'
@@ -12,6 +12,18 @@ import TreeIcon from '../../assets/icons/Tree.svg'
 export default function NavTreeControl() {
   const isNavTreeVisible = useStore((state) => state.isNavTreeVisible)
   const setIsNavTreeVisible = useStore((state) => state.setIsNavTreeVisible)
+  const selectedElements = useStore((state) => state.selectedElements)
+
+  const [lastNumSelected, setLastNumSelected] = useState(0)
+
+  // Open NavTree on selection
+  useEffect(() => {
+    if (lastNumSelected === 0 && selectedElements.length > 0) {
+      setIsNavTreeVisible(true)
+    }
+    setLastNumSelected(selectedElements.length)
+  }, [lastNumSelected, setLastNumSelected, selectedElements, setIsNavTreeVisible])
+
   return (
     <ControlButtonWithHashState
       title='Navigation'

--- a/src/Containers/CadView.jsx
+++ b/src/Containers/CadView.jsx
@@ -20,7 +20,7 @@ import {getLatestCommitHash} from '../net/github/Commits'
 // TODO(pablo): use ^^ instead of this
 import {parseGitHubPath} from '../utils/location'
 import {computeElementPathIds, setupLookupAndParentLinks} from '../utils/TreeUtils'
-import {assertDefined} from '../utils/assert'
+import {assertDefined, assertNumber} from '../utils/assert'
 import debug from '../utils/debug'
 import {handleBeforeUnload} from '../utils/event'
 import {groupElementsByTypes} from '../utils/ifc'
@@ -64,6 +64,7 @@ export default function CadView({
   const setIsSearchBarVisible = useStore((state) => state.setIsSearchBarVisible)
   const setLevelInstance = useStore((state) => state.setLevelInstance)
   const setLoadedFileInfo = useStore((state) => state.setLoadedFileInfo)
+  const rootElement = useStore((state) => state.rootElement)
   const setRootElement = useStore((state) => state.setRootElement)
   const setSelectedElement = useStore((state) => state.setSelectedElement)
   const setSelectedElements = useStore((state) => state.setSelectedElements)
@@ -521,7 +522,7 @@ export default function CadView({
       // Sets the url to the last selected element path.
       if (resultIDs.length > 0 && updateNavigation) {
         const lastId = resultIDs.slice(-1)
-        const pathIds = getPathIdsForElements(lastId)
+        const pathIds = getParentPathIdsForElement(parseInt(lastId))
         const repoFilePath = modelPath.gitpath ? modelPath.getRepoPath() : modelPath.filepath
         const path = pathIds.join('/')
         navWith(
@@ -550,10 +551,11 @@ export default function CadView({
    * @param {number} expressId
    * @return {Array} pathIds
    */
-  function getPathIdsForElements(expressId) {
-    const lookupElt = elementsById[parseInt(expressId)]
+  function getParentPathIdsForElement(expressId) {
+    assertNumber(expressId)
+    const lookupElt = elementsById[expressId]
     if (!lookupElt) {
-      debug().error(`CadView#getPathIdsForElements(${expressId}) missing in table:`, elementsById)
+      debug().error(`CadView#getParentPathIdsForElement(${expressId}) missing in table:`, elementsById)
       return undefined
     }
     const pathIds = computeElementPathIds(lookupElt, (elt) => elt.expressID)
@@ -700,6 +702,28 @@ export default function CadView({
 
   useEffect(() => {
     (async () => {
+      if (Array.isArray(preselectedElementIds) && preselectedElementIds.length && viewer) {
+        await viewer.preselectElementsByIds(0, preselectedElementIds)
+      }
+    })()
+  }, [preselectedElementIds])
+
+
+  // Watch for path changes within the model.
+  // TODO(pablo): would be nice to have more consistent handling of path parsing.
+  useEffect(() => {
+    if (rootElement) {
+      const parts = location.pathname.split(/\.ifc/i)
+      const expectedPartCount = 2
+      if (parts.length === expectedPartCount) {
+        selectElementBasedOnFilepath(parts[1])
+      }
+    }
+  }, [location, model, rootElement])
+
+
+  useEffect(() => {
+    (async () => {
       if (!Array.isArray(selectedElements) || !viewer) {
         return
       }
@@ -709,11 +733,11 @@ export default function CadView({
       // If current selection is not empty
       if (selectedElements.length > 0) {
         // Display the properties of the last one,
-        const lastId = selectedElements.slice(-1)
+        const lastId = selectedElements.slice(-1)[0]
         const props = await viewer.getProperties(0, Number(lastId))
         setSelectedElement(props)
         // Update the expanded elements in NavTreePanel
-        const pathIds = getPathIdsForElements(lastId)
+        const pathIds = getParentPathIdsForElement(parseInt(lastId))
         if (pathIds) {
           setExpandedElements(pathIds.map((n) => `${n}`))
         }
@@ -726,30 +750,6 @@ export default function CadView({
       }
     })()
   }, [selectedElements])
-
-
-  useEffect(() => {
-    (async () => {
-      if (Array.isArray(preselectedElementIds) && preselectedElementIds.length && viewer) {
-        await viewer.preselectElementsByIds(0, preselectedElementIds)
-      }
-    })()
-  }, [preselectedElementIds])
-
-
-  // Watch for path changes within the model.
-  // TODO(pablo): would be nice to have more consistent handling of path parsing.
-  useEffect(() => {
-    if (model) {
-      (() => {
-        const parts = location.pathname.split(/\.ifc/i)
-        const expectedPartCount = 2
-        if (parts.length === expectedPartCount) {
-          selectElementBasedOnFilepath(parts[1])
-        }
-      })()
-    }
-  }, [location, model])
   /* eslint-enable */
 
 

--- a/src/Containers/CadView.jsx
+++ b/src/Containers/CadView.jsx
@@ -517,8 +517,8 @@ export default function CadView({
     }
     try {
       // Update The Component state
-      setSelectedElements(resultIDs.map((id) => `${id}`))
-
+      const resIds = resultIDs.map((id) => `${id}`)
+      setSelectedElements(resIds)
       // Sets the url to the last selected element path.
       if (resultIDs.length > 0 && updateNavigation) {
         const lastId = resultIDs.slice(-1)
@@ -611,6 +611,7 @@ export default function CadView({
     if (!viewer.isolator.canBePickedInScene(expressId)) {
       return
     }
+    let updateNav = false
     if (shiftKey) {
       const selectedInViewer = viewer.getSelectedIds()
       const indexOfItem = selectedInViewer.indexOf(expressId)
@@ -626,8 +627,9 @@ export default function CadView({
       // camera
       removeCameraUrlParams()
       newSelection = [expressId]
+      updateNav = true
     }
-    selectItemsInScene(newSelection)
+    selectItemsInScene(newSelection, updateNav)
   }
 
 

--- a/src/theme/Components.js
+++ b/src/theme/Components.js
@@ -222,12 +222,11 @@ export function getComponentOverrides(palette, typography) {
       styleOverrides: {
         root: {
           '& > div.Mui-selected, & > div.Mui-selected:hover': {
-            // color: palette.primary.contrastText,
-            // backgroundColor: palette.primary.main,
-            borderRadius: '5px',
+            color: palette.secondary.contrastText,
+            backgroundColor: palette.secondary.light,
           },
           '& > div.MuiTreeItem-content': {
-            borderRadius: '5px',
+            borderRadius: '0px',
           },
         },
       },

--- a/src/utils/assert.js
+++ b/src/utils/assert.js
@@ -72,6 +72,18 @@ export function assertArraysEqualLength(...arrays) {
 
 
 /**
+ * Argument must have typeof(n) === 'number' && isFinite(n)
+ *
+ * @param {number} n
+ */
+export function assertNumber(n) {
+  if (!(typeof(n) === 'number' && isFinite(n))) {
+    throw new Error(`Argument must be a number and finite (for ${n})`)
+  }
+}
+
+
+/**
  * Argument must have typeof(o) === 'object'
  *
  * @param {object} o

--- a/src/utils/assert.test.js
+++ b/src/utils/assert.test.js
@@ -1,7 +1,8 @@
 import {
   assert,
-  assertDefined,
   assertArraysEqualLength,
+  assertDefined,
+  assertNumber,
 } from './assert'
 
 
@@ -71,6 +72,23 @@ test('assertArraysEqualLength', () => {
 
   assertArraysEqualLength([1, 1, 1], [2, 2, 2])
   assertArraysEqualLength([1, 1, 1], [2, 2, 2], [3, 3, 3])
+})
+
+
+test('assertNumber', () => {
+  assertNumber(-1)
+  assertNumber(0)
+  assertNumber(1)
+  assertNumber(2 * Math.PI) // Tau >> Pi
+  // @ts-ignore
+  expectFailure(() => assertNumber('-1'))
+  // @ts-ignore
+  expectFailure(() => assertNumber('0'))
+  // @ts-ignore
+  expectFailure(() => assertNumber('1'))
+  // @ts-ignore
+  expectFailure(() => assertNumber('PI'))
+  expectFailure(() => assertNumber(Number.NaN))
 })
 
 


### PR DESCRIPTION
e2e test coming in next pr

# NavTreeControl
- Add useEffect[selectedElements]
# CadView
- Move useEffect[selectedElements] later in initialization (and down file).  This is necessary to have elementsById setup correctly.
- Trigger selectElementBasedOnFilePath on rootElement instead of model to avoid race
# Theme
- re-enable Mui-Selected coloring for NavTreeItem
# Util
- Add assertNumber and test