### PR TITLE
Remove debug console.log/warn calls from production code

### DIFF
--- a/src/OPFS/OPFS.worker.js
+++ b/src/OPFS/OPFS.worker.js
@@ -234,8 +234,6 @@ export async function fetchLatestCommitHash(baseURL, owner, repo, filePath, acce
 
   const latestCommit = data[0]
   const latestCommitHash = latestCommit.sha
-  // eslint-disable-next-line no-console
-  console.log(`The latest commit hash for the file is: ${latestCommitHash}`)
   return {hash: latestCommitHash, date: new Date(latestCommit.commit.author.date).getTime()}
 }
 

--- a/src/loader/Loader.js
+++ b/src/loader/Loader.js
@@ -257,7 +257,6 @@ async function axiosDownload(path, isFormatText, onProgress) {
     )).data
   } catch (error) {
     if (error.response) {
-      console.warn('error.response.status:', error.response.status)
       if (error.response.status === HTTP_NOT_FOUND) {
         throw new NotFoundError('File not found')
       } else {

--- a/src/net/github/Cache.js
+++ b/src/net/github/Cache.js
@@ -142,15 +142,7 @@ async function updateCache(key, response) {
 async function deleteCache(key) {
   const _httpCache = await getCache()
 
-  const success = await _httpCache.delete(key)
-
-  if (success) {
-    // eslint-disable-next-line no-console
-    console.log(`Deleted ${key} from cache`)
-  } else {
-    // eslint-disable-next-line no-console
-    console.log(`Failed to delete ${key} from cache`)
-  }
+  await _httpCache.delete(key)
 }
 
 


### PR DESCRIPTION
## Summary

- Remove `console.warn` in `Loader.js` that fired on every HTTP 404/500 error path (redundant with the thrown exception)
- Remove `console.log` in `OPFS.worker.js` that logged commit hashes on every fetch
- Remove `console.log` in `Cache.js` that logged cache delete success/failure

These debug logs were producing console noise in test output. All 159 test suites pass cleanly with no console output.

## Test plan

- [x] `yarn test-src` — 159 suites, 951 passed, 0 console output

🤖 Generated with [Claude Code](https://claude.com/claude-code)