### PR TITLE
Ignore local Claude Code settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,7 @@ public/test-models
 
 # Local Netlify folder
 .netlify
+
+# Claude Code local settings
+.claude/settings.local.json
+.claude/scheduled_tasks.lock


### PR DESCRIPTION
## Summary
- Adds `.claude/settings.local.json` and `.claude/scheduled_tasks.lock` to `.gitignore`. Both are per-developer / runtime-only files that Claude Code writes into the project directory.
- A shared `.claude/settings.json` or `.claude/commands/` (if added later) will still be checked in.

## Test plan
- [x] `git status` no longer shows `.claude/` as untracked
- [x] Pre-commit lint + typecheck + full jest suite passes (160 suites, 958 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)