### PR TITLE
cypress: use fixed port for cypress server

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -5,6 +5,7 @@ module.exports = defineConfig({
   projectId: 'z36jue',
   e2e: {
     fileServerFolder: 'docs/',
+    port: 61725,
     screenshotOnRunFailure: false,
     video: false,
     pageLoadTimeout: 15000,

--- a/cypress/e2e/view-100/shareable-camera-position.cy.js
+++ b/cypress/e2e/view-100/shareable-camera-position.cy.js
@@ -1,24 +1,22 @@
 import '@percy/cypress'
 import {
   homepageSetup,
-  setIsReturningUser,
-  visitHomepageWaitForModel,
+  returningUserVisitsHomepageWaitForModel,
 } from '../../support/utils'
 
 
 /** {@link https://github.com/bldrs-ai/Share/issues/1043} */
 describe('view 100: Shareable camera position', () => {
-  beforeEach(() => {
-    homepageSetup()
-    setIsReturningUser()
-  })
+  beforeEach(homepageSetup)
+
 
   context('User visits homepage, positions camera, clicks ShareControl', () => {
     beforeEach(() => {
-      visitHomepageWaitForModel()
+      returningUserVisitsHomepageWaitForModel()
       // TODO(pablo): can't move model
       cy.get('[data-testid="control-button-share"]').click()
     })
+
 
     it('ShareDialog opens - Screen', () => {
       cy.get('[data-testid="img-qrcode"]').should('exist')

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bldrs",
-  "version": "1.0.1001",
+  "version": "1.0.1003",
   "main": "src/index.jsx",
   "license": "MIT",
   "homepage": "https://github.com/bldrs-ai/Share",


### PR DESCRIPTION
This should remove flakiness in view-100/share tests that have a screenshot of localhost:port.

You can see the new hard-coded port in the percy screen for view/share.  The other screens are still being diff'd of the same goldens.  They didn't update since we ran out of quota.  So after this one we should have new goldens.

[Percy](https://percy.io/8fe2b2f1/share/builds/33950488/changed/1858260630).