### PR TITLE
Plug memory leaks during multi-model loads

### DIFF
--- a/MEMORY_LEAK_FIXES.md
+++ b/MEMORY_LEAK_FIXES.md
@@ -1,0 +1,109 @@
+# Memory Leak Analysis & Fixes
+
+> Investigation and fixes originally by @MarkusSteinbrecher in [#1477](https://github.com/bldrs-ai/Share/pull/1477); cherry-picked here as a focused PR. Fix #1 also extended with `WebGLRenderer.forceContextLoss()`, an optional call to the viewer's built-in `dispose()`, and disposal of additional texture-map slots (`normalMap`, `roughnessMap`, `metalnessMap`, `emissiveMap`, `aoMap`, `bumpMap`, `displacementMap`, `alphaMap`, `lightMap`, `envMap`).
+
+## Overview
+
+Investigation into increasing Chrome resource usage when running Share for extended periods and loading multiple models. Found 8 memory leak sources across 11 files.
+
+---
+
+## Critical (largest impact)
+
+### 1. Old Three.js viewer never disposed
+
+**Files:** `src/Containers/viewer.js`, `src/Containers/CadView.jsx`
+
+When loading a new model, `initViewer()` created a fresh `IfcViewerAPIExtended` but never called `dispose()` on the previous one. The old WebGL context, renderer, geometries, materials, and textures all stayed in GPU/browser memory. `container.textContent = ''` only removed the canvas DOM element but did not free WebGL resources.
+
+This is the primary cause of increasing Chrome resource usage when loading multiple models.
+
+**Fix:** Added `disposeViewer()` that calls `viewer.dispose()` and clears global event handlers before creating a new viewer. `initViewer()` now automatically disposes the previous viewer.
+
+### 2. Theme change listeners accumulate
+
+**Files:** `src/Containers/CadView.jsx`, `src/theme/Theme.jsx`
+
+Every call to `onModelPath()` added a new theme change listener via `theme.addThemeChangeListener(initViewerCb)` without removing the previous one. Over time, multiple stale callbacks accumulated in the `themeChangeListeners` object, each capturing old viewer instances in closure and preventing garbage collection.
+
+**Fix:** Added `removeThemeChangeListener()` to Theme.jsx. CadView now removes the previous listener before registering a new one.
+
+---
+
+## High (significant leaks)
+
+### 3. Canvas event listeners accumulate
+
+**File:** `src/Components/Camera/CameraControl.jsx`
+
+The `onLoad()` function added `mousemove`, `wheel`, `mouseup`, and `touchend` listeners to the canvas element on every `useEffect` re-run. The previous `removeEventListener` calls used different function references than the ones added, so they were ineffective. Listeners accumulated on the canvas over time.
+
+**Fix:** `onLoad()` now returns a cleanup function that removes all added listeners. The `useEffect` returns this cleanup so React calls it on re-render and unmount.
+
+### 4. Hash listeners never removed
+
+**File:** `src/utils/location.js`
+
+`addHashListener()` stored callbacks in a module-level `hashListeners` object but had no corresponding removal mechanism (the code had a `TODO: add remove method` comment). Listeners accumulated across component lifecycles.
+
+**Fix:** Implemented `removeHashListener(name)` and used it in the CameraControl cleanup function.
+
+### 5. Object URLs never revoked
+
+**Files:** `src/utils/loader.js`, `src/OPFS/utils.js`
+
+`URL.createObjectURL()` was called in 4 places without corresponding `URL.revokeObjectURL()` calls. Each unreleased object URL keeps the underlying file data blob pinned in browser memory until page reload. With multiple file loads, this accumulates significantly.
+
+**Locations fixed:**
+- `loadLocalFileFallback()` in loader.js
+- `loadLocalFile()` in loader.js
+- `saveDnDFileToOpfsFallback()` in loader.js
+- `saveDnDFileToOpfs()` in OPFS/utils.js
+
+**Fix:** Added `URL.revokeObjectURL()` calls after extracting the blob ID from the URL.
+
+---
+
+## Medium
+
+### 6. MessageChannel ports never closed
+
+**Files:** `src/Components/Apps/AppsMessagesHandler.js`, `src/Components/Apps/AppIFrame.jsx`
+
+`IFrameCommunicationChannel` created a `MessageChannel` with two ports but had no destructor or cleanup method. The ports, message handlers, and iframe references were never released. Instances were created in a callback ref but never stored for later cleanup.
+
+**Fix:** Added a `dispose()` method to `IFrameCommunicationChannel` that nulls the `onmessage` handler, closes the port, and releases references. `AppIFrame` now tracks the channel instance via a ref and disposes it on unmount or before creating a new one.
+
+### 7. Notes edit state grows unbounded
+
+**File:** `src/store/NotesSlice.js`
+
+The `editBodies`, `editModes`, and `editOriginalBodies` objects in Zustand state accumulated entries keyed by note ID for every note ever edited during a session. When notes were deleted via `setDeletedNotes`, the corresponding entries in these objects were never pruned.
+
+**Fix:** `setDeletedNotes` now also removes the deleted note's entries from `editBodies`, `editModes`, and `editOriginalBodies`.
+
+### 8. Orphaned setTimeout accumulation
+
+**File:** `src/Components/Open/SaveModelControl.jsx`
+
+Multiple `setTimeout()` calls for clearing snack messages were fired without storing or clearing previous timer IDs. Rapid saves could queue up many timeout callbacks, each trying to set state on potentially unmounted components.
+
+**Fix:** Track the timeout ID in a module-level variable and call `clearTimeout()` before scheduling a new one, ensuring only one timeout is active at a time.
+
+---
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `src/Containers/viewer.js` | Added `disposeViewer()`, auto-dispose in `initViewer()` |
+| `src/Containers/CadView.jsx` | Theme listener cleanup, import `disposeViewer` |
+| `src/theme/Theme.jsx` | Added `removeThemeChangeListener()` |
+| `src/Components/Camera/CameraControl.jsx` | useEffect cleanup, proper listener removal |
+| `src/utils/location.js` | Added `removeHashListener()` |
+| `src/Components/Apps/AppsMessagesHandler.js` | Added `dispose()` method |
+| `src/Components/Apps/AppIFrame.jsx` | Channel lifecycle management via ref |
+| `src/utils/loader.js` | `URL.revokeObjectURL()` in 3 functions |
+| `src/OPFS/utils.js` | `URL.revokeObjectURL()` in `saveDnDFileToOpfs` |
+| `src/store/NotesSlice.js` | Prune edit state on note deletion |
+| `src/Components/Open/SaveModelControl.jsx` | Deduplicate snack timeouts |

--- a/src/Components/Apps/AppIFrame.jsx
+++ b/src/Components/Apps/AppIFrame.jsx
@@ -1,4 +1,4 @@
-import React, {ReactElement, useCallback} from 'react'
+import React, {ReactElement, useCallback, useEffect, useRef} from 'react'
 import {Box} from '@mui/material'
 import {IFrameCommunicationChannel} from './AppsMessagesHandler'
 
@@ -8,11 +8,32 @@ import {IFrameCommunicationChannel} from './AppsMessagesHandler'
  * @return {ReactElement}
  */
 export default function AppIFrame({itemJson}) {
+  const channelRef = useRef(null)
+
   const appFrameRef = useCallback((elt) => {
-    if (elt) {
-      elt.addEventListener('load', () => {
-        new IFrameCommunicationChannel(elt)
-      })
+    // Dispose any prior channel before creating a new one or before
+    // the iframe element detaches.
+    if (channelRef.current) {
+      channelRef.current.dispose()
+      channelRef.current = null
+    }
+    if (!elt) {
+      return
+    }
+    elt.addEventListener('load', () => {
+      if (channelRef.current) {
+        channelRef.current.dispose()
+      }
+      channelRef.current = new IFrameCommunicationChannel(elt)
+    })
+  }, [])
+
+  useEffect(() => {
+    return () => {
+      if (channelRef.current) {
+        channelRef.current.dispose()
+        channelRef.current = null
+      }
     }
   }, [])
 

--- a/src/Components/Apps/AppsMessagesHandler.js
+++ b/src/Components/Apps/AppsMessagesHandler.js
@@ -53,5 +53,24 @@ export class IFrameCommunicationChannel {
   sendMessage = (action, response) => {
     this.port1.postMessage({action, response})
   }
+
+  /**
+   * Release the MessageChannel and drop references so this instance
+   * and the iframe it captured can be garbage-collected.  Safe to call
+   * multiple times.
+   */
+  dispose() {
+    if (this.port1) {
+      this.port1.onmessage = null
+      try {
+        this.port1.close()
+      } catch (e) {
+        console.warn('IFrameCommunicationChannel: port1.close failed:', e)
+      }
+      this.port1 = null
+    }
+    this.channel = null
+    this.iframe = null
+  }
 }
 

--- a/src/Components/Apps/AppsMessagesHandler.test.js
+++ b/src/Components/Apps/AppsMessagesHandler.test.js
@@ -1,0 +1,110 @@
+// jest-fixed-jsdom doesn't expose MessageChannel on globalThis, so
+// install a minimal fake before the module under test imports it.
+// Tracks onmessage assignment + close() so the dispose tests can
+// assert against them.
+if (typeof globalThis.MessageChannel === 'undefined') {
+  /** Minimal MessagePort stand-in for the dispose contract tests. */
+  class FakeMessagePort {
+    onmessage = null
+    postMessage = jest.fn()
+    close = jest.fn()
+  }
+  /** Minimal MessageChannel stand-in. */
+  globalThis.MessageChannel = class FakeMessageChannel {
+    /** @return {void} */
+    constructor() {
+      this.port1 = new FakeMessagePort()
+      this.port2 = new FakeMessagePort()
+    }
+  }
+}
+
+
+import {IFrameCommunicationChannel} from './AppsMessagesHandler'
+
+
+/**
+ * Build a minimal iframe stub the channel will postMessage into.
+ *
+ * @return {object}
+ */
+function makeIframeStub() {
+  return {
+    src: 'http://localhost/widget',
+    contentWindow: {
+      postMessage: jest.fn(),
+    },
+  }
+}
+
+
+describe('IFrameCommunicationChannel', () => {
+  describe('construction', () => {
+    it('opens a MessageChannel and posts port2 to the iframe with init', () => {
+      const iframe = makeIframeStub()
+      const channel = new IFrameCommunicationChannel(iframe)
+      expect(channel.channel).toBeInstanceOf(MessageChannel)
+      expect(channel.port1).toBe(channel.channel.port1)
+      expect(iframe.contentWindow.postMessage).toHaveBeenCalledWith(
+        'init',
+        iframe.src,
+        expect.any(Array),
+      )
+      const [, , transferList] = iframe.contentWindow.postMessage.mock.calls[0]
+      expect(transferList).toHaveLength(1)
+      // We pass the same port2 that the channel exposes — confirming
+      // the iframe receives the active counterpart.
+      expect(transferList[0]).toBe(channel.channel.port2)
+    })
+
+    it('attaches a messageHandler to port1.onmessage', () => {
+      const channel = new IFrameCommunicationChannel(makeIframeStub())
+      expect(typeof channel.port1.onmessage).toBe('function')
+      expect(channel.port1.onmessage).toBe(channel.messageHandler)
+    })
+  })
+
+
+  describe('dispose', () => {
+    it('clears port1.onmessage so handler closures can be GC\'d', () => {
+      const channel = new IFrameCommunicationChannel(makeIframeStub())
+      const port1Ref = channel.port1
+      channel.dispose()
+      expect(port1Ref.onmessage).toBeNull()
+    })
+
+    it('closes port1', () => {
+      const channel = new IFrameCommunicationChannel(makeIframeStub())
+      const closeSpy = jest.spyOn(channel.port1, 'close')
+      channel.dispose()
+      expect(closeSpy).toHaveBeenCalledTimes(1)
+    })
+
+    it('drops references to channel, port1, and iframe', () => {
+      const channel = new IFrameCommunicationChannel(makeIframeStub())
+      channel.dispose()
+      expect(channel.channel).toBeNull()
+      expect(channel.port1).toBeNull()
+      expect(channel.iframe).toBeNull()
+    })
+
+    it('is idempotent — calling twice does not throw', () => {
+      const channel = new IFrameCommunicationChannel(makeIframeStub())
+      channel.dispose()
+      expect(() => channel.dispose()).not.toThrow()
+    })
+
+    it('still releases other resources if port1.close throws', () => {
+      const channel = new IFrameCommunicationChannel(makeIframeStub())
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+      channel.port1.close = () => {
+        throw new Error('close failed')
+      }
+      expect(() => channel.dispose()).not.toThrow()
+      expect(channel.port1).toBeNull()
+      expect(channel.channel).toBeNull()
+      expect(channel.iframe).toBeNull()
+      warnSpy.mockRestore()
+    })
+  })
+})

--- a/src/Components/Camera/CameraControl.jsx
+++ b/src/Components/Camera/CameraControl.jsx
@@ -6,6 +6,7 @@ import {
   addHashListener,
   addHashParams,
   getHashParams,
+  removeHashListener,
 } from '../../utils/location'
 import {roundCoord} from '../../utils/math'
 import {floatStrTrim} from '../../utils/strings'
@@ -34,7 +35,8 @@ export default function CameraControl() {
   useEffect(() => {
     setCameraControls(cameraControls)
     onHash(location, cameraControls)
-    onLoad(location, cameraControls, viewer)
+    const cleanup = onLoad(location, cameraControls, viewer)
+    return cleanup
   }, [location, cameraControls, setCameraControls, viewer])
 
   return <div style={{display: 'none'}}>Camera</div>
@@ -48,6 +50,9 @@ export default function CameraControl() {
  * @param {object} location Either window.location or react-router location
  * @param {object} cameraControls obtained from the viewer
  * @param {object} viewer the viewer, for null testing
+ * @return {Function} cleanup function that removes the listeners this
+ *     call added.  Always returns a function so React useEffect can
+ *     call it unconditionally.
  */
 function onLoad(location, cameraControls, viewer) {
   addHashListener('camera', () => onHash(location, cameraControls))
@@ -63,9 +68,6 @@ function onLoad(location, cameraControls, viewer) {
       }
       isMouseMoved = false
     }
-    canvas.removeEventListener('mousemove', onMouseMove)
-    canvas.addEventListener('mousemove', onMouseMove)
-
     // https://stackoverflow.com/questions/3515446/jquery-mousewheel-detecting-when-the-wheel-stops/28371047#28371047
     const onWheel = () => {
       clearTimeout(document.wheeling)
@@ -74,11 +76,21 @@ function onLoad(location, cameraControls, viewer) {
         removeCameraUrlParams()
       }, WHEEL_DEBOUNCE_WAIT_MS)
     }
+    canvas.addEventListener('mousemove', onMouseMove)
     canvas.addEventListener('wheel', onWheel)
-
-    canvas.removeEventListener('mouseup', onMouseUp)
-    canvas.removeEventListener('touchend', onMouseUp)
     canvas.addEventListener('mouseup', onMouseUp)
+    canvas.addEventListener('touchend', onMouseUp)
+
+    return () => {
+      removeHashListener('camera')
+      canvas.removeEventListener('mousemove', onMouseMove)
+      canvas.removeEventListener('wheel', onWheel)
+      canvas.removeEventListener('mouseup', onMouseUp)
+      canvas.removeEventListener('touchend', onMouseUp)
+    }
+  }
+  return () => {
+    removeHashListener('camera')
   }
 }
 

--- a/src/Components/Camera/CameraControl.test.jsx
+++ b/src/Components/Camera/CameraControl.test.jsx
@@ -69,6 +69,38 @@ describe('CameraControl', () => {
       jest.useRealTimers()
     })
 
+    it('removes every canvas listener it added when the component unmounts', () => {
+      // Locking in the useEffect-cleanup contract: anonymous handlers
+      // were leaking before because removeEventListener was called
+      // with fresh fn refs that didn't match the ones added.
+      const removeEventListenerSpy = jest.spyOn(
+        HTMLCanvasElement.prototype, 'removeEventListener',
+      )
+
+      const {unmount} = render(<ShareMock><CameraControl/></ShareMock>)
+
+      // Capture the handler refs that were added per event name; we'll
+      // then assert removeEventListener was called with the same refs.
+      const tracked = ['mousemove', 'wheel', 'mouseup', 'touchend']
+      const addedByName = {}
+      tracked.forEach((name) => {
+        const call = addEventListenerSpy.mock.calls.find(([n]) => n === name)
+        expect(call).toBeDefined()
+        addedByName[name] = call[1]
+      })
+
+      unmount()
+
+      tracked.forEach((name) => {
+        const removeCall = removeEventListenerSpy.mock.calls.find(
+          ([n, fn]) => n === name && fn === addedByName[name],
+        )
+        expect(removeCall).toBeDefined()
+      })
+
+      removeEventListenerSpy.mockRestore()
+    })
+
     it('calls removeCameraUrlParams only once after multiple wheel events', () => {
       // 1) Render the component
       render(<ShareMock><CameraControl/></ShareMock>)

--- a/src/Components/Open/SaveModelControl.jsx
+++ b/src/Components/Open/SaveModelControl.jsx
@@ -357,6 +357,29 @@ function SaveModelDialog({isDialogDisplayed, setIsDialogDisplayed, navigate, org
   )
 }
 
+// Tracks the active snack-clear timeout so successive saves don't
+// pile up callbacks that could fire on an unmounted component.
+let snackTimeoutId = null
+
+
+/**
+ * Schedule clearing of the snack message after a delay, replacing any
+ * pending clear so only one is ever active.
+ *
+ * @param {Function} setSnackMessage
+ * @param {number} pauseTimeMs
+ */
+function scheduleSnackClear(setSnackMessage, pauseTimeMs) {
+  if (snackTimeoutId !== null) {
+    clearTimeout(snackTimeoutId)
+  }
+  snackTimeoutId = setTimeout(() => {
+    snackTimeoutId = null
+    setSnackMessage(null)
+  }, pauseTimeMs)
+}
+
+
 /**
  * Redirects to a new model after displaying a success message.
  * The function constructs a GitHub path for the committed file
@@ -372,7 +395,7 @@ function SaveModelDialog({isDialogDisplayed, setIsDialogDisplayed, navigate, org
 function redirectToNewModel(onPathname, orgName, repoName, branchName, pathWithFileName, setSnackMessage) {
   setSnackMessage(MSG_SAVE_SUCCESS)
   const pauseTimeMs = 5000
-  setTimeout(() => setSnackMessage(null), pauseTimeMs)
+  scheduleSnackClear(setSnackMessage, pauseTimeMs)
 
   const pathLeadingSlash = `/${ pathWithFileName}`
 
@@ -432,7 +455,7 @@ async function fileSave(
           } else {
             setSnackMessage(MSG_ERROR_OPFS)
             const pauseTimeMs = 5000
-            setTimeout(() => setSnackMessage(null), pauseTimeMs)
+            scheduleSnackClear(setSnackMessage, pauseTimeMs)
           }
         } else {
           redirectToNewModel(onPathname, orgName, repoName, branchName, pathWithFileName, setSnackMessage)
@@ -440,7 +463,7 @@ async function fileSave(
       } else {
         setSnackMessage(MSG_ERROR_GITHUB)
         const pauseTimeMs = 5000
-        setTimeout(() => setSnackMessage(null), pauseTimeMs)
+        scheduleSnackClear(setSnackMessage, pauseTimeMs)
       }
     } catch (error) {
       setSnackMessage(error.message || MSG_ERROR_GITHUB)

--- a/src/Containers/CadView.jsx
+++ b/src/Containers/CadView.jsx
@@ -31,6 +31,11 @@ import {initViewer} from './viewer'
 
 
 let count = 0
+// Tracks the theme-change listener registered by onModelPath() so we
+// can remove it before registering a new one on the next model load.
+// Otherwise each prior listener stays in the registry, capturing its
+// (now-disposed) viewer via closure and pinning it from GC.
+let previousThemeChangeCb = null
 
 /**
  * Only container for the app.  Hosts the IfcViewer as well as nav components.
@@ -140,6 +145,10 @@ export default function CadView({
     if (isModelReady) {
       resetState()
     }
+    if (previousThemeChangeCb) {
+      theme.removeThemeChangeListener(previousThemeChangeCb)
+    }
+    previousThemeChangeCb = initViewerCb
     initViewerCb(undefined, theme)
     theme.addThemeChangeListener(initViewerCb)
   }

--- a/src/Containers/viewer.js
+++ b/src/Containers/viewer.js
@@ -2,13 +2,122 @@ import {Color} from 'three'
 import {IfcViewerAPIExtended} from '../Infrastructure/IfcViewerAPIExtended'
 
 
+// Track the current viewer for cleanup so a subsequent call to
+// initViewer() can dispose its WebGL/Three.js resources before
+// constructing a new one.  Keeps GPU memory bounded across model loads.
+let currentViewer = null
+let mouseDownHandler = null
+let mouseUpHandler = null
+let mouseMoveHandler = null
+
+
+// Texture map slots that may exist on a Three.js material; iterated by
+// disposeViewer to release any GPU textures the scene holds.
+const TEXTURE_MAP_SLOTS = [
+  'map',
+  'normalMap',
+  'roughnessMap',
+  'metalnessMap',
+  'emissiveMap',
+  'aoMap',
+  'bumpMap',
+  'displacementMap',
+  'alphaMap',
+  'lightMap',
+  'envMap',
+]
+
+
+/**
+ * Dispose the previous viewer and all its resources.
+ */
+export function disposeViewer() {
+  if (!currentViewer) {
+    return
+  }
+  try {
+    if (mouseDownHandler) {
+      window.removeEventListener('mousedown', mouseDownHandler)
+    }
+    if (mouseUpHandler) {
+      window.removeEventListener('mouseup', mouseUpHandler)
+    }
+    if (mouseMoveHandler) {
+      window.removeEventListener('mousemove', mouseMoveHandler)
+    }
+    mouseDownHandler = null
+    mouseUpHandler = null
+    mouseMoveHandler = null
+
+    if (currentViewer._resizeObserver) {
+      currentViewer._resizeObserver.disconnect()
+      currentViewer._resizeObserver = null
+    }
+
+    const scene = currentViewer.context.getScene()
+    scene.traverse((obj) => {
+      if (obj.geometry) {
+        obj.geometry.dispose()
+      }
+      if (obj.material) {
+        const materials = Array.isArray(obj.material) ? obj.material : [obj.material]
+        materials.forEach((mat) => {
+          TEXTURE_MAP_SLOTS.forEach((slot) => {
+            if (mat[slot]) {
+              mat[slot].dispose()
+            }
+          })
+          mat.dispose()
+        })
+      }
+    })
+
+    const renderer = currentViewer.context.getRenderer()
+    if (renderer && typeof renderer.dispose === 'function') {
+      renderer.dispose()
+    }
+    // renderer.dispose() does not free the WebGL context itself; force
+    // context loss so the browser can reclaim it.  Browsers cap active
+    // WebGL contexts (~16 in Chrome) and we'd otherwise hit it after
+    // many model loads.
+    if (renderer && typeof renderer.forceContextLoss === 'function') {
+      renderer.forceContextLoss()
+    }
+
+    if (currentViewer.glbClipper && typeof currentViewer.glbClipper.dispose === 'function') {
+      currentViewer.glbClipper.dispose()
+      currentViewer.glbClipper = null
+    }
+
+    // Belt-and-suspenders: call any built-in dispose on the viewer for
+    // subsystems the manual traverse above doesn't reach (controls,
+    // post-processor, highlighter, isolator, viewsManager, etc.).
+    if (typeof currentViewer.dispose === 'function') {
+      try {
+        currentViewer.dispose()
+      } catch (e) {
+        console.warn('viewer.dispose failed:', e)
+      }
+    }
+
+    currentViewer = null
+  } catch (e) {
+    console.warn('Error disposing viewer:', e)
+  }
+}
+
+
 /**
  * @param {string} pathPrefix E.g. /share/v/p
  * @param {string} backgroundColorStr CSS str like '#abcdef'
- * @return {object} IfcViewerAPIExtended viewer, width a .container property
+ * @return {object} IfcViewerAPIExtended viewer, with a .container property
  *     referencing its container.
  */
 export function initViewer(pathPrefix, backgroundColorStr = '#abcdef') {
+  // Dispose previous viewer first so its WebGL context, geometries,
+  // materials and textures are released before we allocate new ones.
+  disposeViewer()
+
   const container = document.getElementById('viewer-container')
 
   // Clear any existing scene.
@@ -23,10 +132,10 @@ export function initViewer(pathPrefix, backgroundColorStr = '#abcdef') {
   viewer.clipper.active = true
   viewer.clipper.orthogonalY = false
 
-  window.onmousedown = () => {
+  mouseDownHandler = () => {
     viewer.clipper.clickDrag = true
   }
-  window.onmouseup = () => {
+  mouseUpHandler = () => {
     viewer.clipper.clickDrag = false
   }
 
@@ -34,7 +143,7 @@ export function initViewer(pathPrefix, backgroundColorStr = '#abcdef') {
   const PICK_INTERVAL = 33 // 30fps
   // Highlight items when hovering over them. Sample when mouse-over.
   // Disable during a click-drag for rotation.
-  window.onmousemove = () => {
+  mouseMoveHandler = () => {
     if (!viewer.clipper.clickDrag) {
       const now = performance.now()
       if (now - lastPickTime < PICK_INTERVAL) {
@@ -47,11 +156,16 @@ export function initViewer(pathPrefix, backgroundColorStr = '#abcdef') {
     }
   }
 
+  window.addEventListener('mousedown', mouseDownHandler)
+  window.addEventListener('mouseup', mouseUpHandler)
+  window.addEventListener('mousemove', mouseMoveHandler)
+
   viewer.container = container
 
   // This is necessary so that canvas can receive key events for shortcuts.
   const canvas = viewer.context.getDomElement()
   canvas.setAttribute('tabIndex', '0')
 
+  currentViewer = viewer
   return viewer
 }

--- a/src/Containers/viewer.test.js
+++ b/src/Containers/viewer.test.js
@@ -1,0 +1,239 @@
+import {__getIfcViewerAPIExtendedMockSingleton} from 'web-ifc-viewer'
+import {disposeViewer, initViewer} from './viewer'
+
+
+/**
+ * Build a fake material with every texture-map slot disposeViewer
+ * iterates over.  Each slot gets its own dispose spy so we can assert
+ * the loop hits all of them.
+ *
+ * @return {object}
+ */
+function makeMaterialWithAllMaps() {
+  const slots = [
+    'map', 'normalMap', 'roughnessMap', 'metalnessMap', 'emissiveMap',
+    'aoMap', 'bumpMap', 'displacementMap', 'alphaMap', 'lightMap', 'envMap',
+  ]
+  const mat = {dispose: jest.fn()}
+  slots.forEach((slot) => {
+    mat[slot] = {dispose: jest.fn()}
+  })
+  return {mat, slots}
+}
+
+
+/**
+ * Override the singleton mock with disposable scene / renderer /
+ * clipper stubs.  The default mock from __mocks__/web-ifc-viewer.js
+ * doesn't model dispose; we patch the singleton in place so that the
+ * version of `currentViewer` captured by initViewer() carries our
+ * spies.  Returns the spies for assertion.
+ *
+ * @param {object} viewer
+ * @return {object}
+ */
+function attachDisposeSpies(viewer) {
+  const meshGeometry = {dispose: jest.fn()}
+  const {mat: meshMaterial, slots: textureMapSlots} = makeMaterialWithAllMaps()
+  const meshes = [
+    {geometry: meshGeometry, material: meshMaterial},
+    {geometry: null, material: null},
+  ]
+  const fakeScene = {
+    add: jest.fn(),
+    traverse: jest.fn((cb) => meshes.forEach(cb)),
+  }
+  const fakeRenderer = {
+    dispose: jest.fn(),
+    forceContextLoss: jest.fn(),
+  }
+  viewer.context.getScene = jest.fn(() => fakeScene)
+  viewer.context.getRenderer = jest.fn(() => fakeRenderer)
+  viewer.context.getDomElement = jest.fn(() => ({
+    setAttribute: jest.fn(),
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+  }))
+  viewer.glbClipper = {dispose: jest.fn()}
+  viewer.dispose = jest.fn()
+  viewer.highlightIfcItem = jest.fn()
+  viewer._resizeObserver = {disconnect: jest.fn()}
+  return {
+    fakeScene,
+    fakeRenderer,
+    meshGeometry,
+    meshMaterial,
+    textureMapSlots,
+    glbClipper: viewer.glbClipper,
+    viewerDispose: viewer.dispose,
+    resizeObserver: viewer._resizeObserver,
+  }
+}
+
+
+describe('Containers/viewer', () => {
+  let windowAddSpy
+  let windowRemoveSpy
+
+  beforeEach(() => {
+    document.body.innerHTML = '<div id="viewer-container"></div>'
+    windowAddSpy = jest.spyOn(window, 'addEventListener')
+    windowRemoveSpy = jest.spyOn(window, 'removeEventListener')
+    // The default singleton mock's scene has no traverse() and the
+    // renderer is undefined, which makes disposeViewer log a warn
+    // during afterEach.  Give it a no-op shape; tests that need to
+    // assert on the dispose chain override via attachDisposeSpies.
+    const baseViewer = __getIfcViewerAPIExtendedMockSingleton()
+    baseViewer.context.getScene = jest.fn(() => ({add: jest.fn(), traverse: jest.fn()}))
+    baseViewer.context.getRenderer = jest.fn(() => ({dispose: jest.fn(), forceContextLoss: jest.fn()}))
+    baseViewer.context.getDomElement = jest.fn(() => ({
+      setAttribute: jest.fn(),
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+    }))
+    baseViewer.glbClipper = null
+    delete baseViewer.dispose
+    delete baseViewer._resizeObserver
+  })
+
+  afterEach(() => {
+    // Make sure no viewer state leaks between tests.
+    disposeViewer()
+    jest.restoreAllMocks()
+  })
+
+
+  describe('initViewer', () => {
+    it('returns a viewer wired to the container', () => {
+      const viewer = initViewer('/share/v/p')
+      expect(viewer).toBeDefined()
+      expect(viewer.container).toBeInstanceOf(HTMLElement)
+      expect(viewer.IFC.setWasmPath).toHaveBeenCalledWith('./static/js/')
+      expect(viewer.clipper.active).toBe(true)
+    })
+
+    it('registers window mousedown / mouseup / mousemove handlers', () => {
+      initViewer('/share/v/p')
+      const events = windowAddSpy.mock.calls.map(([eventName]) => eventName)
+      expect(events).toEqual(expect.arrayContaining(['mousedown', 'mouseup', 'mousemove']))
+    })
+
+    it('disposes the previous viewer before creating the new one', () => {
+      const first = initViewer('/share/v/p')
+      const spies = attachDisposeSpies(first)
+
+      // Second call must invoke disposeViewer() against the first
+      // viewer's resources before constructing the new one.
+      initViewer('/share/v/p')
+
+      expect(spies.fakeScene.traverse).toHaveBeenCalled()
+      expect(spies.meshGeometry.dispose).toHaveBeenCalled()
+      expect(spies.fakeRenderer.dispose).toHaveBeenCalled()
+      expect(spies.fakeRenderer.forceContextLoss).toHaveBeenCalled()
+      expect(spies.glbClipper.dispose).toHaveBeenCalled()
+      expect(spies.viewerDispose).toHaveBeenCalled()
+      expect(spies.resizeObserver.disconnect).toHaveBeenCalled()
+    })
+  })
+
+
+  describe('disposeViewer', () => {
+    it('is a no-op when no viewer has been constructed', () => {
+      expect(() => disposeViewer()).not.toThrow()
+    })
+
+    it('removes the global mouse handlers it added in initViewer', () => {
+      initViewer('/share/v/p')
+      const addedEvents = windowAddSpy.mock.calls
+        .filter(([name]) => name === 'mousedown' || name === 'mouseup' || name === 'mousemove')
+      expect(addedEvents).toHaveLength(3)
+
+      disposeViewer()
+
+      const removedEvents = windowRemoveSpy.mock.calls
+        .filter(([name]) => name === 'mousedown' || name === 'mouseup' || name === 'mousemove')
+      expect(removedEvents).toHaveLength(3)
+
+      // Same handler refs were used for add and remove — otherwise the
+      // browser's removeEventListener would be a no-op and we'd be
+      // back to leaking listeners across loads.
+      ;['mousedown', 'mouseup', 'mousemove'].forEach((name) => {
+        const added = addedEvents.find(([n]) => n === name)[1]
+        const removed = removedEvents.find(([n]) => n === name)[1]
+        expect(removed).toBe(added)
+      })
+    })
+
+    it('disposes geometry, every texture-map slot, and the material itself', () => {
+      const viewer = initViewer('/share/v/p')
+      const spies = attachDisposeSpies(viewer)
+
+      disposeViewer()
+
+      expect(spies.meshGeometry.dispose).toHaveBeenCalledTimes(1)
+      spies.textureMapSlots.forEach((slot) => {
+        expect(spies.meshMaterial[slot].dispose).toHaveBeenCalledTimes(1)
+      })
+      expect(spies.meshMaterial.dispose).toHaveBeenCalledTimes(1)
+    })
+
+    it('calls renderer.dispose() and renderer.forceContextLoss()', () => {
+      const viewer = initViewer('/share/v/p')
+      const spies = attachDisposeSpies(viewer)
+
+      disposeViewer()
+
+      expect(spies.fakeRenderer.dispose).toHaveBeenCalledTimes(1)
+      expect(spies.fakeRenderer.forceContextLoss).toHaveBeenCalledTimes(1)
+    })
+
+    it('calls the viewer\'s built-in dispose when present', () => {
+      const viewer = initViewer('/share/v/p')
+      const spies = attachDisposeSpies(viewer)
+
+      disposeViewer()
+
+      expect(spies.viewerDispose).toHaveBeenCalledTimes(1)
+    })
+
+    it('does not throw when the viewer has no built-in dispose', () => {
+      const viewer = initViewer('/share/v/p')
+      attachDisposeSpies(viewer)
+      delete viewer.dispose
+
+      expect(() => disposeViewer()).not.toThrow()
+    })
+
+    it('disconnects the ResizeObserver and nulls glbClipper', () => {
+      const viewer = initViewer('/share/v/p')
+      const spies = attachDisposeSpies(viewer)
+
+      disposeViewer()
+
+      expect(spies.resizeObserver.disconnect).toHaveBeenCalledTimes(1)
+      expect(spies.glbClipper.dispose).toHaveBeenCalledTimes(1)
+      expect(viewer.glbClipper).toBeNull()
+    })
+
+    it('is idempotent — calling twice does not throw or double-dispose', () => {
+      const viewer = initViewer('/share/v/p')
+      const spies = attachDisposeSpies(viewer)
+
+      disposeViewer()
+      disposeViewer()
+
+      // Each dispose target should still have been called exactly once
+      // because the second disposeViewer() sees no currentViewer.
+      expect(spies.fakeRenderer.dispose).toHaveBeenCalledTimes(1)
+      expect(spies.viewerDispose).toHaveBeenCalledTimes(1)
+    })
+  })
+
+
+  describe('singleton fixture sanity', () => {
+    it('initViewer returns the same singleton object the test mock exposes', () => {
+      const viewer = initViewer('/share/v/p')
+      expect(viewer).toBe(__getIfcViewerAPIExtendedMockSingleton())
+    })
+  })
+})

--- a/src/OPFS/utils.js
+++ b/src/OPFS/utils.js
@@ -431,22 +431,26 @@ export function saveDnDFileToOpfs(file, type, callback) {
   const parts = tmpUrl.split('/')
   const fileNametmpUrl = parts[parts.length - 1]
 
-  // Listener for messages from the worker
+  // Listener for messages from the worker.  We can't revoke tmpUrl
+  // until the worker is done with it, so revoke when the listener
+  // detaches (success or error path).
   const listener = (workerEvent) => {
     if (workerEvent.data.error) {
       debug().error('Error from worker:', workerEvent.data.error)
-      workerRef.removeEventListener('message', listener) // Remove the event listener
+      workerRef.removeEventListener('message', listener)
+      URL.revokeObjectURL(tmpUrl)
     } else if (workerEvent.data.completed) {
       if (workerEvent.data.event === 'write') {
         debug().log('Worker finished writing file')
-        // Perform the navigation logic after the worker is done
         const fileName = workerEvent.data.fileName
         workerRef.removeEventListener('message', listener)
+        URL.revokeObjectURL(tmpUrl)
         callback(fileName)
       } else if (workerEvent.data.event === 'read') {
         debug().log('Worker finished reading file')
         const fileName = workerEvent.data.file.name
-        workerRef.removeEventListener('message', listener) // Remove the event listener
+        workerRef.removeEventListener('message', listener)
+        URL.revokeObjectURL(tmpUrl)
         callback(fileName)
       }
     }

--- a/src/store/NotesSlice.js
+++ b/src/store/NotesSlice.js
@@ -31,7 +31,22 @@ export default function createNotesSlice(set, get) {
     setCreatedNotes: (createdNotes) => set(() => ({createdNotes: createdNotes})),
 
     deletedNotes: null,
-    setDeletedNotes: (deletedNotes) => set(() => ({deletedNotes: deletedNotes})),
+    // Prune per-note edit state when a note is deleted so editBodies,
+    // editModes, and editOriginalBodies don't grow unbounded across a
+    // session.
+    setDeletedNotes: (deletedNotes) => set((state) => {
+      if (!deletedNotes || deletedNotes.id === undefined) {
+        return {deletedNotes}
+      }
+      const id = deletedNotes.id
+      const editBodies = {...state.editBodies}
+      const editModes = {...state.editModes}
+      const editOriginalBodies = {...state.editOriginalBodies}
+      delete editBodies[id]
+      delete editModes[id]
+      delete editOriginalBodies[id]
+      return {deletedNotes, editBodies, editModes, editOriginalBodies}
+    }),
 
     editBodies: {}, // Track editBody for each NoteCard by id
     setEditBody: (id, body) =>

--- a/src/store/NotesSlice.test.js
+++ b/src/store/NotesSlice.test.js
@@ -141,6 +141,56 @@ describe('store/NotesSlice', () => {
   })
 
 
+  describe('setDeletedNotes pruning of edit state', () => {
+    it('removes the deleted note\'s entries from editBodies, editModes, and editOriginalBodies', () => {
+      const store = makeStore()
+      // Seed edit state for two notes
+      store.getState().setEditBody('n1', 'first')
+      store.getState().setEditBody('n2', 'second')
+      store.getState().setEditMode('n1', true)
+      store.getState().setEditMode('n2', false)
+      store.getState().setEditOriginalBody('n1', 'first-orig')
+      store.getState().setEditOriginalBody('n2', 'second-orig')
+
+      // Delete n1
+      store.getState().setDeletedNotes({id: 'n1'})
+
+      const state = store.getState()
+      expect(state.deletedNotes).toEqual({id: 'n1'})
+      expect(state.editBodies).toEqual({n2: 'second'})
+      expect(state.editModes).toEqual({n2: false})
+      expect(state.editOriginalBodies).toEqual({n2: 'second-orig'})
+    })
+
+    it('leaves edit state untouched when deletedNotes is null (e.g. clearing the field)', () => {
+      const store = makeStore()
+      store.getState().setEditBody('n1', 'first')
+      store.getState().setDeletedNotes(null)
+      expect(store.getState().deletedNotes).toBeNull()
+      expect(store.getState().editBodies).toEqual({n1: 'first'})
+    })
+
+    it('leaves edit state untouched when deletedNotes has no id (legacy/array shape)', () => {
+      const store = makeStore()
+      store.getState().setEditBody('n1', 'first')
+      // The pre-existing parameterized test already passes an array
+      // here; preserve that behavior — pruning only kicks in when
+      // we get a concrete {id} payload.
+      store.getState().setDeletedNotes([{id: 2}])
+      expect(store.getState().editBodies).toEqual({n1: 'first'})
+    })
+
+    it('does nothing when the deleted id has no associated edit state', () => {
+      const store = makeStore()
+      store.getState().setEditBody('n1', 'first')
+      store.getState().setDeletedNotes({id: 'unknown-note'})
+      expect(store.getState().editBodies).toEqual({n1: 'first'})
+      expect(store.getState().editModes).toEqual({})
+      expect(store.getState().editOriginalBodies).toEqual({})
+    })
+  })
+
+
   describe('selected place mark in note', () => {
     it('setSelectedPlaceMarkInNoteIdData updates three fields at once', () => {
       const store = makeStore()

--- a/src/theme/Theme.jsx
+++ b/src/theme/Theme.jsx
@@ -106,6 +106,9 @@ function loadTheme(mode, setMode, themeChangeListeners, originalMode) {
     addThemeChangeListener: (onChangeCb) => {
       themeChangeListeners[onChangeCb] = onChangeCb
     },
+    removeThemeChangeListener: (onChangeCb) => {
+      delete themeChangeListeners[onChangeCb]
+    },
   }
   return createTheme(theme)
 }

--- a/src/utils/loader.js
+++ b/src/utils/loader.js
@@ -22,10 +22,11 @@ export function loadLocalFileFallback(onLoad, testingSkipAutoRemove = false) {
       debug().log('loader#loadLocalFile#event:', event)
       const file = event.target.files[0]
       const lastModifiedUtc = file.lastModified
-      let tmpUrl = URL.createObjectURL(file)
-      debug().log('loader#loadLocalFile#event: url: ', tmpUrl)
-      const parts = tmpUrl.split('/')
-      tmpUrl = parts[parts.length - 1]
+      const objectUrl = URL.createObjectURL(file)
+      debug().log('loader#loadLocalFile#event: url: ', objectUrl)
+      const parts = objectUrl.split('/')
+      const tmpUrl = parts[parts.length - 1]
+      URL.revokeObjectURL(objectUrl)
       if (onLoad) {
         onLoad(tmpUrl, lastModifiedUtc)
       }
@@ -69,18 +70,24 @@ export function loadLocalFile(onLoad, testingSkipAutoRemove = false, testingDisa
       const parts = tmpUrl.split('/')
       const fileNametmpUrl = parts[parts.length - 1]
       if (!testingDisableWebWorker) {
-        // Listener for messages from the worker
+        // Listener for messages from the worker.  We can't revoke
+        // tmpUrl until the worker is done with it, so revoke when the
+        // listener detaches (success or error path).
         const listener = (workerEvent) => {
           if (workerEvent.data.error) {
             debug().error('Error from worker:', workerEvent.data.error)
-            workerRef.removeEventListener('message', listener) // Remove the event listener
+            workerRef.removeEventListener('message', listener)
+            URL.revokeObjectURL(tmpUrl)
           } else if (workerEvent.data.completed) {
             if (workerEvent.data.event === 'write') {
               debug().log('Worker finished writing file')
-              // Perform the navigation logic after the worker is done
+              workerRef.removeEventListener('message', listener)
+              URL.revokeObjectURL(tmpUrl)
               onLoad(workerEvent.data.fileName, lastModifiedUtc)
             } else if (workerEvent.data.event === 'read') {
               debug().log('Worker finished reading file')
+              workerRef.removeEventListener('message', listener)
+              URL.revokeObjectURL(tmpUrl)
               onLoad(workerEvent.data.file.name, lastModifiedUtc)
             }
           }
@@ -94,6 +101,7 @@ export function loadLocalFile(onLoad, testingSkipAutoRemove = false, testingDisa
         const ext = dotParts[dotParts.length - 1]
         opfsWriteModel(tmpUrl, filename, `${fileNametmpUrl}.${ext}`)
       } else {
+        URL.revokeObjectURL(tmpUrl)
         onLoad(fileNametmpUrl, lastModifiedUtc)
       }
     },
@@ -116,9 +124,10 @@ export function loadLocalFile(onLoad, testingSkipAutoRemove = false, testingDisa
  */
 export function saveDnDFileToOpfsFallback(file, callback) {
   assertDefined(file, callback)
-  let tmpUrl = URL.createObjectURL(file)
-  debug().log('utils/loader#saveDnDFileToOpfsAndNavFallback: url: ', tmpUrl)
-  const parts = tmpUrl.split('/')
-  tmpUrl = parts[parts.length - 1]
+  const objectUrl = URL.createObjectURL(file)
+  debug().log('utils/loader#saveDnDFileToOpfsAndNavFallback: url: ', objectUrl)
+  const parts = objectUrl.split('/')
+  const tmpUrl = parts[parts.length - 1]
+  URL.revokeObjectURL(objectUrl)
   callback(tmpUrl)
 }

--- a/src/utils/loader.test.js
+++ b/src/utils/loader.test.js
@@ -1,4 +1,4 @@
-import {loadLocalFile} from './loader'
+import {loadLocalFile, loadLocalFileFallback, saveDnDFileToOpfsFallback} from './loader'
 
 
 describe('loadLocalFile', () => {
@@ -6,6 +6,7 @@ describe('loadLocalFile', () => {
     // Set up DOM
     document.body.innerHTML = `<div id="viewer-container"></div>`
     URL.createObjectURL = jest.fn(() => 'testId')
+    URL.revokeObjectURL = jest.fn()
   })
 
   afterEach(() => {
@@ -28,6 +29,21 @@ describe('loadLocalFile', () => {
     expect(onLoad).toHaveBeenCalledWith('testId', expect.any(Number))
   })
 
+  it('revokes the object URL when the worker is disabled (sync fallback path)', () => {
+    // When testingDisableWebWorker=true the worker path is skipped
+    // and onLoad fires synchronously; the revoke must happen by then
+    // so the underlying blob isn't pinned in memory.
+    const onLoad = jest.fn()
+    loadLocalFile(onLoad, true, true)
+
+    const inputElement = document.querySelector('input[type="file"]')
+    Object.defineProperty(inputElement, 'files', {value: [new File(['dummy'], 'test.ifc')]})
+    inputElement.dispatchEvent(new Event('change', {bubbles: true}))
+
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith('testId')
+    expect(URL.revokeObjectURL).toHaveBeenCalledTimes(1)
+  })
+
   it('throws an error if viewer-container is missing', () => {
     document.body.innerHTML = ''
     expect(() => {
@@ -39,5 +55,55 @@ describe('loadLocalFile', () => {
     loadLocalFile(jest.fn(), false, true)
     const inputElement = document.querySelector('input[type="file"]')
     expect(inputElement).toBeNull()
+  })
+})
+
+
+describe('loadLocalFileFallback', () => {
+  beforeEach(() => {
+    document.body.innerHTML = `<div id="viewer-container"></div>`
+    URL.createObjectURL = jest.fn(() => 'testId')
+    URL.revokeObjectURL = jest.fn()
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it('revokes the object URL after extracting the blob id', () => {
+    const onLoad = jest.fn()
+    loadLocalFileFallback(onLoad, true)
+
+    const inputElement = document.querySelector('input[type="file"]')
+    Object.defineProperty(inputElement, 'files', {value: [new File(['dummy'], 'test.ifc')]})
+    inputElement.dispatchEvent(new Event('change', {bubbles: true}))
+
+    expect(URL.createObjectURL).toHaveBeenCalledTimes(1)
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith('testId')
+    expect(onLoad).toHaveBeenCalledWith('testId', expect.any(Number))
+  })
+})
+
+
+describe('saveDnDFileToOpfsFallback', () => {
+  beforeEach(() => {
+    URL.createObjectURL = jest.fn(() => 'http://localhost/blob/abc123')
+    URL.revokeObjectURL = jest.fn()
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it('revokes the object URL before invoking the callback', () => {
+    let revokeCalledBeforeCallback = false
+    const callback = jest.fn(() => {
+      revokeCalledBeforeCallback = URL.revokeObjectURL.mock.calls.length > 0
+    })
+    saveDnDFileToOpfsFallback(new File(['dummy'], 'test.ifc'), callback)
+
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith('http://localhost/blob/abc123')
+    expect(callback).toHaveBeenCalledWith('abc123')
+    expect(revokeCalledBeforeCallback).toBe(true)
   })
 })

--- a/src/utils/location.js
+++ b/src/utils/location.js
@@ -21,11 +21,21 @@ window.onhashchange = () => {
 // See also https://stackoverflow.com/a/71210781/3630172
 /**
  * @param {string} name Name of listener.  Can be used to later remove
- * listener. TODO: add remove method
+ *     listener via removeHashListener.
  * @param {Function} onHashCb Called when window.location.hash changes
  */
 export function addHashListener(name, onHashCb) {
   hashListeners[name] = onHashCb
+}
+
+
+/**
+ * Remove a previously-registered hash listener by name.
+ *
+ * @param {string} name
+ */
+export function removeHashListener(name) {
+  delete hashListeners[name]
 }
 
 /**


### PR DESCRIPTION
## Summary

Cherry-pick of the memory-leak fixes from @MarkusSteinbrecher's #1477, on a focused branch (without the unrelated Google Drive / theme / floor-plan / project-hierarchy work in that PR).

The headline fix: `initViewer()` was building a new `IfcViewerAPIExtended` on every model load without disposing the previous one. The old WebGL context, renderer, geometries, materials, and textures all stayed alive, which is the resource creep we've seen across multi-model sessions. Now `disposeViewer()` runs first, releasing GPU resources before allocating new ones.

Three small extensions on top of Markus's viewer disposal:

- **`WebGLRenderer.forceContextLoss()`** after `renderer.dispose()` — Three.js's `dispose()` frees programs/render targets but the WebGL context itself stays allocated. Chrome caps active contexts at ~16, so without this we could still hit the cap after enough loads.
- **`currentViewer.dispose?.()`** — optional call to any built-in dispose on `IfcViewerAPIExtended`. Belt-and-suspenders against subsystems the manual scene traverse misses (controls, post-processor, highlighter, isolator, viewsManager).
- **Expanded texture-map disposal** — Markus's loop only disposed `material.map`. Now iterates all common slots (`normalMap`, `roughnessMap`, `metalnessMap`, `emissiveMap`, `aoMap`, `bumpMap`, `displacementMap`, `alphaMap`, `lightMap`, `envMap`).

The other 7 leaks fixed (per Markus's `MEMORY_LEAK_FIXES.md`):

- Theme listener accumulation (`onModelPath` re-registered without removal)
- Canvas event listener accumulation (handler refs didn't match between add/remove; `useEffect` had no cleanup)
- Hash listeners had no removal mechanism — added `removeHashListener(name)`
- Object URLs created via `URL.createObjectURL` and never revoked (4 sites). For the two sites whose URL is consumed by a Web Worker, revocation is deferred until the worker reports completion to avoid the worker fetching a dead URL.
- `IFrameCommunicationChannel` had no `dispose()` — added one; `AppIFrame` tracks the channel via a ref and disposes on unmount/recreate
- `setDeletedNotes` left orphaned entries in `editBodies` / `editModes` / `editOriginalBodies`
- `SaveModelControl` snack timeouts piled up — now dedup'd via a single tracked timer

## Test plan

- [x] `yarn lint && yarn typecheck` — clean
- [x] `yarn test-src` — 160 suites, 958 tests, all pass
- [ ] Deploy preview: load 3 IFCs in sequence; in DevTools confirm only one WebGLRenderingContext exists, JS heap returns toward baseline between loads, and `theme.themeChangeListeners` doesn't grow
- [ ] Mobile/desktop smoke: search, section planes, notes, save flow

## Notes

- Branched off `bldrs-ai/Share:main`, not `pablo-mayrgundter/Share:main`, so the PR is a clean diff against the org's main.
- See `MEMORY_LEAK_FIXES.md` for the full per-leak breakdown (Markus's doc, with a one-line preamble noting the cherry-pick origin and the three extensions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)