### PR TITLE
docs: lift connection/testing knowledge from session memory into repo

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,8 @@ This file is the router for AI assistants working in this repo. Keep it small. T
 | Asset pipeline, fonts, icons | [src/assets/README.md](src/assets/README.md) |
 | Route schemas, URL parsing | [src/routes/README.md](src/routes/README.md) |
 | Dev HTTPS certificate setup | [tools/esbuild/certificates/README.md](tools/esbuild/certificates/README.md) |
+| Cloud sources, OAuth flows, token storage, Auth0 gate | [src/connections/README.md](src/connections/README.md) |
+| Sharing PR3 (GitHub adapter) carry-over notes | [design/new/sharing-pr3-github.md](design/new/sharing-pr3-github.md) |
 
 Anything not in this table is invisible to the router. When you create a doc that future assistants should consult, add a row above with a one-line "when to read" hint. Don't rely on filesystem discovery.
 

--- a/PLAYBOOK.md
+++ b/PLAYBOOK.md
@@ -105,3 +105,83 @@ When writing test fixtures for route-derived data (e.g. `modelPath`), use the ex
 production code produces — not a "nicer" variant. The routes layer strips leading slashes from
 `filepath` via `splitAroundExtensionRemoveFirstSlash`. A fixture with `filepath: '/model.ifc'`
 accidentally passes tests that would fail with the real `filepath: 'model.ifc'`, masking bugs.
+
+
+## Playwright locally needs `--workers=1`
+
+`tools/playwright.config.js` computes the dev-server port at import time:
+
+```js
+const port = isCI ? ciPort : runGetPortPlease(ciPort)
+```
+
+Each Playwright worker re-imports the config, so each calls
+`runGetPortPlease` independently and lands on a different random port.
+The webServer started on the FIRST port; workers 2-N point at non-listening
+ports → `net::ERR_CONNECTION_REFUSED`. Tests look "broken" when they're not.
+
+- **Local:** `yarn test-flows --workers=1 [spec]`.
+- **CI:** works fine with parallelism — `isCI` short-circuits to fixed
+  port `9081`, all workers point there.
+
+Pre-existing quirk; flag as a separate cleanup if it bothers you.
+
+
+## Drive Picker fails on Brave with Shields up
+
+When testing the Drive Picker on Brave at `bldrs.ai`:
+
+- **Symptom:** clicking Select on a picked file → OS spinny, picker stays
+  open, console shows two 401s from `docs.google.com/pick…` with empty
+  response body.
+- **Root cause:** Brave Shields (default-on) blocks third-party cookies on
+  `docs.google.com` even when the OAuth `access_token` URL parameter is
+  correct. The picker's confirm-pick endpoint needs the docs.google.com
+  session cookie alongside the OAuth token.
+- **Fix to test:** click the 🦁 icon in URL bar on bldrs.ai → Shields
+  **down** → retry. Chrome works without changes because its 3p-cookie
+  default is currently looser than Brave's.
+
+Not to be confused with Brave's popup blocker (separate feature, default-on
+in all major browsers) — that one trips on `requestAccessToken({prompt:''})`
+outside a user gesture and is handled by the GDrive auth pre-flight
+pattern. See [`src/connections/README.md`](src/connections/README.md).
+
+
+## `gh pr edit` silently drops title/body updates
+
+`gh pr edit <num> --title ... --body ...` warns about Projects (classic)
+deprecation and **silently fails the entire mutation** without a non-zero
+exit. The PR title/body don't actually update — verifying with
+`gh pr view` is the only way to catch it.
+
+Root cause: the underlying GraphQL `updatePullRequest` mutation pulls
+`repository.pullRequest.projectCards`, a field GitHub is sunsetting. The
+whole call rejects.
+
+Use the REST API directly:
+
+```bash
+# Title only
+gh api -X PATCH /repos/<owner>/<repo>/pulls/<num> -f title='...'
+
+# Body — large bodies via --input
+jq -Rs '{body: .}' < /tmp/body.md > /tmp/body.json
+gh api -X PATCH /repos/<owner>/<repo>/pulls/<num> --input /tmp/body.json
+```
+
+Verify with `gh pr view <num> --json title,bodyText`. Once GitHub removes
+the classic Projects GraphQL field, regular `gh pr edit` will work again.
+
+
+## Git network operations need generous timeouts
+
+Use `timeout: 120000` (120 s) or higher for any `git push`, `git pull`,
+`git fetch`, or `git clone` invocation. A 30 s timeout can kill the
+process mid-run and return partial/garbage output that **looks like
+success** — e.g. an aborted push has been observed to produce a bogus
+remote URL string that downstream parsers misread as the destination
+remote.
+
+After a push, verify with `git log origin/<branch>` or `git status` rather
+than trusting the push command's output alone.

--- a/design/new/sharing-pr3-github.md
+++ b/design/new/sharing-pr3-github.md
@@ -1,0 +1,43 @@
+# Sharing PR3: GitHub adapter — implementation notes
+
+**Status:** Not started. Unblocked by identity-decoupling PR1 (#1507) and PR2 (#1508), which together stand up `GitHubProvider` as a `ConnectionProvider` peer of Drive. PR3 is the sharing methods on that provider.
+
+Parent design: [`multi-user-sharing.md`](multi-user-sharing.md). This doc records the carry-over context needed to start a clean PR3 session without re-deriving design.
+
+
+## What PR1 (#1505) already provides — reuse, don't redefine
+
+- `ConnectionProvider` exposes the five optional sharing methods (`listGrants`, `shareWith`, `revokeGrant`, `getVisibility`, `setVisibility`) — `src/connections/types.ts`.
+- `GrantFailedError`, `InsufficientPermissionError`, `NeedsReconnectError` — `src/connections/errors.ts`.
+- `ResourceRef` already has `github-repo` and `github-tree` variants.
+- `Visibility`, `GrantRequest`, `Grant` types are provider-neutral and final.
+- The `'wrong_provider'` cause-string convention is established (Drive helpers reject GitHub resources with this; GH helpers should reject Drive resources the same way).
+- Factoring pattern: a separate `*Sharing.ts` transport file plus provider-object delegation, mirroring `GoogleDriveBrowser.ts` / `GoogleDriveSharing.ts`. Do `GitHubSharing.ts` the same way.
+- The 401/403/4xx-5xx → typed-error mapping pattern lives in `driveFetch` (in `GoogleDriveSharing.ts`). Mirror it as a `githubFetch` wrapper.
+- Tests use direct `global.fetch` stubs, not MSW. See `GoogleDriveSharing.test.ts` for the shape.
+
+
+## Where the GitHub adapter genuinely diverges from Drive
+
+- **`getVisibility`** is a single `GET /repos/{owner}/{repo}` reading the `.private` field. It does **not** derive from `listGrants` like Drive's does. Cleaner.
+- **`'anyone'` principal** must be rejected with `GrantFailedError(cause: 'unsupported')`. GitHub has no link-share at the repo level — only repo-public/private.
+- **`setVisibility('public')`** flips repo `private:false` via `PATCH /repos/{owner}/{repo}`. The design requires a strong confirm modal — that lives at the **UI layer in PR2's Share dialog**, not in the adapter. The adapter just performs the call.
+- **`'org'`** maps to GHE `internal`. Surface this option only when the `internal` field is present on the repo (i.e. owner is an org with GHE-internal available). On github.com personal/team plans, this visibility is not selectable.
+
+
+## Endpoints (per parent design doc)
+
+- `listGrants` for `github-repo`:
+  - `GET /repos/{org}/{repo}/collaborators`
+  - `GET /repos/{org}/{repo}/teams`
+- `shareWith` user: `PUT /repos/{org}/{repo}/collaborators/{username}`
+- `shareWith` team: `PUT /orgs/{org}/teams/{team}/repos/{org}/{repo}`
+- `revokeGrant`: matching `DELETE` on the same paths.
+
+
+## Starting a PR3 session
+
+1. Confirm identity-decoupling has landed — look for `src/connections/github/GitHubProvider.ts`. If absent, identity-decoupling is the prerequisite work.
+2. Mirror the `GoogleDriveSharing.ts` file layout. Lift `driveFetch`'s error-mapping pattern into a `githubFetch` wrapper that returns typed connection errors.
+3. Write the sharing methods one at a time with their tests; reuse the `GoogleDriveSharing.test.ts` shape (direct `global.fetch` stubs).
+4. Wire `githubProvider` to delegate the five methods to the new transport file.

--- a/src/connections/README.md
+++ b/src/connections/README.md
@@ -1,0 +1,156 @@
+# Connections architecture
+
+This directory hosts the `ConnectionProvider` abstraction and per-provider
+implementations (`google-drive/`, `github/`). A connection is one
+authenticated session against a cloud source — tokens, identity, listing,
+download, and (eventually) sharing.
+
+Read this when:
+- Touching `GoogleDriveProvider` / `GitHubProvider` or adding a new provider.
+- Wiring a new caller through `provider.getAccessToken` / `listFiles` /
+  `getFileDownload`.
+- Investigating an auth-popup blocked / token-not-refreshing bug.
+- Adding an OAuth flow that lives across an external origin (COOP risk).
+
+Design context for the Auth0 primary-auth gate (PR2) and the original
+identity-decoupling decisions lives in `design/new/identity-decoupling.md`
+and `design/new/identity-decoupling-decisions.md`. This README is the
+hands-on companion: invariants you must preserve when writing code here.
+
+
+## Auth pre-flight: getAccessToken must run inside a user gesture
+
+GIS `requestAccessToken({prompt:''})` and OAuth popups can both escalate
+to a real popup window whenever the cached server-side consent has lapsed
+(consent revoked, refresh-token age limit, or first-ever connect). Popups
+opened outside a user gesture are blocked by every major browser.
+
+Two patterns in the codebase:
+
+1. **User-initiated entry points** (recent-file click, Browse button) —
+   `await provider.getAccessToken(connection)` *inside* the click handler
+   before any other async work, so the popup inherits the click's user
+   activation. See `src/Components/Open/OpenModelDialog.jsx`'s
+   `handleOpenById` and `src/Components/Connections/SourcesTab.jsx`'s
+   `handleBrowse`.
+
+2. **Gestureless entry points** (deep-link, page reload) — `getAccessToken`
+   throws `NeedsReconnectError` (`src/connections/errors.ts`). The handler
+   converts that into
+   `setAlert({type: 'needsReconnect', connection, message})`; the
+   `AlertDialog` renders a **Reconnect** button. That button click is a
+   fresh user gesture, so the subsequent `getAccessToken` can open its
+   popup safely.
+
+There is no "make refresh always silent" option. Cached consent can lapse
+at any time; the popup must run inside a gesture or it gets blocked. Any
+new flow that touches `getAccessToken` from a non-click context must
+either route via a Reconnect overlay or move onto an existing user-gesture
+path. **Don't add new auto-refresh paths hidden behind navigation.**
+
+
+## Drive token storage layout
+
+`src/connections/google-drive/GoogleDriveProvider.ts`:
+
+- `localStorage['bldrs:gdrive-token:<connectionId>']` — `{token, expiresAt}`
+  for the access token. Survives reloads and is **shared across tabs of the
+  same origin** (so opening a permalink in a new tab inherits the existing
+  token; no popup-blocked silent refresh on the cold tab).
+- In-memory `tokenCache: Map<id, CachedToken>` — fast path; falls back to
+  localStorage on miss.
+- `sessionStorage['gdrive_oauth_state']` — per-flow CSRF nonce. Per-tab on
+  purpose; only the originating tab needs to validate it.
+- `sessionStorage['gdrive_token_<id>']` — **legacy**; the pre-localStorage
+  key. `loadTokenFromStorage` migrates it to the new key on first read,
+  then removes it.
+
+`localStorage['bldrs:connections']` holds connection metadata (ids, labels,
+email hints), also shared across tabs. The matching token in
+`bldrs:gdrive-token:<id>` is keyed by the same `connectionId`.
+
+**Invariant:** never read tokens directly from storage in new code — go
+through `provider.getAccessToken(connection)` so the cache → localStorage
+→ silent-refresh chain runs. Direct storage reads bypass the chain and
+will return a stale token after a refresh succeeds in another tab.
+
+
+## GitHub OAuth popup: COOP severs window.opener
+
+When the OAuth popup navigates through a strict-COOP origin
+(notably `github.com` sets `Cross-Origin-Opener-Policy: same-origin`), the
+browser puts the popup into a different browsing context group and
+**permanently** severs `window.opener` — even after the popup returns to a
+same-origin callback page on our origin.
+
+Symptom: the callback HTML's `window.opener.postMessage(...)` silently
+no-ops because `window.opener === null`. Popup closes itself, opener's
+poll detects close, connect rejects with `"GitHub sign-in was cancelled"`
+— with no console error pointing at the cause.
+
+**Fix in this repo:** use `BroadcastChannel` for the popup → opener
+handoff. Same-origin pub/sub keyed by channel name; doesn't rely on the
+`opener` relationship.
+
+Implemented in `public/auth/gh/callback.html` (callback page) and the
+`waitForCallback` helper in `src/connections/github/GitHubProvider.ts`
+(opener listener). The matching unit test ships a `MockBroadcastChannel`
+in `GitHubProvider.test.ts` because jsdom 20.0.3 has spotty BC support.
+
+The flow also debounces the popup-close detection by ~2 s after BC
+delivery so the close-after-success doesn't race the message handler.
+
+Drive's GIS flow doesn't hit this because GIS uses an in-page token client,
+not a full popup-navigation flow. Any future OAuth provider that sets
+strict COOP (Microsoft and Apple Sign-In are both strict; others vary) will
+need the same BC pattern.
+
+
+## GitHub proxies — two services, two purposes
+
+Bldrs fronts GitHub with two separate services. Don't conflate them.
+
+- **`rawgit.bldrs.dev`** — Fly-hosted **content** proxy. Fronts
+  `raw.githubusercontent.com` for fetching raw model bytes (`.ifc`,
+  `.glb`, etc). Referenced via the `RAW_GIT_PROXY_URL` and
+  `RAW_GIT_PROXY_URL_NEW` env vars across the loader and tests.
+
+- **`bldrs-ai/share-oauth-proxy`** — handles **authenticated GitHub API**
+  calls (despite the OAuth-suggestive name). Use this when you need
+  authenticated access — e.g., listing private repos or orgs the
+  logged-in user can see.
+
+**When NOT to use `share-oauth-proxy`:** when you need the
+unauthenticated public-vs-private discrimination from
+`api.github.com/repos/{owner}/{repo}`. Authenticated requests succeed for
+repos the user has access to regardless of public/private, erasing the
+signal. For privacy detection in quota gating, call `api.github.com`
+directly, unauth, and read the 200/404.
+
+
+## Auth0 primary-auth gate (PR2)
+
+Connect actions are gated behind Auth0 `useAuth0().isAuthenticated`. A
+logged-out user sees the **Connect** button rendered disabled with a
+"Sign in to connect" tooltip. The gate exists so Auth0 `sub` can be the
+quota key for `gh-oauth-*` Netlify Functions and so prod can't be
+anonymously hammered.
+
+Escape hatch: Auth0's **Database connection** (plain email/password
+against Auth0's user DB — distinct from Google or GitHub federation).
+A user who refuses social OAuth can still sign up with email.
+
+Server-side enforcement lives in `netlify/functions/_lib/auth0.js`. The
+`verifyAuth0Bearer` helper validates the `Authorization: Bearer` header
+against `/userinfo` on the Auth0 tenant. When `AUTH0_DOMAIN` is unset
+(unconfigured local dev), the helper short-circuits with `sub=null` and
+fires a one-shot `Sentry.captureMessage` so a misconfigured prod deploy
+is visible in ops dashboards.
+
+The React→non-React bridge for the access token lives in
+`auth0Bridge.ts` and `Auth0BridgeRegistrar.jsx`. The Registrar mounts in
+`src/index.jsx` (inside the Auth0Provider tree) and registers a stable
+closure that providers can call from anywhere via `getAuth0AccessToken()`.
+
+Full design rationale: `design/new/identity-decoupling-decisions.md`
+under "PR2 scope" and "Quota implementation".


### PR DESCRIPTION
Cleanup pass moving durable knowledge out of personal AI memory and into tracked repo docs, so contributors (human and AI) get the same look-and-feel as they move through the code.

## What's added

### New: `src/connections/README.md`
Hands-on guide for the connections layer. Sits next to `design/new/identity-decoupling*.md` (design rationale) as the implementation companion — invariants you must preserve when writing code here:

- GIS user-gesture pre-flight; Reconnect overlay for gestureless paths via `NeedsReconnectError`
- Drive token localStorage layout (`bldrs:gdrive-token:<id>`) + cross-tab sharing rationale
- GitHub OAuth: strict-COOP severs `window.opener` → `BroadcastChannel` handoff
- The two GitHub proxies (`rawgit.bldrs.dev` content vs `share-oauth-proxy` auth API) + when to call `api.github.com` direct/unauth
- Auth0 primary-auth gate + bridge (PR2 surface area), with pointers to design docs for rationale

### `PLAYBOOK.md` — four new sections under *Specific Guides*
- Playwright locally needs `--workers=1` (port-per-worker quirk; CI is fine)
- Drive Picker fails on Brave with Shields up (3p cookies on `docs.google.com`)
- `gh pr edit` silently drops title/body updates — use `gh api -X PATCH /repos/.../pulls/<n>` instead
- Git network operations need ≥120 s timeouts (a 30 s timeout has been observed to produce garbage that parses as success)

### New: `design/new/sharing-pr3-github.md`
Carry-over notes for the next identity-decoupling PR (GitHub sharing adapter). Records what PR1 (#1505) already provides for reuse, where the GH adapter genuinely diverges from Drive, the endpoint map, and the suggested first steps. So a future PR3 session doesn't re-derive design.

### `AGENTS.md` (CLAUDE.md symlink)
Two new routing-table rows pointing at the connections README and the PR3 starter doc.

## What's not in here

No code changes. No public-API impact. Pure documentation lift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)