### PR TITLE
Enable googleOAuth2 and googleDrive feature flags for public launch

### DIFF
--- a/src/Components/Connections/GoogleDriveConnect.spec.ts
+++ b/src/Components/Connections/GoogleDriveConnect.spec.ts
@@ -42,8 +42,7 @@ describe('Google Drive connection', () => {
     await page.addInitScript({path: GOOGLE_APIS_FAKE_PATH})
     await homepageSetup(page)
     await returningUserVisitsHomepageWaitForModel(page)
-    // Re-navigate with googleDrive feature flag so the Google tab is visible
-    await page.goto('/share/v/p/index.ifc?feature=googleDrive', {waitUntil: 'domcontentloaded'})
+    await page.goto('/share/v/p/index.ifc', {waitUntil: 'domcontentloaded'})
     await openSourcesTab(page)
   })
 

--- a/src/Components/Profile/Login.spec.ts
+++ b/src/Components/Profile/Login.spec.ts
@@ -12,18 +12,19 @@ const {beforeEach, describe} = test
 /**
  * @see https://github.com/bldrs-ai/Share/issues/1052
  */
-describe('Profile 100: Login with Github', () => {
+describe('Profile 100: Login', () => {
   beforeEach(async ({page}) => {
     await homepageSetup(page)
     await setupAuthenticationIntercepts(page)
     await returningUserVisitsHomepageWaitForModel(page)
   })
 
-  test('Should only show Github login option - Screen', async ({page}) => {
+  test('Login dialog shows GitHub and Google options - Screen', async ({page}) => {
     await page.getByTestId('control-button-profile').click()
     await page.getByTestId('menu-open-login-dialog').click()
     await expect(page.getByTestId('login-with-github')).toBeVisible()
-    await expect(page.getByTestId('login-with-google')).toHaveCount(0)
+    await expect(page.getByTestId('login-with-google')).toBeVisible()
+    await expectScreen(page, 'login-github-and-google.png')
     // Close login dialog
     await page.getByTestId('control-button-profile').click({force: true})
     // Login with Github
@@ -32,22 +33,8 @@ describe('Profile 100: Login with Github', () => {
     await expectScreen(page, 'logged-in-github.png')
   })
 
-  describe('Returning user visits homepage with Google OAuth feature flag, clicks ProfileControl', () => {
-    beforeEach(async ({page}) => {
-      await page.goto('/share/v/p/index.ifc?feature=googleOAuth2')
-    })
-
-    test('Login should include Google and Github options - Screen', async ({page}) => {
-      await page.getByTestId('control-button-profile').click()
-      await page.getByTestId('menu-open-login-dialog').click()
-      await expect(page.getByTestId('login-with-github')).toBeVisible()
-      await expect(page.getByTestId('login-with-google')).toBeVisible()
-      await expectScreen(page, 'login-github-and-google.png')
-    })
-
-    test('Login with Google - Screen', async ({page}) => {
-      await auth0Login(page, 'google')
-      await expectScreen(page, 'logged-in-google.png')
-    })
+  test('Login with Google - Screen', async ({page}) => {
+    await auth0Login(page, 'google')
+    await expectScreen(page, 'logged-in-google.png')
   })
 })

--- a/src/FeatureFlags.js
+++ b/src/FeatureFlags.js
@@ -2,4 +2,6 @@ export const flags = [
   {
     name: 'authentication', isActive: process.env.NODE_ENV === 'development' || process.env.NODE_ENV === 'test',
   },
+  {name: 'googleOAuth2', isActive: true},
+  {name: 'googleDrive', isActive: true},
 ]

--- a/src/hooks/useExistInFeature.js
+++ b/src/hooks/useExistInFeature.js
@@ -1,10 +1,11 @@
 import {useEffect, useState} from 'react'
 import {useSearchParams} from 'react-router-dom'
 import debug from '../utils/debug'
+import {flags} from '../FeatureFlags'
 
 
 /**
- * This hook checks for the existence of a named feature in the URL SearchParams (via react-router), e.g. feature=app,placemark.
+ * This hook checks for a named feature in static FeatureFlags or URL SearchParams, e.g. feature=app,placemark.
  *
  * @param {string} name Feature flag name
  * @return {Function}
@@ -20,6 +21,13 @@ export default function useExistInFeature(name) {
       return
     }
     const lowerName = name.toLowerCase()
+
+    const staticFlag = flags.find((f) => f.name.toLowerCase() === lowerName)
+    if (staticFlag?.isActive) {
+      setExistInFeature(true)
+      return
+    }
+
     const enabledFeatures = searchParams.get('feature')
     if (!enabledFeatures) {
       return

--- a/src/hooks/useExistInFeature.staticFlags.test.jsx
+++ b/src/hooks/useExistInFeature.staticFlags.test.jsx
@@ -1,0 +1,26 @@
+import {renderHook} from '@testing-library/react'
+import useExistInFeature from './useExistInFeature'
+
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useSearchParams: () => [new URLSearchParams()],
+}))
+
+
+describe('useExistInFeature — static FeatureFlags', () => {
+  it('returns true for googleOAuth2 from static flags', () => {
+    const {result} = renderHook(() => useExistInFeature('googleOAuth2'))
+    expect(result.current).toBeTruthy()
+  })
+
+  it('returns true for googleDrive from static flags', () => {
+    const {result} = renderHook(() => useExistInFeature('googleDrive'))
+    expect(result.current).toBeTruthy()
+  })
+
+  it('returns false for a flag not in static flags or URL', () => {
+    const {result} = renderHook(() => useExistInFeature('unknownFeature'))
+    expect(result.current).toBeFalsy()
+  })
+})


### PR DESCRIPTION
## Summary

- Promotes `googleOAuth2` and `googleDrive` from opt-in URL params (`?feature=googleOAuth2,googleDrive`) to always-active by adding them to `FeatureFlags.js`
- Extends `useExistInFeature` hook to check static `FeatureFlags` before URL search params
- Updates e2e tests (`Login.spec.ts`, `GoogleDriveConnect.spec.ts`) to reflect new always-on defaults — removes `?feature=` URL workarounds and updates assertions
- Adds `useExistInFeature.staticFlags.test.jsx` to explicitly cover the new static-flag code path (previously untested)

## Test plan

- [ ] `yarn test-src --testPathPattern="useExistInFeature"` — all 4 unit tests pass (URL path + 3 new static-flag tests)
- [ ] `yarn test-flows src/Components/Profile/Login.spec.ts` — login dialog shows both GitHub and Google options
- [ ] `yarn test-flows src/Components/Connections/GoogleDriveConnect.spec.ts` — full Google Drive connect/browse/pick flow
- [ ] Full `yarn test` suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)