### PR TITLE
Create-a-Note test fix

### DIFF
--- a/cypress/e2e/notes-100/create-a-note.cy.js
+++ b/cypress/e2e/notes-100/create-a-note.cy.js
@@ -29,8 +29,10 @@ describe('Notes 100: Create a note', () => {
       it('When note is created, navigate to the notes list with a new note created at the top of the list', () => {
         cy.get('[placeholder="Note Title"]').click().type('New Note Title')
         cy.get('[placeholder="Note Body"]').click().type('New Note Body')
-        cy.get('[data-testid="Submit"]').should('be.enabled').click()
+        cy.get('[data-testid="Submit"]').should('be.enabled')
+        cy.get('[data-testid="Submit"]').click()
         cy.get('[data-testid="list-notes"]').should('exist')
+        cy.percySnapshot()
       })
     })
   })

--- a/cypress/e2e/notes-100/create-a-note.cy.js
+++ b/cypress/e2e/notes-100/create-a-note.cy.js
@@ -32,6 +32,7 @@ describe('Notes 100: Create a note', () => {
         cy.get('[data-testid="Submit"]').should('be.enabled')
         cy.get('[data-testid="Submit"]').click()
         cy.get('[data-testid="list-notes"]').should('exist')
+        cy.get('.MuiCardHeader-title').contains('issueTitle_4')
         cy.percySnapshot()
       })
     })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bldrs",
-  "version": "1.0.1046",
+  "version": "1.0.1032",
   "main": "src/index.jsx",
   "license": "MIT",
   "homepage": "https://github.com/bldrs-ai/Share",

--- a/src/Components/Notes/NoteCardCreate.jsx
+++ b/src/Components/Notes/NoteCardCreate.jsx
@@ -37,7 +37,7 @@ export default function NoteCardCreate({
   const notes = useStore((state) => state.notes)
   const setNotes = useStore((state) => state.setNotes)
   const selectedNoteId = useStore((state) => state.selectedNoteId)
-  const toggleIsCreateNoteActive = useStore((state) => state.toggleIsCreateNoteActive)
+  const toggleIsCreateNoteVisible = useStore((state) => state.toggleIsCreateNoteVisible)
   const [title, setTitle] = useState('')
   const [body, setBody] = useState(null)
 
@@ -53,9 +53,8 @@ export default function NoteCardCreate({
       title,
       body: body || '',
     }
-
     await createIssue(repository, issuePayload, accessToken)
-    toggleIsCreateNoteActive()
+    toggleIsCreateNoteVisible()
   }
 
   const fetchComments = async () => {
@@ -163,14 +162,24 @@ export default function NoteCardCreate({
           direction='row'
           sx={{width: '100%'}}
         >
+          {isNote ?
           <TooltipIconButton
             title='Submit'
-            onClick={isNote ? createNote : createNewComment}
+            onClick={createNote}
+            icon={<CheckIcon/>}
+            enabled={submitEnabled}
+            size='small'
+            placement='bottom'
+          /> :
+          <TooltipIconButton
+            title='Submit'
+            onClick={createNewComment}
             icon={<CheckIcon/>}
             enabled={submitEnabled}
             size='small'
             placement='bottom'
           />
+          }
         </Stack>
       </CardActions>
     </Card>

--- a/src/store/NotesSlice.js
+++ b/src/store/NotesSlice.js
@@ -39,8 +39,7 @@ export default function createNotesSlice(set, get) {
     setSelectedNoteId: (noteId) => set(() => ({selectedNoteId: noteId})),
     setSelectedNoteIndex: (noteIndex) => set(() => ({selectedNoteIndex: noteIndex})),
     toggleAddComment: () => set((state) => ({addComment: !state.addComment})),
-    toggleIsCreateNoteVisible: () =>
-      set((state) => ({isCreateNoteVisible: !state.isCreateNoteVisible})),
+    toggleIsCreateNoteVisible: () => set((state) => ({isCreateNoteVisible: !state.isCreateNoteVisible})),
     toggleIsLoadingNotes: () => set((state) => ({isLoadingNotes: !state.isLoadingNotes})),
     toggleIsNotesVisible: () => set((state) => ({isNotesVisible: !state.isNotesVisible})),
     toggleSynchSidebar: () => set((state) => ({synchSidebar: !state.synchSidebar})),


### PR DESCRIPTION
This PR addresses flaky create-a-note e2e test. 
The root cause of the problem was a mismatch in the variable names due to a recent rename in the toggleCreateNoteVisible store variable, which was not updated accordingly in the NoteCardCreate component.

##Updated Tests
Fixed
[Percy](https://percy.io/8fe2b2f1/share/builds/34205787)