### PR TITLE
CadView: re-throw NeedsReconnectError from inner loadModel catch

### DIFF
--- a/src/Containers/CadView.jsx
+++ b/src/Containers/CadView.jsx
@@ -334,6 +334,13 @@ export default function CadView({
         error.isOutOfMemory = true
         throw error
       }
+      // Bubble NeedsReconnect up to onViewer's catch so it can render the
+      // typed Reconnect overlay. Without this re-throw the inner catch
+      // swallowed it, set the alert as a generic Error, and the outer
+      // !tmpModelRef branch then overwrote it with "Failed to parse model".
+      if (error instanceof NeedsReconnectError) {
+        throw error
+      }
 
       setAlert(error)
       return


### PR DESCRIPTION
Follow-up to #1498. The Reconnect overlay landed but didn't actually appear in prod — users still saw "Failed to parse model".

## Root cause

`loadModel` has its own inner `try/catch` (CadView.jsx:332) around the IFC loader pipeline (download + `viewer.load()`). That catch was swallowing `NeedsReconnectError` via `setAlert(error)` and returning `undefined`. Control then fell to the outer `if (!tmpModelRef && !isOOM)` branch in `onViewer`, which overwrote the alert with the literal string `'Failed to parse model'` — the generic UI the user reported.

The outer catch in `onViewer` (which #1498 made `NeedsReconnect`-aware) never ran because nothing threw out of the inner catch.

## Fix

Bubble `NeedsReconnectError` up the same way OOM errors already do (lines 333-336):

```js
} catch (error) {
  if (isOutOfMemoryError(error)) {
    error.isOutOfMemory = true
    throw error
  }
  if (error instanceof NeedsReconnectError) {
    throw error
  }
  setAlert(error)
  return
}
```

Now the typed error reaches `onViewer`'s outer catch, the `needsReconnect` alert dispatches, and `AlertDialog` renders the Reconnect button as designed.

Full precommit suite green: 1006 tests, 163 suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)