### PR TITLE
Fix Google Drive OAuth cancellation in prod (COOP header)

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,14 +1,15 @@
-# COOP same-origin prevents cross-origin windows from retaining a reference to
-# this window (required for cross-origin isolation / SharedArrayBuffer).
-# COEP intentionally omitted: docs.google.com/picker sends CORP: same-site, which
-# Chrome enforces under any COEP value, blocking the Google Picker iframe. Removing
-# COEP loses crossOriginIsolated (WASM multithreading) in production. The correct
-# long-term fix is to load the Picker in a popup window that isn't subject to the
-# parent page's COEP policy (TODO).
+# COOP same-origin-allow-popups lets Google Identity Services deliver OAuth
+# tokens via postMessage without nulling window.opener in the cross-origin
+# popup. COEP is intentionally omitted (docs.google.com/picker sends
+# CORP: same-site, which Chrome enforces under any COEP value and blocks the
+# Picker iframe), so crossOriginIsolated is already false here — stricter
+# COOP: same-origin would block GIS OAuth without gaining any isolation. The
+# long-term fix is to load the Picker in a popup window that isn't subject
+# to the parent page's COEP policy (TODO).
 [[headers]]
   for = "/*"
   [headers.values]
-    Cross-Origin-Opener-Policy = "same-origin"
+    Cross-Origin-Opener-Policy = "same-origin-allow-popups"
 
 # Override headers for the /subscribe route so that no strict isolation is enforced.
 [[headers]]

--- a/src/Components/Connections/ConnectProviderButton.jsx
+++ b/src/Components/Connections/ConnectProviderButton.jsx
@@ -1,6 +1,7 @@
 import React, {useState} from 'react'
 import {Button, CircularProgress} from '@mui/material'
 import {CloudQueue as CloudIcon} from '@mui/icons-material'
+import {useAuth0} from '../../Auth0/Auth0Proxy'
 import useStore from '../../store/useStore'
 import {getProvider} from '../../connections/registry'
 import {saveConnections} from '../../connections/persistence'
@@ -20,6 +21,7 @@ export default function ConnectProviderButton({providerId, label, icon, color = 
   const [error, setError] = useState(null)
   const addConnection = useStore((state) => state.addConnection)
   const connections = useStore((state) => state.connections)
+  const {user} = useAuth0()
 
   const handleConnect = async () => {
     const provider = getProvider(providerId)
@@ -32,7 +34,7 @@ export default function ConnectProviderButton({providerId, label, icon, color = 
     setError(null)
 
     try {
-      const connection = await provider.connect()
+      const connection = await provider.connect(user?.email)
       addConnection(connection)
       // Persist updated connections list
       saveConnections([...connections, connection])

--- a/src/connections/google-drive/GoogleDriveProvider.ts
+++ b/src/connections/google-drive/GoogleDriveProvider.ts
@@ -130,7 +130,7 @@ export const googleDriveProvider: ConnectionProvider = {
   name: 'Google Drive',
   icon: 'google-drive',
 
-  async connect(): Promise<Connection> {
+  async connect(hint?: string): Promise<Connection> {
     await loadGisScript()
 
     const clientId = process.env.GOOGLE_OAUTH2_CLIENT_ID
@@ -178,6 +178,7 @@ export const googleDriveProvider: ConnectionProvider = {
       const client = google.accounts.oauth2.initTokenClient({
         client_id: clientId,
         scope: SCOPES,
+        hint: hint || undefined,
         callback: (response: TokenResponse) => {
           gotCallback = true
           debug().log('[GDrive] OAuth callback received, error:', response.error || 'none')

--- a/src/connections/types.ts
+++ b/src/connections/types.ts
@@ -99,8 +99,13 @@ export interface ConnectionProvider {
   /** Icon identifier or path */
   icon: string
 
-  /** Initiate the connection flow (OAuth popup, etc.). Returns the new Connection. */
-  connect(): Promise<Connection>
+  /**
+   * Initiate the connection flow (OAuth popup, etc.). Returns the new Connection.
+   *
+   * @param hint - Optional login hint (typically email) to pre-select an account
+   *   and skip the provider's account chooser when the user is already signed in.
+   */
+  connect(hint?: string): Promise<Connection>
 
   /** Disconnect and revoke credentials for a connection. */
   disconnect(connectionId: string): Promise<void>

--- a/tools/esbuild/coop.test.js
+++ b/tools/esbuild/coop.test.js
@@ -1,0 +1,50 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import {fileURLToPath} from 'node:url'
+
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const REPO_ROOT = path.resolve(__dirname, '..', '..')
+
+// Google Identity Services OAuth popup delivers tokens via postMessage on
+// window.opener. A stricter COOP nulls the opener in the cross-origin popup
+// and breaks the flow with a silent "Google sign-in was cancelled" — see
+// GoogleDriveProvider.ts error_callback. Prod and dev must both stay on
+// same-origin-allow-popups (or looser) while GIS is in use.
+const REQUIRED_COOP = 'same-origin-allow-popups'
+
+describe('Cross-Origin-Opener-Policy', () => {
+  it('netlify.toml root route uses same-origin-allow-popups (GIS OAuth)', () => {
+    const toml = fs.readFileSync(path.join(REPO_ROOT, 'netlify.toml'), 'utf8')
+    const rootBlock = extractHeadersBlock(toml, '/*')
+    expect(rootBlock).not.toBeNull()
+    const coop = /Cross-Origin-Opener-Policy\s*=\s*"([^"]+)"/.exec(rootBlock)
+    expect(coop).not.toBeNull()
+    expect(coop[1]).toBe(REQUIRED_COOP)
+  })
+
+  it('dev proxy sends same-origin-allow-popups for app routes', () => {
+    const proxy = fs.readFileSync(path.join(REPO_ROOT, 'tools/esbuild/proxy.js'), 'utf8')
+    expect(proxy).toContain(`'Cross-Origin-Opener-Policy': '${REQUIRED_COOP}'`)
+    expect(proxy).not.toMatch(/'Cross-Origin-Opener-Policy':\s*'same-origin'(?!-)/)
+  })
+})
+
+
+/**
+ * Extract the body of a `[[headers]]` block whose `for` field matches `forPath`.
+ *
+ * @param {string} toml Netlify config file contents.
+ * @param {string} forPath The `for = "..."` value to match.
+ * @return {string|null} The block body, or null if not found.
+ */
+function extractHeadersBlock(toml, forPath) {
+  const blocks = toml.split(/\[\[headers\]\]/).slice(1)
+  for (const block of blocks) {
+    const forMatch = /for\s*=\s*"([^"]+)"/.exec(block)
+    if (forMatch && forMatch[1] === forPath) {
+      return block
+    }
+  }
+  return null
+}

--- a/tools/jest/jest.config.js
+++ b/tools/jest/jest.config.js
@@ -6,6 +6,12 @@ export default {
   testEnvironment: 'jest-fixed-jsdom',
   rootDir: '../../',
   roots: ['<rootDir>/src', '<rootDir>/__mocks__'],
+  // Default jest timeout is 5s. Under default parallel worker load (~N-1 cores),
+  // heavy React Testing Library mount tests (CadView, OpenModelControl, Notes,
+  // TabbedPanels, useVersions) intermittently blow past 5s and produce flakes
+  // that pass in isolation. Individual tests needing more should override via
+  // their own arg to it()/test().
+  testTimeout: 20000,
   transform: {
     '\\.[jt]sx?$': 'babel-jest',
     '^.+\\.svg$': '<rootDir>/tools/jest/svgTransform.js',


### PR DESCRIPTION
## Summary
- Fix production "Google sign-in was cancelled" on Connect Google Drive by relaxing COOP from `same-origin` to `same-origin-allow-popups` in `netlify.toml` (matches what the dev proxy already ships). COOP: same-origin was nulling `window.opener` in the cross-origin GIS popup, so the OAuth token callback never reached the app. Because COEP is intentionally omitted, `crossOriginIsolated` is already false in prod — the stricter COOP gave no benefit, only broke OAuth.
- Pass the Auth0 user's email as `hint` to `initTokenClient` in `connect()` so the Google account chooser pre-selects the signed-in account (mirrors the existing refresh path in `getAccessToken`).
- Add `tools/esbuild/coop.test.js` pinning `Cross-Origin-Opener-Policy: same-origin-allow-popups` in both `netlify.toml` and `tools/esbuild/proxy.js` so a future isolation-tightening PR can't silently re-break the flow.
- Bump jest `testTimeout` to 20s in `tools/jest/jest.config.js`. The 5s default was intermittently tripping heavy RTL mount tests (CadView, OpenModelControl, Notes, TabbedPanels, useVersions) under parallel-worker load; all passed in isolation.

## Test plan
- [x] `yarn lint` / `yarn typecheck` clean
- [x] `yarn test` clean (954 passed, 5 skipped, across two consecutive runs)
- [x] `yarn test-tools` includes new COOP regression test (passes)
- [ ] Local repro: temporarily flip `tools/esbuild/proxy.js` COOP to `same-origin`, confirm "Google sign-in was cancelled"; revert and confirm fix
- [ ] Netlify deploy preview: Connect Google Drive → picker opens, no cancellation; account chooser skipped (or pre-selected) when already signed in via Auth0

🤖 Generated with [Claude Code](https://claude.com/claude-code)