### PR TITLE
open: reduce gh api usage by delay of gh orgs fetch until open/save dialog is open

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bldrs",
-  "version": "1.0.1068",
+  "version": "1.0.1069",
   "main": "src/index.jsx",
   "license": "AGPL-3.0",
   "homepage": "https://github.com/bldrs-ai/Share",

--- a/src/Components/Notes/NotesControl.test.jsx
+++ b/src/Components/Notes/NotesControl.test.jsx
@@ -15,7 +15,7 @@ describe('NotesControl', () => {
       result.current.setModel(model)
       result.current.setRepository('pablo-mayrgundter', 'Share')
     })
-    act(() => {
+    await act(async () => {
       render(<ShareMock><NotesControl/></ShareMock>)
     })
     expect(result.current.notes).toBeNull()

--- a/src/Components/Open/OpenModelControl.jsx
+++ b/src/Components/Open/OpenModelControl.jsx
@@ -35,10 +35,10 @@ export default function OpenModelControl() {
       setOrgNamesArray(orgNames)
     }
 
-    if (accessToken) {
+    if (isOpenModelVisible && accessToken) {
       fetchOrganizations()
     }
-  }, [accessToken, user])
+  }, [isOpenModelVisible, accessToken, user])
 
 
   return (

--- a/src/Components/Open/OpenModelControl.test.jsx
+++ b/src/Components/Open/OpenModelControl.test.jsx
@@ -1,5 +1,7 @@
 import React from 'react'
-import {render, fireEvent} from '@testing-library/react'
+import {act, fireEvent, render, renderHook} from '@testing-library/react'
+import {getOrganizations} from '../../net/github/Organizations'
+import useStore from '../../store/useStore'
 import {
   mockedUseAuth0,
   mockedUserLoggedIn,
@@ -8,7 +10,12 @@ import {
 import {OpenModelControlFixture} from './OpenModelControl.fixture'
 
 
-describe('Open Model Dialog', () => {
+jest.mock('../../net/github/Organizations', () => ({
+  getOrganizations: jest.fn(),
+}))
+
+
+describe('OpenModelControl', () => {
   it('Renders a login message if the user is not logged in', () => {
     mockedUseAuth0.mockReturnValue(mockedUserLoggedOut)
     const {getByTestId, getByText} = render(<OpenModelControlFixture/>)
@@ -24,11 +31,9 @@ describe('Open Model Dialog', () => {
       )
       return nodeHasText && childrenDontHaveText
     }
-
     const loginText = getByText(loginTextMatcher)
     expect(loginText).toBeInTheDocument()
   })
-
 
   it('Renders file selector if the user is logged in', async () => {
     mockedUseAuth0.mockReturnValue(mockedUserLoggedIn)
@@ -41,5 +46,31 @@ describe('Open Model Dialog', () => {
     const Repository = await getByTestId('openRepository')
     expect(File).toBeInTheDocument()
     expect(Repository).toBeInTheDocument()
+  })
+
+  it('Does not fetch repo info on initial render when isOpenModelVisible=false in zustand', async () => {
+    mockedUseAuth0.mockReturnValue(mockedUserLoggedIn)
+    getOrganizations.mockResolvedValue({})
+    // eslint-disable-next-line require-await
+    await act(async () => {
+      render(<OpenModelControlFixture/>)
+    })
+    expect(getOrganizations).not.toHaveBeenCalled()
+  })
+
+  it('Fetches repo info on initial render when isOpenModelVisible in zustand', async () => {
+    mockedUseAuth0.mockReturnValue(mockedUserLoggedIn)
+    getOrganizations.mockResolvedValue({})
+    const {result} = renderHook(() => useStore((state) => state))
+    // eslint-disable-next-line require-await
+    await act(async () => {
+      result.current.setAccessToken('foo')
+      result.current.setIsOpenModelVisible(true)
+    })
+    // eslint-disable-next-line require-await
+    await act(async () => {
+      render(<OpenModelControlFixture/>)
+    })
+    expect(getOrganizations).toHaveBeenCalled()
   })
 })

--- a/src/Components/Open/SaveModelControl.jsx
+++ b/src/Components/Open/SaveModelControl.jsx
@@ -21,15 +21,17 @@ import {navigateBaseOnModelPath} from '../../utils/location'
 
 
 /**
- * Displays model open dialog
+ * Displays model save dialog
  *
  * @return {ReactElement}
  */
 export default function SaveModelControl() {
+  const isSaveModelVisible = useStore((state) => state.isSaveModelVisible)
+  const setIsSaveModelVisible = useStore((state) => state.setIsSaveModelVisible)
+
   const {user} = useAuth0()
   const navigate = useNavigate()
   const accessToken = useStore((state) => state.accessToken)
-  const [isDialogDisplayed, setIsDialogDisplayed] = useState(false)
   const [orgNamesArr, setOrgNamesArray] = useState([''])
 
 
@@ -43,23 +45,23 @@ export default function SaveModelControl() {
       return orgs
     }
 
-    if (accessToken) {
+    if (isSaveModelVisible && accessToken) {
       fetchOrganizations()
     }
-  }, [accessToken, user])
+  }, [isSaveModelVisible, accessToken, user])
 
 
   return (
     <ControlButton
       title='Save'
-      isDialogDisplayed={isDialogDisplayed}
-      setIsDialogDisplayed={setIsDialogDisplayed}
+      isDialogDisplayed={isSaveModelVisible}
+      setIsDialogDisplayed={setIsSaveModelVisible}
       icon={<SaveOutlinedIcon className='icon-share'/>}
       placement='bottom'
     >
       <SaveModelDialog
-        isDialogDisplayed={isDialogDisplayed}
-        setIsDialogDisplayed={setIsDialogDisplayed}
+        isDialogDisplayed={isSaveModelVisible}
+        setIsDialogDisplayed={setIsSaveModelVisible}
         navigate={navigate}
         orgNamesArr={orgNamesArr}
       />

--- a/src/store/UISlice.js
+++ b/src/store/UISlice.js
@@ -59,6 +59,9 @@ export default function createUISlice(set, get) {
     isOpenModelVisible: openModelIsVisibleInitially(),
     setIsOpenModelVisible: (is) => set(() => ({isOpenModelVisible: is})),
 
+    isSaveModelVisible: false,
+    setIsSaveModelVisible: (is) => set(() => ({isSaveModelVisible: is})),
+
     isShareVisible: shareIsVisibleInitially(),
     setIsShareVisible: (is) => set(() => ({isShareVisible: is})),
 


### PR DESCRIPTION
Similar to last PR for open, just condition the useEffect on the component visibility.

Added tests for visible and not.