### PR TITLE
Connections: typed reconnect path for stale Drive tokens

### DIFF
--- a/src/Components/AlertDialog.jsx
+++ b/src/Components/AlertDialog.jsx
@@ -2,6 +2,7 @@ import React, {ReactElement} from 'react'
 import {Link} from '@mui/material'
 import {ErrorOutline as ErrorOutlineIcon} from '@mui/icons-material'
 import {NotFoundError} from '../loader/Loader'
+import {getProvider} from '../connections/registry'
 import useStore from '../store/useStore'
 import {trackAlert} from '../utils/alertTracking'
 import Dialog from './Dialog'
@@ -23,16 +24,62 @@ export default function AlertDialog({onClose}) {
   }
 
   const isOom = alert && typeof alert === 'object' && alert.type === 'oom'
+  const isNeedsReconnect = alert && typeof alert === 'object' && alert.type === 'needsReconnect'
+
   const refresh = () => {
     try {
       window.location.reload()
     } catch (_) {/* noop */}
   }
-  const actionCb = isOom ? refresh : onCloseInner
-  const actionTitle = isOom ? 'Refresh' : 'Reset'
+
+  // Reconnect the connection from inside this user-gesture click. The button
+  // press supplies the activation that GIS needs to legally pop a consent
+  // window; on success the token cache is refreshed and we reload so the
+  // page's pending Drive load picks up the new token. If the user cancels or
+  // the popup is blocked again, leave the dialog up so they can try again.
+  const reconnect = async () => {
+    if (!isNeedsReconnect) {
+      return
+    }
+    const provider = getProvider(alert.connection.providerId)
+    if (!provider) {
+      return
+    }
+    try {
+      await provider.getAccessToken(alert.connection)
+      setAlert(null)
+      refresh()
+    } catch (_) {
+      // Stay on the dialog; user can retry.
+    }
+  }
+
+  let actionCb
+  let actionTitle
+  if (isOom) {
+    actionCb = refresh
+    actionTitle = 'Refresh'
+  } else if (isNeedsReconnect) {
+    actionCb = reconnect
+    actionTitle = 'Reconnect'
+  } else {
+    actionCb = onCloseInner
+    actionTitle = 'Reset'
+  }
+
+  let headerText
+  if (isOom) {
+    headerText = 'Out of Memory'
+  } else if (isNeedsReconnect) {
+    headerText = 'Reconnect required'
+  } else {
+    headerText = 'Error'
+  }
+
+  const showHelpFooter = !isOom && !isNeedsReconnect
   return (
     <Dialog
-      headerText={isOom ? 'Out of Memory' : 'Error'}
+      headerText={headerText}
       isDialogDisplayed={alert !== null}
       setIsDialogDisplayed={onCloseInner}
       actionCb={actionCb}
@@ -41,7 +88,7 @@ export default function AlertDialog({onClose}) {
     >
       <p>
         {createAlertReport(alert)}<br/>
-        {!isOom && (
+        {showHelpFooter && (
           <>For more help contact us on our{' '}
             <Link href='https://discord.gg/9SxguBkFfQ' target='_blank' rel='noopener noreferrer'>
               Discord
@@ -68,6 +115,9 @@ function createAlertReport(a) {
     return a
   } else if (typeof a === 'object') {
     if (a && a.type === 'oom') {
+      trackAlert(a.message, a)
+      return a.message
+    } else if (a && a.type === 'needsReconnect') {
       trackAlert(a.message, a)
       return a.message
     } else if (a instanceof NotFoundError) {

--- a/src/Components/AlertDialog.test.jsx
+++ b/src/Components/AlertDialog.test.jsx
@@ -1,0 +1,105 @@
+import React from 'react'
+import {act, fireEvent, render, screen, waitFor} from '@testing-library/react'
+import {StoreRouteThemeCtx} from '../Share.fixture'
+import {getProvider} from '../connections/registry'
+import useStore from '../store/useStore'
+import AlertDialog from './AlertDialog'
+
+
+jest.mock('../connections/registry')
+
+
+/**
+ * Mute Sentry capture and console noise that AlertDialog emits when surfacing
+ * an alert object — the tests are about UX behavior, not log shape.
+ */
+beforeAll(() => {
+  jest.spyOn(console, 'error').mockImplementation(() => {})
+})
+
+
+afterAll(() => {
+  console.error.mockRestore?.()
+})
+
+
+describe('AlertDialog — needsReconnect alert type', () => {
+  const onClose = jest.fn()
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    act(() => {
+      useStore.getState().setAlert(null)
+    })
+  })
+
+  it('renders a Reconnect action button when alert.type is needsReconnect', () => {
+    const connection = {id: 'conn-1', providerId: 'google-drive', label: 'a@x.com', meta: {}}
+    act(() => {
+      useStore.getState().setAlert({
+        type: 'needsReconnect',
+        connection,
+        message: 'Your Google Drive session expired.',
+      })
+    })
+    render(<AlertDialog onClose={onClose}/>, {wrapper: StoreRouteThemeCtx})
+    expect(screen.getByText('Reconnect required')).toBeInTheDocument()
+    expect(screen.getByText('Reconnect')).toBeInTheDocument()
+    expect(screen.getByText('Your Google Drive session expired.')).toBeInTheDocument()
+  })
+
+  it('omits the Discord help footer for needsReconnect (it is recoverable, not a defect)', () => {
+    const connection = {id: 'conn-1', providerId: 'google-drive', label: 'a@x.com', meta: {}}
+    act(() => {
+      useStore.getState().setAlert({
+        type: 'needsReconnect',
+        connection,
+        message: 'Reconnect to continue.',
+      })
+    })
+    render(<AlertDialog onClose={onClose}/>, {wrapper: StoreRouteThemeCtx})
+    expect(screen.queryByText(/Discord/i)).not.toBeInTheDocument()
+  })
+
+  it('invokes provider.getAccessToken when Reconnect is clicked', async () => {
+    const connection = {id: 'conn-1', providerId: 'google-drive', label: 'a@x.com', meta: {}}
+    const getAccessToken = jest.fn().mockResolvedValue('refreshed-token')
+    getProvider.mockReturnValue({getAccessToken})
+
+    act(() => {
+      useStore.getState().setAlert({type: 'needsReconnect', connection, message: 'x'})
+    })
+    render(<AlertDialog onClose={onClose}/>, {wrapper: StoreRouteThemeCtx})
+
+    // Stub reload so the test environment doesn't actually reload jsdom.
+    const reload = jest.fn()
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: {...window.location, reload},
+    })
+
+    fireEvent.click(screen.getByText('Reconnect'))
+    await waitFor(() => {
+      expect(getAccessToken).toHaveBeenCalledWith(expect.objectContaining({id: 'conn-1'}))
+    })
+    expect(reload).toHaveBeenCalled()
+  })
+
+  it('keeps the dialog open when Reconnect is clicked but the user cancels the popup', async () => {
+    const connection = {id: 'conn-1', providerId: 'google-drive', label: 'a@x.com', meta: {}}
+    const getAccessToken = jest.fn().mockRejectedValue(new Error('user cancelled'))
+    getProvider.mockReturnValue({getAccessToken})
+
+    act(() => {
+      useStore.getState().setAlert({type: 'needsReconnect', connection, message: 'x'})
+    })
+    render(<AlertDialog onClose={onClose}/>, {wrapper: StoreRouteThemeCtx})
+
+    fireEvent.click(screen.getByText('Reconnect'))
+    await waitFor(() => {
+      expect(getAccessToken).toHaveBeenCalled()
+    })
+    // Alert is still set — user can retry.
+    expect(useStore.getState().alert).toMatchObject({type: 'needsReconnect'})
+  })
+})

--- a/src/Components/Open/OpenModelDialog.jsx
+++ b/src/Components/Open/OpenModelDialog.jsx
@@ -4,11 +4,13 @@ import {useAuth0} from '../../Auth0/Auth0Proxy'
 import {checkOPFSAvailability} from '../../OPFS/utils'
 import useStore from '../../store/useStore'
 import {loadLocalFile, loadLocalFileFallback} from '../../utils/loader'
+import {NeedsReconnectError} from '../../connections/errors'
 import {
   addRecentFileEntry,
   loadRecentFilesBySource,
   setPendingModelNameUpdate,
 } from '../../connections/persistence'
+import {getProvider} from '../../connections/registry'
 import {disablePageReloadApprovalCheck} from '../../utils/event'
 import {navigateToModel} from '../../utils/navigate'
 import Dialog from '../Dialog'
@@ -68,7 +70,31 @@ export default function OpenModelDialog({
     setPickerConnection(connection)
   }
 
-  const handleOpenById = (connection, fileId, fileName) => {
+  const setAlert = useStore((state) => state.setAlert)
+
+  const handleOpenById = async (connection, fileId, fileName) => {
+    // Pre-flight token acquisition INSIDE this user-gesture click handler so
+    // that if GIS needs to pop a consent window, the popup inherits the click
+    // activation and the browser allows it. If we navigate first, the gesture
+    // is gone by the time CadView's load chain calls getAccessToken — and a
+    // stale token there hits popup_failed_to_open and bricks the load.
+    const provider = getProvider(connection.providerId)
+    if (provider) {
+      try {
+        await provider.getAccessToken(connection)
+      } catch (err) {
+        if (err instanceof NeedsReconnectError) {
+          setAlert({
+            type: 'needsReconnect',
+            connection: err.connection,
+            message: 'Your Google Drive session needs to be reconnected to open this file.',
+          })
+          return
+        }
+        setAlert(err)
+        return
+      }
+    }
     disablePageReloadApprovalCheck()
     addRecentFileEntry({
       id: fileId,

--- a/src/Components/Open/OpenModelDialog.test.jsx
+++ b/src/Components/Open/OpenModelDialog.test.jsx
@@ -1,8 +1,10 @@
 import React from 'react'
-import {act, fireEvent, render, screen} from '@testing-library/react'
+import {act, fireEvent, render, screen, waitFor} from '@testing-library/react'
 import {HelmetStoreRouteThemeCtx} from '../../Share.fixture'
 import {useAuth0} from '../../Auth0/Auth0Proxy'
+import {NeedsReconnectError} from '../../connections/errors'
 import {loadRecentFilesBySource} from '../../connections/persistence'
+import {getProvider} from '../../connections/registry'
 import {navigateToModel} from '../../utils/navigate'
 import useStore from '../../store/useStore'
 import OpenModelDialog from './OpenModelDialog'
@@ -11,6 +13,7 @@ import OpenModelDialog from './OpenModelDialog'
 jest.mock('../../Auth0/Auth0Proxy')
 jest.mock('../../connections/persistence')
 jest.mock('../../connections/google-drive/index', () => {})
+jest.mock('../../connections/registry')
 jest.mock('../../hooks/useExistInFeature', () => jest.fn().mockReturnValue(false))
 jest.mock('./GitHubFileBrowser', () => function MockGitHubFileBrowser({onCancel}) {
   return (
@@ -208,6 +211,7 @@ describe('OpenModelDialog — Google Drive tab', () => {
     useExistInFeature.mockReturnValue(true)
     act(() => {
       useStore.getState().setCurrentTab(1) // Sources tab is index 1 when Google Drive enabled
+      useStore.getState().setAlert(null)
     })
   })
 
@@ -219,21 +223,67 @@ describe('OpenModelDialog — Google Drive tab', () => {
     })
   })
 
-  it('navigates to /v/g/<fileId> when onOpenById is called', () => {
+  it('navigates to /v/g/<fileId> when onOpenById succeeds', async () => {
+    getProvider.mockReturnValue({
+      getAccessToken: jest.fn().mockResolvedValue('fresh-token'),
+    })
     render(<OpenModelDialog {...defaultProps}/>, {wrapper: HelmetStoreRouteThemeCtx})
     fireEvent.click(screen.getByTestId('button-open-by-id'))
-    expect(navigateToModel).toHaveBeenCalledWith(
-      expect.stringMatching(/\/v\/g\/file-id-abc$/),
-      mockNavigate,
-    )
+    await waitFor(() => {
+      expect(navigateToModel).toHaveBeenCalledWith(
+        expect.stringMatching(/\/v\/g\/file-id-abc$/),
+        mockNavigate,
+      )
+    })
   })
 
-  it('does not navigate to /v/new/ when onOpenById is called', () => {
+  it('does not navigate to /v/new/ when onOpenById is called', async () => {
+    getProvider.mockReturnValue({
+      getAccessToken: jest.fn().mockResolvedValue('fresh-token'),
+    })
     render(<OpenModelDialog {...defaultProps}/>, {wrapper: HelmetStoreRouteThemeCtx})
     fireEvent.click(screen.getByTestId('button-open-by-id'))
+    await waitFor(() => {
+      expect(navigateToModel).toHaveBeenCalled()
+    })
     expect(navigateToModel).not.toHaveBeenCalledWith(
       expect.stringMatching(/\/v\/new\//),
       mockNavigate,
     )
+  })
+
+  it('pre-flights getAccessToken inside the click before navigating', async () => {
+    const getAccessToken = jest.fn().mockResolvedValue('fresh-token')
+    getProvider.mockReturnValue({getAccessToken})
+    render(<OpenModelDialog {...defaultProps}/>, {wrapper: HelmetStoreRouteThemeCtx})
+    fireEvent.click(screen.getByTestId('button-open-by-id'))
+    await waitFor(() => {
+      expect(getAccessToken).toHaveBeenCalled()
+      expect(navigateToModel).toHaveBeenCalled()
+    })
+    // Auth must run before the navigate, so the user-gesture popup window
+    // (if needed) inherits this click's activation.
+    const authCallOrder = getAccessToken.mock.invocationCallOrder[0]
+    const navCallOrder = navigateToModel.mock.invocationCallOrder[0]
+    expect(authCallOrder).toBeLessThan(navCallOrder)
+  })
+
+  it('surfaces a needsReconnect alert and skips navigation when refresh is popup-blocked', async () => {
+    const connection = {id: 'conn-1', providerId: 'google-drive', label: 'a@x.com', meta: {}}
+    getProvider.mockReturnValue({
+      getAccessToken: jest.fn().mockRejectedValue(
+        new NeedsReconnectError(connection, 'popup_failed_to_open', 'blocked'),
+      ),
+    })
+    render(<OpenModelDialog {...defaultProps}/>, {wrapper: HelmetStoreRouteThemeCtx})
+    fireEvent.click(screen.getByTestId('button-open-by-id'))
+    await waitFor(() => {
+      const alert = useStore.getState().alert
+      expect(alert).toMatchObject({
+        type: 'needsReconnect',
+        connection: expect.objectContaining({id: 'conn-1'}),
+      })
+    })
+    expect(navigateToModel).not.toHaveBeenCalled()
   })
 })

--- a/src/Containers/CadView.jsx
+++ b/src/Containers/CadView.jsx
@@ -11,6 +11,7 @@ import {gtagEvent} from '../privacy/analytics'
 import {resetState as resetCutPlaneState} from '../Components/CutPlane/CutPlaneMenu'
 import {useIsMobile} from '../Components/Hooks'
 import {load} from '../loader/Loader'
+import {NeedsReconnectError} from '../connections/errors'
 import {getBrowser} from '../connections/registry'
 import useStore from '../store/useStore'
 import {getParentPathIdsForElement, setupLookupAndParentLinks} from '../utils/TreeUtils'
@@ -210,6 +211,16 @@ export default function CadView({
           message: 'We ran out of memory attempting to load this model. ' +
             'Try opening it on a desktop browser with more memory or ' +
             'refresh the page.',
+        })
+      } else if (e instanceof NeedsReconnectError) {
+        // Deep-link / reload landed on a Drive route with a stale token, and
+        // GIS couldn't escalate to a popup outside a user gesture. Surface a
+        // Reconnect button (a future user gesture) instead of "Failed to
+        // parse model".
+        setAlert({
+          type: 'needsReconnect',
+          connection: e.connection,
+          message: 'Your Google Drive session expired. Reconnect to load this file.',
         })
       } else {
         setAlert(e)

--- a/src/connections/errors.ts
+++ b/src/connections/errors.ts
@@ -1,0 +1,32 @@
+import type {Connection} from './types'
+
+
+/**
+ * Thrown when a connection's access token cannot be silently refreshed and
+ * the provider's interactive consent flow could not be completed without
+ * direct user attention. Typical causes: GIS popup blocked by the browser
+ * because the call wasn't inside a user gesture, or the user dismissed the
+ * consent popup.
+ *
+ * Carrying the offending Connection lets the UI route the user to a
+ * Reconnect affordance bound to that specific connection, where a
+ * subsequent click is a fresh user gesture and the popup is allowed.
+ */
+export class NeedsReconnectError extends Error {
+  readonly connection: Connection
+  readonly cause?: string
+
+  /**
+   * @param connection The connection that needs reconnecting
+   * @param cause Underlying GIS error type (e.g. 'popup_failed_to_open')
+   * @param message Human-readable message for logs/dialogs
+   */
+  constructor(connection: Connection, cause?: string, message?: string) {
+    super(message ?? `Reconnect required for ${connection.label}`)
+    this.name = 'NeedsReconnectError'
+    this.connection = connection
+    this.cause = cause
+    // Preserve correct prototype chain through transpilation (TS quirk).
+    Object.setPrototypeOf(this, NeedsReconnectError.prototype)
+  }
+}

--- a/src/connections/google-drive/GoogleDriveProvider.test.ts
+++ b/src/connections/google-drive/GoogleDriveProvider.test.ts
@@ -2,6 +2,7 @@
  * Tests for GoogleDriveProvider, focused on OAuth state (CSRF) verification.
  */
 
+import {NeedsReconnectError} from '../errors'
 import {googleDriveProvider} from './GoogleDriveProvider'
 
 
@@ -13,6 +14,7 @@ jest.useFakeTimers()
 
 
 let capturedCallback: ((response: Record<string, unknown>) => void) | null = null
+let capturedErrorCallback: ((error: {type: string; message?: string}) => void) | null = null
 const mockRequestAccessToken = jest.fn()
 
 let originalFetch: typeof global.fetch
@@ -24,6 +26,7 @@ beforeAll(() => {
         oauth2: {
           initTokenClient: jest.fn((config) => {
             capturedCallback = config.callback
+            capturedErrorCallback = config.error_callback
             return {requestAccessToken: mockRequestAccessToken}
           }),
           revoke: jest.fn(),
@@ -59,6 +62,7 @@ afterAll(() => {
 beforeEach(() => {
   jest.clearAllMocks()
   capturedCallback = null
+  capturedErrorCallback = null
   sessionStorage.clear()
 })
 
@@ -238,5 +242,58 @@ describe('GoogleDriveProvider — checkStatus tokeninfo validation', () => {
     } as Parameters<typeof googleDriveProvider.checkStatus>[0])
 
     expect(status).toBe('connected')
+  })
+})
+
+
+describe('GoogleDriveProvider — getAccessToken refresh failure modes', () => {
+  /**
+   * Build a connection without seeding any cached token — forces refresh path.
+   *
+   * @return A bare connection with no cached token in any store.
+   */
+  function bareConnection(): Parameters<typeof googleDriveProvider.getAccessToken>[0] {
+    return {
+      id: `bare-${Date.now()}`,
+      providerId: 'google-drive',
+      label: 'bare@example.com - GDrive',
+      status: 'expired',
+      createdAt: new Date().toISOString(),
+      meta: {email: 'bare@example.com'},
+    }
+  }
+
+  it('rejects with NeedsReconnectError on popup_failed_to_open', async () => {
+    const tokenPromise = googleDriveProvider.getAccessToken(bareConnection())
+    await flushMicrotasks()
+    capturedErrorCallback?.({type: 'popup_failed_to_open', message: 'Failed to open popup window'})
+    await expect(tokenPromise).rejects.toBeInstanceOf(NeedsReconnectError)
+  })
+
+  it('rejects with NeedsReconnectError on popup_closed (was previously hanging silently)', async () => {
+    const tokenPromise = googleDriveProvider.getAccessToken(bareConnection())
+    await flushMicrotasks()
+    capturedErrorCallback?.({type: 'popup_closed', message: 'User closed the popup'})
+    await expect(tokenPromise).rejects.toBeInstanceOf(NeedsReconnectError)
+  })
+
+  it('attaches the originating connection to NeedsReconnectError', async () => {
+    const conn = bareConnection()
+    const tokenPromise = googleDriveProvider.getAccessToken(conn)
+    await flushMicrotasks()
+    capturedErrorCallback?.({type: 'popup_failed_to_open', message: 'blocked'})
+    await expect(tokenPromise).rejects.toMatchObject({
+      name: 'NeedsReconnectError',
+      connection: expect.objectContaining({id: conn.id}),
+      cause: 'popup_failed_to_open',
+    })
+  })
+
+  it('still raises a generic Error for unknown GIS error types', async () => {
+    const tokenPromise = googleDriveProvider.getAccessToken(bareConnection())
+    await flushMicrotasks()
+    capturedErrorCallback?.({type: 'invalid_request', message: 'bad params'})
+    await expect(tokenPromise).rejects.toThrow(/Google OAuth refresh error/)
+    await expect(tokenPromise).rejects.not.toBeInstanceOf(NeedsReconnectError)
   })
 })

--- a/src/connections/google-drive/GoogleDriveProvider.ts
+++ b/src/connections/google-drive/GoogleDriveProvider.ts
@@ -9,6 +9,7 @@
 
 import type {Connection, ConnectionProvider, ConnectionStatus} from '../types'
 import debug from '../../utils/debug'
+import {NeedsReconnectError} from '../errors'
 import {loadGisScript} from './loadGisScript'
 import type {TokenResponse} from './loadGisScript'
 
@@ -367,13 +368,21 @@ export const googleDriveProvider: ConnectionProvider = {
           }
         },
         error_callback: (error) => {
-          if (error.type === 'popup_closed') {
+          if (settled) {
             return
           }
-          if (!settled) {
-            settled = true
-            reject(new Error(`Google OAuth refresh error: ${error.type} - ${error.message}`))
+          settled = true
+          // popup_closed and popup_failed_to_open both leave the user in a
+          // recoverable state: the connection metadata is still valid, but
+          // we couldn't prompt for fresh consent. Surface a typed error so
+          // callers can route to a Reconnect affordance bound to a real user
+          // gesture instead of throwing a generic "OAuth refresh error" that
+          // would render as a useless "Failed to parse model" overlay.
+          if (error.type === 'popup_closed' || error.type === 'popup_failed_to_open') {
+            reject(new NeedsReconnectError(connection, error.type, error.message))
+            return
           }
+          reject(new Error(`Google OAuth refresh error: ${error.type} - ${error.message}`))
         },
       })
 


### PR DESCRIPTION
Yesterday's prod failure: clicking a Google Drive recent file navigated, then CadView's load chain called `getAccessToken` with a stale token, which silently escalated to a popup outside any user gesture and got blocked by the browser. The user saw a generic "Failed to parse model" overlay with no recovery path.

Three coordinated changes, one PR:

## 1. `NeedsReconnectError` (`src/connections/errors.ts`)

Typed `Error` carrying the offending `Connection`. `GoogleDriveProvider.getAccessToken` now rejects with it on `popup_failed_to_open` and `popup_closed` — instead of swallowing `popup_closed` (which was leaving the promise to hang silently) or surfacing a generic "OAuth refresh error" that downstream code couldn't recognize.

## 2. Pre-flight in `handleOpenById` (OpenModelDialog)

When the user clicks a Drive recent in the Sources tab, `await provider.getAccessToken` inside the click handler before navigating. The popup, if needed, inherits the click's user activation and is allowed by the browser. On `NeedsReconnect`, surface the typed alert and skip navigation instead of bricking the load downstream.

## 3. Reconnect overlay (CadView + AlertDialog)

A deep-link or page reload that lands on `/v/g/<fileId>` with a stale token has no preceding gesture, and silent refresh can still escalate to a blocked popup. CadView catches `NeedsReconnectError` and sets a `needsReconnect` alert; `AlertDialog` renders a **Reconnect** button (instead of the generic "Reset") with header "Reconnect required". The button click is a fresh user gesture — `getAccessToken` is allowed to pop a consent window, and on success the page reloads so the pending Drive load picks up the fresh token. If the user cancels the popup, the dialog stays up so they can retry.

## Tests

- **GoogleDriveProvider**: 4 new cases — `popup_failed_to_open` → `NeedsReconnect`, `popup_closed` → `NeedsReconnect` (was previously hanging), the error carries the connection + cause, unknown GIS error types still raise a generic Error.
- **OpenModelDialog**: navigation-after-pre-flight ordering (auth runs strictly before navigate), surfaces a `needsReconnect` alert and skips navigation when the provider rejects with `NeedsReconnect`.
- **AlertDialog (new spec)**: renders the Reconnect button + "Reconnect required" header for `needsReconnect` type; hides the Discord help footer for this recoverable case; calls `provider.getAccessToken` on click and reloads on success; keeps the dialog up if the user cancels the popup.

Full precommit suite green: **1006 tests, 163 suites**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)