### PR TITLE
open-200: support .stp and .step URLs

### DIFF
--- a/cypress/e2e/open/200/open-step-model.cy.js
+++ b/cypress/e2e/open/200/open-step-model.cy.js
@@ -13,16 +13,28 @@ import {
 describe('Open 200: Open STEP Model', () => {
   beforeEach(homepageSetup)
   context('Returning user visits homepage', () => {
-    const interceptTag = 'stepLoad'
+    const stepPath = '/share/v/gh/bldrs-ai/test-models/main/step/gear.step'
+    const stepInterceptTag = 'stepLoad'
+
+    const stpPath = '/share/v/gh/bldrs-ai/test-models/main/step/gear.stp'
+    const stpInterceptTag = 'stpLoad'
+
     beforeEach(() => {
       setIsReturningUser()
-      const sharePathToGear = '/share/v/gh/bldrs-ai/test-models/main/step/gear.step.ifc'
-      setupVirtualPathIntercept(sharePathToGear, '/gear.step', interceptTag)
-      cy.visit(sharePathToGear)
+      // Use same actual file for both
+      setupVirtualPathIntercept(stepPath, '/gear.step', stepInterceptTag)
+      setupVirtualPathIntercept(stpPath, '/gear.step', stpInterceptTag)
     })
 
-    it('Loads gear.step (with .ifc hack) - Screen', () => {
-      waitForModelReady(interceptTag)
+    it('Loads gear.step - Screen', () => {
+      cy.visit(stepPath)
+      waitForModelReady(stepInterceptTag)
+      cy.percySnapshot()
+    })
+
+    it('Loads gear.stp - Screen', () => {
+      cy.visit(stpPath)
+      waitForModelReady(stpInterceptTag)
       cy.percySnapshot()
     })
   })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bldrs",
-  "version": "1.0.1036",
+  "version": "1.0.1037",
   "main": "src/index.jsx",
   "license": "MIT",
   "homepage": "https://github.com/bldrs-ai/Share",

--- a/src/Containers/CadView.jsx
+++ b/src/Containers/CadView.jsx
@@ -4,6 +4,7 @@ import {MeshLambertMaterial} from 'three'
 import Box from '@mui/material/Box'
 import Typography from '@mui/material/Typography'
 import useTheme from '@mui/styles/useTheme'
+import {filetypeRegex} from '../Filetype'
 import {useAuth0} from '../Auth0/Auth0Proxy'
 import AboutControl from '../Components/About/AboutControl'
 import {onHash} from '../Components/Camera/CameraControl'
@@ -673,7 +674,7 @@ export default function CadView({
   // TODO(pablo): would be nice to have more consistent handling of path parsing.
   useEffect(() => {
     if (rootElement) {
-      const parts = location.pathname.split(/\.ifc/i)
+      const parts = location.pathname.split(filetypeRegex)
       const expectedPartCount = 2
       if (parts.length === expectedPartCount && parts[1] !== '') {
         selectElementBasedOnFilepath(parts[1])

--- a/src/Filetype.js
+++ b/src/Filetype.js
@@ -1,12 +1,18 @@
-export const supportedTypes = ['ifc']
+import {assertDefined} from './utils/assert.js'
+
+
+// TODO: 3dm, glb
+export const supportedTypes = ['ifc', 'stp', 'step']
+
+export const supportedTypesUsageStr = `${supportedTypes.join(',')}`
 
 
 /** Make a non-capturing group of a choice of filetypes. */
-const typeRegexStr = `(?:${supportedTypes.join('|')})`
+export const typeRegexStr = `(?:${supportedTypes.join('|')})`
 
 
 /** */
-const filetypeRegex = new RegExp(typeRegexStr, 'i')
+export const filetypeRegex = new RegExp(typeRegexStr, 'i')
 
 
 /** Prepend it with a '.' to make a file suffix*/
@@ -40,9 +46,10 @@ export function pathSuffixSupported(pathWithSuffix) {
  * @return {{parts: Array.<string>, extension: string}}
  */
 export function splitAroundExtension(filepath) {
+  assertDefined(filepath)
   const match = fileSuffixRegex.exec(filepath)
   if (!match) {
-    throw new FilenameParseError(`Filepath must contain ".${typeRegexStr}" (case-insensitive)`)
+    throw new FilenameParseError(`Filepath(${filepath}) must contain ".${typeRegexStr}" (case-insensitive)`)
   }
   const parts = filepath.split(fileSuffixRegex)
   return {parts, extension: match[0]}

--- a/src/Filetype.test.js
+++ b/src/Filetype.test.js
@@ -30,7 +30,7 @@ describe('Filetype', () => {
       expect(extension).toStrictEqual(`.${ext}`)
     }
     expect(() => {
-      splitAroundExtension(`asdf.obj/blah`)
+      splitAroundExtension(`asdf.com/blah`)
     }).toThrow(FilenameParseError)
   })
 })


### PR DESCRIPTION
Demo:

https://deploy-preview-1198--bldrs-share.netlify.app/share/v/gh/bldrs-ai/test-models/main/step/zoo.dev/a-gear.step

Percy
https://percy.io/8fe2b2f1/share/builds/34513539

Diffs:
- First 2 gear ones are from new test case names, one each for .stp and .step
- Not sure why Open 100 has no prior.  I recently changed the way we get base images, so maybe let's just note and approve these for a bit
- There's jitter in a few below, plus a little change in notes that should have been picked up in that pr
