### PR TITLE
GDrive: persist tokens in localStorage so new tabs inherit them

### DIFF
--- a/src/connections/google-drive/GoogleDriveProvider.test.ts
+++ b/src/connections/google-drive/GoogleDriveProvider.test.ts
@@ -64,6 +64,7 @@ beforeEach(() => {
   capturedCallback = null
   capturedErrorCallback = null
   sessionStorage.clear()
+  localStorage.clear()
 })
 
 
@@ -295,5 +296,91 @@ describe('GoogleDriveProvider — getAccessToken refresh failure modes', () => {
     capturedErrorCallback?.({type: 'invalid_request', message: 'bad params'})
     await expect(tokenPromise).rejects.toThrow(/Google OAuth refresh error/)
     await expect(tokenPromise).rejects.not.toBeInstanceOf(NeedsReconnectError)
+  })
+})
+
+
+describe('GoogleDriveProvider — token persistence in localStorage', () => {
+  /**
+   * Build a Connection shell pointing at a known cached token in storage.
+   *
+   * @return A connection with the given id and stable test metadata.
+   */
+  function connectionFor(id: string): Parameters<typeof googleDriveProvider.checkStatus>[0] {
+    return {
+      id,
+      providerId: 'google-drive',
+      label: 'a@x.com - GDrive',
+      status: 'connected',
+      createdAt: new Date().toISOString(),
+      meta: {email: 'a@x.com'},
+    }
+  }
+
+  it('persists tokens under the bldrs:gdrive-token: prefix in localStorage', async () => {
+    const conn = await mintConnection()
+    const raw = localStorage.getItem(`bldrs:gdrive-token:${conn.id}`)
+    expect(raw).not.toBeNull()
+    expect(JSON.parse(raw as string)).toMatchObject({
+      token: 'live-token',
+      expiresAt: expect.any(Number),
+    })
+  })
+
+  it('reads the persisted token even when the in-memory cache is empty (cross-tab simulation)', async () => {
+    // Prime localStorage as if a sibling tab signed in. Importantly, we do NOT
+    // call connect() here — the in-memory tokenCache for this "tab" stays empty.
+    const id = 'sibling-tab-conn'
+    // eslint-disable-next-line no-magic-numbers
+    const future = Date.now() + 60_000
+    localStorage.setItem(
+      `bldrs:gdrive-token:${id}`,
+      JSON.stringify({token: 'sibling-token', expiresAt: future}),
+    )
+
+    // tokeninfo should be hit and 200 — token is still valid.
+    const fetchMock = jest.fn().mockResolvedValue({ok: true, status: 200})
+    global.fetch = fetchMock as unknown as typeof global.fetch
+
+    const status = await googleDriveProvider.checkStatus(connectionFor(id))
+    expect(status).toBe('connected')
+    expect(fetchMock).toHaveBeenCalledWith(expect.stringContaining('access_token=sibling-token'))
+  })
+
+  it('migrates a legacy sessionStorage token onto localStorage and removes it from session', async () => {
+    const id = 'legacy-conn'
+    // eslint-disable-next-line no-magic-numbers
+    const future = Date.now() + 60_000
+    sessionStorage.setItem(
+      `gdrive_token_${id}`,
+      JSON.stringify({token: 'legacy-token', expiresAt: future}),
+    )
+
+    const fetchMock = jest.fn().mockResolvedValue({ok: true, status: 200})
+    global.fetch = fetchMock as unknown as typeof global.fetch
+
+    const status = await googleDriveProvider.checkStatus(connectionFor(id))
+    expect(status).toBe('connected')
+
+    // Legacy entry has been migrated and removed.
+    expect(sessionStorage.getItem(`gdrive_token_${id}`)).toBeNull()
+    const migrated = localStorage.getItem(`bldrs:gdrive-token:${id}`)
+    expect(migrated).not.toBeNull()
+    expect(JSON.parse(migrated as string)).toMatchObject({token: 'legacy-token'})
+  })
+
+  it('disconnect() clears both localStorage and any leftover legacy sessionStorage entries', async () => {
+    const conn = await mintConnection()
+    // Plant a legacy entry under the same id, simulating a partially-migrated user.
+    sessionStorage.setItem(
+      `gdrive_token_${conn.id}`,
+      // eslint-disable-next-line no-magic-numbers
+      JSON.stringify({token: 'legacy', expiresAt: Date.now() + 60_000}),
+    )
+
+    await googleDriveProvider.disconnect(conn.id)
+
+    expect(localStorage.getItem(`bldrs:gdrive-token:${conn.id}`)).toBeNull()
+    expect(sessionStorage.getItem(`gdrive_token_${conn.id}`)).toBeNull()
   })
 })

--- a/src/connections/google-drive/GoogleDriveProvider.ts
+++ b/src/connections/google-drive/GoogleDriveProvider.ts
@@ -37,33 +37,72 @@ interface CachedToken {
 /** In-memory token store keyed by connection ID. */
 const tokenCache = new Map<string, CachedToken>()
 
-const SESSION_TOKEN_PREFIX = 'gdrive_token_'
+// Tokens live in localStorage (not sessionStorage) so a permalink opened in a
+// new tab inherits the existing token instead of forcing a popup-blocked
+// silent refresh on every cold tab. Connection metadata is already in
+// localStorage under 'bldrs:connections', so the trust scope is unchanged.
+// Tokens self-expire via their cached `expiresAt` and are cleared on
+// disconnect; lifetime is bounded by Google's 1h access-token TTL.
+const STORAGE_TOKEN_PREFIX = 'bldrs:gdrive-token:'
+
+// Legacy sessionStorage prefix from before the localStorage move. Still read
+// once on cold start as a fallback so existing tabs don't force a one-time
+// reconnect; the entry is migrated to localStorage and removed from session.
+const LEGACY_SESSION_TOKEN_PREFIX = 'gdrive_token_'
 
 
-/** Persist token to sessionStorage so it survives same-tab page reloads. */
-function saveTokenToSession(connectionId: string, cached: CachedToken): void {
+/** Persist token to localStorage so it survives reloads and is shared across tabs. */
+function saveTokenToStorage(connectionId: string, cached: CachedToken): void {
   try {
-    sessionStorage.setItem(SESSION_TOKEN_PREFIX + connectionId, JSON.stringify(cached))
+    localStorage.setItem(STORAGE_TOKEN_PREFIX + connectionId, JSON.stringify(cached))
   } catch {
-    // sessionStorage unavailable — in-memory cache only
+    // localStorage unavailable — in-memory cache only
   }
 }
 
 
 /**
- * Load a previously persisted token from sessionStorage (if not expired).
+ * Load a previously persisted token, preferring localStorage with a one-time
+ * sessionStorage fallback for users mid-migration. Tokens past their cached
+ * expiry are removed and reported as missing.
  *
  * @return The cached token, or null if absent or expired.
  */
-function loadTokenFromSession(connectionId: string): CachedToken | null {
+function loadTokenFromStorage(connectionId: string): CachedToken | null {
+  const cached = readTokenAtKey(localStorage, STORAGE_TOKEN_PREFIX + connectionId)
+  if (cached) {
+    return cached
+  }
+  // Migrate any legacy sessionStorage token onto localStorage exactly once.
+  const legacy = readTokenAtKey(sessionStorage, LEGACY_SESSION_TOKEN_PREFIX + connectionId)
+  if (legacy) {
+    saveTokenToStorage(connectionId, legacy)
+    try {
+      sessionStorage.removeItem(LEGACY_SESSION_TOKEN_PREFIX + connectionId)
+    } catch {
+      // ignore
+    }
+    return legacy
+  }
+  return null
+}
+
+
+/**
+ * Read a CachedToken from a Storage at a given key, returning null when
+ * absent, malformed, or past its expiry. Expired entries are removed.
+ *
+ * @return The cached token, or null.
+ */
+function readTokenAtKey(store: Storage, key: string): CachedToken | null {
   try {
-    const raw = sessionStorage.getItem(SESSION_TOKEN_PREFIX + connectionId)
+    const raw = store.getItem(key)
     if (!raw) {
       return null
     }
     const cached = JSON.parse(raw) as CachedToken
     if (Date.now() >= cached.expiresAt) {
-      sessionStorage.removeItem(SESSION_TOKEN_PREFIX + connectionId)
+      store.removeItem(key)
       return null
     }
     return cached
@@ -73,10 +112,15 @@ function loadTokenFromSession(connectionId: string): CachedToken | null {
 }
 
 
-/** Remove token from sessionStorage on disconnect. */
-function clearTokenFromSession(connectionId: string): void {
+/** Remove token from both stores on disconnect. */
+function clearTokenFromStorage(connectionId: string): void {
   try {
-    sessionStorage.removeItem(SESSION_TOKEN_PREFIX + connectionId)
+    localStorage.removeItem(STORAGE_TOKEN_PREFIX + connectionId)
+  } catch {
+    // ignore
+  }
+  try {
+    sessionStorage.removeItem(LEGACY_SESSION_TOKEN_PREFIX + connectionId)
   } catch {
     // ignore
   }
@@ -209,7 +253,7 @@ export const googleDriveProvider: ConnectionProvider = {
 
           const cached: CachedToken = {token: response.access_token, expiresAt: Date.now() + expiresInMs}
           tokenCache.set(connectionId, cached)
-          saveTokenToSession(connectionId, cached)
+          saveTokenToStorage(connectionId, cached)
 
           // Fetch user email with a 5s timeout — don't let it block connection
           const emailPromise = Promise.race([
@@ -265,13 +309,13 @@ export const googleDriveProvider: ConnectionProvider = {
       }
       tokenCache.delete(connectionId)
     }
-    clearTokenFromSession(connectionId)
+    clearTokenFromStorage(connectionId)
   },
 
   async checkStatus(connection: Connection): Promise<ConnectionStatus> {
     let cached = tokenCache.get(connection.id) ?? null
     if (!cached) {
-      const fromSession = loadTokenFromSession(connection.id)
+      const fromSession = loadTokenFromStorage(connection.id)
       if (fromSession) {
         tokenCache.set(connection.id, fromSession)
         cached = fromSession
@@ -313,7 +357,7 @@ export const googleDriveProvider: ConnectionProvider = {
     }
 
     // Try sessionStorage before triggering a new OAuth popup (survives same-tab reloads)
-    const fromSession = loadTokenFromSession(connection.id)
+    const fromSession = loadTokenFromStorage(connection.id)
     if (fromSession) {
       tokenCache.set(connection.id, fromSession)
       return fromSession.token
@@ -360,7 +404,7 @@ export const googleDriveProvider: ConnectionProvider = {
           const expiresInMs = (response.expires_in || DEFAULT_TOKEN_EXPIRES_S) * MS_PER_S
           const refreshed: CachedToken = {token: response.access_token, expiresAt: Date.now() + expiresInMs}
           tokenCache.set(connection.id, refreshed)
-          saveTokenToSession(connection.id, refreshed)
+          saveTokenToStorage(connection.id, refreshed)
 
           if (!settled) {
             settled = true


### PR DESCRIPTION
Companion to #1498 / #1499. With the Reconnect overlay actually working, the next UX wart was that opening a Drive permalink in a new tab *always* forced the overlay, even when a sibling tab was happily authenticated.

## Why

Tokens were persisted to `sessionStorage`, which is scoped per tab. The connection metadata (`bldrs:connections`) is already in `localStorage`, so a new tab knew which connection to use but had no token to use with it — silent refresh escalated to a popup outside any user gesture and the overlay caught it.

The "tokens are too sensitive for `localStorage`" intuition doesn't hold up here: the same XSS that could read `localStorage` can read `sessionStorage` on the originating tab equally well, and we already store enough connection state in `localStorage` to identify the user. There's no real isolation gain from using `sessionStorage` for the token while keeping the connection metadata in `localStorage`.

## Change

- Token persistence moves to `localStorage['bldrs:gdrive-token:<id>']`, keyed by connection id, with the same `expiresAt`-based expiry.
- `disconnect()` clears both `localStorage` and any leftover legacy `sessionStorage` entry.
- One-release migration: `loadTokenFromStorage()` reads the legacy `gdrive_token_<id>` session entry once, copies it to `localStorage`, and removes the session entry. Existing authenticated users don't experience a forced reconnect on rollout.
- CSRF state (`gdrive_oauth_state`) stays in `sessionStorage`. It's a per-flow nonce only the originating tab needs to validate, and it should not survive the browser session.

## Tests

4 new cases in `GoogleDriveProvider.test`:
- Token written by `connect()` lands at `bldrs:gdrive-token:<id>` in `localStorage`.
- A "new tab" simulation (empty in-memory `tokenCache`) reads the persisted token and treats the connection as connected.
- A legacy `sessionStorage` token is migrated to `localStorage` on first read and removed from `sessionStorage`.
- `disconnect()` clears both stores.

Full precommit suite green: 1006 tests, 163 suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)