### PR TITLE
1360 error failed to parse model

### DIFF
--- a/src/net/github/utils.js
+++ b/src/net/github/utils.js
@@ -27,9 +27,12 @@ export const parseGitHubRepositoryUrl = (githubUrl) => {
   if (host !== 'github.com' && host !== 'raw.githubusercontent.com') {
     throw new Error('Not a valid GitHub repository URL')
   }
-  const match = url.pathname.match(`^/${pathParts.join('/')}$`)
-  if (match === null) {
+  const match = re.exec(url.pathname)
+  if (!match) {
     throw new Error('Could not match GitHub repository URL')
+  }
+  if (!match.groups) {
+    throw new Error('GitHub repository URL does not expose named groups')
   }
   const {groups: {org, repo, branch, file}} = match
   return {

--- a/src/net/github/utils.test.js
+++ b/src/net/github/utils.test.js
@@ -31,6 +31,14 @@ describe('net/github/utils', () => {
       expect(actual.ref).toEqual('main')
       expect(actual.path).toEqual('haus.ifc')
     })
+
+    it('throws an error if a match has no named capture groups', () => {
+      const execSpy = jest.spyOn(RegExp.prototype, 'exec')
+      execSpy.mockReturnValueOnce([''])
+      expect(() => parseGitHubRepositoryUrl('https://github.com/org/repo/blob/main/file.ifc'))
+        .toThrowError('GitHub repository URL does not expose named groups')
+      execSpy.mockRestore()
+    })
   })
 
 


### PR DESCRIPTION
- Updated GitHub repository URL parsing to use the shared regex and added a guard for missing named capture groups to prevent destructuring failures during URL parsing.

- Added a regression test that simulates a regex match without named capture groups to ensure the GitHub URL parsing guard throws a clear error.