### PR TITLE
PlaceMark / Notes Bug Fixes

### DIFF
--- a/cypress/e2e/notes-100/comments-on-a-note.cy.js
+++ b/cypress/e2e/notes-100/comments-on-a-note.cy.js
@@ -24,6 +24,15 @@ describe('Notes 100: Comments on a note', () => {
         cy.get('[placeholder="Leave a comment ..."]')
         cy.percySnapshot()
       })
+      it('Allows writing over 256 characters in the comment box', () => {
+        auth0Login()
+        // eslint-disable-next-line no-magic-numbers
+        const longText = 'a'.repeat(300) // 300 characters
+        cy.get('[placeholder="Leave a comment ..."]')
+          .type(longText)
+          .should('have.value', longText) // Assert that the textbox contains the long input
+        cy.percySnapshot()
+      })
     })
   })
 })

--- a/cypress/e2e/notes-100/select-a-note.cy.js
+++ b/cypress/e2e/notes-100/select-a-note.cy.js
@@ -24,7 +24,11 @@ describe('Notes 100: Select a note', () => {
 
         cy.get('[data-testid="panelTitle"]').should('have.text', 'NOTE')
 
-        cy.get('[data-testid="Back to the list"]')
+        cy.get('[data-testid="Back to the list"]').click()
+
+        // Ensure we navigate back to the full list of notes
+        cy.get('[data-testid="list-notes"]').should('exist')
+        cy.get('[data-testid="list-notes"] :nth-child(1) > [data-testid="note-body"]').should('exist')
 
         cy.percySnapshot()
       })

--- a/cypress/e2e/placemarks-100/marker-selection.cy.js
+++ b/cypress/e2e/placemarks-100/marker-selection.cy.js
@@ -1,6 +1,9 @@
 import '@percy/cypress'
 import {Raycaster, Vector2, Vector3} from 'three'
-import {homepageSetup, returningUserVisitsHomepageWaitForModel} from '../../support/utils'
+import {homepageSetup,
+   returningUserVisitsHomepageWaitForModel,
+   auth0Login,
+  } from '../../support/utils'
 import {MOCK_MARKERS} from '../../../src/Components/Markers/Marker.fixture'
 
 
@@ -71,7 +74,74 @@ describe('Placemarks 100: Not visible when notes is not open', () => {
         // Assert that the URL hash contains marker coordinates
         const expectedHash = `#m:${markerCoordinates[0]},${markerCoordinates[1]},${markerCoordinates[2]}`
         cy.url().should('include', expectedHash)
+
+        cy.percySnapshot()
       })
-    })
+      it('should click a marker link with a camera coordinate in it and the camera should change', () => {
+        auth0Login()
+        cy.get('[data-testid="list-notes"]')
+        .children()
+        .eq(5) // Select the 6th child (0-based index)
+        .click() // Click the element
+
+        // Intercept the hyperlink click to prevent navigation
+        cy.get('a[href*="#m:-18,20.289,-3.92,1,0,0;c:71.225,28.586,-45.341,-33,15,-5.613"]')
+        .should('exist') // Ensure the link exists
+        .then(($link) => {
+          // Attach a click handler to prevent default behavior
+          cy.wrap($link).invoke('on', 'click', (event) => {
+            event.preventDefault() // Prevent the redirect
+          })
+
+          // Now click the hyperlink
+          cy.wrap($link).click()
+        })
+
+        cy.percySnapshot()
+      })
+      it('should add a placemark to the scene, and make sure the placemark appends to and exists in the right issue', () => {
+        auth0Login()
+        cy.get('[data-testid="list-notes"]')
+        .children()
+        .eq(4) // Select the 5th child (0-based index)
+        .click() // Click the element
+
+        cy.get('[placeholder="Leave a comment ..."]')
+        .type('test')
+        .should('have.value', 'test') // Assert that the textbox contains the test input
+
+        // Select the "Place Mark" button
+        cy.get('[data-testid="Place Mark"]')
+        .filter(':not(:disabled)') // Select only the enabled "Place Mark" button
+        .click() // Click the enabled button
+
+
+        // Get the canvas element and calculate the click position for placing the marker
+        cy.get('[data-testid="cadview-dropzone"]').then(($el) => {
+          const canvasRect = $el[0].getBoundingClientRect()
+          // eslint-disable-next-line no-mixed-operators
+          const screenX = canvasRect.left + canvasRect.width / 2 // X coordinate at the center
+          // eslint-disable-next-line no-mixed-operators
+          const screenY = canvasRect.top + canvasRect.height / 2 // Y coordinate at the center
+
+          // Dispatch a double-click event at the calculated position
+          const event = new MouseEvent('dblclick', {
+            bubbles: true,
+            cancelable: true,
+            clientX: screenX,
+            clientY: screenY,
+          })
+          $el[0].dispatchEvent(event)
+        })
+
+        // Verify that the correct text is added to the "Leave a comment" text area
+        cy.get('[placeholder="Leave a comment ..."]').should(($textarea) => {
+          const value = $textarea.val() // Get the current value of the text area
+          expect(value).to.match(/\[placemark\]\(.*#m:.+\)/) // Match the expected format
+        })
+
+        cy.percySnapshot()
+        })
+      })
   })
 })

--- a/cypress/e2e/placemarks-100/marker-visibility.cy.js
+++ b/cypress/e2e/placemarks-100/marker-visibility.cy.js
@@ -37,6 +37,8 @@ describe('Placemarks 100: Not visible when notes is not open', () => {
         // eslint-disable-next-line no-unused-expressions
           expect(marker.userData.id).to.exist
         })
+
+        cy.percySnapshot()
       })
     })
   })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bldrs",
-  "version": "1.0.1151",
+  "version": "1.0.1153",
   "main": "src/index.jsx",
   "license": "AGPL-3.0",
   "homepage": "https://github.com/bldrs-ai/Share",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bldrs",
-  "version": "1.0.1153",
+  "version": "1.0.1154",
   "main": "src/index.jsx",
   "license": "AGPL-3.0",
   "homepage": "https://github.com/bldrs-ai/Share",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bldrs",
-  "version": "1.0.1154",
+  "version": "1.0.1156",
   "main": "src/index.jsx",
   "license": "AGPL-3.0",
   "homepage": "https://github.com/bldrs-ai/Share",

--- a/src/Components/Markers/MarkerControl.jsx
+++ b/src/Components/Markers/MarkerControl.jsx
@@ -363,21 +363,15 @@ function PlacemarkHandlers() {
       return
     }
 
-    const newNotes = [...notes]
-    const placeMarkNote = newNotes.find((note) => note.id === placeMarkId)
-    if (!placeMarkNote) {
-      return
-    }
-
     // Get the current note body and append the new placemark link
-    const editMode = editModes?.[placeMarkNote.id]
+    const editMode = editModes?.[placeMarkId]
     const newCommentBody = `[placemark](${window.location.href})`
-    const currentBody = editMode ? (editBodies[placeMarkNote.id] || '') : (body || '') // Retrieve the existing body
+    const currentBody = editMode ? (editBodies[placeMarkId] || '') : (body || '') // Retrieve the existing body
     const updatedBody = `${currentBody}\n${newCommentBody}`
 
     // Set the updated body in the global store so NoteCard can use it
     if (editMode) {
-      setEditBodyGlobal(placeMarkNote.id, updatedBody)
+      setEditBodyGlobal(placeMarkId, updatedBody)
     } else {
       setBody(updatedBody) // Fallback to set the local body if not in edit mode
     }

--- a/src/Components/Markers/MarkerControl.jsx
+++ b/src/Components/Markers/MarkerControl.jsx
@@ -43,6 +43,12 @@ function MarkerControl({context, oppositeObjects, postProcessor}) {
   const isNotesVisible = useStore((state) => state.isNotesVisible)
   const selectedPlaceMarkId = useStore((state) => state.selectedPlaceMarkId)
   const markers = useStore((state) => state.markers)
+  // eslint-disable-next-line no-unused-vars
+  const {selectedPlaceMarkInNoteId, cameraHash, forceMarkerNoteSync} = useStore((state) => ({
+    selectedPlaceMarkInNoteId: state.selectedPlaceMarkInNoteId,
+    cameraHash: state.cameraHash,
+    forceMarkerNoteSync: state.forceMarkerNoteSync,
+  }))
 
   useEffect(() => {
     if (!selectedPlaceMarkId || !markers || markers.length === 0) {
@@ -63,11 +69,12 @@ function MarkerControl({context, oppositeObjects, postProcessor}) {
       // Construct the issue/comment hash segment
       const issueHash = `;${HASH_PREFIX_NOTES}:${id}${commentId ? `;${HASH_PREFIX_COMMENT}:${commentId}` : ''}`
 
+
       // Combine both segments
-      const hash = `${coordinatesHash}${issueHash}`
+      const hash_ = `${coordinatesHash}${issueHash}${cameraHash ? `;${cameraHash}` : ''}`
 
       // Set the location hash
-      window.location.hash = hash
+      window.location.hash = hash_
     } else {
       // see if we have a temporary marker in the local group map
       const temporaryMarker = placeMarkGroupMap.get(selectedPlaceMarkId)
@@ -76,7 +83,8 @@ function MarkerControl({context, oppositeObjects, postProcessor}) {
         window.location.hash = `#${selectedPlaceMarkId}`
       }
     }
-  }, [selectedPlaceMarkId, markers]) // Add markers as a dependency if it can change
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedPlaceMarkId, markers, forceMarkerNoteSync]) // Add markers as a dependency if it can change
 
 
   // Toggle visibility of all placemarks based on isNotesVisible
@@ -232,7 +240,11 @@ function PlacemarkHandlers() {
   // Access markers and the necessary store functions
   const markers = useStore((state) => state.markers)
   const setSelectedPlaceMarkId = useStore((state) => state.setSelectedPlaceMarkId)
-  const selectedPlaceMarkInNoteId = useStore((state) => state.selectedPlaceMarkInNoteId)
+  // eslint-disable-next-line no-unused-vars
+  const {selectedPlaceMarkInNoteId, cameraHash} = useStore((state) => ({
+    selectedPlaceMarkInNoteId: state.selectedPlaceMarkInNoteId,
+    cameraHash: state.cameraHash,
+  }))
 
   useEffect(() => {
     if (!selectedPlaceMarkInNoteId) {

--- a/src/Components/Notes/NoteBodyEdit.jsx
+++ b/src/Components/Notes/NoteBodyEdit.jsx
@@ -26,7 +26,6 @@ export default function EditCardBody({handleTextUpdate, value = ''}) {
           fullWidth
           multiline
           placeholder={'Note body'}
-          inputProps={{maxLength: 256}}
         />
       </Stack>
     </CardContent>

--- a/src/Components/Notes/NoteCard.jsx
+++ b/src/Components/Notes/NoteCard.jsx
@@ -80,6 +80,8 @@ export default function NoteCard({
   const [editMode, setEditMode] = useState(false)
   const [editBody, setEditBody] = useState(body)
 
+  const setEditOriginalBody = useStore((state) => state.setEditOriginalBody)
+
 
   const handleEditBodyChange = (newBody) => {
     setEditBody(newBody) // Update local editBody state
@@ -283,6 +285,9 @@ export default function NoteCard({
                onEditClick={() => {
                 setEditMode(true)
                 setEditModeGlobal(id, true)
+                setEditBody(body)
+                setEditOriginalBody(id, body)
+                setEditBodyGlobal(id, body) // Update global editBody state
               }}
                onDeleteClick={() => onDeleteClick(noteNumber)}
                noteNumber={noteNumber}

--- a/src/Components/Notes/NoteCardCreate.jsx
+++ b/src/Components/Notes/NoteCardCreate.jsx
@@ -1,4 +1,4 @@
-import React, {useState} from 'react'
+import React, {useEffect, useState} from 'react'
 import {useAuth0} from '@auth0/auth0-react'
 import Avatar from '@mui/material/Avatar'
 import Box from '@mui/material/Box'
@@ -8,6 +8,7 @@ import CardContent from '@mui/material/CardContent'
 import CardHeader from '@mui/material/CardHeader'
 import InputBase from '@mui/material/InputBase'
 import Stack from '@mui/material/Stack'
+import useTheme from '@mui/styles/useTheme'
 import {TooltipIconButton} from '../Buttons'
 import useStore from '../../store/useStore'
 import {createIssue, getIssueComments} from '../../net/github/Issues'
@@ -44,6 +45,22 @@ export default function NoteCardCreate({
   const body = useStore((state) => state.body)
   const setBody = useStore((state) => state.setBody)
   const {togglePlaceMarkActive} = placemarkHandlers()
+  const placeMarkActivated = useStore((state) => state.placeMarkActivated)
+  const theme = useTheme()
+  const tempId = -1
+  const placeMarkId = useStore((state) => state.placeMarkId)
+  const editModes = useStore((state) => state.editModes)
+  const [placeMarkEnabled, setPlaceMarkEnabled] = useState()
+
+
+  useEffect(() => {
+    const hasAnyEditModeActive = Object.values(editModes).some((mode) => mode === true)
+    if (hasAnyEditModeActive) {
+      setPlaceMarkEnabled(!hasAnyEditModeActive)
+    } else {
+      setPlaceMarkEnabled(true)
+    }
+  }, [editModes])
 
   /**
    * create issue takes in the title and body of the note from the state
@@ -175,15 +192,28 @@ export default function NoteCardCreate({
     />
   ) : (
     <>
-    <TooltipIconButton
+    {!isNote &&
+       <Box
+         sx={{
+           '& svg': {
+             fill: (placeMarkId === tempId && placeMarkActivated) ?
+               'red' :
+               theme.palette.mode === 'light' ? 'black' : 'white',
+           },
+         }}
+       >
+         <TooltipIconButton
            title='Place Mark'
+           enabled={placeMarkEnabled}
            size='small'
            placement='bottom'
            onClick={() => {
-             togglePlaceMarkActive(selectedNoteId)
+             togglePlaceMarkActive(tempId)
            }}
            icon={<PlaceMarkIcon className='icon-share'/>}
-    />
+         />
+       </Box>
+      }
       <TooltipIconButton
         title='Submit Comment'
         onClick={createNewComment}

--- a/src/Components/Notes/NoteCardCreate.jsx
+++ b/src/Components/Notes/NoteCardCreate.jsx
@@ -153,7 +153,6 @@ export default function NoteCardCreate({
             fullWidth
             multiline
             placeholder={isNote ? 'Note Body' : 'Leave a comment ...' }
-            inputProps={{maxLength: 256}}
             data-testid={isNote ? 'CreateNote' : 'CreateComment' }
           />
         </Box>

--- a/src/Components/Notes/NoteContent.jsx
+++ b/src/Components/Notes/NoteContent.jsx
@@ -4,6 +4,7 @@ import useStore from '../../store/useStore'
 import CardContent from '@mui/material/CardContent'
 import {modifyPlaceMarkHash, parsePlacemarkFromURL} from '../Markers/MarkerControl'
 import {getHashParamsFromHashStr, getObjectParams} from '../../utils/location'
+import {HASH_PREFIX_CAMERA} from '../Camera/hashState'
 import {HASH_PREFIX_NOTES, HASH_PREFIX_COMMENT} from './hashState'
 
 /**
@@ -11,7 +12,14 @@ import {HASH_PREFIX_NOTES, HASH_PREFIX_COMMENT} from './hashState'
  * @return {ReactElement}
  */
 export default function NoteContent({markdownContent, issueID, commentID}) {
-  const setSelectedPlaceMarkInNoteId = useStore((state) => state.setSelectedPlaceMarkInNoteId)
+  const setSelectedPlaceMarkInNoteIdData = useStore((state) => state.setSelectedPlaceMarkInNoteIdData)
+
+  // eslint-disable-next-line no-unused-vars
+  const {selectedPlaceMarkInNoteId, cameraHash, forceMarkerNoteSync} = useStore((state) => ({
+    selectedPlaceMarkInNoteId: state.selectedPlaceMarkInNoteId,
+    cameraHash: state.cameraHash,
+    forceMarkerNoteSync: state.forceMarkerNoteSync,
+  }))
 
   /**
    * @param {string} urlStr
@@ -51,16 +59,18 @@ export default function NoteContent({markdownContent, issueID, commentID}) {
         const params = Object.values(getObjectParams(`#${commentHash}`))
 
         if (params) {
-          setSelectedPlaceMarkInNoteId(params[0])
+          const cameraHash_ = getHashParamsFromHashStr(url.hash, HASH_PREFIX_CAMERA)
+          setSelectedPlaceMarkInNoteIdData(params[0], cameraHash_, !forceMarkerNoteSync)
           event.preventDefault() // Prevent the default navigation
         }
       } else if (noteHash) {
           const params = Object.values(getObjectParams(`#${noteHash}`))
 
           if (params) {
-            setSelectedPlaceMarkInNoteId(params[0])
+            const cameraHash_ = getHashParamsFromHashStr(url.hash, HASH_PREFIX_CAMERA)
+            setSelectedPlaceMarkInNoteIdData(params[0], cameraHash_, !forceMarkerNoteSync)
             event.preventDefault() // Prevent the default navigation
-          }
+        }
       }
     }
   }

--- a/src/Components/Notes/NoteFooter.jsx
+++ b/src/Components/Notes/NoteFooter.jsx
@@ -129,6 +129,7 @@ export default function NoteFooter({
        >
          <TooltipIconButton
            title='Place Mark'
+           enabled={editMode}
            size='small'
            placement='bottom'
            onClick={() => {

--- a/src/Components/Notes/NoteFooter.jsx
+++ b/src/Components/Notes/NoteFooter.jsx
@@ -46,6 +46,8 @@ export default function NoteFooter({
   const placeMarkId = useStore((state) => state.placeMarkId)
   const placeMarkActivated = useStore((state) => state.placeMarkActivated)
   const setEditModeGlobal = useStore((state) => state.setEditMode)
+  const editOriginalBodies = useStore((state) => state.editOriginalBodies)
+  const setEditBodyGlobal = useStore((state) => state.setEditBody)
 
   const [shareIssue, setShareIssue] = useState(false)
   const [screenshotUri, setScreenshotUri] = useState(null)
@@ -166,6 +168,7 @@ export default function NoteFooter({
             placement='left'
             icon={<CloseIcon className='icon-share'/>}
             onClick={() => {
+              setEditBodyGlobal(id, editOriginalBodies[id])
               setEditModeGlobal(id, false) // Update global edit mode state
             }}
           />

--- a/src/Components/Notes/Notes.fixture.js
+++ b/src/Components/Notes/Notes.fixture.js
@@ -5,7 +5,8 @@ export const MOCK_NOTES = [
     id: 13,
     number: 3,
     title: 'placemark_test_1',
-    body: 'Placemark test1 note: [placemark](https://bldrs.ai/share/v/gh/nickcastel50/test-public/main/index.ifc#m:-18,20.289,-3.92,1,0,0)',
+    // eslint-disable-next-line max-len
+    body: 'Placemark test1 note: [placemark](https://bldrs.ai/share/v/gh/nickcastel50/test-public/main/index.ifc#m:-18,20.289,-3.92,1,0,0;c:71.225,28.586,-45.341,-33,15,-5.613)',
     date: '2022-06-01T22:10:49Z',
     username: 'TEST_ISSUE_USERNAME',
     numberOfComments: 2,

--- a/src/Components/Notes/NotesNavBar.jsx
+++ b/src/Components/Notes/NotesNavBar.jsx
@@ -23,6 +23,7 @@ export default function NotesNavBar() {
   const setSelectedNoteIndex = useStore((state) => state.setSelectedNoteIndex)
   const toggleIsCreateNoteVisible = useStore((state) => state.toggleIsCreateNoteVisible)
   const setSelectedPlaceMarkId = useStore((state) => state.setSelectedPlaceMarkId)
+  const setSelectedPlaceMarkInNoteIdData = useStore((state) => state.setSelectedPlaceMarkInNoteIdData)
 
 
   /**
@@ -81,6 +82,7 @@ export default function NotesNavBar() {
            onClick={() => {
              setSelectedPlaceMarkId(null)
              setSelectedNoteId(null)
+             setSelectedPlaceMarkInNoteIdData(null)
              const _location = window.location
              batchUpdateHash(_location, [
               (hash) => removeMarkerUrlParams({hash}), // Remove marker params

--- a/src/net/github/Issues.fixture.js
+++ b/src/net/github/Issues.fixture.js
@@ -4,7 +4,8 @@ export const sampleIssues = [
   {
     id: 13,
     title: 'placemark_test_1',
-    body: 'Placemark test1 note: [placemark](https://bldrs.ai/share/v/gh/nickcastel50/test-public/main/index.ifc#m:-18,20.289,-3.92,1,0,0)',
+    // eslint-disable-next-line max-len
+    body: 'Placemark test1 note: [placemark](https://bldrs.ai/share/v/gh/nickcastel50/test-public/main/index.ifc#m:-18,20.289,-3.92,1,0,0;c:71.225,28.586,-45.341,-33,15,-5.613)',
   },
   {
     id: 14,

--- a/src/store/NotesSlice.js
+++ b/src/store/NotesSlice.js
@@ -61,6 +61,11 @@ export default function createNotesSlice(set, get) {
       set((state) => ({
         editBodies: {...state.editBodies, [id]: body},
       })),
+      editOriginalBodies: {}, // Track editBody for each NoteCard by id
+      setEditOriginalBody: (id, body) =>
+        set((state) => ({
+          editOriginalBodies: {...state.editOriginalBodies, [id]: body},
+        })),
     // Action to set the body
     setBody: (newBody) => set({body: newBody}),
     setIssueBody: (newIssueBody) => set({issueBody: newIssueBody}),
@@ -70,6 +75,13 @@ export default function createNotesSlice(set, get) {
     writeMarkers: (newMarkers) => set({markers: newMarkers}), // Set markers
     clearMarkers: () => set({markers: []}), // Clear markers
     selectedPlaceMarkInNoteId: null,
-    setSelectedPlaceMarkInNoteId: (_selectedPlaceMarkInNoteId) => set(() => ({selectedPlaceMarkInNoteId: _selectedPlaceMarkInNoteId})),
+    cameraHash: null,
+    forceMarkerNoteSync: false,
+    setSelectedPlaceMarkInNoteIdData: (placeMarkId, camHash, forceMarkerNoteSync) =>
+      set({
+        selectedPlaceMarkInNoteId: placeMarkId,
+        cameraHash: camHash,
+        forceMarkerNoteSync: forceMarkerNoteSync,
+      }),
   }
 }


### PR DESCRIPTION
Addresses the following:

- [x] comment has a camera embedded in it, but when i click the marker is activated, but not the camera

editing the issue body:
- [x] adding a placemark to an existing issue/comment clears the body, which may already have text in it.  it should instead append the marker markdown
- [x] once it's cleared the text, I can't paste back in a large amount of text.. it's limited somehow
canceling doesn't restore the issue body to its original state.. but page refresh shows original state
- [x] something is weird with note navigation.. clicking back doesn't take me out of the current issue.. but if i click a few times fast it does
- [ ] comments don't have Edit menu "..."
- [x] clicking the placemark icon on issue will add to comment if you are clicked into the new comment edit box, will fix that