### PR TITLE
Percy script takes spec arg

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bldrs",
-  "version": "1.0.1003",
+  "version": "1.0.1005",
   "main": "src/index.jsx",
   "license": "MIT",
   "homepage": "https://github.com/bldrs-ai/Share",
@@ -27,7 +27,7 @@
     "cy-headed": "cypress run --headed --browser chrome --no-exit",
     "cy-headed-spec": "cypress run --headed --browser chrome --no-exit --spec",
     "cy-parallel": "time ./cypress/e2e/parallel.sh",
-    "cy-percy": "./tools/cy-percy.sh",
+    "cy-percy": "./tools/cy-percy.sh $@",
     "cy-spec": "cypress run --browser chrome --spec",
     "deps-graph": "npx dependency-cruiser src --include-only 'jsx?' --config --output-type dot | dot -T svg > deps.svg",
     "husky-init": "husky install",

--- a/src/Components/About/AboutControl.jsx
+++ b/src/Components/About/AboutControl.jsx
@@ -16,6 +16,15 @@ import PkgJson from '../../../package.json'
 export default function AboutControl() {
   const isAboutVisible = useStore((state) => state.isAboutVisible)
   const setIsAboutVisible = useStore((state) => state.setIsAboutVisible)
+
+  // Ensure that the dialog can be closed by updating the state appropriately
+  const handleDialogClose = () => {
+    if (isFirst()) {
+      setVisited() // Mark as visited to prevent the dialog from being forced open again
+    }
+    setIsAboutVisible(false) // Always close the dialog when onClose is triggered
+  }
+
   return (
     <ControlButtonWithHashState
       title={`Bldrs: ${PkgJson.version}`}
@@ -29,14 +38,10 @@ export default function AboutControl() {
       <AboutDialog
         isDialogDisplayed={isFirst() || isAboutVisible}
         setIsDialogDisplayed={setIsAboutVisible}
-        onClose={() => {
-          setIsAboutVisible(false)
-          setVisited()
-        }}
+        onClose={handleDialogClose}
       />
     </ControlButtonWithHashState>
   )
 }
-
 
 const ABOUT_PREFIX = 'about'

--- a/tools/cy-percy.sh
+++ b/tools/cy-percy.sh
@@ -6,6 +6,6 @@ if [ -z "$PERCY_TOKEN" ]; then
   exit 1
 fi
 
-yarn cy-build && yarn percy exec -- yarn cy
+yarn cy-build && yarn percy exec -- yarn cy $@
 
 echo "Add the above percy URL to your PR description, with any notes about differences."


### PR DESCRIPTION
our package.json `cy-percy` calls `tools/percy.sh`

Both now pass additional args, e.g. for --spec to run only a given spec.  I just ran this with my last pr as:

```
yarn cy-build && yarn cy-percy --spec cypress/e2e/view-100/initial-model-load-and-view.cy.js
```

[Percy result](https://percy.io/8fe2b2f1/share/builds/33966996/unchanged/1859195834?browser=safari&browser_ids=47%2C56&viewLayout=overlay&viewMode=new&width=1280&widths=375%2C1280)