### PR TITLE
1134-first-time-about-doesnt-close-transient

### DIFF
--- a/src/Components/About/AboutControl.jsx
+++ b/src/Components/About/AboutControl.jsx
@@ -16,6 +16,15 @@ import PkgJson from '../../../package.json'
 export default function AboutControl() {
   const isAboutVisible = useStore((state) => state.isAboutVisible)
   const setIsAboutVisible = useStore((state) => state.setIsAboutVisible)
+
+  // Ensure that the dialog can be closed by updating the state appropriately
+  const handleDialogClose = () => {
+    if (isFirst()) {
+      setVisited() // Mark as visited to prevent the dialog from being forced open again
+    }
+    setIsAboutVisible(false) // Always close the dialog when onClose is triggered
+  }
+
   return (
     <ControlButtonWithHashState
       title={`Bldrs: ${PkgJson.version}`}
@@ -29,14 +38,10 @@ export default function AboutControl() {
       <AboutDialog
         isDialogDisplayed={isFirst() || isAboutVisible}
         setIsDialogDisplayed={setIsAboutVisible}
-        onClose={() => {
-          setIsAboutVisible(false)
-          setVisited()
-        }}
+        onClose={handleDialogClose}
       />
     </ControlButtonWithHashState>
   )
 }
-
 
 const ABOUT_PREFIX = 'about'


### PR DESCRIPTION
I tested cursor.sh AI assistant here:
- highlighted the whole About dialog
- Apple-K: *described the bug and asked for a fix* (i couldn't find the actual log in vscode)
- copilot++ went thru line-by-line and edited to this fix

Percy for just view/100/initial-load-and-view, [no changes](https://percy.io/8fe2b2f1/share/builds/33966996/unchanged/1859195834)