### PR TITLE
design: identity decoupling + Drive recents HEAD-check proposals

### DIFF
--- a/design/new/drive-recents-head-check.md
+++ b/design/new/drive-recents-head-check.md
@@ -1,0 +1,122 @@
+# Drive recents: HEAD-check before navigate
+
+**Status:** Proposed
+**Date:** 2026-05-07
+**Owner:** Pablo
+**Related code:** `src/Components/Open/OpenModelDialog.jsx`, `src/Components/Connections/SourcesTab.jsx`, `src/connections/google-drive/GoogleDriveBrowser.ts`, `src/Containers/CadView.jsx`
+
+
+## Problem
+
+When a user clicks a Drive file in the recents list and the underlying file no longer exists or is no longer shared with this account, the load fails late and noisily:
+
+1. Click recent → `onOpenById` pre-flights `getAccessToken` (PR #1498) and navigates to `/v/g/<fileId>`.
+2. CadView mounts, calls `getFileDownload(connection, null, fileId)`.
+3. Google Drive API returns 404 (deleted) or 403 (revoked share).
+4. The IFC loader receives a non-IFC body or empty blob and `viewer.load()` fails.
+5. CadView's outer `if (!tmpModelRef && !isOOM)` branch fires `setAlert('Failed to parse model')`.
+
+The user sees a generic parse error for what is actually a "this file is gone or not shared with you anymore" situation. They have no path forward except guessing — and the recent entry stays in the list, ready to fail the same way next time.
+
+The fix that lets us close the deep-link case (typed `NeedsReconnectError` + Reconnect overlay) doesn't help here because this isn't an auth failure. The token is fine; the file just isn't reachable.
+
+
+## Proposal
+
+Pre-flight a Drive metadata HEAD/GET before navigating, and surface a typed alert with a clear remediation if the file is unreachable.
+
+### Where the check lives
+
+In `OpenModelDialog.handleOpenById` (the recent-file click path), immediately after the existing `getAccessToken` pre-flight:
+
+```js
+const handleOpenById = async (connection, fileId, fileName) => {
+  const provider = getProvider(connection.providerId)
+  if (provider) {
+    try {
+      await provider.getAccessToken(connection)        // existing
+      await provider.checkFileAccess(connection, fileId) // new
+    } catch (err) {
+      if (err instanceof NeedsReconnectError) { ... }   // existing
+      if (err instanceof FileUnreachableError) {
+        setAlert({
+          type: 'fileUnreachable',
+          connection: err.connection,
+          fileId: err.fileId,
+          fileName,
+          reason: err.reason, // 'not_found' | 'forbidden'
+        })
+        return
+      }
+      ...
+    }
+  }
+  // navigate as before
+}
+```
+
+`provider.checkFileAccess(connection, fileId)` does a `GET https://www.googleapis.com/drive/v3/files/<fileId>?fields=id,name,trashed`:
+- 200 + `trashed=false` → return.
+- 200 + `trashed=true` → throw `FileUnreachableError(connection, fileId, 'trashed')`.
+- 404 → throw `FileUnreachableError(connection, fileId, 'not_found')`.
+- 403 → throw `FileUnreachableError(connection, fileId, 'forbidden')`.
+- Other status → return (don't block on transient flakes).
+
+### UI surface
+
+`AlertDialog` learns a third typed alert variant: `fileUnreachable`. Header reads `File not available`. Body contains the filename and a contextual reason ("This file was deleted from Drive" / "You no longer have access to this file" / "This file is in the Drive trash"). Actions:
+
+- **Remove from recents** (primary): calls a new `removeRecentFileEntry({connectionId, fileId})` on `connections/persistence`, then closes the alert.
+- **Try a different account** (secondary, only when the user has multiple Drive connections): closes the alert, leaves the Open dialog up, scrolls to the Sources tab. The user picks another connection and re-clicks the file in *that* recent list.
+
+### Same check on deep-link / reload
+
+Deep-link (`/v/g/<fileId>` typed in URL bar, no preceding click) hits the same Drive 404/403 inside CadView's `loadModel → getFileDownload`. Today that surfaces as "Failed to parse model"; with this change, `getFileDownload` is the natural place to throw `FileUnreachableError`, CadView's outer catch routes it the same way it routes `NeedsReconnectError`, and `AlertDialog` shows the same `fileUnreachable` overlay. Only difference vs. the recents click: "Remove from recents" is a no-op (we navigated in directly, not via a recent click) — replace it with "Open another file" that closes the alert and routes back to the Open dialog.
+
+
+## Cost / latency
+
+One Drive metadata GET per recent click. Empirically ~150–300ms for healthy Drive API. Critique: this slows the happy path for a UX win on the unhappy path.
+
+Two mitigations:
+
+- **Run the metadata GET in parallel with navigation, not before it.** Fire the request inside the click handler, but kick off `navigate` immediately. CadView's load and the metadata check race; if the metadata check returns 404/403 first, route to the unreachable overlay; if the load succeeds first, ignore the late metadata response.
+- **Skip the check when we have a strong recency signal.** If the recent's `lastAccessedAt` is < N minutes ago (e.g. 60), assume it's still reachable and skip the metadata GET. Most clicks are repeat opens of recently-loaded models; the failure mode mostly affects long-stale recents.
+
+**Recommendation: ship the in-series version first.** The 150–300ms cost is small relative to model-load time (multi-second for non-trivial IFC files), and serializing avoids a race that's harder to reason about. Optimize to parallel/skip-recent only if telemetry shows the latency mattering.
+
+
+## Alternatives considered
+
+- **Don't pre-flight, improve only the post-load error UI.** Catch the 404/403 inside CadView's load chain and route to a typed alert there. Cheaper; no extra request. But the user has already paid the navigation + viewer-init cost before we tell them the file is gone, and removing a stale recent requires bouncing back to the dialog. Worse UX, especially on slow networks.
+- **Pre-flight on dialog mount, not on click.** Validate every recent's reachability when the Open dialog opens. Pro: greys out unreachable recents before the user clicks. Con: N requests on every dialog open, most of which are wasted because the user clicks at most one. The on-click variant has better cost shape.
+- **Do nothing; trust the user to figure it out.** What we do today. The cost of "Failed to parse model" surfacing for non-parse problems has come up multiple times.
+
+
+## Migration
+
+Pure additive. No schema changes. Adds:
+
+- `FileUnreachableError` class in `src/connections/errors.ts` next to `NeedsReconnectError`.
+- `checkFileAccess` method on the `ConnectionProvider` interface (optional; default implementation is a no-op for providers that don't support it). GitHub's provider when it lands will have its own version.
+- `removeRecentFileEntry({connectionId, fileId})` in `connections/persistence`.
+- `fileUnreachable` alert variant + handler in `AlertDialog`.
+
+Tests:
+- `GoogleDriveProvider.checkFileAccess` returns / throws on 200, 404, 403, trashed=true, network error.
+- `OpenModelDialog.handleOpenById` skips navigation and surfaces the typed alert when `checkFileAccess` throws `FileUnreachableError`.
+- `AlertDialog` renders the unreachable header + body + Remove-from-recents action; click invokes `removeRecentFileEntry`.
+- `CadView.loadModel`'s outer catch routes `FileUnreachableError` to `setAlert({type:'fileUnreachable',...})`.
+
+
+## Scope
+
+Single PR. Estimated 1–3 days including tests.
+
+
+## Open questions
+
+- **Trashed handling.** A trashed file is technically reachable via `?supportsAllDrives=true&includeItemsFromAllDrives=true&trashed=true`, and the user could conceivably recover it. Do we treat `trashed=true` as `fileUnreachable` (simplest) or surface "this file is in your trash, restore it"? First version: treat as unreachable; revisit if anyone asks.
+- **Shared Drives.** The metadata endpoint behaves differently for files in Shared Drives. Need to add `?supportsAllDrives=true` to the query and confirm 404/403 semantics match. Verify against a Shared Drive file in a manual test.
+- **Rate limits.** Drive's metadata endpoint is cheap but rate-limited per-user. If a user has a recents list with hundreds of entries and we move to the dialog-mount pre-flight variant later, we'd want batching. Not relevant for the on-click design.
+- **Telemetry.** Worth tagging `fileUnreachable` events in analytics so we can see how often the unhappy path fires before vs. after this lands. The before/after delta calibrates whether the latency cost was worth it.

--- a/design/new/identity-decoupling.md
+++ b/design/new/identity-decoupling.md
@@ -1,0 +1,112 @@
+# Identity decoupling: GitHub as a per-account Sources connection
+
+**Status:** Proposed
+**Date:** 2026-05-07
+**Owner:** Pablo
+**Related code:** `src/connections/`, `src/Components/Open/OpenModelDialog.jsx`, `src/Components/Connections/SourcesTab.jsx`, `src/Auth0/`
+
+
+## Problem
+
+Today the app has two non-symmetric notions of identity:
+
+1. **Primary auth (Auth0).** A single login. Either GitHub (`github` connection) or Google (`google-oauth2`). This auth controls who the user is to Bldrs and provides the GitHub access token via federated identity.
+2. **Per-account connections (Sources tab).** Google Drive lives here as one or more accounts the user has linked, each with its own OAuth grant via GIS, persisted at `localStorage['bldrs:gdrive-token:<id>']`.
+
+GitHub straddles the two. It's the primary auth *and* the only way to browse private repos — there is no "GitHub Sources connection" parallel to Google Drive. That asymmetry causes three observable problems:
+
+- **Cannot browse GitHub when primary auth is Google.** A user logged in via Google has no GitHub federated identity; the GitHub tab in the Open dialog can show recents but can't list repos.
+- **Cannot browse multiple GitHub accounts.** Drive supports two (work + personal) connected accounts; GitHub does not.
+- **Switching primary auth flips access to BOTH systems.** Logging out of GitHub-as-primary loses the user's Drive *connections* visually because the dialog re-renders against a fresh user state.
+
+The user's mental model — and the model implied by the Sources tab UI we already built — is that "primary identity" and "what data sources I've connected" are independent.
+
+
+## Proposal
+
+Promote GitHub to a `ConnectionProvider` peer of `googleDriveProvider`. The Sources tab becomes the canonical surface for *all* per-source auth; the existing top-level Auth0 login degrades to "who you are on Bldrs" (subscription, profile, save attribution), not "what sources you can browse."
+
+### Data shape
+
+A new `GitHubProvider` implementing `ConnectionProvider` from `src/connections/types.ts`:
+
+```ts
+{
+  id: 'github',
+  name: 'GitHub',
+  icon: 'github',
+  connect(hint?: string): Promise<Connection>     // OAuth popup, returns Connection
+  disconnect(connectionId: string): Promise<void> // revoke + clear local
+  checkStatus(connection): Promise<ConnectionStatus>  // tokeninfo equivalent
+  getAccessToken(connection): Promise<string>
+}
+```
+
+Tokens persist at `localStorage['bldrs:github-token:<connectionId>']`, mirroring `bldrs:gdrive-token:<id>`. A `Connection` object lives in `localStorage['bldrs:connections']` alongside Drive entries, with `providerId: 'github'` and `meta: { username, avatarUrl }`.
+
+### OAuth flow
+
+GitHub doesn't have a GIS-equivalent in-page token client; the standard browser flow is a popup to `https://github.com/login/oauth/authorize` followed by a code exchange against the GitHub token endpoint. The exchange step requires a server (the client_secret can't ship to the browser). Two viable routes:
+
+1. **Reuse our existing Auth0 GitHub connection** as the "GitHub OAuth App" — Auth0 already brokers the code exchange and stores the access token. We'd add an Auth0 endpoint (or reuse an existing one) that returns just the GitHub access token to the page on demand, scoped to the connection the user authorized via popup. Pro: no new server-side surface. Con: tightly couples per-account connections to Auth0's notion of the identity, which is what we're trying to decouple from.
+2. **Stand up a small token-exchange endpoint** (e.g. on the existing share-oauth-proxy worker) that takes a code + state and returns `{access_token, scope, expires_at?}`. The browser does the popup, posts the code to our endpoint, gets back a token, persists it. Pro: clean separation; one GitHub OAuth App per environment, owned by us. Con: adds an endpoint to maintain.
+
+**Recommendation: option 2.** It's the architecturally honest version and matches the GIS pattern we use for Drive. The existing share-oauth-proxy already does this kind of brokering for the Auth0 flow, so there's no greenfield infrastructure.
+
+### UI
+
+`SourcesTab` already iterates `connections` and renders a card per-connection. The two changes:
+
+- **"Connect GitHub" button** alongside "Connect Google Drive" in the empty-state and the "Add another account" footer. Distinguished by `providerId` and icon; otherwise the existing card / Browse / Reconnect flow works unchanged.
+- **GitHub tab in OpenModelDialog** loses its bespoke auth UI. The recents list and Browse button stay, but Browse now goes through `provider.getAccessToken(connection)` like Drive does. Eventually, the GitHub tab can be removed entirely in favor of Sources — but for one release we'd run them in parallel for migration.
+
+### Auth0 reduces in scope
+
+After this lands, Auth0 is responsible for:
+
+- Subscription / billing identity (Stripe customer, quota tracking, profile).
+- Bldrs-level user profile (display name, avatar, preferences).
+- Federated identity claims (the `https://bldrs.ai/identities` claim) — kept for backward compatibility, no longer the source of GitHub repo access.
+
+The "P" avatar in the top-right represents the Auth0 user, *not* a GitHub username. A user logged in via Google with two connected GitHub accounts in Sources sees their Google name in the corner and chooses which GitHub identity to commit as via the Save dialog.
+
+
+## Migration
+
+Existing users today have:
+- Auth0 GitHub identity → GitHub access token via federated claim.
+- No `bldrs:github-token:*` entries in localStorage.
+
+On first load after rollout:
+
+1. If the user has an Auth0 GitHub identity AND no GitHub connection in `bldrs:connections`, auto-create a GitHub connection seeded from the Auth0 identity (label = nickname, meta.email = primary email). The token isn't migrated — first Browse click re-authorizes via the new GitHub OAuth App.
+2. If the user already has private GitHub repos in their recents, the recent list still resolves: the new GitHub connection's id replaces whatever stand-in id the recent entries had, and we backfill `connectionId` on `loadRecentFilesBySource('github')`.
+3. The bespoke GitHub tab UI stays for one release (feature-flagged) so users with no Sources connection don't lose access during the transition.
+
+We do NOT auto-revoke the Auth0 GitHub identity — the user can keep using it as their primary login. Many will. We just stop relying on its access token for Sources.
+
+
+## Alternatives considered
+
+- **Status quo.** Keep GitHub special. Acceptable until the symmetry frictions accumulate. Symptom escalation is what triggered this proposal: users hitting "I'm logged in via Google, where are my repos?" and "can I have a work and personal GitHub linked?"
+- **Move Drive into Auth0 instead.** I.e. make Drive a federated identity. Worse: GIS gives us tokens with the right scope for the picker without requiring a server-side code exchange; routing through Auth0 would either add latency or cost picker-compatibility.
+- **Keep GitHub primary-only, add a second "secondary GitHub" link in Auth0.** Solves the multi-account case but not the "Google primary can't browse GitHub" case, and Auth0's account-linking UX is worse than per-source connection UX we already have.
+
+
+## Scope
+
+Three PRs, sequenced:
+
+1. **Provider scaffolding + token endpoint.** `GitHubProvider` registered in `src/connections/`. Token-exchange endpoint added to `share-oauth-proxy` worker. No UI changes; provider is wired but unreachable. Lands behind a feature flag.
+2. **SourcesTab integration + recents migration.** "Connect GitHub" button, connection cards, Browse routes through `provider.getAccessToken`. Auto-create connection from Auth0 identity on first load. Feature flag still up.
+3. **Switch over and remove flag.** GitHub tab in OpenModelDialog deprecated (still mounted, marked legacy). Remove in a follow-up after metrics show >X% of repo browses going through Sources.
+
+Estimated effort: ~1–2 weeks per PR with reviews; biggest unknown is the token-exchange endpoint design (see Open Questions).
+
+
+## Open questions
+
+- **Token TTL.** GitHub access tokens issued via OAuth App don't expire by default unless we use the new fine-grained PATs / installation tokens. Do we want to opt into a finite TTL via GitHub Apps + installation tokens for parity with Drive's 1h tokens? Probably yes long-term; not blocking for v1.
+- **Scope.** Bldrs needs `repo` for private read + commit, plus `read:user`. Should "Connect GitHub" prompt for the union, or split read vs. write into two consent steps? Drive's `drive.file` is intentionally narrow; GitHub doesn't have an equivalent narrow-scope-with-picker model, so we likely need broader read scope upfront.
+- **Save-flow attribution.** A user with Google primary auth + connected GitHub via Sources commits to a repo. Does the commit author come from the Sources GitHub identity, or the Auth0 user? Almost certainly the GitHub one (the API only accepts that account anyway), but the UX needs to surface the choice clearly.
+- **Quota / abuse.** Today the Auth0 GitHub identity is the unique user key for quota tracking. Per-source connections decouple "user count" from "GitHub identity count". Either keep Auth0 user as the quota key, or move to a different model. Coordinate with the quotas work.


### PR DESCRIPTION
Two RFC-style design docs land in `design/new/` for follow-up work surfaced during the Drive auth thread (#1496–#1501). Both are proposals only — no implementation in this PR.

## 1. [identity-decoupling.md](design/new/identity-decoupling.md)

Promote GitHub to a per-account Sources provider symmetric with Google Drive, decoupled from Auth0 primary auth. Closes the asymmetries that already show up against today's Sources tab UI:

- Google-primary user can't browse GitHub repos (no federated GitHub identity).
- No multi-GitHub-account support (work + personal).
- Switching primary auth visually affects access to data sources that should be independent.

Proposal: a `GitHubProvider` implementing `ConnectionProvider`, with tokens at `localStorage['bldrs:github-token:<id>']` mirroring the Drive layout. Three-PR scope (provider scaffolding + endpoint, SourcesTab integration + recents migration, switchover + flag removal). Biggest unknown is the OAuth code-exchange endpoint design — covered in Open Questions.

## 2. [drive-recents-head-check.md](design/new/drive-recents-head-check.md)

Pre-flight a Drive metadata GET before navigating from a recents click. Today, clicking a deleted-or-unshared recent surfaces as `Failed to parse model` deep in `CadView` because the IFC loader gets a non-IFC body. With this change, a typed `FileUnreachableError` routes to a `fileUnreachable` AlertDialog overlay with a "Remove from recents" action.

Same path applies on deep-link / reload (no preceding click) — `getFileDownload` throws the typed error and the same overlay surfaces. Single-PR scope, ~1–3 days.

## Format

Each doc includes: Problem, Proposal, Alternatives considered, Migration, Scope, Open questions. Aim is to make these reviewable design conversations rather than ship-tomorrow specs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)