### PR TITLE
Auth0 Proxy + Save e2e tests

### DIFF
--- a/cypress/e2e/versions-100/save-imported-model.cy.js
+++ b/cypress/e2e/versions-100/save-imported-model.cy.js
@@ -1,62 +1,49 @@
 
-import {setupAuthenticationIntercepts, waitForModel, homepageSetup} from '../../support/utils'
+import '@percy/cypress'
+import {waitForModel, homepageSetup, auth0Login} from '../../support/utils'
 
 
 describe('save model', () => {
   context('when no model is loaded', () => {
     beforeEach(() => {
       homepageSetup()
-
       cy.setCookie('isFirstTime', '1')
-
-      setupAuthenticationIntercepts()
     })
 
     it('should not find Save IFC button before login', () => {
       cy.visit('/')
       waitForModel()
       cy.findByTestId('Save', {timeout: 10000}).should('not.exist')
-      // cy.screenshot()
+      cy.percySnapshot()
     })
 
-    /* it('should only find Save IFC button after login', () => {
+     it('should only find Save IFC button after login', () => {
       cy.visit('/')
-      // Now trigger the login process, which will use the mocked loginWithPopup
-      cy.url().then((currentUrl) => {
-        const url = new URL(currentUrl)
-        setPort(url.port)
-        waitForModel()
-        cy.findByTitle('Save', {timeout: 5000}).should('not.exist')
-        auth0Login()
-        cy.findByTitle('Save', {timeout: 5000}).should('exist')
+      waitForModel()
+      cy.findByTitle('Save', {timeout: 5000}).should('not.exist')
+      auth0Login()
+      cy.findByTitle('Save', {timeout: 5000}).should('exist')
 
-        //  cy.screenshot()
-      })
-    })*/
+      cy.percySnapshot()
+    })
 
-    /* it.only('should log in and save a model', () => {
+     it.only('should log in and save a model', () => {
       cy.visit('/')
-      // Now trigger the login process, which will use the mocked loginWithPopup
-      cy.url().then((currentUrl) => {
-        const url = new URL(currentUrl)
-        setPort(url.port)
-        waitForModel()
-        cy.findByTitle('Save', {timeout: 5000}).should('not.exist')
-        auth0Login()
-        cy.findByTitle('Save', {timeout: 5000}).should('exist').click({force: true})
+      waitForModel()
+      cy.findByTitle('Save', {timeout: 5000}).should('not.exist')
+      auth0Login()
+      cy.findByTitle('Save', {timeout: 5000}).should('exist').click({force: true})
+      cy.findByLabelText('Organization', {timeout: 5000}).click()
+      cy.contains('@cypresstester').click()
+      cy.findByLabelText('Repository', {timeout: 5000}).eq(0).click()
+      cy.contains('test-repo').click()
+      cy.findByLabelText('Enter file name').click().type('save-model-test.ifc')
+      cy.contains('button', 'Save model').click()
 
-        cy.findByLabelText('Organization', {timeout: 5000}).click()
-
-        cy.contains('@cypresstester').click()
-
-        cy.findByLabelText('Repository', {timeout: 5000}).eq(0).click()
-
-        cy.contains('test-repo').click()
-
-        cy.findByLabelText('Enter file name').click().type('save-model-test.ifc')
-
-        cy.contains('button', 'Save model').click()
-      })
-    })*/
+      const animWaitTimeMs = 2000
+      // eslint-disable-next-line cypress/no-unnecessary-waiting
+      cy.wait(animWaitTimeMs)
+      cy.percySnapshot()
+    })
   })
 })

--- a/cypress/e2e/versions-100/save-imported-model.cy.js
+++ b/cypress/e2e/versions-100/save-imported-model.cy.js
@@ -1,36 +1,32 @@
-
 import '@percy/cypress'
 import {waitForModel, homepageSetup, auth0Login} from '../../support/utils'
 
 
-describe('save model', () => {
-  context('when no model is loaded', () => {
-    beforeEach(() => {
-      homepageSetup()
-      cy.setCookie('isFirstTime', '1')
-    })
+describe('Versions 100: Save Model', () => {
+  beforeEach(() => {
+    homepageSetup()
+    cy.setCookie('isFirstTime', '1')
+    cy.visit('/')
+  })
 
-    it('should not find Save IFC button before login', () => {
-      cy.visit('/')
+  context('Visit homepage without model loaded', () => {
+    it('Check absence of Save IFC button pre-login', () => {
       waitForModel()
       cy.findByTestId('Save', {timeout: 10000}).should('not.exist')
       cy.percySnapshot()
     })
 
-     it('should only find Save IFC button after login', () => {
-      cy.visit('/')
+    it('Confirm presence of Save IFC button post-login', () => {
       waitForModel()
-      cy.findByTitle('Save', {timeout: 5000}).should('not.exist')
       auth0Login()
       cy.findByTitle('Save', {timeout: 5000}).should('exist')
-
       cy.percySnapshot()
     })
+  })
 
-     it.only('should log in and save a model', () => {
-      cy.visit('/')
+  context('Save model action', () => {
+    it('Login, click Save IFC button, input details and save', () => {
       waitForModel()
-      cy.findByTitle('Save', {timeout: 5000}).should('not.exist')
       auth0Login()
       cy.findByTitle('Save', {timeout: 5000}).should('exist').click({force: true})
       cy.findByLabelText('Organization', {timeout: 5000}).click()

--- a/cypress/support/utils.js
+++ b/cypress/support/utils.js
@@ -102,6 +102,7 @@ export function auth0Login() {
   cy.log('simulating login')
   cy.get('[data-testid="login-with-github"]').click()
   cy.contains('span', 'Log out').should('exist')
+  cy.get('[data-testid="control-button-profile"]').realClick()
 }
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bldrs",
-  "version": "1.0.999",
+  "version": "1.0.1000",
   "main": "src/index.jsx",
   "license": "MIT",
   "homepage": "https://github.com/bldrs-ai/Share",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bldrs",
-  "version": "1.0.998",
+  "version": "1.0.999",
   "main": "src/index.jsx",
   "license": "MIT",
   "homepage": "https://github.com/bldrs-ai/Share",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bldrs",
-  "version": "1.0.997",
+  "version": "1.0.998",
   "main": "src/index.jsx",
   "license": "MIT",
   "homepage": "https://github.com/bldrs-ai/Share",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bldrs",
-  "version": "1.0.993",
+  "version": "1.0.997",
   "main": "src/index.jsx",
   "license": "MIT",
   "homepage": "https://github.com/bldrs-ai/Share",

--- a/src/Auth0/Auth0ProviderProxy.jsx
+++ b/src/Auth0/Auth0ProviderProxy.jsx
@@ -1,6 +1,6 @@
 import React, {useState} from 'react'
 import {Auth0Provider as OriginalAuth0Provider} from '@auth0/auth0-react'
-import {MockAuth0Context} from './Auth0Proxy'
+import {MockAuth0Context, mockGitHubUser} from './Auth0Proxy'
  // Adjust the import path
 
 const OAUTH_2_CLIENT_ID = process.env.OAUTH2_CLIENT_ID
@@ -53,10 +53,7 @@ export const Auth0Provider = ({children, onRedirectCallback, ...props}) => {
   const loginWithPopup = () => {
     setState({
       isAuthenticated: true,
-      user: {
-        name: 'Mock User',
-        email: 'mockuser@example.com',
-      },
+      user: mockGitHubUser,
       token: 'mock_access_token',
     })
   }

--- a/src/Auth0/Auth0ProviderProxy.jsx
+++ b/src/Auth0/Auth0ProviderProxy.jsx
@@ -1,0 +1,90 @@
+import React, {useState} from 'react'
+import {Auth0Provider as OriginalAuth0Provider} from '@auth0/auth0-react'
+import {MockAuth0Context} from './Auth0Proxy'
+ // Adjust the import path
+
+const OAUTH_2_CLIENT_ID = process.env.OAUTH2_CLIENT_ID
+
+const useMock = OAUTH_2_CLIENT_ID === 'cypresstestaudience'
+
+export const Auth0Provider = ({children, onRedirectCallback, ...props}) => {
+  /* eslint-disable react-hooks/rules-of-hooks*/
+  if (!useMock) {
+    return (
+        <OriginalAuth0Provider
+        {...props}
+        onRedirectCallback={onRedirectCallback}
+        >
+        {children}
+        </OriginalAuth0Provider>
+    )
+  }
+  const [state, setState] = useState({
+    isAuthenticated: false,
+    user: null,
+    token: '',
+  })
+
+  const getAccessTokenSilently = (options) => {
+    return new Promise((resolve, reject) => {
+      if (state.isAuthenticated) {
+        if (options && options.detailedResponse) {
+          // Detailed response based on the options
+          const response = {
+            access_token: 'mock_access_token',
+            id_token: 'mock_id_token',
+            expires_in: 3600, // Expiry in seconds
+            token_type: 'Bearer',
+            scope: 'openid profile email offline_access repo',
+          }
+          resolve(response)
+        } else {
+          // Default to returning a simple string access token
+          resolve('mock_access_token')
+        }
+      } else {
+        // eslint-disable-next-line prefer-promise-reject-errors
+        reject({error: 'login_required'})
+      }
+    })
+  }
+
+  // Simulate the login functionality
+  const loginWithPopup = () => {
+    setState({
+      isAuthenticated: true,
+      user: {
+        name: 'Mock User',
+        email: 'mockuser@example.com',
+      },
+      token: 'mock_access_token',
+    })
+  }
+
+  // Simulate the logout functionality
+  const logout = () => {
+    setState({
+      isAuthenticated: false,
+      user: null,
+      token: '',
+    })
+  }
+
+  // Provide these functions and state through the context
+  const providerValue = {
+    ...state,
+    loginWithPopup,
+    logout,
+    getAccessTokenSilently,
+  }
+
+
+  return (
+    <MockAuth0Context.Provider value={providerValue}>
+      {children}
+    </MockAuth0Context.Provider>
+  )
+  /* eslint-enable react-hooks/rules-of-hooks*/
+}
+
+export default Auth0Provider

--- a/src/Auth0/Auth0Proxy.js
+++ b/src/Auth0/Auth0Proxy.js
@@ -56,7 +56,7 @@ function mockLogout() {
 }
 
 // Mock implementation of Auth0Context
-const MockAuth0Context = React.createContext({
+export const MockAuth0Context = React.createContext({
   error: undefined,
   isAuthenticated: false,
   isLoading: false,

--- a/src/Auth0/Auth0Proxy.js
+++ b/src/Auth0/Auth0Proxy.js
@@ -29,16 +29,22 @@ function mockGetAccessTokenSilently(options) {
 
 /* eslint-enable jsdoc/no-undefined-types*/
 
-const mockGitHubUser = {
+export const mockGitHubUser = {
   name: 'Unit Testing',
   nickname: 'cypresstester',
   picture: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAAAAACPAi4CAAAAwUlEQVR42u3VLQvCUBTGcT/LX6vMjyAIliVhYLELmgSzRbALA0EUVix' +
       'GQUEmFkG2riiO813EF+5Y8040nSed54ZfOOGegnyZggIKKKCAAj8DpnBOW4WhSINM3P8D8eGRBQTPIbYGXglhnXMHCihgD8zhlDaHkS2whMiUpIhvC0QQmLKBlS0gVTwzt' +
       '3Fu1sAEBu9xTLqCzwFpgetvj/tZE7wkB3Dtms+nc5EcgEjYq5VLTr2/yzxaAHqZFFBAAQXy5g5KPEV7KOa7LAAAAABJRU5ErkJggg==',
-  email: 'testing@example.com',
+  updated_at: '2024-02-20T02:57:40.324Z',
+  email: 'cypresstest@bldrs.ai',
   email_verified: true,
-  sub: 'github|1234567',
-  updated_at: '2023-02-22T17:07:29.123Z',
+  iss: 'https://bldrs.us.auth0.com.msw/',
+  aud: 'cypresstestaudience',
+  iat: 0,
+  exp: 0,
+  sub: 'github|11111111',
+  sid: 'cypresssession-abcdef',
+  nonce: 'testnonce',
 }
 
 /**
@@ -46,6 +52,7 @@ const mockGitHubUser = {
  */
 function mockLoginWithPopup() {
   MockAuth0Context._currentValue.isAuthenticated = true
+  MockAuth0Context._currentValue.user = mockGitHubUser
 }
 
 /**

--- a/src/Auth0/Auth0Proxy.js
+++ b/src/Auth0/Auth0Proxy.js
@@ -31,7 +31,7 @@ function mockGetAccessTokenSilently(options) {
 
 const mockGitHubUser = {
   name: 'Unit Testing',
-  nickname: 'testing',
+  nickname: 'cypresstester',
   picture: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAAAAACPAi4CAAAAwUlEQVR42u3VLQvCUBTGcT/LX6vMjyAIliVhYLELmgSzRbALA0EUVix' +
       'GQUEmFkG2riiO813EF+5Y8040nSed54ZfOOGegnyZggIKKKCAAj8DpnBOW4WhSINM3P8D8eGRBQTPIbYGXglhnXMHCihgD8zhlDaHkS2whMiUpIhvC0QQmLKBlS0gVTwzt' +
       '3Fu1sAEBu9xTLqCzwFpgetvj/tZE7wkB3Dtms+nc5EcgEjYq5VLTr2/yzxaAHqZFFBAAQXy5g5KPEV7KOa7LAAAAABJRU5ErkJggg==',

--- a/src/Auth0ProviderWithHistory.jsx
+++ b/src/Auth0ProviderWithHistory.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import {useNavigate} from 'react-router-dom'
-import {Auth0Provider} from '@auth0/auth0-react'
+import {Auth0Provider} from './Auth0/Auth0ProviderProxy'
 
 
 /** @return {React.ReactContext} */

--- a/src/Components/Profile/ProfileControl.jsx
+++ b/src/Components/Profile/ProfileControl.jsx
@@ -12,9 +12,6 @@ import WbSunnyOutlinedIcon from '@mui/icons-material/WbSunnyOutlined'
 import {useAuth0} from '../../Auth0/Auth0Proxy'
 
 
-const OAUTH_2_CLIENT_ID = process.env.OAUTH2_CLIENT_ID
-
-
 /**
  * ProfileControl contains the option to log in/log out and to theme control
  *
@@ -29,33 +26,17 @@ export default function ProfileControl() {
 
   const [isDay, setIsDay] = useState(theme.palette.mode === 'light')
 
-  const [toggledLogin, setToggledLogin] = useState(false)
-  const useMock = OAUTH_2_CLIENT_ID === 'cypresstestaudience'
-
   const onLoginClick = async () => {
     await loginWithPopup({
       appState: {
         returnTo: window.location.pathname,
       },
     })
-
-    if (useMock) {
-      setToggledLogin((prev) => !prev)
-    }
   }
   const onLogoutClick = () => {
     logout({returnTo: process.env.OAUTH2_REDIRECT_URI || window.location.origin})
-    if (useMock) {
-      setToggledLogin((prev) => !prev) // Toggle to force re-render
-   }
   }
   const onCloseClick = () => setAnchorEl(null)
-
-
-  useEffect(() => {
-    // This effect will run whenever the authentication state changes
-    // (only when mocked to enable rerender)
-  }, [toggledLogin])
 
   useEffect(() => {
     setIsDay(theme.palette.mode === 'light')


### PR DESCRIPTION
Added Auth0ProxyProvider to fully mock Auth0 with pre-rendering post login. 

Added end to end save model test.


#980 
#1142

[Cypress](https://github.com/bldrs-ai/Share/blob/ca1f3f717c5f2e9668cdd3b9a4db5bcaf0ec580b/cypress/e2e/versions-100/save-imported-model.cy.js)
[Percy](https://percy.io/8fe2b2f1/share/builds/33885913)

