### PR TITLE
opfs: worker url case test OPFS.Worker.js -> OPFS.worker.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bldrs",
-  "version": "1.0.1845",
+  "version": "1.0.1846",
   "main": "src/index.jsx",
   "license": "AGPL-3.0",
   "homepage": "https://github.com/bldrs-ai/Share",

--- a/src/OPFS/OPFSService.js
+++ b/src/OPFS/OPFSService.js
@@ -17,7 +17,8 @@ let workerRef = null
  */
 export function initializeWorker() {
   if (workerRef === null) {
-    workerRef = new Worker(new URL('/OPFS.worker.js', import.meta.url), {type: 'module'})
+    const workerUrl = new URL('./OPFS.worker.js', import.meta.url)
+    workerRef = new Worker(workerUrl, {type: 'module', name: 'OPFS Worker'})
 
     workerRef.postMessage({
       command: 'initializeWorker',


### PR DESCRIPTION
Couple of tweaks to address #1449.

- Change work URL from '/OPFS.Worker.js' -> './OPFS.worker.js'

Tested in Desktop and mobile with Chrome, Safari & FF