### PR TITLE
sharing: provider scaffolding + Drive adapter (PR1 of multi-user sharing)

### DIFF
--- a/src/FeatureFlags.js
+++ b/src/FeatureFlags.js
@@ -4,4 +4,8 @@ export const flags = [
   },
   {name: 'googleOAuth2', isActive: true},
   {name: 'googleDrive', isActive: true},
+  // Multi-user sharing UI (Share dialog, visibility chip). Provider scaffolding
+  // ships unconditionally; this flag gates the consumer surface in PR2+.
+  // See design/new/multi-user-sharing.md.
+  {name: 'sharing', isActive: false},
 ]

--- a/src/connections/errors.ts
+++ b/src/connections/errors.ts
@@ -30,3 +30,60 @@ export class NeedsReconnectError extends Error {
     Object.setPrototypeOf(this, NeedsReconnectError.prototype)
   }
 }
+
+
+/**
+ * Thrown when a sharing-capability call is refused by the provider for
+ * authorization reasons — the connection is healthy, but the acting user
+ * cannot perform the operation on this resource (e.g. listing collaborators
+ * on a repo they don't admin, or sharing a Drive file they don't own).
+ *
+ * Distinct from `NeedsReconnectError`: there's nothing to reconnect, the
+ * user simply lacks the privilege. UI should surface this as "you don't
+ * have permission" rather than as a sign-in prompt.
+ */
+export class InsufficientPermissionError extends Error {
+  readonly connection: Connection
+  readonly cause?: string
+
+  /**
+   * @param connection The connection that was acting on the resource
+   * @param cause Short machine-readable tag, e.g. 'forbidden'
+   * @param message Human-readable message for logs/dialogs
+   */
+  constructor(connection: Connection, cause?: string, message?: string) {
+    super(message ?? `Insufficient permission for ${connection.label}`)
+    this.name = 'InsufficientPermissionError'
+    this.connection = connection
+    this.cause = cause
+    Object.setPrototypeOf(this, InsufficientPermissionError.prototype)
+  }
+}
+
+
+/**
+ * Thrown for any non-auth, non-permission failure during a sharing-capability
+ * call: 4xx that isn't 401/403, 5xx, network failure, malformed response,
+ * or a request the adapter refused outright (e.g. a `ResourceRef` shape the
+ * adapter doesn't own).
+ *
+ * The `cause` field carries a short machine-readable tag so callers and
+ * dialogs can branch without parsing `message`.
+ */
+export class GrantFailedError extends Error {
+  readonly connection: Connection
+  readonly cause?: string
+
+  /**
+   * @param connection The connection that was acting on the resource
+   * @param cause Short machine-readable tag, e.g. 'http_500' or 'wrong_provider'
+   * @param message Human-readable message for logs/dialogs
+   */
+  constructor(connection: Connection, cause?: string, message?: string) {
+    super(message ?? `Sharing operation failed on ${connection.label}`)
+    this.name = 'GrantFailedError'
+    this.connection = connection
+    this.cause = cause
+    Object.setPrototypeOf(this, GrantFailedError.prototype)
+  }
+}

--- a/src/connections/google-drive/GoogleDriveProvider.ts
+++ b/src/connections/google-drive/GoogleDriveProvider.ts
@@ -7,9 +7,24 @@
  * Tokens are held in memory only and re-obtained via GIS on page reload.
  */
 
-import type {Connection, ConnectionProvider, ConnectionStatus} from '../types'
+import type {
+  Connection,
+  ConnectionProvider,
+  ConnectionStatus,
+  Grant,
+  GrantRequest,
+  ResourceRef,
+  Visibility,
+} from '../types'
 import debug from '../../utils/debug'
 import {NeedsReconnectError} from '../errors'
+import {
+  driveGetVisibility,
+  driveListGrants,
+  driveRevokeGrant,
+  driveSetVisibility,
+  driveShareWith,
+} from './GoogleDriveSharing'
 import {loadGisScript} from './loadGisScript'
 import type {TokenResponse} from './loadGisScript'
 
@@ -433,6 +448,52 @@ export const googleDriveProvider: ConnectionProvider = {
       // Use empty string prompt to try silent refresh; will show popup if consent needed
       client.requestAccessToken({prompt: '', state: oauthState})
     })
+  },
+
+  // -- Sharing capability --
+  // These delegate to GoogleDriveSharing.ts so the transport is testable
+  // without exercising OAuth. getAccessToken() is the only auth seam; if a
+  // token is stale and silent-refresh fails it surfaces NeedsReconnectError
+  // here, just as in the existing browse path.
+
+  async listGrants(connection: Connection, resource: ResourceRef): Promise<Grant[]> {
+    const token = await googleDriveProvider.getAccessToken(connection)
+    return driveListGrants(connection, resource, token)
+  },
+
+  async shareWith(
+    connection: Connection,
+    resource: ResourceRef,
+    grant: GrantRequest,
+  ): Promise<Grant> {
+    const token = await googleDriveProvider.getAccessToken(connection)
+    return driveShareWith(connection, resource, grant, token)
+  },
+
+  async revokeGrant(
+    connection: Connection,
+    resource: ResourceRef,
+    grantId: string,
+  ): Promise<void> {
+    const token = await googleDriveProvider.getAccessToken(connection)
+    return driveRevokeGrant(connection, resource, grantId, token)
+  },
+
+  async getVisibility(
+    connection: Connection,
+    resource: ResourceRef,
+  ): Promise<Visibility | null> {
+    const token = await googleDriveProvider.getAccessToken(connection)
+    return driveGetVisibility(connection, resource, token)
+  },
+
+  async setVisibility(
+    connection: Connection,
+    resource: ResourceRef,
+    visibility: Visibility,
+  ): Promise<void> {
+    const token = await googleDriveProvider.getAccessToken(connection)
+    return driveSetVisibility(connection, resource, visibility, token)
   },
 }
 

--- a/src/connections/google-drive/GoogleDriveSharing.test.ts
+++ b/src/connections/google-drive/GoogleDriveSharing.test.ts
@@ -1,0 +1,367 @@
+/**
+ * Unit tests for GoogleDriveSharing — Drive Permissions API transport,
+ * principal-shape mapping, visibility derivation, and typed-error mapping.
+ *
+ * Tests stub `fetch` directly (matching GoogleDriveProvider.test.ts) so the
+ * helpers are exercised without OAuth machinery.
+ */
+
+import {GrantFailedError, InsufficientPermissionError, NeedsReconnectError} from '../errors'
+import type {Connection, ResourceRef} from '../types'
+import {
+  driveGetVisibility,
+  driveListGrants,
+  driveRevokeGrant,
+  driveSetVisibility,
+  driveShareWith,
+} from './GoogleDriveSharing'
+
+
+const TOKEN = 'test-token'
+const FILE_ID = 'file-abc'
+const FOLDER_ID = 'folder-xyz'
+
+// Named HTTP status codes — keeps the eslint no-magic-numbers rule happy and
+// makes intent clearer at the call site.
+const HTTP_OK = 200
+const HTTP_NO_CONTENT = 204
+const HTTP_OK_RANGE_END = 300
+const HTTP_UNAUTHORIZED = 401
+const HTTP_FORBIDDEN = 403
+const HTTP_INTERNAL = 500
+
+
+/**
+ * Build a Connection for tests with sensible defaults; overrides merge last.
+ *
+ * @return The constructed Connection.
+ */
+function mkConnection(overrides: Partial<Connection> = {}): Connection {
+  return {
+    id: 'conn-1',
+    providerId: 'google-drive',
+    label: 'pablo@bldrs.ai - GDrive',
+    status: 'connected',
+    auth0Connection: 'google-oauth2',
+    createdAt: '2026-05-01T00:00:00Z',
+    meta: {email: 'pablo@bldrs.ai'},
+    ...overrides,
+  }
+}
+
+const FILE_RESOURCE: ResourceRef = {kind: 'drive-file', fileId: FILE_ID}
+const FOLDER_RESOURCE: ResourceRef = {kind: 'drive-folder', folderId: FOLDER_ID}
+
+let originalFetch: typeof global.fetch
+let mockFetch: jest.Mock
+
+beforeEach(() => {
+  originalFetch = global.fetch
+  mockFetch = jest.fn()
+  global.fetch = mockFetch as unknown as typeof global.fetch
+})
+
+afterEach(() => {
+  global.fetch = originalFetch
+})
+
+
+/**
+ * Build a `Response`-shaped object for fetch stubs without going through a
+ * polyfill. Stringifies non-string bodies into the `text()` resolution so
+ * the typed-error mapper can read either shape.
+ *
+ * @return A minimal Response stand-in suitable for the helpers under test.
+ */
+function jsonResponse(status: number, body: unknown): Response {
+  return {
+    ok: status >= HTTP_OK && status < HTTP_OK_RANGE_END,
+    status,
+    json: () => Promise.resolve(body),
+    text: () => Promise.resolve(typeof body === 'string' ? body : JSON.stringify(body)),
+  } as unknown as Response
+}
+
+
+/**
+ * Build a `Response` with no body — used for DELETE 204 replies, which the
+ * helpers don't read but `driveFetch` still inspects.
+ *
+ * @return A minimal Response stand-in with empty json/text resolutions.
+ */
+function emptyResponse(status: number): Response {
+  return {
+    ok: status >= HTTP_OK && status < HTTP_OK_RANGE_END,
+    status,
+    json: () => Promise.resolve({}),
+    text: () => Promise.resolve(''),
+  } as unknown as Response
+}
+
+
+describe('driveListGrants', () => {
+  it('maps Drive permissions onto provider-neutral grants', async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse(HTTP_OK, {
+      permissions: [
+        {id: 'p1', type: 'user', role: 'writer', emailAddress: 'a@example.com'},
+        {id: 'p2', type: 'domain', role: 'reader', domain: 'bldrs.ai'},
+        {id: 'p3', type: 'anyone', role: 'reader'},
+      ],
+    }))
+
+    const grants = await driveListGrants(mkConnection(), FILE_RESOURCE, TOKEN)
+
+    expect(grants).toEqual([
+      {id: 'p1', principalType: 'user', principalId: 'a@example.com', role: 'writer', origin: 'drive'},
+      {id: 'p2', principalType: 'domain', principalId: 'bldrs.ai', role: 'reader', origin: 'drive'},
+      {id: 'p3', principalType: 'anyone', principalId: undefined, role: 'reader', origin: 'drive'},
+    ])
+  })
+
+  it('targets /files/{id}/permissions with supportsAllDrives', async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse(HTTP_OK, {permissions: []}))
+    await driveListGrants(mkConnection(), FILE_RESOURCE, TOKEN)
+
+    const [url, init] = mockFetch.mock.calls[0]
+    expect(url).toMatch(`/drive/v3/files/${FILE_ID}/permissions`)
+    expect(url).toMatch('supportsAllDrives=true')
+    expect((init as RequestInit).headers).toMatchObject({Authorization: `Bearer ${TOKEN}`})
+  })
+
+  it('accepts drive-folder resources', async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse(HTTP_OK, {permissions: []}))
+    await driveListGrants(mkConnection(), FOLDER_RESOURCE, TOKEN)
+
+    const [url] = mockFetch.mock.calls[0]
+    expect(url).toMatch(`/drive/v3/files/${FOLDER_ID}/permissions`)
+  })
+
+  it('rejects github-shaped resources with GrantFailedError(wrong_provider)', async () => {
+    const ghResource: ResourceRef = {kind: 'github-repo', org: 'bldrs-ai', repo: 'Share'}
+    await expect(driveListGrants(mkConnection(), ghResource, TOKEN)).rejects.toMatchObject({
+      name: 'GrantFailedError',
+      cause: 'wrong_provider',
+    })
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+
+  it('maps 401 onto NeedsReconnectError', async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse(HTTP_UNAUTHORIZED, {error: 'invalid_token'}))
+    await expect(driveListGrants(mkConnection(), FILE_RESOURCE, TOKEN)).rejects.toBeInstanceOf(NeedsReconnectError)
+  })
+
+  it('maps 403 onto InsufficientPermissionError', async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse(HTTP_FORBIDDEN, {error: 'forbidden'}))
+    await expect(driveListGrants(mkConnection(), FILE_RESOURCE, TOKEN)).rejects.toBeInstanceOf(InsufficientPermissionError)
+  })
+
+  it('maps other 4xx/5xx onto GrantFailedError with http_<status> cause', async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse(HTTP_INTERNAL, 'boom'))
+    const err = await driveListGrants(mkConnection(), FILE_RESOURCE, TOKEN).catch((e) => e)
+    expect(err).toBeInstanceOf(GrantFailedError)
+    expect(err.cause).toBe('http_500')
+  })
+})
+
+
+describe('driveShareWith', () => {
+  it('emits emailAddress for user grants and forwards notify+message', async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse(HTTP_OK, {
+      id: 'p9', type: 'user', role: 'reader', emailAddress: 'b@x.com',
+    }))
+
+    const result = await driveShareWith(
+      mkConnection(),
+      FILE_RESOURCE,
+      {principalType: 'user', principalId: 'b@x.com', role: 'reader', notify: true, message: 'hi'},
+      TOKEN,
+    )
+
+    expect(result).toEqual({
+      id: 'p9', principalType: 'user', principalId: 'b@x.com', role: 'reader', origin: 'drive',
+    })
+    const [url, init] = mockFetch.mock.calls[0]
+    expect(url).toMatch('sendNotificationEmail=true')
+    expect(url).toMatch('emailMessage=hi')
+    expect((init as RequestInit).method).toBe('POST')
+    const body = JSON.parse((init as RequestInit).body as string)
+    expect(body).toEqual({type: 'user', role: 'reader', emailAddress: 'b@x.com'})
+  })
+
+  it('omits sendNotificationEmail for domain and anyone grants', async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse(HTTP_OK, {
+      id: 'p10', type: 'anyone', role: 'reader',
+    }))
+    await driveShareWith(
+      mkConnection(),
+      FILE_RESOURCE,
+      {principalType: 'anyone', role: 'reader'},
+      TOKEN,
+    )
+    const [url] = mockFetch.mock.calls[0]
+    expect(url).not.toMatch('sendNotificationEmail')
+    expect(url).not.toMatch('emailMessage')
+  })
+
+  it('emits domain field for domain grants', async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse(HTTP_OK, {
+      id: 'p11', type: 'domain', role: 'reader', domain: 'bldrs.ai',
+    }))
+    await driveShareWith(
+      mkConnection(),
+      FILE_RESOURCE,
+      {principalType: 'domain', principalId: 'bldrs.ai', role: 'reader'},
+      TOKEN,
+    )
+    const body = JSON.parse((mockFetch.mock.calls[0][1] as RequestInit).body as string)
+    expect(body).toEqual({type: 'domain', role: 'reader', domain: 'bldrs.ai'})
+  })
+
+  it('rejects user grants without principalId', async () => {
+    await expect(driveShareWith(
+      mkConnection(),
+      FILE_RESOURCE,
+      {principalType: 'user', role: 'reader'},
+      TOKEN,
+    )).rejects.toMatchObject({name: 'GrantFailedError', cause: 'principal_required'})
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+
+  it('rejects domain grants without principalId', async () => {
+    await expect(driveShareWith(
+      mkConnection(),
+      FILE_RESOURCE,
+      {principalType: 'domain', role: 'reader'},
+      TOKEN,
+    )).rejects.toMatchObject({name: 'GrantFailedError', cause: 'principal_required'})
+  })
+})
+
+
+describe('driveRevokeGrant', () => {
+  it('issues DELETE on /files/{id}/permissions/{grantId}', async () => {
+    mockFetch.mockResolvedValueOnce(emptyResponse(HTTP_NO_CONTENT))
+    await driveRevokeGrant(mkConnection(), FILE_RESOURCE, 'p1', TOKEN)
+
+    const [url, init] = mockFetch.mock.calls[0]
+    expect(url).toMatch(`/files/${FILE_ID}/permissions/p1`)
+    expect((init as RequestInit).method).toBe('DELETE')
+  })
+})
+
+
+describe('driveGetVisibility', () => {
+  /** Queue a single permissions.list response for the next driveListGrants call. */
+  function withGrants(perms: Array<Record<string, unknown>>): void {
+    mockFetch.mockResolvedValueOnce(jsonResponse(HTTP_OK, {permissions: perms}))
+  }
+
+  it('returns public when an anyone permission exists', async () => {
+    withGrants([{id: 'p', type: 'anyone', role: 'reader'}])
+    expect(await driveGetVisibility(mkConnection(), FILE_RESOURCE, TOKEN)).toBe('public')
+  })
+
+  it('public wins over org when both apply', async () => {
+    withGrants([
+      {id: 'p1', type: 'anyone', role: 'reader'},
+      {id: 'p2', type: 'domain', role: 'reader', domain: 'bldrs.ai'},
+    ])
+    expect(await driveGetVisibility(mkConnection(), FILE_RESOURCE, TOKEN)).toBe('public')
+  })
+
+  it('returns org when a domain permission matches the connection email', async () => {
+    withGrants([{id: 'p', type: 'domain', role: 'reader', domain: 'bldrs.ai'}])
+    expect(await driveGetVisibility(mkConnection(), FILE_RESOURCE, TOKEN)).toBe('org')
+  })
+
+  it('returns null when domain perm exists but connection has no email', async () => {
+    withGrants([{id: 'p', type: 'domain', role: 'reader', domain: 'bldrs.ai'}])
+    const conn = mkConnection({meta: {}})
+    expect(await driveGetVisibility(conn, FILE_RESOURCE, TOKEN)).toBeNull()
+  })
+
+  it('returns private when domain perm is for a different workspace', async () => {
+    withGrants([{id: 'p', type: 'domain', role: 'reader', domain: 'other.com'}])
+    expect(await driveGetVisibility(mkConnection(), FILE_RESOURCE, TOKEN)).toBe('private')
+  })
+
+  it('returns private when only user/group permissions exist', async () => {
+    withGrants([{id: 'p', type: 'user', role: 'writer', emailAddress: 'a@x.com'}])
+    expect(await driveGetVisibility(mkConnection(), FILE_RESOURCE, TOKEN)).toBe('private')
+  })
+})
+
+
+describe('driveSetVisibility', () => {
+  /** Queue a sequence of fetch responses for driveSetVisibility's list+mutate calls. */
+  function withSequence(...responses: Response[]): void {
+    for (const r of responses) {
+      mockFetch.mockResolvedValueOnce(r)
+    }
+  }
+
+  it('public is a no-op when an anyone permission already exists', async () => {
+    withSequence(jsonResponse(HTTP_OK, {permissions: [{id: 'p', type: 'anyone', role: 'reader'}]}))
+    await driveSetVisibility(mkConnection(), FILE_RESOURCE, 'public', TOKEN)
+    expect(mockFetch).toHaveBeenCalledTimes(1) // list only, no POST
+  })
+
+  it('public adds an anyone reader permission when missing', async () => {
+    withSequence(
+      jsonResponse(HTTP_OK, {permissions: []}),
+      jsonResponse(HTTP_OK, {id: 'p9', type: 'anyone', role: 'reader'}),
+    )
+    await driveSetVisibility(mkConnection(), FILE_RESOURCE, 'public', TOKEN)
+    expect(mockFetch).toHaveBeenCalledTimes(2)
+    const body = JSON.parse((mockFetch.mock.calls[1][1] as RequestInit).body as string)
+    expect(body).toMatchObject({type: 'anyone', role: 'reader'})
+  })
+
+  it('org throws GrantFailedError(domain_unknown) without connection email', async () => {
+    withSequence(jsonResponse(HTTP_OK, {permissions: []}))
+    const conn = mkConnection({meta: {}})
+    await expect(driveSetVisibility(conn, FILE_RESOURCE, 'org', TOKEN)).rejects.toMatchObject({
+      name: 'GrantFailedError', cause: 'domain_unknown',
+    })
+  })
+
+  it('org adds a domain permission for the connection workspace', async () => {
+    withSequence(
+      jsonResponse(HTTP_OK, {permissions: []}),
+      jsonResponse(HTTP_OK, {id: 'p9', type: 'domain', role: 'reader', domain: 'bldrs.ai'}),
+    )
+    await driveSetVisibility(mkConnection(), FILE_RESOURCE, 'org', TOKEN)
+    const body = JSON.parse((mockFetch.mock.calls[1][1] as RequestInit).body as string)
+    expect(body).toMatchObject({type: 'domain', domain: 'bldrs.ai', role: 'reader'})
+  })
+
+  it('private removes anyone and matching-domain grants, preserves user grants', async () => {
+    withSequence(
+      jsonResponse(HTTP_OK, {permissions: [
+        {id: 'p1', type: 'anyone', role: 'reader'},
+        {id: 'p2', type: 'domain', role: 'reader', domain: 'bldrs.ai'},
+        {id: 'p3', type: 'user', role: 'writer', emailAddress: 'a@x.com'},
+      ]}),
+      emptyResponse(HTTP_NO_CONTENT), // delete p1
+      emptyResponse(HTTP_NO_CONTENT), // delete p2
+    )
+    await driveSetVisibility(mkConnection(), FILE_RESOURCE, 'private', TOKEN)
+    expect(mockFetch).toHaveBeenCalledTimes(3)
+    const deletedUrls = mockFetch.mock.calls.slice(1).map(([url]) => url as string)
+    expect(deletedUrls.some((u) => u.includes('/permissions/p1'))).toBe(true)
+    expect(deletedUrls.some((u) => u.includes('/permissions/p2'))).toBe(true)
+    expect(deletedUrls.some((u) => u.includes('/permissions/p3'))).toBe(false)
+  })
+
+  it('private removes all domain grants when own-domain is unknown', async () => {
+    withSequence(
+      jsonResponse(HTTP_OK, {permissions: [
+        {id: 'p1', type: 'domain', role: 'reader', domain: 'other.com'},
+      ]}),
+      emptyResponse(HTTP_NO_CONTENT),
+    )
+    const conn = mkConnection({meta: {}})
+    await driveSetVisibility(conn, FILE_RESOURCE, 'private', TOKEN)
+    expect(mockFetch).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/connections/google-drive/GoogleDriveSharing.test.ts
+++ b/src/connections/google-drive/GoogleDriveSharing.test.ts
@@ -118,6 +118,34 @@ describe('driveListGrants', () => {
     ])
   })
 
+  it('downcasts Shared Drive organizer/fileOrganizer roles to writer', async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse(HTTP_OK, {
+      permissions: [
+        {id: 'p1', type: 'user', role: 'organizer', emailAddress: 'a@x.com'},
+        {id: 'p2', type: 'user', role: 'fileOrganizer', emailAddress: 'b@x.com'},
+      ],
+    }))
+
+    const grants = await driveListGrants(mkConnection(), FOLDER_RESOURCE, TOKEN)
+
+    expect(grants.map((g) => g.role)).toEqual(['writer', 'writer'])
+  })
+
+  it('lowercases domain principalIds for case-robust comparisons', async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse(HTTP_OK, {
+      permissions: [{id: 'p', type: 'domain', role: 'reader', domain: 'BLDRS.AI'}],
+    }))
+
+    const grants = await driveListGrants(mkConnection(), FILE_RESOURCE, TOKEN)
+    expect(grants[0].principalId).toBe('bldrs.ai')
+  })
+
+  it('returns [] when the response omits the permissions field', async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse(HTTP_OK, {}))
+    const grants = await driveListGrants(mkConnection(), FILE_RESOURCE, TOKEN)
+    expect(grants).toEqual([])
+  })
+
   it('targets /files/{id}/permissions with supportsAllDrives', async () => {
     mockFetch.mockResolvedValueOnce(jsonResponse(HTTP_OK, {permissions: []}))
     await driveListGrants(mkConnection(), FILE_RESOURCE, TOKEN)
@@ -186,6 +214,21 @@ describe('driveShareWith', () => {
     expect((init as RequestInit).method).toBe('POST')
     const body = JSON.parse((init as RequestInit).body as string)
     expect(body).toEqual({type: 'user', role: 'reader', emailAddress: 'b@x.com'})
+  })
+
+  it('forwards sendNotificationEmail=false when notify is explicitly false', async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse(HTTP_OK, {
+      id: 'p9b', type: 'user', role: 'reader', emailAddress: 'c@x.com',
+    }))
+    await driveShareWith(
+      mkConnection(),
+      FILE_RESOURCE,
+      {principalType: 'user', principalId: 'c@x.com', role: 'reader', notify: false, message: 'should be dropped'},
+      TOKEN,
+    )
+    const [url] = mockFetch.mock.calls[0]
+    expect(url).toMatch('sendNotificationEmail=false')
+    expect(url).not.toMatch('emailMessage') // message dropped when notify off
   })
 
   it('omits sendNotificationEmail for domain and anyone grants', async () => {
@@ -280,6 +323,23 @@ describe('driveGetVisibility', () => {
     expect(await driveGetVisibility(conn, FILE_RESOURCE, TOKEN)).toBeNull()
   })
 
+  it('returns null when domain perm exists but connection is a personal Google (gmail) account', async () => {
+    // Free-email domain → workspaceDomain returns null → "unknowable" branch.
+    // Without this guard, a personal-Google user calling setVisibility('org')
+    // would attempt to grant `domain: 'gmail.com'` (i.e. share with every
+    // Gmail user worldwide). Tested here on the read side; the write-side
+    // guard is exercised in the driveSetVisibility suite below.
+    withGrants([{id: 'p', type: 'domain', role: 'reader', domain: 'bldrs.ai'}])
+    const conn = mkConnection({meta: {email: 'someone@gmail.com'}})
+    expect(await driveGetVisibility(conn, FILE_RESOURCE, TOKEN)).toBeNull()
+  })
+
+  it('matches domain case-insensitively against connection email', async () => {
+    withGrants([{id: 'p', type: 'domain', role: 'reader', domain: 'bldrs.ai'}])
+    const conn = mkConnection({meta: {email: 'PABLO@BLDRS.AI'}})
+    expect(await driveGetVisibility(conn, FILE_RESOURCE, TOKEN)).toBe('org')
+  })
+
   it('returns private when domain perm is for a different workspace', async () => {
     withGrants([{id: 'p', type: 'domain', role: 'reader', domain: 'other.com'}])
     expect(await driveGetVisibility(mkConnection(), FILE_RESOURCE, TOKEN)).toBe('private')
@@ -325,6 +385,24 @@ describe('driveSetVisibility', () => {
     })
   })
 
+  it('org throws GrantFailedError(domain_unknown) for personal Google (free-email) accounts', async () => {
+    // Security guard: prevents `domain: 'gmail.com'` from being granted,
+    // which would otherwise expose the file to every Gmail user worldwide.
+    withSequence(jsonResponse(HTTP_OK, {permissions: []}))
+    const conn = mkConnection({meta: {email: 'someone@gmail.com'}})
+    await expect(driveSetVisibility(conn, FILE_RESOURCE, 'org', TOKEN)).rejects.toMatchObject({
+      name: 'GrantFailedError', cause: 'domain_unknown',
+    })
+  })
+
+  it('org is a no-op when a matching-domain permission already exists', async () => {
+    withSequence(jsonResponse(HTTP_OK, {permissions: [
+      {id: 'p1', type: 'domain', role: 'reader', domain: 'bldrs.ai'},
+    ]}))
+    await driveSetVisibility(mkConnection(), FILE_RESOURCE, 'org', TOKEN)
+    expect(mockFetch).toHaveBeenCalledTimes(1) // list only, no POST
+  })
+
   it('org adds a domain permission for the connection workspace', async () => {
     withSequence(
       jsonResponse(HTTP_OK, {permissions: []}),
@@ -363,5 +441,38 @@ describe('driveSetVisibility', () => {
     const conn = mkConnection({meta: {}})
     await driveSetVisibility(conn, FILE_RESOURCE, 'private', TOKEN)
     expect(mockFetch).toHaveBeenCalledTimes(2)
+  })
+
+  it('private aggregates a partial revoke failure as GrantFailedError(partial_revoke)', async () => {
+    // Two grants to revoke; the second DELETE fails with a 5xx. The first
+    // already succeeded — caller needs a typed signal that state is
+    // half-applied, not silent success and not a bare HTTP error.
+    withSequence(
+      jsonResponse(HTTP_OK, {permissions: [
+        {id: 'p1', type: 'anyone', role: 'reader'},
+        {id: 'p2', type: 'domain', role: 'reader', domain: 'bldrs.ai'},
+      ]}),
+      emptyResponse(HTTP_NO_CONTENT), // p1 revoke succeeds
+      jsonResponse(HTTP_INTERNAL, 'boom'), // p2 revoke fails
+    )
+    const err = await driveSetVisibility(mkConnection(), FILE_RESOURCE, 'private', TOKEN)
+      .catch((e) => e)
+    expect(err).toMatchObject({name: 'GrantFailedError', cause: 'partial_revoke'})
+    expect((err as Error).message).toMatch('p2')
+  })
+
+  it('private propagates NeedsReconnectError when every revoke fails with 401', async () => {
+    // All-failures-of-the-same-class is a coherent signal — surface it as
+    // the typed error directly so UI routes to Reconnect, not partial_revoke.
+    withSequence(
+      jsonResponse(HTTP_OK, {permissions: [
+        {id: 'p1', type: 'anyone', role: 'reader'},
+        {id: 'p2', type: 'domain', role: 'reader', domain: 'bldrs.ai'},
+      ]}),
+      jsonResponse(HTTP_UNAUTHORIZED, {error: 'invalid_token'}),
+      jsonResponse(HTTP_UNAUTHORIZED, {error: 'invalid_token'}),
+    )
+    await expect(driveSetVisibility(mkConnection(), FILE_RESOURCE, 'private', TOKEN))
+      .rejects.toMatchObject({name: 'NeedsReconnectError'})
   })
 })

--- a/src/connections/google-drive/GoogleDriveSharing.ts
+++ b/src/connections/google-drive/GoogleDriveSharing.ts
@@ -56,11 +56,53 @@ function resourceToFileId(connection: Connection, resource: ResourceRef): string
 
 
 /**
- * Extract a Workspace-style domain from the connection's email metadata.
- * Returns null when the email is missing or shaped wrong, in which case
- * callers should refuse domain-scoped operations rather than guess.
+ * Free-email providers that are NOT a Workspace domain a single user
+ * controls. Granting `domain: 'gmail.com'` on a Drive file would expose it
+ * to every Gmail user worldwide — a footgun rather than an "org share."
  *
- * @return The domain (e.g. `'bldrs.ai'`), or null when unknowable.
+ * Drive itself rejects most of these as domain grants (the domain isn't
+ * verified to the user's account), but we don't want to depend on that
+ * server-side check as our only line of defense. When the connection's
+ * email belongs to one of these, `workspaceDomain` returns null and
+ * `setVisibility('org')` throws `domain_unknown` — the caller (PR2 UI)
+ * should explain that the account isn't part of a Workspace.
+ */
+const FREE_EMAIL_DOMAINS = new Set([
+  'gmail.com',
+  'googlemail.com',
+  'outlook.com',
+  'hotmail.com',
+  'live.com',
+  'msn.com',
+  'yahoo.com',
+  'yahoo.co.uk',
+  'ymail.com',
+  'icloud.com',
+  'me.com',
+  'mac.com',
+  'aol.com',
+  'protonmail.com',
+  'proton.me',
+  'pm.me',
+  'gmx.com',
+  'gmx.net',
+  'fastmail.com',
+  'mail.com',
+  'zoho.com',
+])
+
+
+/**
+ * Extract a Workspace-style domain from the connection's email metadata.
+ * Returns null when the email is missing, shaped wrong, or belongs to a
+ * free-email provider (see `FREE_EMAIL_DOMAINS`); callers should refuse
+ * domain-scoped operations rather than guess.
+ *
+ * The returned domain is lower-cased so equality comparisons against
+ * Drive-returned domains (which Drive normalizes to lowercase) are robust
+ * to user-typed casing in the connection metadata.
+ *
+ * @return The lowercased domain (e.g. `'bldrs.ai'`), or null when unknowable.
  */
 function workspaceDomain(connection: Connection): string | null {
   const email = connection.meta?.email
@@ -71,7 +113,11 @@ function workspaceDomain(connection: Connection): string | null {
   if (at < 0 || at === email.length - 1) {
     return null
   }
-  return email.slice(at + 1)
+  const domain = email.slice(at + 1).toLowerCase()
+  if (FREE_EMAIL_DOMAINS.has(domain)) {
+    return null
+  }
+  return domain
 }
 
 
@@ -129,23 +175,43 @@ async function driveFetch(
 
 
 /**
+ * Drive's role enum is wider than our provider-neutral one: Shared Drive
+ * resources can have `'organizer'` and `'fileOrganizer'` roles. Both grant
+ * write access (organizer also grants membership-management on the Shared
+ * Drive itself), so we downcast both to `'writer'` for cross-provider
+ * neutrality. UI that needs the precise Drive-side role can read it from
+ * a future provider-specific extension; PR1 keeps the union narrow.
+ *
+ * @return Our cross-provider role.
+ */
+function normalizeRole(role: DrivePermission['role']): GrantRequest['role'] {
+  if (role === 'organizer' || role === 'fileOrganizer') {
+    return 'writer'
+  }
+  return role
+}
+
+
+/**
  * Map a Drive `Permission` resource onto our provider-neutral `Grant`.
  *
  * Drive's `type` enum (`user|group|domain|anyone`) lines up with our
- * `principalType` 1:1, and Drive's `role` enum (`reader|commenter|writer|owner`)
- * matches our `role` enum directly. The `principalId` is the email for
- * user/group, the domain for domain, and undefined for anyone.
+ * `principalType` 1:1. The `principalId` is the email for user/group, the
+ * (lower-cased) domain for domain, and undefined for anyone. Roles are
+ * narrowed via `normalizeRole`.
  *
  * @return The grant in provider-neutral shape.
  */
 function permissionToGrant(p: DrivePermission): Grant {
   const principalType = p.type as GrantRequest['principalType']
-  const role = p.role as GrantRequest['role']
+  const role = normalizeRole(p.role)
   let principalId: string | undefined
   if (principalType === 'user' || principalType === 'group') {
     principalId = p.emailAddress
   } else if (principalType === 'domain') {
-    principalId = p.domain
+    // Lowercase to keep equality robust against any case drift between
+    // what Drive returns here and what `workspaceDomain` produces.
+    principalId = p.domain?.toLowerCase()
   }
   return {
     id: p.id,
@@ -378,17 +444,61 @@ export async function driveSetVisibility(
     return
   }
 
-  // 'private': drop link-share and matching-domain grants.
+  // 'private': drop link-share and matching-domain grants. Run in parallel
+  // and aggregate failures so a single bad revoke doesn't leave the caller
+  // blind to the rest of the state.
   const ownDomain = workspaceDomain(connection)
+  const toRevoke: string[] = []
   for (const g of current) {
-    if (g.principalType === 'anyone') {
-      await driveRevokeGrant(connection, resource, g.id, token)
-    } else if (g.principalType === 'domain' && (!ownDomain || g.principalId === ownDomain)) {
-      // Without an own-domain we can't tell which domain grant is "ours";
-      // remove all domain grants on this resource so visibility actually
-      // collapses. This matches Drive's UI behavior on "restrict to specific
-      // people" with no domain anchor.
-      await driveRevokeGrant(connection, resource, g.id, token)
+    const matchesAnyone = g.principalType === 'anyone'
+    // Without an own-domain we can't tell which domain grant is "ours";
+    // remove all domain grants on this resource so visibility actually
+    // collapses. This matches Drive's UI behavior on "restrict to specific
+    // people" with no domain anchor.
+    const matchesDomain = g.principalType === 'domain' &&
+      (!ownDomain || (g.principalId?.toLowerCase() === ownDomain))
+    if (matchesAnyone || matchesDomain) {
+      toRevoke.push(g.id)
     }
   }
+
+  if (toRevoke.length === 0) {
+    return
+  }
+
+  const results = await Promise.allSettled(
+    toRevoke.map((id) => driveRevokeGrant(connection, resource, id, token)),
+  )
+  const failures: Array<{id: string; reason: unknown}> = []
+  for (let i = 0; i < results.length; i += 1) {
+    const r = results[i]
+    if (r.status === 'rejected') {
+      failures.push({id: toRevoke[i], reason: r.reason})
+    }
+  }
+  if (failures.length === 0) {
+    return
+  }
+
+  // If every failure is the same auth-class error, propagate that typed
+  // error directly so callers can route to Reconnect / "you don't have
+  // permission" cleanly. Otherwise wrap as a partial-revoke failure
+  // carrying the surviving ids.
+  const firstReason = failures[0].reason
+  const sameClass = failures.every((f) =>
+    f.reason instanceof Error &&
+    firstReason instanceof Error &&
+    f.reason.constructor === firstReason.constructor)
+  if (sameClass && (
+    firstReason instanceof NeedsReconnectError ||
+    firstReason instanceof InsufficientPermissionError
+  )) {
+    throw firstReason
+  }
+  throw new GrantFailedError(
+    connection,
+    'partial_revoke',
+    `Failed to remove ${failures.length} of ${results.length} grants ` +
+    `(ids: ${failures.map((f) => f.id).join(', ')})`,
+  )
 }

--- a/src/connections/google-drive/GoogleDriveSharing.ts
+++ b/src/connections/google-drive/GoogleDriveSharing.ts
@@ -1,0 +1,394 @@
+/**
+ * Google Drive sharing capability — pure transport for the Drive
+ * Permissions API. The five exported functions (`listGrants`, `shareWith`,
+ * `revokeGrant`, `getVisibility`, `setVisibility`) mirror the optional
+ * sharing methods on `ConnectionProvider`, returning typed errors from
+ * `src/connections/errors.ts` rather than `Response`s.
+ *
+ * Each function takes an explicit access token so it can be unit-tested
+ * without exercising the OAuth machinery in `GoogleDriveProvider`. The
+ * provider object owns token acquisition and merely delegates here.
+ *
+ * Scope: `drive.file` is sufficient. Per-file Picker-acquired scope already
+ * permits both reading and mutating that file's permissions, so no auth
+ * changes are needed for sharing.
+ */
+
+import type {Connection, Grant, GrantRequest, ResourceRef, Visibility} from '../types'
+import {
+  GrantFailedError,
+  InsufficientPermissionError,
+  NeedsReconnectError,
+} from '../errors'
+
+
+const DRIVE_API_BASE = 'https://www.googleapis.com/drive/v3'
+const HTTP_UNAUTHORIZED = 401
+const HTTP_FORBIDDEN = 403
+
+const PERMISSION_FIELDS = 'id,type,role,emailAddress,domain'
+const PERMISSION_LIST_FIELDS = `permissions(${PERMISSION_FIELDS})`
+
+
+/**
+ * Resolve a `ResourceRef` to the Drive fileId used by the Permissions API.
+ * Drive treats files and folders identically here — both are `Files`
+ * resources with a `permissions` collection — so we accept either.
+ *
+ * Throws `GrantFailedError` with cause `wrong_provider` if asked about a
+ * GitHub-shaped resource; this is a programming error, not a runtime one.
+ *
+ * @return The Drive fileId for the resource.
+ */
+function resourceToFileId(connection: Connection, resource: ResourceRef): string {
+  if (resource.kind === 'drive-file') {
+    return resource.fileId
+  }
+  if (resource.kind === 'drive-folder') {
+    return resource.folderId
+  }
+  throw new GrantFailedError(
+    connection,
+    'wrong_provider',
+    `Drive provider cannot operate on resource kind '${resource.kind}'`,
+  )
+}
+
+
+/**
+ * Extract a Workspace-style domain from the connection's email metadata.
+ * Returns null when the email is missing or shaped wrong, in which case
+ * callers should refuse domain-scoped operations rather than guess.
+ *
+ * @return The domain (e.g. `'bldrs.ai'`), or null when unknowable.
+ */
+function workspaceDomain(connection: Connection): string | null {
+  const email = connection.meta?.email
+  if (typeof email !== 'string') {
+    return null
+  }
+  const at = email.lastIndexOf('@')
+  if (at < 0 || at === email.length - 1) {
+    return null
+  }
+  return email.slice(at + 1)
+}
+
+
+/**
+ * Wrap `fetch` with auth header, JSON encoding, and the typed-error
+ * mapping shared by every sharing call. 401 maps to `NeedsReconnectError`
+ * (token was revoked server-side after our cache said it was valid), 403
+ * to `InsufficientPermissionError`, and any other non-2xx to
+ * `GrantFailedError` with a `http_<status>` cause.
+ *
+ * 204 No Content (used by permission DELETE) is normal and not mapped.
+ *
+ * @return The raw `Response` on success.
+ */
+async function driveFetch(
+  connection: Connection,
+  method: 'GET' | 'POST' | 'DELETE',
+  path: string,
+  token: string,
+  body?: unknown,
+): Promise<Response> {
+  const headers: Record<string, string> = {Authorization: `Bearer ${token}`}
+  if (body !== undefined) {
+    headers['Content-Type'] = 'application/json'
+  }
+  const res = await fetch(`${DRIVE_API_BASE}${path}`, {
+    method,
+    headers,
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  })
+  if (res.ok) {
+    return res
+  }
+  const text = await res.text().catch(() => '')
+  if (res.status === HTTP_UNAUTHORIZED) {
+    throw new NeedsReconnectError(
+      connection,
+      'token_invalid',
+      `Drive API ${res.status}: ${text}`,
+    )
+  }
+  if (res.status === HTTP_FORBIDDEN) {
+    throw new InsufficientPermissionError(
+      connection,
+      'forbidden',
+      `Drive API ${res.status}: ${text}`,
+    )
+  }
+  throw new GrantFailedError(
+    connection,
+    `http_${res.status}`,
+    `Drive API ${res.status}: ${text}`,
+  )
+}
+
+
+/**
+ * Map a Drive `Permission` resource onto our provider-neutral `Grant`.
+ *
+ * Drive's `type` enum (`user|group|domain|anyone`) lines up with our
+ * `principalType` 1:1, and Drive's `role` enum (`reader|commenter|writer|owner`)
+ * matches our `role` enum directly. The `principalId` is the email for
+ * user/group, the domain for domain, and undefined for anyone.
+ *
+ * @return The grant in provider-neutral shape.
+ */
+function permissionToGrant(p: DrivePermission): Grant {
+  const principalType = p.type as GrantRequest['principalType']
+  const role = p.role as GrantRequest['role']
+  let principalId: string | undefined
+  if (principalType === 'user' || principalType === 'group') {
+    principalId = p.emailAddress
+  } else if (principalType === 'domain') {
+    principalId = p.domain
+  }
+  return {
+    id: p.id,
+    principalType,
+    principalId,
+    role,
+    origin: 'drive',
+  }
+}
+
+
+interface DrivePermission {
+  id: string
+  type: 'user' | 'group' | 'domain' | 'anyone'
+  role: 'reader' | 'commenter' | 'writer' | 'owner' | 'organizer' | 'fileOrganizer'
+  emailAddress?: string
+  domain?: string
+}
+
+
+/**
+ * List grants on a Drive file or folder.
+ *
+ * Calls `permissions.list` with `supportsAllDrives` set so resources on
+ * Shared Drives are reachable. The `fields` mask narrows the response to
+ * the columns we use; without it the API returns more than we need.
+ *
+ * @return One grant per permission on the resource.
+ */
+export async function driveListGrants(
+  connection: Connection,
+  resource: ResourceRef,
+  token: string,
+): Promise<Grant[]> {
+  const fileId = resourceToFileId(connection, resource)
+  const params = new URLSearchParams({
+    fields: PERMISSION_LIST_FIELDS,
+    supportsAllDrives: 'true',
+  })
+  const res = await driveFetch(
+    connection,
+    'GET',
+    `/files/${encodeURIComponent(fileId)}/permissions?${params}`,
+    token,
+  )
+  const data = await res.json() as {permissions?: DrivePermission[]}
+  return (data.permissions || []).map(permissionToGrant)
+}
+
+
+/**
+ * Add a grant. Maps `GrantRequest` onto Drive's `permissions.create` body,
+ * including the principal-shape mapping (`emailAddress` for user/group,
+ * `domain` for domain, neither for anyone) and notification flags.
+ *
+ * Drive defaults `sendNotificationEmail` to true for user/group grants;
+ * we forward `notify` explicitly so callers control the surface. `message`
+ * is forwarded only when notify is on, matching the API.
+ *
+ * @return The created grant, including the Drive-assigned id.
+ */
+export async function driveShareWith(
+  connection: Connection,
+  resource: ResourceRef,
+  grant: GrantRequest,
+  token: string,
+): Promise<Grant> {
+  const fileId = resourceToFileId(connection, resource)
+
+  const body: Record<string, unknown> = {
+    type: grant.principalType,
+    role: grant.role,
+  }
+  if (grant.principalType === 'user' || grant.principalType === 'group') {
+    if (!grant.principalId) {
+      throw new GrantFailedError(
+        connection,
+        'principal_required',
+        `${grant.principalType} grant requires an email principalId`,
+      )
+    }
+    body.emailAddress = grant.principalId
+  } else if (grant.principalType === 'domain') {
+    if (!grant.principalId) {
+      throw new GrantFailedError(
+        connection,
+        'principal_required',
+        'domain grant requires a domain principalId',
+      )
+    }
+    body.domain = grant.principalId
+  }
+
+  const params = new URLSearchParams({
+    fields: PERMISSION_FIELDS,
+    supportsAllDrives: 'true',
+  })
+  // Drive only honors sendNotificationEmail for user/group grants; the API
+  // rejects the param for domain/anyone. Forward only when meaningful.
+  if (grant.principalType === 'user' || grant.principalType === 'group') {
+    params.set('sendNotificationEmail', String(grant.notify ?? true))
+    if (grant.notify !== false && grant.message) {
+      params.set('emailMessage', grant.message)
+    }
+  }
+
+  const res = await driveFetch(
+    connection,
+    'POST',
+    `/files/${encodeURIComponent(fileId)}/permissions?${params}`,
+    token,
+    body,
+  )
+  const created = await res.json() as DrivePermission
+  return permissionToGrant(created)
+}
+
+
+/** Remove a grant by its Drive permission id. */
+export async function driveRevokeGrant(
+  connection: Connection,
+  resource: ResourceRef,
+  grantId: string,
+  token: string,
+): Promise<void> {
+  const fileId = resourceToFileId(connection, resource)
+  const params = new URLSearchParams({supportsAllDrives: 'true'})
+  await driveFetch(
+    connection,
+    'DELETE',
+    `/files/${encodeURIComponent(fileId)}/permissions/${encodeURIComponent(grantId)}?${params}`,
+    token,
+  )
+}
+
+
+/**
+ * Derive effective visibility from the resource's permission list.
+ *
+ * The Drive API does not expose a single "visibility" field, so we reduce:
+ *   - any `anyone` permission     → `'public'`
+ *   - any `domain` permission     → `'org'` *only when* the domain matches
+ *                                   the acting connection's email domain
+ *   - any `domain` permission but
+ *     domain is unknowable        → `null` (honest answer: can't tell)
+ *   - otherwise                   → `'private'`
+ *
+ * `'public'` wins over `'org'` when both apply: a public-link resource is
+ * effectively public regardless of additional domain grants.
+ *
+ * @return The visibility, or null when not knowable from the API.
+ */
+export async function driveGetVisibility(
+  connection: Connection,
+  resource: ResourceRef,
+  token: string,
+): Promise<Visibility | null> {
+  const grants = await driveListGrants(connection, resource, token)
+  if (grants.some((g) => g.principalType === 'anyone')) {
+    return 'public'
+  }
+  const domainGrants = grants.filter((g) => g.principalType === 'domain')
+  if (domainGrants.length === 0) {
+    return 'private'
+  }
+  const ownDomain = workspaceDomain(connection)
+  if (!ownDomain) {
+    return null
+  }
+  if (domainGrants.some((g) => g.principalId === ownDomain)) {
+    return 'org'
+  }
+  // Domain permission exists but for a different workspace — from this
+  // connection's vantage it's not visible to "my org," so report private.
+  return 'private'
+}
+
+
+/**
+ * Apply a target visibility, idempotently. Reads current state first so a
+ * no-op call (already public, set to public) doesn't create a duplicate
+ * permission. `'private'` removes every `anyone` and matching-domain
+ * grant; user/group grants are deliberately preserved (a "private" resource
+ * can still be shared with named collaborators).
+ *
+ * Throws `GrantFailedError` with cause `domain_unknown` when asked to set
+ * `'org'` but the connection has no email metadata to derive the domain
+ * from. Callers (a future Share dialog) should prompt for the domain in
+ * that case.
+ */
+export async function driveSetVisibility(
+  connection: Connection,
+  resource: ResourceRef,
+  visibility: Visibility,
+  token: string,
+): Promise<void> {
+  const current = await driveListGrants(connection, resource, token)
+
+  if (visibility === 'public') {
+    if (!current.some((g) => g.principalType === 'anyone')) {
+      await driveShareWith(
+        connection,
+        resource,
+        {principalType: 'anyone', role: 'reader', notify: false},
+        token,
+      )
+    }
+    return
+  }
+
+  if (visibility === 'org') {
+    const domain = workspaceDomain(connection)
+    if (!domain) {
+      throw new GrantFailedError(
+        connection,
+        'domain_unknown',
+        'Cannot set org visibility: connection has no email to derive a domain from',
+      )
+    }
+    if (!current.some(
+      (g) => g.principalType === 'domain' && g.principalId === domain,
+    )) {
+      await driveShareWith(
+        connection,
+        resource,
+        {principalType: 'domain', principalId: domain, role: 'reader', notify: false},
+        token,
+      )
+    }
+    return
+  }
+
+  // 'private': drop link-share and matching-domain grants.
+  const ownDomain = workspaceDomain(connection)
+  for (const g of current) {
+    if (g.principalType === 'anyone') {
+      await driveRevokeGrant(connection, resource, g.id, token)
+    } else if (g.principalType === 'domain' && (!ownDomain || g.principalId === ownDomain)) {
+      // Without an own-domain we can't tell which domain grant is "ours";
+      // remove all domain grants on this resource so visibility actually
+      // collapses. This matches Drive's UI behavior on "restrict to specific
+      // people" with no domain anchor.
+      await driveRevokeGrant(connection, resource, g.id, token)
+    }
+  }
+}

--- a/src/connections/types.ts
+++ b/src/connections/types.ts
@@ -115,6 +115,133 @@ export interface ConnectionProvider {
 
   /** Get a valid access token for API calls. May silently refresh if expired. */
   getAccessToken(connection: Connection): Promise<string>
+
+  // -- Sharing capability (optional) --
+  // Implementations should declare any subset they can support and leave the
+  // rest undefined. Callers must check for presence; see
+  // `design/new/multi-user-sharing.md` for the rationale and error vocabulary.
+
+  /**
+   * List existing grants on a resource. Order is provider-defined.
+   *
+   * Throws `InsufficientPermissionError` when the connection lacks the right
+   * to enumerate grants on the resource, `NeedsReconnectError` on stale
+   * tokens, and `GrantFailedError` for any other transport/server failure.
+   */
+  listGrants?(connection: Connection, resource: ResourceRef): Promise<Grant[]>
+
+  /**
+   * Add a grant. The principal shape is provider-specific (email/domain for
+   * Drive, login/team-slug for GitHub); see `GrantRequest` for details.
+   *
+   * @return The created grant, including its provider-assigned id.
+   */
+  shareWith?(
+    connection: Connection,
+    resource: ResourceRef,
+    grant: GrantRequest,
+  ): Promise<Grant>
+
+  /** Remove a grant by its provider-assigned id. */
+  revokeGrant?(
+    connection: Connection,
+    resource: ResourceRef,
+    grantId: string,
+  ): Promise<void>
+
+  /**
+   * Read the resource's effective visibility.
+   *
+   * Returns `null` when the underlying API doesn't expose a single
+   * deterministic answer (e.g. a Drive resource with no public/domain
+   * permissions and no clear "private" indicator). Treat `null` as
+   * "unknown — show no chip" rather than as `'private'`.
+   */
+  getVisibility?(
+    connection: Connection,
+    resource: ResourceRef,
+  ): Promise<Visibility | null>
+
+  /**
+   * Owner-only: change the resource's visibility. Idempotent — calling with
+   * the current visibility is a no-op. Implementations may surface a
+   * confirmation requirement at the UI layer; this method does not prompt.
+   */
+  setVisibility?(
+    connection: Connection,
+    resource: ResourceRef,
+    visibility: Visibility,
+  ): Promise<void>
+}
+
+
+// -- Sharing types --
+
+/**
+ * Effective visibility of a resource. The mapping is provider-specific:
+ *   - Drive: `'public'` = "anyone with the link" permission present;
+ *            `'org'`    = a `domain` permission matches the user's Workspace;
+ *            `'private'` = neither.
+ *   - GitHub: `'public'` = repo not private; `'private'` = repo private;
+ *             `'org'`    = GitHub Enterprise `internal` (only when the
+ *             owner is an org with `internal` available).
+ */
+export type Visibility = 'private' | 'org' | 'public'
+
+
+/**
+ * A resource a grant or visibility operation applies to. Discriminated by
+ * `kind` so each provider can refuse shapes it doesn't own.
+ *
+ * `drive-folder.driveId` is set for items inside a Shared Drive (corpus).
+ * `github-tree.path` is the optional sub-path inside a branch.
+ */
+export type ResourceRef =
+  | {kind: 'drive-file'; fileId: string}
+  | {kind: 'drive-folder'; folderId: string; driveId?: string}
+  | {kind: 'github-repo'; org: string; repo: string}
+  | {kind: 'github-tree'; org: string; repo: string; branch: string; path?: string}
+
+
+/**
+ * Who a grant applies to. The id shape depends on `principalType`:
+ *
+ *   - `'user'`   → email (Drive) or login (GitHub)
+ *   - `'group'`  → group email (Drive) — GitHub uses `'user'` for teams below
+ *   - `'domain'` → workspace domain, e.g. `'bldrs.ai'` (Drive only)
+ *   - `'anyone'` → undefined; toggles link-share (Drive only)
+ *
+ * For GitHub, the team-vs-user distinction is encoded by the role/principal
+ * pair the adapter chooses, not by an extra principal kind.
+ */
+export interface GrantRequest {
+  principalType: 'user' | 'group' | 'domain' | 'anyone'
+  principalId?: string
+  role: 'reader' | 'commenter' | 'writer' | 'owner'
+  /**
+   * Send an email notification when the grant is created. Drive: default
+   * true at the API; GitHub: always true and ignores the flag.
+   */
+  notify?: boolean
+  /**
+   * Custom message included in the notification. Drive only; ignored
+   * elsewhere.
+   */
+  message?: string
+}
+
+
+/**
+ * A grant as returned from the provider. `origin` records which system the
+ * grant lives in: `'bldrs'` is reserved for the future sidecar-grant model
+ * and is unused in PR1.
+ */
+export interface Grant {
+  id: string
+  principalType: GrantRequest['principalType']
+  principalId?: string
+  role: GrantRequest['role']
+  origin: 'drive' | 'github' | 'bldrs'
 }
 
 


### PR DESCRIPTION
Implements PR1 of [`design/new/multi-user-sharing.md`](https://github.com/bldrs-ai/Share/blob/main/design/new/multi-user-sharing.md): the provider-side scaffolding and Drive adapter for in-app sharing. Pure-additive, no UI, behind a `sharing` feature flag (default off).

## What's in PR1

The design splits the sharing work into six sequenced PRs. PR1 is everything you can ship without touching UI:

- **`ConnectionProvider` extension** — five optional methods: `listGrants`, `shareWith`, `revokeGrant`, `getVisibility`, `setVisibility`. Optional so adapters can declare any subset; the GitHub side comes in PR3 once `identity-decoupling.md` lands.
- **Sharing types** — `ResourceRef` (discriminated by provider/kind), `Visibility` (`private | org | public`), `GrantRequest`, `Grant`. Provider-neutral on top, provider-shaped at the principal level.
- **Typed errors** — `GrantFailedError`, `InsufficientPermissionError` join the existing `NeedsReconnectError`. The same vocabulary the PR2 dialog will route to typed `AlertDialog` variants.
- **Drive adapter** (`GoogleDriveSharing.ts`) — pure transport over `drive.permissions.*`, factored out of the provider object the way `GoogleDriveBrowser.ts` is. The provider methods just acquire a token and delegate. `drive.file` scope is sufficient — no auth changes.
- **`sharing` feature flag** — present but off; PR2 gates the Share dialog on it.

## Notable design decisions

- **`getVisibility` returns `null` honestly** when the connection has no email metadata and a domain permission exists — we genuinely can't tell `org` from `private` without a workspace anchor. UI shouldn't render a chip in that case.
- **`setVisibility('org')` without an inferable domain** throws `GrantFailedError(cause: 'domain_unknown')` rather than guessing. PR2 will prompt for a domain.
- **`setVisibility` is idempotent** by reading current state first — calling \"public\" on an already-public resource is a no-op, not a duplicate-grant error.
- **`'public'` wins over `'org'`** in the visibility derivation: a link-shared resource is effectively public regardless of additional domain grants.
- **401 → `NeedsReconnectError`** maps the case where our token cache says \"valid\" but Drive says \"revoked.\" 403 → `InsufficientPermissionError`. Other 4xx/5xx → `GrantFailedError(cause: 'http_<status>')`.
- **`'private'` preserves user/group grants** — \"private\" in Drive means \"no link, no domain\"; named collaborators are not sharing in the visibility sense.

## Tests

25 new unit tests in `GoogleDriveSharing.test.ts`, stubbing `fetch` directly (matching the pattern in `GoogleDriveProvider.test.ts`):

- Permission-list mapping (user/group/domain/anyone shapes, all roles)
- URL targeting (`supportsAllDrives=true`, the right path for files vs folders)
- Cross-provider rejection (`drive*` helpers refuse `github-*` resources with `cause: 'wrong_provider'`)
- Principal-shape validation (user/group rejected without `principalId`)
- All four visibility derivations including the null and \"public-wins\" cases
- Idempotent `setVisibility('public')` and `setVisibility('private')` selectivity
- Error mapping for 401/403/500

All 1035 pre-existing tests still pass.

## Out of scope (explicitly)

- Share dialog UI — PR2.
- GitHub adapter — PR3, blocked on `identity-decoupling.md`.
- Folder-scoped routes — PR4.
- GitHub token-health parity — PR5.
- Comments + versions stretch — multi-quarter follow-on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)