### PR TITLE
Add OPFS cache clear and OPFS directory snapshot debug utility functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bldrs",
-  "version": "1.0.1073",
+  "version": "1.0.1059",
   "main": "src/index.jsx",
   "license": "AGPL-3.0",
   "homepage": "https://github.com/bldrs-ai/Share",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bldrs",
-  "version": "1.0.1059",
+  "version": "1.0.1060",
   "main": "src/index.jsx",
   "license": "AGPL-3.0",
   "homepage": "https://github.com/bldrs-ai/Share",

--- a/src/BaseRoutes.jsx
+++ b/src/BaseRoutes.jsx
@@ -1,7 +1,7 @@
 import React, {useEffect} from 'react'
 import {Outlet, Route, Routes, useLocation, useNavigate} from 'react-router-dom'
 import ShareRoutes from './ShareRoutes'
-import {checkOPFSAvailability} from './OPFS/utils'
+import {checkOPFSAvailability, setUpGlobalDebugFunctions} from './OPFS/utils'
 import debug from './utils/debug'
 import {navWith} from './utils/navigate'
 import useStore from './store/useStore'
@@ -46,6 +46,10 @@ export default function BaseRoutes({testElt = null}) {
   useEffect(() => {
     const checkAvailability = async () => {
       const available = await checkOPFSAvailability()
+
+      if (available) {
+        setUpGlobalDebugFunctions()
+      }
 
       setIsOpfsAvailable(available)
     }

--- a/src/OPFS/OPFSService.js
+++ b/src/OPFS/OPFSService.js
@@ -252,6 +252,34 @@ export function opfsReadModel(modelKey) {
 }
 
 /**
+ * Clears the OPFS cache
+ */
+export function opfsClearCache() {
+  if (!workerRef) {
+    debug().error('Worker not initialized')
+    return
+  }
+
+  workerRef.postMessage({
+    command: 'clearCache',
+  })
+}
+
+/**
+ * Retrives a directory snapshot of the opfs cache.
+ */
+export function opfsSnapshotCache() {
+  if (!workerRef) {
+    debug().error('Worker not initialized')
+    return
+  }
+
+  workerRef.postMessage({
+    command: 'snapshotCache',
+  })
+}
+
+/**
  * Sets a callback function to handle messages from the worker.
  *
  * Registers a callback function to be invoked whenever the worker

--- a/src/OPFS/utils.js
+++ b/src/OPFS/utils.js
@@ -6,6 +6,8 @@ import {
   opfsWriteModelFileHandle,
   opfsDoesFileExist,
   opfsDeleteModel,
+  opfsSnapshotCache,
+  opfsClearCache,
 } from '../OPFS/OPFSService.js'
 import {assertDefined} from '../utils/assert'
 import debug from '../utils/debug'
@@ -186,6 +188,16 @@ function makePromise(callback, originalFilePath, commitHash, owner, repo, branch
             resolve(false) // Resolve the promise with false
           } else if (event.data.event === eventStatus) {
             workerRef.removeEventListener('message', listener) // Remove the event listener
+
+            if (event.data.event === 'clear') {
+              // eslint-disable-next-line no-console
+              console.log('OPFS cache cleared.')
+            }
+
+            if (event.data.directoryStructure) {
+              // eslint-disable-next-line no-console
+              console.log(`OPFS Directory Structure:\n${ event.data.directoryStructure}`)
+            }
             resolve(true) // Resolve the promise with true
           }
         }
@@ -218,6 +230,24 @@ export function doesFileExistInOPFS(
   assertDefined(originalFilePath, commitHash, owner, repo, branch)
 
   return makePromise(opfsDoesFileExist, originalFilePath, commitHash, owner, repo, branch, 'exist')
+}
+
+/**
+ * Prints a snapshot of the OPFS directory structure
+ *
+ * @return {boolean}
+ */
+export function snapshotOPFS() {
+  return makePromise(opfsSnapshotCache, null, null, null, null, null, 'snapshot')
+}
+
+/**
+ * Deletes entirety of OPFS cache
+ *
+ * @return {boolean}
+ */
+export function clearOPFSCache() {
+  return makePromise(opfsClearCache, null, null, null, null, null, 'clear')
 }
 
 /**
@@ -316,4 +346,12 @@ export async function checkOPFSAvailability() {
   } else {
     return false
   }
+}
+
+/**
+ *
+ */
+export function setUpGlobalDebugFunctions() {
+  window.snapshotOPFS = snapshotOPFS
+  window.clearOPFSCache = clearOPFSCache
 }

--- a/src/OPFS/utils.test.js
+++ b/src/OPFS/utils.test.js
@@ -6,7 +6,9 @@ import {
   downloadToOPFS,
   doesFileExistInOPFS,
   deleteFileFromOPFS,
-  checkOPFSAvailability} from './utils'
+  checkOPFSAvailability,
+  snapshotOPFS,
+  clearOPFSCache} from './utils'
 
 
 jest.mock('../OPFS/OPFSService.js')
@@ -293,6 +295,46 @@ describe('OPFS Test Suite', () => {
 
       const result = await checkOPFSAvailability()
       expect(result).toBe(false)
+    })
+  })
+
+  describe('snapshotOPFS', () => {
+    it('should resolve true if the snapshot was retrieved', async () => {
+      const mockWorker = {
+        addEventListener: jest.fn((_, handler) => {
+          // Simulate successful file deletion
+          process.nextTick(() => handler({data: {completed: true, event: 'snapshot', directoryStructure: []}}))
+        }),
+        removeEventListener: jest.fn(),
+      }
+      OPFSService.initializeWorker.mockReturnValue(mockWorker)
+
+      const result = await snapshotOPFS()
+
+      expect(result).toBe(true)
+      expect(OPFSService.initializeWorker).toHaveBeenCalled()
+      expect(mockWorker.addEventListener).toHaveBeenCalled()
+      expect(mockWorker.removeEventListener).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('clearOPFS', () => {
+    it('should resolve true if the OPFS cache was cleared', async () => {
+      const mockWorker = {
+        addEventListener: jest.fn((_, handler) => {
+          // Simulate successful file deletion
+          process.nextTick(() => handler({data: {completed: true, event: 'clear'}}))
+        }),
+        removeEventListener: jest.fn(),
+      }
+      OPFSService.initializeWorker.mockReturnValue(mockWorker)
+
+      const result = await clearOPFSCache()
+
+      expect(result).toBe(true)
+      expect(OPFSService.initializeWorker).toHaveBeenCalled()
+      expect(mockWorker.addEventListener).toHaveBeenCalled()
+      expect(mockWorker.removeEventListener).toHaveBeenCalledTimes(1)
     })
   })
 })


### PR DESCRIPTION
Add OPFS cache clear and OPFS directory snapshot debug utility functions:

```await snapshotOPFS() --> prints current OPFS directory structure```
<img width="647" alt="Screenshot 2024-06-17 at 1 50 42 PM" src="https://github.com/bldrs-ai/Share/assets/17447690/02168537-6bb2-46e0-b12a-73adc503042f">

```await clearOPFSCache() --> deletes all OPFS entries```

<img width="256" alt="Screenshot 2024-06-17 at 1 51 24 PM" src="https://github.com/bldrs-ai/Share/assets/17447690/d87d16c3-8619-4f2f-926b-b8fd819e66d4">
