### PR TITLE
Fix silent model-load block for Google-only users

### DIFF
--- a/src/BaseRoutes.jsx
+++ b/src/BaseRoutes.jsx
@@ -46,6 +46,7 @@ export default function BaseRoutes({testElt = null}) {
   const {isLoading, isAuthenticated, getAccessTokenSilently, logout} = useAuth0()
   const setAccessToken = useStore((state) => state.setAccessToken)
   const setHasGithubIdentity = useStore((state) => state.setHasGithubIdentity)
+  const setIsAuthResolved = useStore((state) => state.setIsAuthResolved)
   const appPrefix = `${basePath}share`
   const setAppPrefix = useStore((state) => state.setAppPrefix)
   const setIsOpfsAvailable = useStore((state) => state.setIsOpfsAvailable)
@@ -89,6 +90,9 @@ export default function BaseRoutes({testElt = null}) {
 
     if (process.env.NODE_ENV === 'development' && process.env.GITHUB_API_TOKEN) {
       setAccessToken(process.env.GITHUB_API_TOKEN)
+      setIsAuthResolved(true)
+    } else if (!isLoading && !isAuthenticated) {
+      setIsAuthResolved(true)
     } else if (!isLoading && isAuthenticated) {
       getAccessTokenSilently({
         authorizationParams: {
@@ -150,6 +154,9 @@ export default function BaseRoutes({testElt = null}) {
             throw err
           }
         })
+        .finally(() => {
+          setIsAuthResolved(true)
+        })
     }
   }, [
     appPrefix,
@@ -164,6 +171,7 @@ export default function BaseRoutes({testElt = null}) {
     setAccessToken,
     setAppMetadata,
     setHasGithubIdentity,
+    setIsAuthResolved,
     logout,
   ])
 

--- a/src/Containers/CadView.jsx
+++ b/src/Containers/CadView.jsx
@@ -48,8 +48,8 @@ export default function CadView({
   // Begin useStore //
 
   const accessToken = useStore((state) => state.accessToken)
+  const isAuthResolved = useStore((state) => state.isAuthResolved)
   const connections = useStore((state) => state.connections)
-  const hasGitHubIdentity = useStore((state) => state.hasGithubIdentity)
   const customViewSettings = useStore((state) => state.customViewSettings)
   const elementTypesMap = useStore((state) => state.elementTypesMap)
   const preselectedElementIds = useStore((state) => state.preselectedElementIds)
@@ -157,9 +157,11 @@ export default function CadView({
       return
     }
 
-    if (isAuthLoading || (!isAuthLoading &&
-      (isAuthenticated && ( accessToken === '' && !hasGitHubIdentity )))) {
-      debug().warn('Do not have auth token yet, waiting.')
+    // Wait only while auth is still being resolved. Once resolved, proceed
+    // regardless of whether a GitHub token landed — Google-only users
+    // legitimately have accessToken='' and hasGithubIdentity=false.
+    if (isAuthLoading || (isAuthenticated && !isAuthResolved)) {
+      debug().warn('Auth not yet resolved, waiting.')
       return
     }
 
@@ -623,19 +625,15 @@ export default function CadView({
   /* eslint-disable react-hooks/exhaustive-deps */
   useEffect(() => {
     if (!isViewerLoaded) {
-      // This function gets called whenever there's a change in authentication state
-      debug().log('Auth state changed. isAuthLoading:', isAuthLoading, 'isAuthenticated:', isAuthenticated)
-      /* eslint-disable no-mixed-operators */
-      if (!isAuthLoading &&
-          (isAuthenticated && ( accessToken !== '' || !hasGitHubIdentity )) ||
-          (!isAuthLoading && !isAuthenticated) && isOpfsAvailable !== null) {
+      debug().log('Auth state changed. isAuthLoading:', isAuthLoading,
+        'isAuthenticated:', isAuthenticated, 'isAuthResolved:', isAuthResolved)
+      if (!isAuthLoading && isOpfsAvailable !== null && (!isAuthenticated || isAuthResolved)) {
         (async () => {
           await onViewer()
         })()
       }
-      /* eslint-enable no-mixed-operators */
     }
-  }, [isAuthLoading, isAuthenticated, accessToken, isOpfsAvailable])
+  }, [isAuthLoading, isAuthenticated, isAuthResolved, accessToken, isOpfsAvailable])
 
 
   // ModelPath changes in parent (ShareRoutes) from user and

--- a/src/store/RepositorySlice.js
+++ b/src/store/RepositorySlice.js
@@ -14,6 +14,14 @@ export default function createRepositorySlice(set, get) {
     hasGithubIdentity: false,
     setHasGithubIdentity: (hasIdentity) => set(() => ({hasGithubIdentity: hasIdentity})),
 
+    // Distinguishes "not yet checked" from "checked, no GitHub identity".
+    // Google-only users legitimately end up with accessToken='' and
+    // hasGithubIdentity=false — the same as the initial pre-auth state —
+    // so consumers that gate on auth (e.g. CadView model load) need this
+    // flag to know whether they should wait or proceed.
+    isAuthResolved: false,
+    setIsAuthResolved: (resolved) => set(() => ({isAuthResolved: resolved})),
+
     appMetadata: {},
     setAppMetadata: (metadata) => set({appMetadata: metadata}),
 


### PR DESCRIPTION
## Summary
After the `googleOAuth2` / `googleDrive` flag flip in #1485, users signing in with Google (not GitHub) hit a silent failure: no model loaded after login — the default `index.ifc` never fetched, no console error, no network request.

**Root cause (latent since launch prep, surfaced by the flag flip):** `CadView.jsx:onViewer` guarded against `isAuthenticated && accessToken === '' && !hasGitHubIdentity`. For a Google-only user, `BaseRoutes.jsx` legitimately sets `accessToken = ''` and `hasGithubIdentity = false` after resolving the Auth0 JWT — byte-identical to the pre-auth defaults in `RepositorySlice`. The guard couldn't distinguish "still checking" from "checked, no GitHub identity" and blocked forever.

**Fix:** tri-state `isAuthResolved` in `RepositorySlice` (default `false`), flipped to `true` via `.finally` on the `getAccessTokenSilently` call — covers every termination branch (GitHub success, Google-only success, reauth-modal detour, `invalid_grant` logout, `login_required` swallow). Also set in the dev `GITHUB_API_TOKEN` and `!isAuthenticated` branches. `CadView` guard simplifies to "block only while `isAuthenticated && !isAuthResolved`"; matching `useEffect` trigger becomes `!isAuthenticated || isAuthResolved`.

## Test plan
- [x] `yarn lint` / `yarn typecheck` clean
- [x] Full `yarn test` clean (954 passed, 5 skipped)
- [ ] Local dev repro: sign in with Google (not GitHub), reload `index.ifc`, model loads; network shows the IFC fetch
- [ ] Prod: sign in with Google, choose Drive file via Picker, file loads into viewer
- [ ] Regression check: sign in with GitHub, model still loads (existing path unchanged)
- [ ] Regression check: anonymous / logged-out, model still loads (`!isAuthenticated` branch sets `isAuthResolved = true` immediately)

Follows #1486.

🤖 Generated with [Claude Code](https://claude.com/claude-code)