### PR TITLE
Connections: validate persisted tokens via tokeninfo on Sources tab mount

### DIFF
--- a/src/Components/Connections/SourcesTab.jsx
+++ b/src/Components/Connections/SourcesTab.jsx
@@ -1,6 +1,6 @@
-import React, {useState} from 'react'
+import React, {useEffect, useState} from 'react'
 import {Divider, Stack, Typography} from '@mui/material'
-import {Google as GoogleIcon} from '@mui/icons-material'
+import {Google as GoogleIcon, Refresh as RefreshIcon} from '@mui/icons-material'
 import useStore from '../../store/useStore'
 import {getProvider} from '../../connections/registry'
 import {loadAllRecentFiles} from '../../connections/persistence'
@@ -23,6 +23,50 @@ export default function SourcesTab({onPickerReady, onOpenById}) {
 
   const [browseError, setBrowseError] = useState(null)
   const [recentFiles] = useState(() => loadAllRecentFiles())
+  // Per-connection liveness, keyed by connection.id. 'expired' flips the
+  // Browse button to "Reconnect" so the user gets a clear cue before hitting
+  // the picker with a doomed token.
+  const [statuses, setStatuses] = useState({})
+
+  // Validate each persisted connection in parallel when the tab mounts (and
+  // whenever the connections list changes). This is a pure HTTP ping —
+  // no GIS popup, no user interaction. Refresh of an expired token still
+  // happens lazily on Browse via getAccessToken().
+  useEffect(() => {
+    if (connections.length === 0) {
+      return undefined
+    }
+    let cancelled = false
+    /** Fire checkStatus for every connection and merge results into state. */
+    async function validateAll() {
+      const results = await Promise.all(connections.map(async (c) => {
+        const provider = getProvider(c.providerId)
+        if (!provider) {
+          return [c.id, 'error']
+        }
+        try {
+          const status = await provider.checkStatus(c)
+          return [c.id, status]
+        } catch {
+          return [c.id, 'error']
+        }
+      }))
+      if (cancelled) {
+        return
+      }
+      setStatuses((prev) => {
+        const next = {...prev}
+        for (const [id, status] of results) {
+          next[id] = status
+        }
+        return next
+      })
+    }
+    validateAll()
+    return () => {
+      cancelled = true
+    }
+  }, [connections])
 
   const handleBrowse = async (connection) => {
     const provider = getProvider(connection.providerId)
@@ -32,6 +76,9 @@ export default function SourcesTab({onPickerReady, onOpenById}) {
     setBrowseError(null)
     try {
       const token = await provider.getAccessToken(connection)
+      // Successful token acquisition implies the connection is healthy now,
+      // even if it was 'expired' before — clear the stale marker.
+      setStatuses((prev) => ({...prev, [connection.id]: 'connected'}))
       onPickerReady(token, connection)
     } catch (err) {
       setBrowseError(err.message || 'Failed to open file picker')
@@ -65,11 +112,22 @@ export default function SourcesTab({onPickerReady, onOpenById}) {
     >
       {connections.map((connection) => {
         const connectionRecents = recentFiles.filter((f) => f.connectionId === connection.id)
+        const isStale = statuses[connection.id] === 'expired'
         return (
           <Stack key={connection.id} spacing={1} sx={{width: '100%'}}>
-            {connectionRecents.length === 0 && (
+            {connectionRecents.length === 0 && !isStale && (
               <Typography variant='body2' color='text.secondary' sx={{textAlign: 'center'}}>
                 Browse your Google Drive for models.
+              </Typography>
+            )}
+            {isStale && (
+              <Typography
+                variant='body2'
+                color='text.secondary'
+                sx={{textAlign: 'center'}}
+                data-testid={`stale-hint-${connection.id}`}
+              >
+                Your session expired. Reconnect to continue.
               </Typography>
             )}
 
@@ -77,6 +135,8 @@ export default function SourcesTab({onPickerReady, onOpenById}) {
               files={connectionRecents}
               onOpen={(file) => onOpenById(connection, file.id, file.name)}
               onBrowse={() => handleBrowse(connection)}
+              browseButtonLabel={isStale ? 'Reconnect' : 'Browse'}
+              browseButtonIcon={isStale ? <RefreshIcon/> : undefined}
               browseButtonTestId={`button-browse-drive-${connection.id}`}
             />
 

--- a/src/Components/Connections/SourcesTab.test.jsx
+++ b/src/Components/Connections/SourcesTab.test.jsx
@@ -23,11 +23,32 @@ const mockConnection = {
 }
 
 
+/**
+ * Flush the validate-on-mount effect's Promise.all chain so the trailing
+ * setStatuses lands inside an act() block. The chain has ~4 microtask hops
+ * (await Promise.all → each connection's await checkStatus → resolution →
+ * setState), so we drain generously.
+ */
+async function flushValidateEffect() {
+  await act(async () => {
+    for (let i = 0; i < 6; i++) {
+      await Promise.resolve()
+    }
+  })
+}
+
+
 describe('SourcesTab', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     // Reset connections in the store
     useStore.getState().removeConnection(mockConnection.id)
+    // Default provider stub: validate-on-mount sees a healthy connection.
+    // Individual tests override this to drive specific behaviors.
+    getProvider.mockReturnValue({
+      checkStatus: jest.fn().mockResolvedValue('connected'),
+      getAccessToken: jest.fn(),
+    })
   })
 
 
@@ -50,6 +71,7 @@ describe('SourcesTab', () => {
       <SourcesTab onPickerReady={onPickerReady}/>,
       {wrapper: StoreRouteThemeCtx},
     )
+    await flushValidateEffect()
 
     expect(screen.getByTestId('sources-tab')).toBeInTheDocument()
     expect(screen.getByTestId(`connection-card-${mockConnection.id}`)).toBeInTheDocument()
@@ -65,6 +87,7 @@ describe('SourcesTab', () => {
       <SourcesTab onPickerReady={onPickerReady}/>,
       {wrapper: StoreRouteThemeCtx},
     )
+    await flushValidateEffect()
 
     expect(screen.getByText('Add another Google account')).toBeInTheDocument()
   })
@@ -74,6 +97,7 @@ describe('SourcesTab', () => {
       useStore.getState().addConnection(mockConnection)
     })
     getProvider.mockReturnValue({
+      checkStatus: jest.fn().mockResolvedValue('connected'),
       getAccessToken: jest.fn().mockRejectedValue(new Error('Token expired')),
     })
 
@@ -81,6 +105,7 @@ describe('SourcesTab', () => {
       <SourcesTab onPickerReady={onPickerReady}/>,
       {wrapper: StoreRouteThemeCtx},
     )
+    await flushValidateEffect()
     fireEvent.click(screen.getByTestId(`button-browse-drive-${mockConnection.id}`))
 
     await waitFor(() => {
@@ -93,6 +118,7 @@ describe('SourcesTab', () => {
       useStore.getState().addConnection(mockConnection)
     })
     getProvider.mockReturnValue({
+      checkStatus: jest.fn().mockResolvedValue('connected'),
       getAccessToken: jest.fn().mockResolvedValue('test-token'),
     })
 
@@ -100,10 +126,98 @@ describe('SourcesTab', () => {
       <SourcesTab onPickerReady={onPickerReady}/>,
       {wrapper: StoreRouteThemeCtx},
     )
+    await flushValidateEffect()
     fireEvent.click(screen.getByTestId(`button-browse-drive-${mockConnection.id}`))
 
     await waitFor(() => {
       expect(onPickerReady).toHaveBeenCalledWith('test-token', mockConnection)
+    })
+  })
+
+  describe('stale-connection validation on mount', () => {
+    it('calls provider.checkStatus for each connection on mount', async () => {
+      await act(() => {
+        useStore.getState().addConnection(mockConnection)
+      })
+      const checkStatus = jest.fn().mockResolvedValue('connected')
+      getProvider.mockReturnValue({checkStatus, getAccessToken: jest.fn()})
+
+      render(
+        <SourcesTab onPickerReady={onPickerReady}/>,
+        {wrapper: StoreRouteThemeCtx},
+      )
+
+      await waitFor(() => {
+        expect(checkStatus).toHaveBeenCalledWith(expect.objectContaining({id: mockConnection.id}))
+      })
+    })
+
+    it('renders \'Reconnect\' label and stale hint when checkStatus returns \'expired\'', async () => {
+      await act(() => {
+        useStore.getState().addConnection(mockConnection)
+      })
+      getProvider.mockReturnValue({
+        checkStatus: jest.fn().mockResolvedValue('expired'),
+        getAccessToken: jest.fn(),
+      })
+
+      render(
+        <SourcesTab onPickerReady={onPickerReady}/>,
+        {wrapper: StoreRouteThemeCtx},
+      )
+
+      await waitFor(() => {
+        expect(screen.getByTestId(`stale-hint-${mockConnection.id}`)).toBeInTheDocument()
+      })
+      const browseBtn = screen.getByTestId(`button-browse-drive-${mockConnection.id}`)
+      expect(browseBtn).toHaveTextContent('Reconnect')
+    })
+
+    it('renders default \'Browse\' label when checkStatus returns \'connected\'', async () => {
+      await act(() => {
+        useStore.getState().addConnection(mockConnection)
+      })
+      getProvider.mockReturnValue({
+        checkStatus: jest.fn().mockResolvedValue('connected'),
+        getAccessToken: jest.fn(),
+      })
+
+      render(
+        <SourcesTab onPickerReady={onPickerReady}/>,
+        {wrapper: StoreRouteThemeCtx},
+      )
+
+      await waitFor(() => {
+        const btn = screen.getByTestId(`button-browse-drive-${mockConnection.id}`)
+        expect(btn).toHaveTextContent('Browse')
+      })
+      expect(screen.queryByTestId(`stale-hint-${mockConnection.id}`)).not.toBeInTheDocument()
+    })
+
+    it('flips stale → healthy after a successful Reconnect click clears it', async () => {
+      await act(() => {
+        useStore.getState().addConnection(mockConnection)
+      })
+      getProvider.mockReturnValue({
+        checkStatus: jest.fn().mockResolvedValue('expired'),
+        getAccessToken: jest.fn().mockResolvedValue('refreshed-token'),
+      })
+
+      render(
+        <SourcesTab onPickerReady={onPickerReady}/>,
+        {wrapper: StoreRouteThemeCtx},
+      )
+
+      await waitFor(() => {
+        expect(screen.getByTestId(`stale-hint-${mockConnection.id}`)).toBeInTheDocument()
+      })
+
+      fireEvent.click(screen.getByTestId(`button-browse-drive-${mockConnection.id}`))
+
+      await waitFor(() => {
+        expect(onPickerReady).toHaveBeenCalledWith('refreshed-token', mockConnection)
+      })
+      expect(screen.queryByTestId(`stale-hint-${mockConnection.id}`)).not.toBeInTheDocument()
     })
   })
 })

--- a/src/connections/google-drive/GoogleDriveProvider.test.ts
+++ b/src/connections/google-drive/GoogleDriveProvider.test.ts
@@ -143,3 +143,100 @@ describe('GoogleDriveProvider — OAuth state (CSRF protection)', () => {
     await expect(connectPromise).resolves.toMatchObject({providerId: 'google-drive'})
   })
 })
+
+
+/**
+ * Mint a connection (and seed the in-memory token cache) by driving connect()
+ * to completion via the captured GIS callback.
+ *
+ * @return The completed Connection with a known access_token.
+ */
+async function mintConnection(): Promise<{id: string; providerId: string}> {
+  const connectPromise = googleDriveProvider.connect()
+  await flushMicrotasks()
+  capturedCallback?.({
+    access_token: 'live-token',
+
+    expires_in: 3600,
+    scope: 'drive.file',
+    token_type: 'Bearer',
+    state: 'test-uuid-1234',
+  })
+  // eslint-disable-next-line no-magic-numbers
+  jest.advanceTimersByTime(6_000)
+  await flushMicrotasks()
+  return await connectPromise as {id: string; providerId: string}
+}
+
+
+describe('GoogleDriveProvider — checkStatus tokeninfo validation', () => {
+  let fetchMock: jest.Mock
+
+  beforeEach(() => {
+    fetchMock = jest.fn()
+    global.fetch = fetchMock as unknown as typeof global.fetch
+  })
+
+  it('returns \'disconnected\' when no token is cached', async () => {
+    const status = await googleDriveProvider.checkStatus({
+      id: 'never-connected',
+      providerId: 'google-drive',
+      label: 'x',
+      status: 'disconnected',
+      createdAt: new Date().toISOString(),
+      meta: {},
+    })
+    expect(status).toBe('disconnected')
+    // tokeninfo must not be called when there's no token to validate
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('returns \'connected\' when tokeninfo replies 200', async () => {
+    fetchMock.mockResolvedValueOnce({ok: false}) // userinfo fetch during connect
+    const conn = await mintConnection()
+
+    fetchMock.mockResolvedValueOnce({ok: true, status: 200})
+    const status = await googleDriveProvider.checkStatus({
+      ...conn,
+      label: 'x',
+      status: 'connected',
+      createdAt: new Date().toISOString(),
+      meta: {},
+    } as Parameters<typeof googleDriveProvider.checkStatus>[0])
+
+    expect(status).toBe('connected')
+    expect(fetchMock).toHaveBeenCalledWith(expect.stringContaining('oauth2.googleapis.com/tokeninfo'))
+  })
+
+  it('returns \'expired\' when tokeninfo replies 400 (server-revoked token)', async () => {
+    fetchMock.mockResolvedValueOnce({ok: false}) // userinfo
+    const conn = await mintConnection()
+
+    fetchMock.mockResolvedValueOnce({ok: false, status: 400})
+    const status = await googleDriveProvider.checkStatus({
+      ...conn,
+      label: 'x',
+      status: 'connected',
+      createdAt: new Date().toISOString(),
+      meta: {},
+    } as Parameters<typeof googleDriveProvider.checkStatus>[0])
+
+    expect(status).toBe('expired')
+  })
+
+  it('treats network errors as healthy (\'connected\') so offline doesn\'t poison the cache', async () => {
+    fetchMock.mockResolvedValueOnce({ok: false}) // userinfo
+    const conn = await mintConnection()
+
+    fetchMock.mockRejectedValueOnce(new Error('offline'))
+    const status = await googleDriveProvider.checkStatus({
+      ...conn,
+      label: 'x',
+      status: 'connected',
+      createdAt: new Date().toISOString(),
+      meta: {},
+    } as Parameters<typeof googleDriveProvider.checkStatus>[0])
+
+    expect(status).toBe('connected')
+  })
+})

--- a/src/connections/google-drive/GoogleDriveProvider.ts
+++ b/src/connections/google-drive/GoogleDriveProvider.ts
@@ -18,6 +18,8 @@ const DEFAULT_TOKEN_EXPIRES_S = 3600
 const MS_PER_S = 1000
 const EMAIL_FETCH_TIMEOUT_MS = 5000
 const POPUP_CLOSE_DEBOUNCE_MS = 2000
+const HTTP_BAD_REQUEST = 400
+const HTTP_UNAUTHORIZED = 401
 
 // drive.file: per-file access granted via Picker only. Non-sensitive scope —
 // no Google verification review and no unverified-app consent warning.
@@ -265,21 +267,42 @@ export const googleDriveProvider: ConnectionProvider = {
     clearTokenFromSession(connectionId)
   },
 
-  checkStatus(connection: Connection): Promise<ConnectionStatus> {
-    const inMemory = tokenCache.get(connection.id)
-    if (inMemory) {
-      if (Date.now() >= inMemory.expiresAt) {
-        return Promise.resolve('expired')
+  async checkStatus(connection: Connection): Promise<ConnectionStatus> {
+    let cached = tokenCache.get(connection.id) ?? null
+    if (!cached) {
+      const fromSession = loadTokenFromSession(connection.id)
+      if (fromSession) {
+        tokenCache.set(connection.id, fromSession)
+        cached = fromSession
       }
-      return Promise.resolve('connected')
     }
-    // Fall back to sessionStorage (e.g. after page reload)
-    const fromSession = loadTokenFromSession(connection.id)
-    if (fromSession) {
-      tokenCache.set(connection.id, fromSession)
-      return Promise.resolve('connected')
+    if (!cached) {
+      return 'disconnected'
     }
-    return Promise.resolve('disconnected')
+    if (Date.now() >= cached.expiresAt) {
+      return 'expired'
+    }
+
+    // Local cache says the token is still valid — verify with Google. A token
+    // can be revoked server-side (consent removed, app un-authorized, password
+    // reset) before our cached `expiresAt`. Without this check we hand a doomed
+    // token to the picker and watch it 401 with no client-side signal.
+    try {
+      const url = `https://oauth2.googleapis.com/tokeninfo?access_token=${encodeURIComponent(cached.token)}`
+      const res = await fetch(url)
+      if (res.ok) {
+        return 'connected'
+      }
+      // 400 = invalid_token (revoked, malformed, expired server-side)
+      if (res.status === HTTP_BAD_REQUEST || res.status === HTTP_UNAUTHORIZED) {
+        return 'expired'
+      }
+      // Other statuses are likely transient (5xx) — don't poison the connection
+      return 'connected'
+    } catch {
+      // Network error / offline — fall back to local cache verdict
+      return 'connected'
+    }
   },
 
   async getAccessToken(connection: Connection): Promise<string> {


### PR DESCRIPTION
Today, `GoogleDriveProvider.checkStatus` only consults the local cache. A token can be revoked server-side (consent removed, app un-authorized, password reset) before our cached `expiresAt` — when that happens we hand a doomed token to the picker and it 401s with no signal back to the user, leaving them stuck on a stale connection.

## Validate-then-display

- **`GoogleDriveProvider.checkStatus`** is now async and pings Google's `tokeninfo` endpoint when the local cache says the token is still valid. HTTP 200 → `connected`; HTTP 400/401 → `expired`; network error → `connected` (offline shouldn't poison a healthy connection).
- **`SourcesTab`** fires `checkStatus` in parallel for every persisted connection on mount and stores results per-connection. Stale connections render a hint plus a **Reconnect** button (with refresh icon) instead of Browse.
- The Reconnect handler is the same as Browse — `getAccessToken`'s silent-refresh path covers the happy case, and the GIS popup only appears when consent is actually needed. A successful reconnect clears the stale marker.
- **No GIS popups on dialog mount** (validation is pure HTTP). Refresh remains user-initiated, which keeps it out of popup-blocker territory.

## Why this matters

Closes the gap discussed in #1496's diagnostics: persisted connection metadata (in `localStorage`) outlived the token's actual server-side validity, and we had no way to tell. With this in place the user sees a clear "Reconnect to continue" affordance instead of a silent picker 401.

## Tests

- **`GoogleDriveProvider.test`**: 4 new cases covering `disconnected` (no cache), `connected` (tokeninfo 200), `expired` (tokeninfo 400), and the offline fallback.
- **`SourcesTab.test`**: 4 new cases — `checkStatus` is called on mount, `expired` renders Reconnect + stale hint, `connected` renders the default Browse, and a successful Reconnect click clears the stale marker. Existing tests stub `checkStatus` alongside `getAccessToken`.

Full precommit suite green: 996 tests, 162 suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)