### PR TITLE
Open dialog: lazy GitHub-orgs fetch + GDrive picker dispose-rebuild fix

### DIFF
--- a/src/Components/Connections/GoogleDrivePickerDialog.jsx
+++ b/src/Components/Connections/GoogleDrivePickerDialog.jsx
@@ -1,4 +1,4 @@
-import {useCallback, useEffect, useRef} from 'react'
+import {useEffect, useRef} from 'react'
 import {loadPickerScript} from '../../connections/google-drive/loadGisScript'
 
 
@@ -34,6 +34,14 @@ export default function GoogleDrivePickerDialog({
   onCancel,
 }) {
   const pickerRef = useRef(null)
+  // The picker is constructed once per (isOpen, accessToken, mode) toggle and
+  // reads `onSelect`/`onCancel` through this ref. Without this indirection,
+  // every parent re-render that gives us a new callback identity would force
+  // the build effect to dispose and rebuild the picker — and a click on the
+  // picker's Select button mid-rebuild lands on a disposed iframe whose
+  // postMessage channel is gone, leaving the user stuck with no callback.
+  const callbacksRef = useRef({onSelect, onCancel})
+  callbacksRef.current = {onSelect, onCancel}
 
   // Inject CSS to lift Google Picker's overlay above the MUI Dialog.
   useEffect(() => {
@@ -54,32 +62,32 @@ export default function GoogleDrivePickerDialog({
     return () => style.remove()
   }, [isOpen])
 
-  const handlePickerCallback = useCallback((data) => {
-    const action = data[google.picker.Response.ACTION]
-
-    if (action === google.picker.Action.PICKED) {
-      const docs = data[google.picker.Response.DOCUMENTS]
-      if (docs && docs.length > 0) {
-        onSelect(docs.map((doc) => ({
-          id: doc[google.picker.Document.ID],
-          name: doc[google.picker.Document.NAME],
-          url: doc[google.picker.Document.URL],
-          mimeType: doc[google.picker.Document.MIME_TYPE],
-          parentId: doc[google.picker.Document.PARENT_ID],
-          lastModifiedUtc: doc[google.picker.Document.LAST_EDITED_UTC] || null,
-        })))
-      }
-    } else if (action === google.picker.Action.CANCEL) {
-      onCancel()
-    }
-  }, [onSelect, onCancel])
-
   useEffect(() => {
     if (!isOpen || !accessToken) {
       return
     }
 
     let disposed = false
+
+    const handlePickerCallback = (data) => {
+      const action = data[google.picker.Response.ACTION]
+
+      if (action === google.picker.Action.PICKED) {
+        const docs = data[google.picker.Response.DOCUMENTS]
+        if (docs && docs.length > 0) {
+          callbacksRef.current.onSelect(docs.map((doc) => ({
+            id: doc[google.picker.Document.ID],
+            name: doc[google.picker.Document.NAME],
+            url: doc[google.picker.Document.URL],
+            mimeType: doc[google.picker.Document.MIME_TYPE],
+            parentId: doc[google.picker.Document.PARENT_ID],
+            lastModifiedUtc: doc[google.picker.Document.LAST_EDITED_UTC] || null,
+          })))
+        }
+      } else if (action === google.picker.Action.CANCEL) {
+        callbacksRef.current.onCancel()
+      }
+    }
 
     const buildPicker = async () => {
       await loadPickerScript()
@@ -133,7 +141,7 @@ export default function GoogleDrivePickerDialog({
         pickerRef.current = null
       }
     }
-  }, [isOpen, accessToken, mode, handlePickerCallback])
+  }, [isOpen, accessToken, mode])
 
   // This component only triggers the Google Picker overlay; it renders nothing
   return null

--- a/src/Components/Connections/GoogleDrivePickerDialog.test.jsx
+++ b/src/Components/Connections/GoogleDrivePickerDialog.test.jsx
@@ -1,0 +1,255 @@
+import React, {useState} from 'react'
+import {act, fireEvent, render} from '@testing-library/react'
+import GoogleDrivePickerDialog from './GoogleDrivePickerDialog'
+
+
+jest.mock('../../connections/google-drive/loadGisScript', () => ({
+  loadPickerScript: jest.fn().mockResolvedValue(undefined),
+}))
+
+
+/**
+ * Make a chainable no-op object: every method on `methodNames` returns the
+ * same instance. Avoids class boilerplate in test fakes.
+ *
+ * @param {Array<string>} methodNames Names of chainable methods to install
+ * @return {object} Instance with each named method as a chainable no-op
+ */
+function chainable(methodNames) {
+  const obj = {}
+  methodNames.forEach((name) => {
+    obj[name] = () => obj
+  })
+  return obj
+}
+
+
+/**
+ * Install a minimal `window.google.picker` fake on the global so the dialog
+ * can build a picker without the real script. Records each `build()` call
+ * and exposes the most recently built picker (with the registered callback)
+ * for invocation from tests.
+ *
+ * @return {object} {buildSpy, getLastPicker}
+ */
+function installGoogleFake() {
+  const buildSpy = jest.fn()
+  let lastPicker = null
+
+  /**
+   * Construct a fake picker builder. Each setter is chainable; setCallback
+   * stashes the callback for retrieval after build().
+   *
+   * @return {object} Chainable builder with build()
+   */
+  function PickerBuilder() {
+    let storedCallback = null
+    const builder = chainable([
+      'addView', 'setOAuthToken', 'setDeveloperKey', 'setAppId',
+      'enableFeature', 'setTitle', 'setSize',
+    ])
+    /**
+     * @param {Function} cb Callback to invoke on PICKED/CANCEL
+     * @return {object} The builder
+     */
+    builder.setCallback = (cb) => {
+      storedCallback = cb
+      return builder
+    }
+    /**
+     * @return {object} A picker instance with the registered callback
+     */
+    builder.build = () => {
+      buildSpy()
+      lastPicker = {
+        _callback: storedCallback,
+        setVisible: jest.fn(),
+        dispose: jest.fn(),
+      }
+      return lastPicker
+    }
+    return builder
+  }
+
+  /**
+   * @return {object} A chainable DocsView fake
+   */
+  function DocsView() {
+    return chainable(['setMimeTypes', 'setIncludeFolders', 'setSelectFolderEnabled', 'setMode'])
+  }
+
+  window.google = {
+    picker: {
+      PickerBuilder,
+      DocsView,
+      ViewId: {DOCS: 'DOCS', FOLDERS: 'FOLDERS'},
+      DocsViewMode: {LIST: 'LIST', GRID: 'GRID'},
+      Feature: {SUPPORT_DRIVES: 'SUPPORT_DRIVES'},
+      Action: {PICKED: 'PICKED', CANCEL: 'CANCEL'},
+      Response: {ACTION: 'action', DOCUMENTS: 'docs'},
+      Document: {
+        ID: 'id',
+        NAME: 'name',
+        URL: 'url',
+        MIME_TYPE: 'mimeType',
+        PARENT_ID: 'parentId',
+        LAST_EDITED_UTC: 'lastEditedUtc',
+      },
+    },
+  }
+
+  /**
+   * @return {object|null} The most recently built picker, or null
+   */
+  const getLastPicker = () => lastPicker
+  return {buildSpy, getLastPicker}
+}
+
+
+describe('GoogleDrivePickerDialog', () => {
+  let originalGoogle
+
+  beforeEach(() => {
+    originalGoogle = window.google
+  })
+
+  afterEach(() => {
+    window.google = originalGoogle
+    jest.clearAllMocks()
+  })
+
+  it('builds the picker exactly once across parent re-renders with fresh callback identities', async () => {
+    const {buildSpy} = installGoogleFake()
+    const onSelect = jest.fn()
+    const onCancel = jest.fn()
+
+    /**
+     * Force re-renders with fresh inline callback identity each time —
+     * exactly the scenario that used to thrash the build effect.
+     *
+     * @return {React.Element}
+     */
+    function Host() {
+      const [tick, setTick] = useState(0)
+      return (
+        <div>
+          <button data-testid='bump' onClick={() => setTick(tick + 1)}>{`bump-${tick}`}</button>
+          <GoogleDrivePickerDialog
+            accessToken='fake-token'
+            isOpen={true}
+            mode='file'
+            onSelect={(docs) => onSelect(docs)}
+            onCancel={() => onCancel()}
+          />
+        </div>
+      )
+    }
+
+    const {getByTestId} = render(<Host/>)
+    await act(async () => {
+      await Promise.resolve()
+    })
+    expect(buildSpy).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      fireEvent.click(getByTestId('bump'))
+      fireEvent.click(getByTestId('bump'))
+      fireEvent.click(getByTestId('bump'))
+      await Promise.resolve()
+    })
+    expect(buildSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('routes PICKED through the latest onSelect even after parent swaps it', async () => {
+    const {getLastPicker} = installGoogleFake()
+    const calls = []
+    const onCancel = jest.fn()
+
+    let setOnSelectExternal
+    /**
+     * @return {React.Element}
+     */
+    function SwappableHost() {
+      const [onSelect, setOnSelect] = useState(() => (docs) => calls.push({version: 'initial', docs}))
+      setOnSelectExternal = setOnSelect
+      return (
+        <GoogleDrivePickerDialog
+          accessToken='fake-token'
+          isOpen={true}
+          mode='file'
+          onSelect={onSelect}
+          onCancel={onCancel}
+        />
+      )
+    }
+
+    render(<SwappableHost/>)
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    await act(async () => {
+      setOnSelectExternal(() => (docs) => calls.push({version: 'updated', docs}))
+      await Promise.resolve()
+    })
+
+    const picker = getLastPicker()
+    act(() => {
+      picker._callback({
+        action: 'PICKED',
+        docs: [{
+          id: 'file-id-1',
+          name: 'haus.ifc',
+          url: 'https://drive/x',
+          mimeType: 'application/octet-stream',
+          parentId: 'parent-1',
+          lastEditedUtc: 1735000000000,
+        }],
+      })
+    })
+
+    expect(calls).toHaveLength(1)
+    expect(calls[0].version).toBe('updated')
+    expect(calls[0].docs[0]).toEqual({
+      id: 'file-id-1',
+      name: 'haus.ifc',
+      url: 'https://drive/x',
+      mimeType: 'application/octet-stream',
+      parentId: 'parent-1',
+      lastModifiedUtc: 1735000000000,
+    })
+  })
+
+  it('disposes the picker when isOpen flips to false', async () => {
+    const {getLastPicker} = installGoogleFake()
+    const onSelect = jest.fn()
+    const onCancel = jest.fn()
+
+    /**
+     * @param {object} props
+     * @param {boolean} props.open Whether the picker is open
+     * @return {React.Element}
+     */
+    function Toggleable({open}) {
+      return (
+        <GoogleDrivePickerDialog
+          accessToken='fake-token'
+          isOpen={open}
+          mode='file'
+          onSelect={onSelect}
+          onCancel={onCancel}
+        />
+      )
+    }
+
+    const {rerender} = render(<Toggleable open={true}/>)
+    await act(async () => {
+      await Promise.resolve()
+    })
+    const picker = getLastPicker()
+    expect(picker).not.toBeNull()
+
+    rerender(<Toggleable open={false}/>)
+    expect(picker.dispose).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/Components/Open/GitHubFileBrowser.jsx
+++ b/src/Components/Open/GitHubFileBrowser.jsx
@@ -1,11 +1,12 @@
 
-import React, {ReactElement, useState} from 'react'
+import React, {ReactElement, useEffect, useState} from 'react'
 import {Button, Stack, Typography} from '@mui/material'
 import {navigateBaseOnModelPath} from '../../utils/location'
 import {navigateToModel} from '../../utils/navigate'
 import {useAuth0} from '../../Auth0/Auth0Proxy'
 import {pathSuffixSupported} from '../../Filetype'
 import {getFilesAndFolders} from '../../net/github/Files'
+import {getOrganizations} from '../../net/github/Organizations'
 import {getRepositories, getUserRepositories} from '../../net/github/Repositories'
 import {getBranches} from '../../net/github/Branches'
 import useStore from '../../store/useStore'
@@ -28,17 +29,17 @@ function resolveValue(value, list) {
 
 /**
  * @property {Function} navigate Callback from CadView to change page url
- * @property {Array<string>} orgNamesArr List of org names for the current user.
  * @property {Function} setIsDialogDisplayed callback
  * @property {Function} onCancel Called when user clicks Cancel to go back
  * @return {ReactElement}
  */
 export default function GitHubFileBrowser({
   navigate,
-  orgNamesArr,
   setIsDialogDisplayed,
   onCancel,
 }) {
+  const accessToken = useStore((state) => state.accessToken)
+  const [orgNamesArr, setOrgNamesArr] = useState([''])
   const [currentPath, setCurrentPath] = useState('')
   const [foldersArr, setFoldersArr] = useState([''])
   const {user} = useAuth0()
@@ -50,12 +51,35 @@ export default function GitHubFileBrowser({
   const [filesArr, setFilesArr] = useState([''])
   const [branchesArr, setBranchesArr] = useState([''])
   const [selectedBranchName, setSelectedBranchName] = useState('')
-  const accessToken = useStore((state) => state.accessToken)
   const orgNamesArrWithAt = orgNamesArr.map((name) => `@${name}`)
   const orgName = resolveValue(selectedOrgName, orgNamesArr)
   const repoName = resolveValue(selectedRepoName, repoNamesArr)
   const fileName = filesArr[selectedFileIndex]
   const branchName = resolveValue(selectedBranchName, branchesArr)
+
+  // Lazy-fetch the user's GitHub organizations only when this browser is mounted
+  // (i.e. user clicked Browse on the GitHub tab). Avoids spurious /user/orgs
+  // calls when the Open dialog is opened on a non-GitHub tab.
+  useEffect(() => {
+    if (!accessToken) {
+      return
+    }
+    let cancelled = false
+    /** Asynchronously fetch organizations */
+    async function fetchOrganizations() {
+      const orgs = await getOrganizations(accessToken)
+      if (cancelled) {
+        return
+      }
+      const orgNamesFetched = Object.keys(orgs).map((key) => orgs[key].login)
+      const orgNames = [...orgNamesFetched, user && user.nickname].filter(Boolean)
+      setOrgNamesArr(orgNames.length > 0 ? orgNames : [''])
+    }
+    fetchOrganizations()
+    return () => {
+      cancelled = true
+    }
+  }, [accessToken, user])
 
   const selectOrg = async (orgOrIndex) => {
     setSelectedOrgName(orgOrIndex)

--- a/src/Components/Open/GitHubFileBrowser.test.jsx
+++ b/src/Components/Open/GitHubFileBrowser.test.jsx
@@ -4,13 +4,17 @@ import {RouteThemeCtx} from '../../Share.fixture'
 import GitHubFileBrowser from './GitHubFileBrowser'
 
 
+jest.mock('../../net/github/Organizations', () => ({
+  getOrganizations: jest.fn().mockResolvedValue({}),
+}))
+
+
 describe('GitHubFileBrowser', () => {
-  const orgNamesArr = ['org1', 'org2']
   const navigate = jest.fn()
 
   it('renders all the UI elements', () => {
     render(
-      <GitHubFileBrowser navigate={navigate} orgNamesArr={orgNamesArr}/>,
+      <GitHubFileBrowser navigate={navigate}/>,
       {wrapper: RouteThemeCtx},
     )
     expect(screen.getByText(/Browse files on Github/i)).toBeInTheDocument()

--- a/src/Components/Open/OpenModelControl.jsx
+++ b/src/Components/Open/OpenModelControl.jsx
@@ -1,7 +1,5 @@
-import React, {ReactElement, useState, useEffect} from 'react'
+import React, {ReactElement} from 'react'
 import {useNavigate} from 'react-router-dom'
-import {useAuth0} from '../../Auth0/Auth0Proxy'
-import {getOrganizations} from '../../net/github/Organizations'
 import useStore from '../../store/useStore'
 import {ControlButtonWithHashState} from '../Buttons'
 import OpenModelDialog from './OpenModelDialog'
@@ -15,31 +13,10 @@ import {FolderOpen as FolderOpenIcon} from '@mui/icons-material'
  * @return {ReactElement}
  */
 export default function OpenModelControl() {
-  const accessToken = useStore((state) => state.accessToken)
-
   const isOpenModelVisible = useStore((state) => state.isOpenModelVisible)
   const setIsOpenModelVisible = useStore((state) => state.setIsOpenModelVisible)
 
-  const [orgNamesArr, setOrgNamesArray] = useState([''])
-
-  const {user} = useAuth0()
   const navigate = useNavigate()
-
-
-  useEffect(() => {
-    /** Asynchronously fetch organizations */
-    async function fetchOrganizations() {
-      const orgs = await getOrganizations(accessToken)
-      const orgNamesFetched = Object.keys(orgs).map((key) => orgs[key].login)
-      const orgNames = [...orgNamesFetched, user && user.nickname]
-      setOrgNamesArray(orgNames)
-    }
-
-    if (isOpenModelVisible && accessToken) {
-      fetchOrganizations()
-    }
-  }, [isOpenModelVisible, accessToken, user])
-
 
   return (
     <ControlButtonWithHashState
@@ -55,7 +32,6 @@ export default function OpenModelControl() {
         isDialogDisplayed={isOpenModelVisible}
         setIsDialogDisplayed={setIsOpenModelVisible}
         navigate={navigate}
-        orgNamesArr={orgNamesArr}
       />
     </ControlButtonWithHashState>
   )

--- a/src/Components/Open/OpenModelControl.test.jsx
+++ b/src/Components/Open/OpenModelControl.test.jsx
@@ -48,7 +48,7 @@ describe('OpenModelControl', () => {
     expect(getOrganizations).not.toHaveBeenCalled()
   })
 
-  it('Fetches repo info on initial render when isOpenModelVisible in zustand', async () => {
+  it('Does not fetch repo info just because Open dialog is visible (Google tab is default)', async () => {
     mockedUseAuth0.mockReturnValue(mockedUserLoggedIn)
     getOrganizations.mockResolvedValue({})
     const {result} = renderHook(() => useStore((state) => state))
@@ -60,6 +60,26 @@ describe('OpenModelControl', () => {
     // eslint-disable-next-line require-await
     await act(async () => {
       render(<OpenModelControlFixture/>)
+    })
+    // GitHub orgs are only fetched once GitHubFileBrowser mounts (user clicks
+    // Browse on the GitHub tab), not on dialog open.
+    expect(getOrganizations).not.toHaveBeenCalled()
+  })
+
+  it('Fetches repo info when GitHubFileBrowser is opened from the GitHub tab', async () => {
+    mockedUseAuth0.mockReturnValue(mockedUserLoggedIn)
+    getOrganizations.mockResolvedValue({})
+    const {result} = renderHook(() => useStore((state) => state))
+    // eslint-disable-next-line require-await
+    await act(async () => {
+      result.current.setAccessToken('foo')
+      result.current.setIsOpenModelVisible(true)
+    })
+    const {getByTestId, getByText} = render(<OpenModelControlFixture/>)
+    fireEvent.click(getByText(LABEL_GITHUB))
+    // eslint-disable-next-line require-await
+    await act(async () => {
+      fireEvent.click(getByTestId('button-browse-github'))
     })
     expect(getOrganizations).toHaveBeenCalled()
   })

--- a/src/Components/Open/OpenModelDialog.jsx
+++ b/src/Components/Open/OpenModelDialog.jsx
@@ -30,14 +30,12 @@ import {FolderOpen as FolderOpenIcon, GitHub as GitHubIcon} from '@mui/icons-mat
  * @property {boolean} isDialogDisplayed Passed to dialog to be controlled
  * @property {Function} setIsDialogDisplayed Passed to dialog to be controlled
  * @property {Function} navigate Callback from CadView to change page url
- * @property {Array<string>} orgNamesArr List of org names for the current user.
  * @return {ReactElement}
  */
 export default function OpenModelDialog({
   isDialogDisplayed,
   setIsDialogDisplayed,
   navigate,
-  orgNamesArr,
 }) {
   const isGoogleDriveEnabled = useExistInFeature('googleDrive')
   const tabLabels = isGoogleDriveEnabled ?
@@ -219,7 +217,6 @@ export default function OpenModelDialog({
                 >
                   <GitHubFileBrowser
                     navigate={navigate}
-                    orgNamesArr={orgNamesArr}
                     setIsDialogDisplayed={setIsDialogDisplayed}
                     onCancel={() => setShowGithubBrowser(false)}
                   />

--- a/src/Components/Open/OpenModelDialog.test.jsx
+++ b/src/Components/Open/OpenModelDialog.test.jsx
@@ -48,7 +48,6 @@ const defaultProps = {
   isDialogDisplayed: true,
   setIsDialogDisplayed: mockSetIsDialogDisplayed,
   navigate: mockNavigate,
-  orgNamesArr: ['testorg'],
 }
 
 


### PR DESCRIPTION
Two independent fixes to the Open dialog flow.

## 1. Lazy GitHub-orgs fetch (`6c27d1f6`)

`OpenModelControl`'s effect fired `getOrganizations` whenever the dialog became visible, irrespective of which tab the user was on. Net effect: opening the dialog with the Google tab selected (the default) triggered three `/user/orgs` requests — wasted bandwidth and a poor signal of intent. The dependency list `[isOpenModelVisible, accessToken, user]` also caused redundant re-runs.

Hoisted the fetch into `GitHubFileBrowser` so it only runs when the user actually clicks Browse on the GitHub tab. Dropped the `orgNamesArr` prop chain `OpenModelControl → OpenModelDialog → GitHubFileBrowser`. `SaveModelControl` keeps its own fetch (Save flow is GitHub-only, eager fetch is appropriate there).

## 2. GDrive picker dispose-rebuild fix (`64b2c5ae`)

The picker's build effect listed `handlePickerCallback` in its deps, and the callback's deps were `[onSelect, onCancel]` — both inline arrow handlers in `OpenModelDialog`, freshly minted on every render. Any state change in the parent caused the effect to `dispose()` the live picker and rebuild it. A user click on the picker's Select button during that gap landed on a torn-down iframe whose `postMessage` channel back to the parent was gone — the user saw a brief OS spinner and a stuck picker with no callback firing.

Stash `{onSelect, onCancel}` in a ref that updates inline on every render, and define the picker callback inside the build effect itself, reading from the ref. The build effect now depends only on the legitimate triggers — `[isOpen, accessToken, mode]` — so the picker is constructed once per open and forwards Select/Cancel to whatever the parent's latest handlers are.

Note: the immediately-reported "click Select, nothing happens" symptom on bldrs.ai turned out to be **Brave Shields' default 3rd-party cookie blocking on `docs.google.com`** — not this race. Toggling Shields off for `bldrs.ai` makes the picker work. The dispose-rebuild race was a separate latent bug worth hardening regardless.

## Tests

New `GoogleDrivePickerDialog.test.jsx` locks in three regression guards:
- `builder.build()` runs exactly once across multiple parent re-renders with fresh callback identities
- A `PICKED` event after `onSelect` is swapped routes through the new handler
- The picker is disposed when `isOpen` flips to false

Updated specs:
- `OpenModelControl.test.jsx`: replace "fetches on dialog open" with the inverse, plus a new test that fetching fires when `GitHubFileBrowser` mounts.
- `OpenModelDialog.test.jsx`: drop `orgNamesArr` from default props.
- `GitHubFileBrowser.test.jsx`: mock `getOrganizations` now that the fetch is internal.

Full precommit suite green: 988 tests, 162 suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)