### PR TITLE
gha: ignore MD changes committed directly to main

### DIFF
--- a/.github/workflows/end-to-end-tests.yml
+++ b/.github/workflows/end-to-end-tests.yml
@@ -2,13 +2,12 @@ name: flow-tests
 
 on:
   push:
-    branches:
-      - main
-
+    branches: [ main ]
+    paths-ignore:
+      - '**/*.md'
+      - 'README.md'
   pull_request:
-    branches:
-      - main
-
+    branches: [ main ]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,6 +3,9 @@ name: build
 on:
   push:
     branches: [ main ]
+    paths-ignore:
+      - '**/*.md'
+      - 'README.md'
   pull_request:
     branches: [ main ]
   workflow_dispatch:


### PR DESCRIPTION
Just saw we're kicking off Actions when I changed README, so filtering so that we don't on directly commits to main.