### PR TITLE
ci: skip GH Actions and Netlify preview on docs-only changes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,9 +5,14 @@ on:
     branches: [ main ]
     paths-ignore:
       - '**/*.md'
-      - 'README.md'
+      - 'design/**'
+      - 'notes/**'
   pull_request:
     branches: [ main ]
+    paths-ignore:
+      - '**/*.md'
+      - 'design/**'
+      - 'notes/**'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/test-flows.yml
+++ b/.github/workflows/test-flows.yml
@@ -5,9 +5,14 @@ on:
     branches: [ main ]
     paths-ignore:
       - '**/*.md'
-      - 'README.md'
+      - 'design/**'
+      - 'notes/**'
   pull_request:
     branches: [ main ]
+    paths-ignore:
+      - '**/*.md'
+      - 'design/**'
+      - 'notes/**'
   workflow_dispatch:
 
 jobs:

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,8 @@
+# Skip the deploy preview when the only changes are documentation. The script
+# exits 0 to skip and 1 to build; logic and edge cases are documented inline.
+[build]
+  ignore = "bash tools/netlify/ignore-build.sh"
+
 # COOP same-origin-allow-popups lets Google Identity Services deliver OAuth
 # tokens via postMessage without nulling window.opener in the cross-origin
 # popup. COEP is intentionally omitted (docs.google.com/picker sends

--- a/tools/netlify/ignore-build.sh
+++ b/tools/netlify/ignore-build.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+#
+# Netlify [build].ignore hook — exit 0 to SKIP the build, exit 1 to BUILD.
+# We skip when every file changed since the last successful deploy is a
+# documentation file (markdown anywhere, or anything under design/ or
+# notes/). On any failure or ambiguity we err toward building so the
+# branch never ends up un-deployed.
+#
+# Netlify supplies $CACHED_COMMIT_REF (last successful deploy) and
+# $COMMIT_REF (current). See https://docs.netlify.com/configure-builds/ignore-builds/.
+
+set -u
+
+# Build defensively if we can't compute a diff (shallow clone, fresh site, …).
+if [ -z "${CACHED_COMMIT_REF:-}" ] || [ -z "${COMMIT_REF:-}" ]; then
+  exit 1
+fi
+
+files=$(git diff --name-only "$CACHED_COMMIT_REF" "$COMMIT_REF" 2>/dev/null) || exit 1
+
+# Empty diff (e.g. force-push to same SHA) — build to be safe.
+[ -z "$files" ] && exit 1
+
+# If any changed file is NOT a doc, we need to build.
+if echo "$files" | grep -qvE '(\.md$|^design/|^notes/)'; then
+  exit 1
+fi
+
+# All changes are docs — skip.
+exit 0


### PR DESCRIPTION
PR #1502 (design docs only) burned a full CI cycle — build, playwright, Netlify deploy preview — for two markdown files. That's wasted minutes per docs PR and a slower review loop, both fixable.

## Why it was firing

- `.github/workflows/main.yml` and `test-flows.yml` already had a `paths-ignore` block, but **only on the `push:` trigger.** The `pull_request:` trigger had no filter, so every PR ran the full suite.
- Netlify had no `ignore` hook configured, so the deploy preview ran on every PR commit regardless of content.

## Changes

1. **Both workflows' `pull_request:` triggers gain the same `paths-ignore`** as their `push:` triggers, broadened to:
   ```yaml
   paths-ignore:
     - '**/*.md'
     - 'design/**'
     - 'notes/**'
   ```
   `README.md` drops out — it was redundant alongside `**/*.md`.

2. **New `tools/netlify/ignore-build.sh`** wired into `netlify.toml`'s `[build].ignore`. The script diffs `$CACHED_COMMIT_REF..$COMMIT_REF`; exits 0 (skip) only when every changed path matches the doc patterns. Defaults to building (exit 1) on any failure or ambiguity, so a branch never ends up un-deployed.

## Verification

Tested locally with the `CACHED_COMMIT_REF` / `COMMIT_REF` env shim Netlify provides:

- Docs-only range over `upstream/main` → exits 0 (skip) ✓
- Range with code changes → exits 1 (build) ✓
- Missing env vars → exits 1 (defensive build) ✓

## Defaults

The "default to build" stance is deliberate: a stale or shallow git checkout shouldn't quietly suppress a needed deploy. The cost of one false-positive build is much lower than one missed real one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)