### PR TITLE
Add OAuth state parameter to Google Drive auth (CSRF protection)

### DIFF
--- a/src/Components/Connections/googleApisFake.js
+++ b/src/Components/Connections/googleApisFake.js
@@ -23,15 +23,17 @@ window.google = {
       initTokenClient(config) {
         return {
           /**
+           * @param {object} [tokenConfig] Optional config including state for CSRF verification
            * @return {void}
            */
-          requestAccessToken() {
+          requestAccessToken(tokenConfig) {
             setTimeout(() => {
               config.callback({
                 access_token: 'fake-gis-access-token',
                 expires_in: FAKE_EXPIRES_IN,
                 scope: 'https://www.googleapis.com/auth/drive.readonly',
                 token_type: 'Bearer',
+                state: tokenConfig?.state,
               })
             }, 50)
           },

--- a/src/connections/google-drive/GoogleDriveProvider.test.ts
+++ b/src/connections/google-drive/GoogleDriveProvider.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Tests for GoogleDriveProvider, focused on OAuth state (CSRF) verification.
+ */
+
+import {googleDriveProvider} from './GoogleDriveProvider'
+
+
+jest.mock('./loadGisScript', () => ({
+  loadGisScript: jest.fn().mockResolvedValue(undefined),
+}))
+
+jest.useFakeTimers()
+
+
+let capturedCallback: ((response: Record<string, unknown>) => void) | null = null
+const mockRequestAccessToken = jest.fn()
+
+beforeAll(() => {
+  Object.defineProperty(global, 'google', {
+    value: {
+      accounts: {
+        oauth2: {
+          initTokenClient: jest.fn((config) => {
+            capturedCallback = config.callback
+            return {requestAccessToken: mockRequestAccessToken}
+          }),
+          revoke: jest.fn(),
+        },
+      },
+    },
+    writable: true,
+  })
+
+  if (!global.crypto?.randomUUID) {
+    Object.defineProperty(global, 'crypto', {
+      value: {randomUUID: () => 'test-uuid-1234'},
+      writable: true,
+    })
+  }
+
+  // Resolve email fetch immediately with null (not found)
+  global.fetch = jest.fn().mockResolvedValue({ok: false})
+
+  process.env.GOOGLE_OAUTH2_CLIENT_ID = 'test-client-id'
+})
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  capturedCallback = null
+  sessionStorage.clear()
+})
+
+
+/**
+ * Flush the microtask queue so awaited promises inside the provider resolve.
+ *
+ * @return Promise that resolves after pending microtasks drain.
+ */
+async function flushMicrotasks(): Promise<void> {
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
+
+describe('GoogleDriveProvider — OAuth state (CSRF protection)', () => {
+  it('passes state to requestAccessToken in connect()', async () => {
+    googleDriveProvider.connect()
+    await flushMicrotasks()
+    expect(mockRequestAccessToken).toHaveBeenCalledWith(
+      expect.objectContaining({state: expect.any(String)}),
+    )
+  })
+
+  it('rejects connect() when response state does not match', async () => {
+    const connectPromise = googleDriveProvider.connect()
+    await flushMicrotasks()
+
+    capturedCallback?.({
+      access_token: 'tok',
+      expires_in: 3600,
+      scope: 'drive.readonly',
+      token_type: 'Bearer',
+      state: 'wrong-state',
+    })
+
+    await expect(connectPromise).rejects.toThrow('OAuth state mismatch')
+  })
+
+  it('resolves connect() when response state matches', async () => {
+    const connectPromise = googleDriveProvider.connect()
+    await flushMicrotasks()
+
+    capturedCallback?.({
+      access_token: 'tok',
+      expires_in: 3600,
+      scope: 'drive.readonly',
+      token_type: 'Bearer',
+      state: 'test-uuid-1234',
+    })
+
+    // Advance past the 5s email-fetch race timeout (but not the 120s connect timeout)
+    // eslint-disable-next-line no-magic-numbers
+    jest.advanceTimersByTime(6_000)
+    await flushMicrotasks()
+
+    await expect(connectPromise).resolves.toMatchObject({
+      providerId: 'google-drive',
+      status: 'connected',
+    })
+  })
+
+  it('does not reject when state is absent from response (sessionStorage unavailable)', async () => {
+    const connectPromise = googleDriveProvider.connect()
+    await flushMicrotasks()
+
+    // Clear stored state to simulate unavailable sessionStorage
+    sessionStorage.clear()
+
+    capturedCallback?.({
+      access_token: 'tok',
+      expires_in: 3600,
+      scope: 'drive.readonly',
+      token_type: 'Bearer',
+      // no state in response — expectedState is null, validation skipped
+    })
+
+    // eslint-disable-next-line no-magic-numbers
+    jest.advanceTimersByTime(6_000)
+    await flushMicrotasks()
+
+    await expect(connectPromise).resolves.toMatchObject({providerId: 'google-drive'})
+  })
+})

--- a/src/connections/google-drive/GoogleDriveProvider.test.ts
+++ b/src/connections/google-drive/GoogleDriveProvider.test.ts
@@ -15,6 +15,8 @@ jest.useFakeTimers()
 let capturedCallback: ((response: Record<string, unknown>) => void) | null = null
 const mockRequestAccessToken = jest.fn()
 
+let originalFetch: typeof global.fetch
+
 beforeAll(() => {
   Object.defineProperty(global, 'google', {
     value: {
@@ -29,19 +31,29 @@ beforeAll(() => {
       },
     },
     writable: true,
+    configurable: true,
   })
 
   if (!global.crypto?.randomUUID) {
     Object.defineProperty(global, 'crypto', {
       value: {randomUUID: () => 'test-uuid-1234'},
       writable: true,
+      configurable: true,
     })
   }
 
   // Resolve email fetch immediately with null (not found)
+  originalFetch = global.fetch
   global.fetch = jest.fn().mockResolvedValue({ok: false})
 
   process.env.GOOGLE_OAUTH2_CLIENT_ID = 'test-client-id'
+})
+
+afterAll(() => {
+  global.fetch = originalFetch
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  delete global.google
 })
 
 beforeEach(() => {

--- a/src/connections/google-drive/GoogleDriveProvider.ts
+++ b/src/connections/google-drive/GoogleDriveProvider.ts
@@ -235,6 +235,10 @@ export const googleDriveProvider: ConnectionProvider = {
             }, POPUP_CLOSE_DEBOUNCE_MS)
             return
           }
+          if (error.type === 'popup_failed_to_open') {
+            settle(() => reject(new Error('Please allow pop-ups to sign in with Google.')))
+            return
+          }
           settle(() => reject(new Error(`Google OAuth error: ${error.type} - ${error.message}`)))
         },
       })

--- a/src/connections/google-drive/GoogleDriveProvider.ts
+++ b/src/connections/google-drive/GoogleDriveProvider.ts
@@ -77,6 +77,45 @@ function clearTokenFromSession(connectionId: string): void {
   }
 }
 
+const SESSION_STATE_KEY = 'gdrive_oauth_state'
+
+
+/**
+ * Generate a cryptographically random state value for CSRF protection.
+ *
+ * @return A UUID string.
+ */
+function generateState(): string {
+  return crypto.randomUUID()
+}
+
+
+/** Store the expected state in sessionStorage before launching the OAuth popup. */
+function saveStateToSession(state: string): void {
+  try {
+    sessionStorage.setItem(SESSION_STATE_KEY, state)
+  } catch {
+    // sessionStorage unavailable — state validation will be skipped
+  }
+}
+
+
+/**
+ * Read and remove the expected state from sessionStorage.
+ * Returns null if absent (e.g. sessionStorage unavailable).
+ *
+ * @return The stored state string, or null.
+ */
+function consumeStateFromSession(): string | null {
+  try {
+    const state = sessionStorage.getItem(SESSION_STATE_KEY)
+    sessionStorage.removeItem(SESSION_STATE_KEY)
+    return state
+  } catch {
+    return null
+  }
+}
+
 let idCounter = 0
 
 /** @return A unique connection ID */
@@ -133,6 +172,9 @@ export const googleDriveProvider: ConnectionProvider = {
         meta: email ? {email} : {},
       })
 
+      const oauthState = generateState()
+      saveStateToSession(oauthState)
+
       const client = google.accounts.oauth2.initTokenClient({
         client_id: clientId,
         scope: SCOPES,
@@ -141,9 +183,17 @@ export const googleDriveProvider: ConnectionProvider = {
           debug().log('[GDrive] OAuth callback received, error:', response.error || 'none')
 
           if (response.error) {
+            consumeStateFromSession()
             settle(() => reject(new Error(
               `Google OAuth error: ${response.error} - ${response.error_description || ''}`,
             )))
+            return
+          }
+
+          // Verify state to prevent CSRF
+          const expectedState = consumeStateFromSession()
+          if (expectedState !== null && response.state !== expectedState) {
+            settle(() => reject(new Error('OAuth state mismatch — possible CSRF attack')))
             return
           }
 
@@ -190,7 +240,7 @@ export const googleDriveProvider: ConnectionProvider = {
       })
 
       debug().log('[GDrive] Calling requestAccessToken...')
-      client.requestAccessToken()
+      client.requestAccessToken({state: oauthState})
     })
   },
 
@@ -246,6 +296,9 @@ export const googleDriveProvider: ConnectionProvider = {
       throw new Error('GOOGLE_OAUTH2_CLIENT_ID environment variable is not set')
     }
 
+    const oauthState = generateState()
+    saveStateToSession(oauthState)
+
     return new Promise<string>((resolve, reject) => {
       let settled = false
 
@@ -255,9 +308,20 @@ export const googleDriveProvider: ConnectionProvider = {
         hint: (connection.meta.email as string) || undefined,
         callback: (response: TokenResponse) => {
           if (response.error) {
+            consumeStateFromSession()
             if (!settled) {
               settled = true
               reject(new Error(`Google OAuth refresh error: ${response.error}`))
+            }
+            return
+          }
+
+          // Verify state to prevent CSRF
+          const expectedState = consumeStateFromSession()
+          if (expectedState !== null && response.state !== expectedState) {
+            if (!settled) {
+              settled = true
+              reject(new Error('OAuth state mismatch — possible CSRF attack'))
             }
             return
           }
@@ -284,7 +348,7 @@ export const googleDriveProvider: ConnectionProvider = {
       })
 
       // Use empty string prompt to try silent refresh; will show popup if consent needed
-      client.requestAccessToken({prompt: ''})
+      client.requestAccessToken({prompt: '', state: oauthState})
     })
   },
 }

--- a/src/connections/google-drive/loadGisScript.ts
+++ b/src/connections/google-drive/loadGisScript.ts
@@ -145,10 +145,11 @@ export interface TokenClientConfig {
   error_callback?: (error: {type: string; message: string}) => void
   hint?: string
   prompt?: string
+  state?: string
 }
 
 export interface TokenClient {
-  requestAccessToken(config?: {prompt?: string; hint?: string}): void
+  requestAccessToken(config?: {prompt?: string; hint?: string; state?: string}): void
 }
 
 export interface TokenResponse {
@@ -158,6 +159,7 @@ export interface TokenResponse {
   token_type: string
   error?: string
   error_description?: string
+  state?: string
 }
 
 export interface PickerBuilder {


### PR DESCRIPTION
This PR satisfies a security measure required by Google, to pass a state token back and forth to goog on login flow.

## Summary

- Generates a cryptographically random `state` value (`crypto.randomUUID()`) before each OAuth popup
- Stores it in `sessionStorage`, passes it to `requestAccessToken({state})`
- Verifies it matches in the GIS callback — mismatches reject with `'OAuth state mismatch — possible CSRF attack'`
- Applies to both `connect()` and `getAccessToken()` flows
- Graceful degradation: if `sessionStorage` is unavailable (`expectedState === null`), verification is skipped rather than breaking the flow
- Also adds `state?` to `TokenClientConfig`, `TokenClient.requestAccessToken`, and `TokenResponse` type interfaces

Fixes the Google OAuth Console warning: *"OAuth clients are not using the state parameter"*.

## Test plan

- [ ] New `GoogleDriveProvider.test.ts` with 4 tests covering: state passed to `requestAccessToken`, mismatch rejection, match resolution, graceful skip when sessionStorage cleared
- [ ] Full unit suite passes (558 tests)
- [ ] Manual: connect Google Drive, open a file — verify no console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)