### PR TITLE
fix(security): derive Stripe customer server-side in portal session

### DIFF
--- a/netlify/functions/create-portal-session.js
+++ b/netlify/functions/create-portal-session.js
@@ -1,4 +1,20 @@
+/*
+ * Netlify Function: create-portal-session.js
+ * -------------------------------------------
+ * Issue a Stripe Billing Portal session for the *authenticated* caller.
+ *
+ *   POST /.netlify/functions/create-portal-session
+ *   Headers: Authorization: Bearer <user access token>
+ *   Body:    {} (the customer is derived server-side, not from the client)
+ *
+ * The caller's Stripe customer ID is read from Auth0 app_metadata via the
+ * Management API after the user's access token is verified against
+ * /userinfo. This prevents an unauthenticated attacker from minting a
+ * portal URL for someone else's `cus_…` ID — see
+ * https://github.com/bldrs-ai/Share/pull/1489 for the report.
+ */
 
+const axios = require('axios')
 const Sentry = require('@sentry/serverless')
 
 
@@ -8,28 +24,138 @@ Sentry.AWSLambda.init({
   environment: process.env.NODE_ENV,
 })
 
+const HTTP_OK = 200
+const HTTP_UNAUTHORIZED = 401
+const HTTP_NOT_FOUND = 404
+const HTTP_METHOD_NOT_ALLOWED = 405
+const HTTP_BAD_GATEWAY = 502
+const HTTP_INTERNAL_ERROR = 500
+
+// Refresh management tokens this many seconds before their stated expiry to
+// avoid using a token that expires mid-flight.
+const MGMT_TOKEN_REFRESH_SAFETY_SEC = 60
+const MILLIS_PER_SECOND = 1000
+
+// Cached across warm invocations of the same Lambda container. Skips one of
+// the three Auth0 round trips on the hot path. Cold starts pay the full cost.
+let cachedMgmtToken = null
+let cachedMgmtTokenExpiresAt = 0
+
 /**
-  User clicks Profile > "Manage subscription" in Share, and this redirects
-  to a page on Stripe that lets them configure their sub.
+ * Fetch (or reuse) an Auth0 Management API token via Client Credentials.
+ *
+ * @return {Promise<string>}
+ */
+async function getManagementApiToken() {
+  const now = Date.now()
+  if (cachedMgmtToken && now < cachedMgmtTokenExpiresAt) {
+    return cachedMgmtToken
+  }
+  const resp = await axios.post(
+    `https://${process.env.AUTH0_DOMAIN}/oauth/token`,
+    {
+      client_id: process.env.AUTH0_CLIENT_ID,
+      client_secret: process.env.AUTH0_CLIENT_SECRET,
+      audience: `https://${process.env.AUTH0_DOMAIN}/api/v2/`,
+      grant_type: 'client_credentials',
+    },
+    {headers: {'Content-Type': 'application/json'}},
+  )
+  cachedMgmtToken = resp.data.access_token
+  const expiresInSec = Number(resp.data.expires_in) || 0
+  cachedMgmtTokenExpiresAt = now + ((expiresInSec - MGMT_TOKEN_REFRESH_SAFETY_SEC) * MILLIS_PER_SECOND)
+  return cachedMgmtToken
+}
+
+/**
+ * Validate a user access token via /userinfo and return the user_id (sub).
+ *
+ * @param {string} userToken
+ * @return {Promise<string|null>}
+ */
+async function getUserIdFromToken(userToken) {
+  const resp = await axios.get(
+    `https://${process.env.AUTH0_DOMAIN}/userinfo`,
+    {headers: {Authorization: `Bearer ${userToken}`}},
+  )
+  return resp.data && resp.data.sub
+}
+
+/**
+ * Read app_metadata.stripeCustomerId for the given Auth0 user.
+ *
+ * @param {string} mgmtToken
+ * @param {string} auth0UserId
+ * @return {Promise<string|null>}
+ */
+async function getStripeCustomerId(mgmtToken, auth0UserId) {
+  const resp = await axios.get(
+    `https://${process.env.AUTH0_DOMAIN}/api/v2/users/${encodeURIComponent(auth0UserId)}`,
+    {headers: {Authorization: `Bearer ${mgmtToken}`}},
+  )
+  return resp.data && resp.data.app_metadata && resp.data.app_metadata.stripeCustomerId
+}
+
+/**
+ * Netlify handler.
  */
 exports.handler = Sentry.AWSLambda.wrapHandler(async (event) => {
-  const stripe = require('stripe')(process.env.STRIPE_SECRET_KEY)
+  if (event.httpMethod !== 'POST') {
+    return {statusCode: HTTP_METHOD_NOT_ALLOWED, body: 'Method Not Allowed'}
+  }
+
+  const authHeader = event.headers.authorization || event.headers.Authorization || ''
+  const match = authHeader.match(/^Bearer\s+(.+)$/i)
+  if (!match) {
+    return {statusCode: HTTP_UNAUTHORIZED, body: 'Missing or invalid Authorization header'}
+  }
+  const userToken = match[1]
+
+  let auth0UserId
+  try {
+    auth0UserId = await getUserIdFromToken(userToken)
+  } catch (err) {
+    Sentry.captureException(err)
+    return {statusCode: HTTP_UNAUTHORIZED, body: 'Invalid access token'}
+  }
+  if (!auth0UserId) {
+    return {statusCode: HTTP_UNAUTHORIZED, body: 'Unable to resolve user'}
+  }
+
+  let stripeCustomerId
+  try {
+    const mgmtToken = await getManagementApiToken()
+    stripeCustomerId = await getStripeCustomerId(mgmtToken, auth0UserId)
+  } catch (err) {
+    Sentry.captureException(err)
+    return {statusCode: HTTP_BAD_GATEWAY, body: 'Failed to look up customer'}
+  }
+  if (!stripeCustomerId) {
+    return {
+      statusCode: HTTP_NOT_FOUND,
+      body: JSON.stringify({error: 'No subscription on file for this account'}),
+      headers: {'Content-Type': 'application/json'},
+    }
+  }
 
   try {
-    const body = JSON.parse(event.body)
-    const {stripeCustomerId} = body
-
+    const stripe = require('stripe')(process.env.STRIPE_SECRET_KEY)
     const portalSession = await stripe.billingPortal.sessions.create({
       customer: stripeCustomerId,
       return_url: 'https://bldrs.ai/',
     })
-
     return {
-      statusCode: 200,
+      statusCode: HTTP_OK,
       body: JSON.stringify({url: portalSession.url}),
+      headers: {'Content-Type': 'application/json'},
     }
-  } catch (error) {
-    Sentry.captureException(error)
-    return {statusCode: 500, body: JSON.stringify({error: error.message})}
+  } catch (err) {
+    Sentry.captureException(err)
+    return {
+      statusCode: HTTP_INTERNAL_ERROR,
+      body: JSON.stringify({error: err.message}),
+      headers: {'Content-Type': 'application/json'},
+    }
   }
 })
+

--- a/src/Components/Profile/ProfileControl.jsx
+++ b/src/Components/Profile/ProfileControl.jsx
@@ -125,10 +125,18 @@ export default function ProfileControl() {
 
     if (stripeCustomerId) {
       try {
+        const token = await getAccessTokenSilently({
+          authorizationParams: {
+            audience: 'https://api.github.com/',
+            scope: 'openid profile email offline_access',
+          },
+        })
         const response = await fetch('/.netlify/functions/create-portal-session', {
           method: 'POST',
-          headers: {'Content-Type': 'application/json'},
-          body: JSON.stringify({stripeCustomerId}),
+          headers: {
+            'Content-Type': 'application/json',
+            'Authorization': `Bearer ${token}`,
+          },
         })
         const data = await response.json()
         if (data.url) {

--- a/src/__mocks__/api-handlers.js
+++ b/src/__mocks__/api-handlers.js
@@ -1,5 +1,6 @@
 import {http, passthrough} from 'msw'
 import {
+  HTTP_AUTHORIZATION_REQUIRED,
   HTTP_BAD_REQUEST,
   HTTP_OK,
 } from '../net/http'
@@ -105,21 +106,22 @@ function workersAndWasmPassthrough() {
  */
 function netlifyHandlers() {
   return [
-    http.post('/.netlify/functions/create-portal-session', async ({request}) => {
-      const {stripeCustomerId} = await request.json()
-
-      if (!stripeCustomerId) {
+    http.post('/.netlify/functions/create-portal-session', ({request}) => {
+      // Real handler derives the Stripe customer server-side from the bearer
+      // token; mock asserts the contract by requiring the Authorization
+      // header rather than trusting a body field.
+      const auth = request.headers.get('authorization') || ''
+      if (!/^Bearer\s+.+/i.test(auth)) {
         return new Response(
-          JSON.stringify({error: 'Missing stripeCustomerId'}),
+          JSON.stringify({error: 'Missing Authorization'}),
           {
-            status: HTTP_BAD_REQUEST,
+            status: HTTP_AUTHORIZATION_REQUIRED,
             headers: {'Content-Type': 'application/json'},
           },
         )
       }
 
-      // return a mocked Stripe billing-portal URL
-      const fakeUrl = `https://stripe.portal.msw/mockportal/session/${stripeCustomerId}`
+      const fakeUrl = 'https://stripe.portal.msw/mockportal/session/cus_test_mock'
       return new Response(
         JSON.stringify({url: fakeUrl}),
         {


### PR DESCRIPTION
## Summary
Closes the IDOR reported in #1489 (without merging that PR).

`netlify/functions/create-portal-session.js` previously trusted a client-supplied `stripeCustomerId` and returned a Stripe Billing Portal URL for that customer with no auth. Anyone who guessed or harvested another user's `cus_…` (HARs, support screenshots, JWT app_metadata, etc.) could mint a fully-authenticated portal URL — view invoices, swap payment methods, cancel the subscription.

## Fix
Mirrors the auth pattern in `netlify/functions/unlink-identity.js`:
- Require `Authorization: Bearer <user access token>`; reject non-POST.
- Validate the token via Auth0 `/userinfo` to get `sub`.
- Read `app_metadata.stripeCustomerId` via the Auth0 Management API.
- Pass the **server-derived** customer ID to Stripe; the request body is ignored.
- Return 404 with a JSON error when the user has no Stripe customer rather than 500ing into Stripe.

The management-API token is cached in module scope (refreshed 60s before expiry) so warm Lambda invocations skip one of the three Auth0 round trips. The whole flow only fires when a Pro user clicks "Manage Subscription" — a rare click already followed by a cross-domain redirect to Stripe — so the added latency is invisible.

## Client + tests
- `ProfileControl.onSubscriptionClick` now calls `getAccessTokenSilently` and sends the bearer token instead of the customer ID.
- The MSW mock at `src/__mocks__/api-handlers.js` asserts the new contract by requiring the Authorization header (rejects with 401 if absent).
- No new dependencies. Reuses existing `axios` + `@sentry/serverless`.

## Test plan
- [x] `yarn lint` (eslint + tsc) clean
- [x] `yarn test` — full jest suite, 958 tests pass
- [x] `yarn test-flows Subscription` — both Pro (clicks "Manage Subscription" → portal redirect) and Free user paths pass
- [ ] After deploy: confirm a Pro user can still reach the Stripe portal end-to-end

## Notes for reviewer
- Did not merge #1489 per discussion: that PR also modified `public/mod.js` (the unrelated Matrix-widget host demo) and the contributor's body field validation still trusts a client-provided ID; this fix removes it entirely.
- After this lands, worth a quick scan of recent Stripe `billing_portal.session.created` logs for anomalous sources before considering the loop closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)