### PR TITLE
fix: resolve ESLint and JSDoc warnings in Profile components

### DIFF
--- a/src/Components/Profile/ProfileControl.jsx
+++ b/src/Components/Profile/ProfileControl.jsx
@@ -35,7 +35,9 @@ const OAUTH_2_CLIENT_ID = process.env.OAUTH2_CLIENT_ID
 const useMock = OAUTH_2_CLIENT_ID === 'cypresstestaudience'
 
 /**
+ * Login dialog component with provider selection
  *
+ * @return {React.Component} Dialog component for login
  */
 function LoginDialog({open, onClose, onLogin, isGoogleEnabled}) {
   return (


### PR DESCRIPTION
## Summary
- Add missing JSDoc @return declarations with proper spacing for ManageProfile and LoginDialog components
- Wrap refreshUser function in useCallback to prevent React Hook dependency warnings
- Move refreshUser definition before useEffect to avoid hoisting issues
- Add useCallback import to ManageProfile component

## Test plan
- [x] All ESLint warnings are resolved (`yarn lint` passes)
- [x] All tests pass (`yarn test` passes)  
- [x] Profile components functionality remains unchanged

🤖 Generated with [Claude Code](https://claude.ai/code)