### PR TITLE
cutplanes: fix regression that broke Clear All in #1271

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bldrs",
-  "version": "1.0.1181",
+  "version": "1.0.1166",
   "main": "src/index.jsx",
   "license": "AGPL-3.0",
   "homepage": "https://github.com/bldrs-ai/Share",

--- a/src/Components/CutPlane/CutPlaneMenu.jsx
+++ b/src/Components/CutPlane/CutPlaneMenu.jsx
@@ -152,7 +152,7 @@ export default function CutPlaneMenu() {
         <MenuItem
           onClick={() => {
             setAnchorEl(null)
-            resetState(viewer, setCutPlaneDirections, setIsCutPlaneActive)
+            resetState(location, viewer, setCutPlaneDirections, setIsCutPlaneActive)
           }}
           data-testid='menu-item-clear-all'
         >
@@ -175,7 +175,7 @@ export default function CutPlaneMenu() {
  */
 export function resetState(location, viewer, setCutPlaneDirections, setIsCutPlaneActive) {
   // These aren't setup when CadView inits
-  if (viewer && setCutPlaneDirections && setIsCutPlaneActive) {
+  if (location && viewer && setCutPlaneDirections && setIsCutPlaneActive) {
     removePlanes(viewer)
     removeHashParams(location)
     setCutPlaneDirections([])


### PR DESCRIPTION
We caught this in Percy.  Fix just needed to line up some positional params

This looks correct to me:
https://percy.io/8fe2b2f1/web/share/builds/37686044/changed/2050599839