### PR TITLE
Allow selecting git branch in open & save flows

### DIFF
--- a/cypress/e2e/versions-100/save-imported-model.cy.js
+++ b/cypress/e2e/versions-100/save-imported-model.cy.js
@@ -28,6 +28,8 @@ describe('Versions 100: Save model', () => {
         cy.contains('@cypresstester').click()
         cy.findByLabelText('Repository', {timeout: 5000}).eq(0).click()
         cy.contains('test-repo').click()
+        cy.findByLabelText('Branch').eq(0).click()
+        cy.contains('main').click()
         cy.findByLabelText('Enter file name').click().type('save-model-test.ifc')
         cy.percySnapshot(`${percyLabelPrefix} form filled`)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bldrs",
-  "version": "1.0.1390",
+  "version": "1.0.1410",
   "main": "src/index.jsx",
   "license": "AGPL-3.0",
   "homepage": "https://github.com/bldrs-ai/Share",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bldrs",
-  "version": "1.0.1410",
+  "version": "1.0.1413",
   "main": "src/index.jsx",
   "license": "AGPL-3.0",
   "homepage": "https://github.com/bldrs-ai/Share",

--- a/src/Components/Open/GitHubFileBrowser.test.jsx
+++ b/src/Components/Open/GitHubFileBrowser.test.jsx
@@ -13,6 +13,7 @@ describe('GitHubFileBrowser', () => {
     expect(screen.getByText(/Browse files on Github/i)).toBeInTheDocument()
     expect(screen.getByLabelText(/Organization/i)).toBeInTheDocument()
     expect(screen.getByLabelText(/Repository/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/Branch/i)).toBeInTheDocument()
     expect(screen.getByLabelText(/Folder/i)).toBeInTheDocument()
     expect(screen.getByLabelText(/File/i)).toBeInTheDocument()
   })

--- a/src/Components/Open/SaveModelControl.jsx
+++ b/src/Components/Open/SaveModelControl.jsx
@@ -40,10 +40,8 @@ export default function SaveModelControl() {
     /** @return {Array<string>} organizations */
     async function fetchOrganizations() {
       const orgs = await getOrganizations(accessToken)
-      console.log('ORGS:', orgs)
       const orgNamesFetched = Object.keys(orgs).map((key) => orgs[key].login)
       const orgNames = [...orgNamesFetched, user && user.nickname]
-      console.log('ORGS NAMES:', orgNames)
       setOrgNamesArray(orgNames)
       return orgs
     }

--- a/src/Components/Open/SaveModelControl.jsx
+++ b/src/Components/Open/SaveModelControl.jsx
@@ -40,8 +40,10 @@ export default function SaveModelControl() {
     /** @return {Array<string>} organizations */
     async function fetchOrganizations() {
       const orgs = await getOrganizations(accessToken)
+      console.log('ORGS:', orgs)
       const orgNamesFetched = Object.keys(orgs).map((key) => orgs[key].login)
       const orgNames = [...orgNamesFetched, user && user.nickname]
+      console.log('ORGS NAMES:', orgNames)
       setOrgNamesArray(orgNames)
       return orgs
     }
@@ -54,7 +56,7 @@ export default function SaveModelControl() {
 
   return (
     <ControlButton
-      title='Save'
+      title={MSG_SAVE}
       isDialogDisplayed={isSaveModelVisible}
       setIsDialogDisplayed={setIsSaveModelVisible}
       icon={<SaveOutlinedIcon className='icon-share'/>}
@@ -137,6 +139,15 @@ function SaveModelDialog({isDialogDisplayed, setIsDialogDisplayed, navigate, org
             navigate({pathname: pathname})
           },
       )
+      // Store the branch name for subsequent saves
+      if (requestCreateBranch) {
+        // If it was a new branch, add it to the branches array and select it
+        const newBranchesArr = [...branchesArr.slice(0, -2), branchName, {isSeparator: true}, MSG_CREATE_BRANCH]
+        setBranchesArr(newBranchesArr)
+        setSelectedBranchName(newBranchesArr.indexOf(branchName))
+      }
+      // Only hide the create branch text field, keep the branch selector visible
+      setRequestCreateBranch(false)
       setIsDialogDisplayed(false)
     }
   }
@@ -166,7 +177,7 @@ function SaveModelDialog({isDialogDisplayed, setIsDialogDisplayed, navigate, org
     const branchesArrWithSeparator = [
       ...branchNames,
       {isSeparator: true},
-      'Create a branch',
+      MSG_CREATE_BRANCH,
     ]
     setBranchesArr(branchesArrWithSeparator)
     setSelectedBranchName(branchNames.length > 0 ? 0 : '')
@@ -180,7 +191,7 @@ function SaveModelDialog({isDialogDisplayed, setIsDialogDisplayed, navigate, org
     const foldersArrWithSeparator = [
       ...directoryNames, // All the folders
       {isSeparator: true}, // Separator item
-      'Create a folder',
+      MSG_CREATE_FOLDER,
     ]
 
     setFoldersArr([...foldersArrWithSeparator])
@@ -201,7 +212,7 @@ function SaveModelDialog({isDialogDisplayed, setIsDialogDisplayed, navigate, org
       newPath = pathSegments.join('/')
 
       setRequestCreateFolder(false)
-    } else if (selectedFolderName_ === 'Create a folder') {
+    } else if (selectedFolderName_ === MSG_CREATE_FOLDER) {
       newPath = currentPath
       setRequestCreateFolder(true)
     } else {
@@ -227,7 +238,7 @@ function SaveModelDialog({isDialogDisplayed, setIsDialogDisplayed, navigate, org
     const foldersArrWithSeparator = [
       ...navigationOptions, // All the folders
       {isSeparator: true}, // Separator item
-      'Create a folder',
+      MSG_CREATE_FOLDER,
     ]
 
     setFoldersArr(foldersArrWithSeparator)
@@ -235,7 +246,7 @@ function SaveModelDialog({isDialogDisplayed, setIsDialogDisplayed, navigate, org
 
   const selectBranch = (branchIndex) => {
     const branchName_ = branchesArr[branchIndex]
-    if (branchName_ === 'Create a branch') {
+    if (branchName_ === MSG_CREATE_BRANCH) {
       setRequestCreateBranch(true)
     } else {
       setSelectedBranchName(branchIndex)
@@ -246,10 +257,10 @@ function SaveModelDialog({isDialogDisplayed, setIsDialogDisplayed, navigate, org
   return (
     <Dialog
       headerIcon={<SaveOutlinedIcon className='icon-share'/>}
-      headerText='Save'
+      headerText={MSG_SAVE}
       isDialogDisplayed={isDialogDisplayed}
       setIsDialogDisplayed={setIsDialogDisplayed}
-      actionTitle='Save model'
+      actionTitle={MSG_SAVE_MODEL}
       actionCb={saveFile}
     >
       <Stack
@@ -263,23 +274,23 @@ function SaveModelDialog({isDialogDisplayed, setIsDialogDisplayed, navigate, org
         ) : (
           file instanceof File && (
             <Stack>
-              <Typography variant='overline' sx={{marginBottom: '6px'}}>Projects</Typography>
+              <Typography variant='overline' sx={{marginBottom: '6px'}}>{MSG_PROJECTS}</Typography>
               <Selector
-                label='Organization'
+                label={MSG_ORGANIZATION}
                 list={orgNamesArrWithAt}
                 selected={selectedOrgName}
                 setSelected={selectOrg}
                 data-testid='saveOrganization'
               />
               <Selector
-                label='Repository'
+                label={MSG_REPOSITORY}
                 list={repoNamesArr}
                 selected={selectedRepoName}
                 setSelected={selectRepo}
                 data-testid='saveRepository'
               />
               <SelectorSeparator
-                label='Branch'
+                label={MSG_BRANCH}
                 list={branchesArr}
                 selected={selectedBranchName}
                 setSelected={selectBranch}
@@ -288,7 +299,7 @@ function SaveModelDialog({isDialogDisplayed, setIsDialogDisplayed, navigate, org
               {requestCreateBranch && (
                 <div style={{display: 'flex', alignItems: 'center', marginBottom: '.5em'}}>
                   <TextField
-                    label='Enter branch name'
+                    label={MSG_ENTER_BRANCH_NAME}
                     variant='outlined'
                     size='small'
                     onChange={(e) => setCreateBranchName(e.target.value)}
@@ -307,7 +318,7 @@ function SaveModelDialog({isDialogDisplayed, setIsDialogDisplayed, navigate, org
                 </div>
               )}
               <SelectorSeparator
-                label={currentPath === '' ? 'Folder' : `Folder: ${currentPath}`}
+                label={currentPath === '' ? MSG_FOLDER : `${MSG_FOLDER}: ${currentPath}`}
                 list={foldersArr}
                 selected={selectedFolderName}
                 setSelected={selectFolder}
@@ -316,14 +327,13 @@ function SaveModelDialog({isDialogDisplayed, setIsDialogDisplayed, navigate, org
               {requestCreateFolder && (
                 <div style={{display: 'flex', alignItems: 'center', marginBottom: '.5em'}}>
                   <TextField
-                    label='Enter folder name'
+                    label={MSG_ENTER_FOLDER_NAME}
                     variant='outlined'
                     size='small'
                     onChange={(e) => setCreateFolderName(e.target.value)}
                     data-testid='CreateFolderId'
                     sx={{flexGrow: 1}}
                     onKeyDown={(e) => {
-                      // Stops the event from propagating up to parent elements
                       e.stopPropagation()
                     }}
                   />
@@ -336,7 +346,7 @@ function SaveModelDialog({isDialogDisplayed, setIsDialogDisplayed, navigate, org
                 </div>
               )}
               <TextField
-                label='Enter file name'
+                label={MSG_ENTER_FILE_NAME}
                 variant='outlined'
                 size='small'
                 onChange={(e) => setSelectedFileName(e.target.value)}
@@ -365,7 +375,7 @@ function SaveModelDialog({isDialogDisplayed, setIsDialogDisplayed, navigate, org
  * @param {Function} setSnackMessage - Function to set a snack message displayed to the user.
  */
 function redirectToNewModel(onPathname, orgName, repoName, branchName, pathWithFileName, setSnackMessage) {
-  setSnackMessage('Model saved successfully!')
+  setSnackMessage(MSG_SAVE_SUCCESS)
   const pauseTimeMs = 5000
   setTimeout(() => setSnackMessage(null), pauseTimeMs)
 
@@ -424,7 +434,7 @@ async function fileSave(
       if (opfsResult) {
         redirectToNewModel(onPathname, orgName, repoName, branchName, pathWithFileName, setSnackMessage)
       } else {
-        setSnackMessage('Error: Could not write file to OPFS.')
+        setSnackMessage(MSG_ERROR_OPFS)
         const pauseTimeMs = 5000
         setTimeout(() => setSnackMessage(null), pauseTimeMs)
       }
@@ -432,9 +442,26 @@ async function fileSave(
       redirectToNewModel(onPathname, orgName, repoName, branchName, pathWithFileName, setSnackMessage)
     }
     } else {
-      setSnackMessage('Error: Could not commit to GitHub.')
+      setSnackMessage(MSG_ERROR_GITHUB)
       const pauseTimeMs = 5000
       setTimeout(() => setSnackMessage(null), pauseTimeMs)
     }
   }
 }
+
+
+const MSG_BRANCH = 'Branch'
+const MSG_CREATE_BRANCH = 'Create a branch'
+const MSG_CREATE_FOLDER = 'Create a folder'
+const MSG_ENTER_BRANCH_NAME = 'Enter branch name'
+const MSG_ENTER_FOLDER_NAME = 'Enter folder name'
+const MSG_ENTER_FILE_NAME = 'Enter file name'
+const MSG_ERROR_GITHUB = 'Error: Could not commit to GitHub.'
+const MSG_ERROR_OPFS = 'Error: Could not write file to OPFS.'
+const MSG_FOLDER = 'Folder'
+const MSG_ORGANIZATION = 'Organization'
+const MSG_PROJECTS = 'Projects'
+const MSG_SAVE = 'Save'
+const MSG_SAVE_MODEL = 'Save model'
+const MSG_SAVE_SUCCESS = 'Model saved successfully!'
+const MSG_REPOSITORY = 'Repository'

--- a/src/Components/Open/SaveModelControl.test.jsx
+++ b/src/Components/Open/SaveModelControl.test.jsx
@@ -22,10 +22,21 @@ jest.mock('../../net/github/Branches', () => ({
 
 
 describe('SaveModelControl', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    getBranches.mockResolvedValue([{name: 'main'}, {name: 'dev'}])
+    getOrganizations.mockResolvedValue(MOCK_ORGANIZATIONS.data)
+    // Reset store state
+    const {result} = renderHook(() => useStore((state) => state))
+    act(() => {
+      result.current.setIsSaveModelVisible(false)
+      result.current.setAccessToken(null)
+      result.current.setOpfsFile(null)
+    })
+  })
+
   it('Renders a login message if the user is not logged in', async () => {
     mockedUseAuth0.mockReturnValue(mockedUserLoggedOut)
-    getBranches.mockResolvedValue([{name: 'main'}, {name: 'dev'}])
-    getOrganizations.mockResolvedValue([])
     const {getByTestId, getByText, getByRole} = render(<SaveModelControlFixture/>)
     const saveControlButton = getByTestId('control-button-save')
     fireEvent.click(saveControlButton)
@@ -47,9 +58,7 @@ describe('SaveModelControl', () => {
 
   it('Renders branch selector after selecting a repository', async () => {
     mockedUseAuth0.mockReturnValue(mockedUserLoggedIn)
-    getBranches.mockResolvedValue([{name: 'main'}, {name: 'dev'}])
-    getOrganizations.mockResolvedValue(MOCK_ORGANIZATIONS.data)
-
+    
     // Set up store state using renderHook and act
     const {result} = renderHook(() => useStore((state) => state))
     await act(() => {
@@ -64,7 +73,6 @@ describe('SaveModelControl', () => {
     // Wait for dialog to be visible
     const dialog = await waitFor(() => getByRole('dialog'))
     expect(dialog).toBeVisible()
-
 
     // Wait for the repository selector to be available and click it
     const repoSelect = await waitFor(() => getByTestId('saveRepository'))

--- a/src/Components/Open/SaveModelControl.test.jsx
+++ b/src/Components/Open/SaveModelControl.test.jsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import {act, fireEvent, render, renderHook, waitFor} from '@testing-library/react'
-import {prettyDOM} from '@testing-library/dom'
 import {getOrganizations} from '../../net/github/Organizations'
 import {getBranches} from '../../net/github/Branches'
 import useStore from '../../store/useStore'
@@ -58,7 +57,6 @@ describe('SaveModelControl', () => {
 
   it('Renders branch selector after selecting a repository', async () => {
     mockedUseAuth0.mockReturnValue(mockedUserLoggedIn)
-    
     // Set up store state using renderHook and act
     const {result} = renderHook(() => useStore((state) => state))
     await act(() => {

--- a/src/Components/Open/SaveModelControl.test.jsx
+++ b/src/Components/Open/SaveModelControl.test.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import {act, fireEvent, render, renderHook} from '@testing-library/react'
 import {getOrganizations} from '../../net/github/Organizations'
+import {getBranches} from '../../net/github/Branches'
 import useStore from '../../store/useStore'
 import {
   mockedUseAuth0,
@@ -12,6 +13,9 @@ import {SaveModelControlFixture} from './SaveModelControl.fixture'
 
 jest.mock('../../net/github/Organizations', () => ({
   getOrganizations: jest.fn(),
+}))
+jest.mock('../../net/github/Branches', () => ({
+  getBranches: jest.fn(),
 }))
 
 
@@ -33,15 +37,16 @@ describe('SaveModelControl', () => {
     expect(loginText).toBeInTheDocument()
   })
 
-   it('Renders file selector if the user is logged in', async () => {
+  it('Renders branch selector after selecting a repository', async () => {
     mockedUseAuth0.mockReturnValue(mockedUserLoggedIn)
+    getBranches.mockResolvedValue([{name: 'main'}, {name: 'dev'}])
     const {getByTestId} = render(<SaveModelControlFixture/>)
     const saveControlButton = getByTestId('control-button-save')
     fireEvent.click(saveControlButton)
-    const File = getByTestId('CreateFileId')
-    const Repository = await getByTestId('saveRepository')
-    expect(File).toBeInTheDocument()
-    expect(Repository).toBeInTheDocument()
+    const repoSelect = await getByTestId('saveRepository')
+    fireEvent.change(repoSelect, {target: {value: 0}})
+    const branchSelect = await getByTestId('saveBranch')
+    expect(branchSelect).toBeInTheDocument()
   })
 
   it('Does not fetch repo info on initial render when isSaveModelVisible=false in zustand', async () => {

--- a/src/OPFS/utils.js
+++ b/src/OPFS/utils.js
@@ -19,7 +19,7 @@ import debug from '../utils/debug'
  * Write model to OPFS.
  *
  * @param {string} filepath
- * @return {File}
+ * @return {Promise<File>}
  */
 export function writeSavedGithubModelOPFS(modelFile, originalFilePath, commitHash, owner, repo, branch) {
   return new Promise((resolve, reject) => {

--- a/src/__mocks__/api-handlers.js
+++ b/src/__mocks__/api-handlers.js
@@ -405,7 +405,7 @@ function githubHandlers(defines, authed) {
     rest.get(`${authed ? GH_BASE_AUTHED : GH_BASE_UNAUTHED}/repos/:owner/:repo/branches`, (req, res, ctx) => {
       return res(
         ctx.status(httpOk),
-        ctx.json(MOCK_BRANCHES),
+        ctx.json(MOCK_BRANCHES.data),
       )
     }),
 

--- a/src/net/github/Branches.js
+++ b/src/net/github/Branches.js
@@ -5,7 +5,7 @@ import {getGitHub} from './Http'
 /**
  * @param {object} repository
  * @param {string} [accessToken]
- * @return {Array}
+ * @return {Promise<Array>}
  */
 export async function getBranches(repository, accessToken = '') {
   assertDefined(...arguments)

--- a/src/net/github/Files.js
+++ b/src/net/github/Files.js
@@ -1,7 +1,7 @@
 import {assertDefined} from '../../utils/assert'
-import {octokit} from './OctokitExport'
-import {getGitHub, getGitHubResource} from './Http' // TODO(pablo): don't use octokit directly
 import {checkCache, updateCache} from './Cache'
+import {getGitHub, getGitHubResource, HTTP_CREATED, HTTP_NOT_MODIFIED, HTTP_NOT_FOUND} from './Http'
+import {octokit} from './OctokitExport'
 
 
 /**
@@ -20,7 +20,7 @@ import {checkCache, updateCache} from './Cache'
  * @param {string} message The commit message
  * @param {string} branch The branch to which the commit will be made
  * @param {string} accessToken The access token for authentication
- * @return {string} newCommitSha
+ * @return {Promise<string>} A promise that resolves to the new commit SHA
  */
 export async function commitFile(owner, repo, path, file, message, branch, accessToken) {
   assertDefined(...arguments)
@@ -47,18 +47,21 @@ export async function commitFile(owner, repo, path, file, message, branch, acces
   }
 
   let cacheKey = `${owner}/${repo}/${path}/getRef`
-  let cached = checkCache(cacheKey)
+  let cached = await checkCache(cacheKey)
 
-  // If we have a cached ETag, add If-None-Match header
-  if (cached && cached.headers && cached.headers.etag) {
-    headers['If-None-Match'] = cached.headers.get('etag')
-  } else {
-    headers['If-None-Match'] = ''
+  const addIfNoneMatchHeader = (headersObj, cachedObj) => {
+    if (cachedObj && cachedObj.headers && cachedObj.headers.etag) {
+      headersObj['If-None-Match'] = cachedObj.headers.etag
+    } else {
+      headersObj['If-None-Match'] = ''
+    }
   }
+  addIfNoneMatchHeader(headers, cached)
 
   let refData
+  let response
   try {
-    const response = await octokit.rest.git.getRef({
+    response = await octokit.rest.git.getRef({
       owner,
       repo,
       ref: `heads/${branch}`,
@@ -67,12 +70,54 @@ export async function commitFile(owner, repo, path, file, message, branch, acces
     refData = response.data
     await updateCache(cacheKey, response)
   } catch (error) {
-    const NOTMODIFIED = 304
-    if (error.status === NOTMODIFIED && cached) {
-      refData = cached
+    if (error.status === HTTP_NOT_MODIFIED && cached) {
+      refData = cached.data
+    } else if (
+      error.status === HTTP_NOT_FOUND &&
+      error.message.includes('https://docs.github.com/rest/git/refs#get-a-reference')) {
+      // If the branch doesn't exist, create it.
+      // 1. Get the default branch
+      let newRefResponse
+      try {
+        const repoInfo = await octokit.rest.repos.get({
+          owner,
+          repo,
+          headers,
+        })
+        const defaultBranch = repoInfo.data.default_branch
+        // 2. Get the latest commit on the default branch
+        const baseRefResponse = await octokit.rest.git.getRef({
+          owner,
+          repo,
+          ref: `heads/${defaultBranch}`,
+          headers,
+        })
+        const baseSha = baseRefResponse.data.object.sha
+        // 3. Create a new branch with the default branch as the base
+        newRefResponse = await octokit.rest.git.createRef({
+          owner,
+          repo,
+          ref: `refs/heads/${branch}`, // must include "refs/"
+          sha: baseSha,
+          headers,
+        })
+
+        if (newRefResponse.status !== HTTP_CREATED) {
+          throw new Error('Failed to create new branch')
+        }
+      } catch (err) {
+        throw new Error(`Failed to create branch: ${err.message}`)
+      }
+
+      refData = newRefResponse.data
+      await updateCache(cacheKey, newRefResponse)
     } else {
       throw error
     }
+  }
+
+  if (!refData || !refData.object || !refData.object.sha) {
+    throw new Error('Failed to get or create branch reference')
   }
 
   const parentSha = refData.object.sha
@@ -80,16 +125,12 @@ export async function commitFile(owner, repo, path, file, message, branch, acces
   cacheKey = `${owner}/${repo}/${path}/getCommit`
   cached = await checkCache(cacheKey)
 
-  if (cached && cached.headers && cached.headers.etag) {
-    headers['If-None-Match'] = cached.headers.get('etag')
-  } else {
-    headers['If-None-Match'] = ''
-  }
+  addIfNoneMatchHeader(headers, cached)
 
   let commitData
   try {
     // 2. Get the SHA of the tree associated with the latest commit
-    const response = await octokit.rest.git.getCommit({
+    response = await octokit.rest.git.getCommit({
       owner,
       repo,
       commit_sha: parentSha,
@@ -98,9 +139,8 @@ export async function commitFile(owner, repo, path, file, message, branch, acces
     commitData = response.data
     await updateCache(cacheKey, response)
   } catch (error) {
-    const NOTMODIFIED = 304
-    if (error.status === NOTMODIFIED && cached) {
-      commitData = cached
+    if (error.status === HTTP_NOT_MODIFIED && cached) {
+      commitData = cached.data
     } else {
       throw error
     }

--- a/src/net/github/Http.js
+++ b/src/net/github/Http.js
@@ -2,6 +2,13 @@ import {assertDefined} from '../../utils/assert'
 import {checkCache, updateCache} from './Cache'
 import {octokit} from './OctokitExport'
 
+// HTTP Status Codes
+export const HTTP_OK = 200
+export const HTTP_CREATED = 201
+export const HTTP_NOT_MODIFIED = 304
+export const HTTP_NOT_FOUND = 404
+export const HTTP_INTERNAL_SERVER_ERROR = 500
+
 /**
  * Fetch the resource at the given path from GitHub, optionally using cache checks (ETag).
  *
@@ -65,8 +72,7 @@ export async function getGitHubResource(repository, path, args = {}, useCache = 
       isCacheHit,
     }
   } catch (error) {
-    const NOTMODIFIED = 304
-    if (useCache && error.status === NOTMODIFIED) {
+    if (useCache && error.status === HTTP_NOT_MODIFIED) {
       // We got a 304 Not Modified, meaning we can safely use our cached copy
       if (cached) {
         isCacheHit = true
@@ -124,8 +130,7 @@ export async function getGitHub(repository, path, args = {}, accessToken = '') {
 
     return response
   } catch (error) {
-    const NOTMODIFIED = 304
-    if (error.status === NOTMODIFIED) {
+    if (error.status === HTTP_NOT_MODIFIED) {
       // Handle 304 Not Modified
       // Return cached data if available
       if (cached) {


### PR DESCRIPTION
## Summary
- let users choose a repo branch when saving a model
- show a branch selector and option to create a new branch
- show branch selector in GitHub open flow
- update unit and e2e tests for branch selection

## Testing
- `yarn lint` *(fails: This package doesn't seem to be present in your lockfile)*
- `yarn test` *(fails: This package doesn't seem to be present in your lockfile)*