### PR TITLE
Add OPFS does file exist check + bubble up cache hit on http cache

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bldrs",
-  "version": "1.0.1290",
+  "version": "1.0.1293",
   "main": "src/index.jsx",
   "license": "AGPL-3.0",
   "homepage": "https://github.com/bldrs-ai/Share",

--- a/src/loader/urls.js
+++ b/src/loader/urls.js
@@ -113,7 +113,7 @@ export function parseCoords(url) {
  * @return {Array<string>} A tuple of urlStr (changed to our proxy if
  * github.com) and a sha if available.
  */
-export async function dereferenceAndProxyDownloadUrl(urlStr, accessToken, isOpfsAvailable) {
+export async function dereferenceAndProxyDownloadUrl(urlStr, accessToken, isOpfsAvailable, useCache = true) {
   const u = new URL(urlStr)
   switch (u.host.toLowerCase()) {
     case 'github.com':
@@ -135,13 +135,13 @@ export async function dereferenceAndProxyDownloadUrl(urlStr, accessToken, isOpfs
           u.pathname = proxyUrl.pathname + u.pathname
         }
 
-        return [u.toString(), '']
+        return [u.toString(), '', false]
       }
 
-      return await getGitHubPathContents(urlStr, accessToken)
+      return await getGitHubPathContents(urlStr, accessToken, useCache)
 
     default:
-      return [urlStr, '']
+      return [urlStr, '', false]
   }
 }
 
@@ -151,16 +151,17 @@ export async function dereferenceAndProxyDownloadUrl(urlStr, accessToken, isOpfs
  * @param {string} accessToken
  * @return {Array<string>} Pair of [downloadUrl, sha]
  */
-async function getGitHubPathContents(urlStr, accessToken) {
+async function getGitHubPathContents(urlStr, accessToken, useCache) {
   const repo = parseGitHubRepositoryUrl(urlStr)
-  const [downloadUrl, sha] = await getPathContents(
+  const [downloadUrl, sha, cacheHit] = await getPathContents(
     {
       orgName: repo.owner,
       name: repo.repository,
     },
     repo.path,
+    useCache,
     repo.ref,
     accessToken,
   )
-  return [downloadUrl, sha]
+  return [downloadUrl, sha, cacheHit]
 }

--- a/src/loader/urls.test.js
+++ b/src/loader/urls.test.js
@@ -110,10 +110,10 @@ describe('With environment variables', () => {
 
     let isOpfsAvailable = false
     expect(await dereferenceAndProxyDownloadUrl(
-      'https://github.com/', '', isOpfsAvailable)).toStrictEqual([`${testProxy}/foo/`, ''])
+      'https://github.com/', '', isOpfsAvailable)).toStrictEqual([`${testProxy}/foo/`, '', false])
 
     isOpfsAvailable = true
     expect(await dereferenceAndProxyDownloadUrl(
-      'https://github.com/', '', isOpfsAvailable)).toStrictEqual([`${testProxy}/bar/`, ''])
+      'https://github.com/', '', isOpfsAvailable)).toStrictEqual([`${testProxy}/bar/`, '', false])
   })
 })


### PR DESCRIPTION
- Add OPFS does file exist check + bubble up cache hit on http cache
- Satisfies new flow, does not handle using base 64 content for small files (yet)

```
first time
   /contents
   For small files, maybe just use the content
   download OTURL, story <sha>.ext
      Browser context keeps cache API to store etag data
Next time
   REQ /contents w/etag
   304 Not Modified, no body, but we have a cached RSP
      Use cached SHA to see if file exists in OPFS (now we're safe with clearOPFSCache); if so, use it no DL
      If not GET /contents w/o ETAG
         For small files, maybe just use the content
```