### PR TITLE
Fix Safari load failures: handle leaks, rename race, double load

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bldrs",
-  "version": "1.0.230",
+  "version": "1.0.232",
   "main": "src/index.jsx",
   "license": "AGPL-3.0",
   "homepage": "https://github.com/bldrs-ai/Share",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bldrs",
-  "version": "1.0.234",
+  "version": "1.0.230",
   "main": "src/index.jsx",
   "license": "AGPL-3.0",
   "homepage": "https://github.com/bldrs-ai/Share",

--- a/src/Containers/CadView.jsx
+++ b/src/Containers/CadView.jsx
@@ -1,4 +1,4 @@
-import React, {ReactElement, useEffect, useState} from 'react'
+import React, {ReactElement, useEffect, useRef, useState} from 'react'
 import {useNavigate, useSearchParams, useLocation} from 'react-router-dom'
 import {MeshLambertMaterial} from 'three'
 import {Box} from '@mui/material'
@@ -32,11 +32,6 @@ import {initViewer} from './viewer'
 
 
 let count = 0
-// Tracks the theme-change listener registered by onModelPath() so we
-// can remove it before registering a new one on the next model load.
-// Otherwise each prior listener stays in the registry, capturing its
-// (now-disposed) viewer via closure and pinning it from GC.
-let previousThemeChangeCb = null
 
 /**
  * Only container for the app.  Hosts the IfcViewer as well as nav components.
@@ -81,6 +76,14 @@ export default function CadView({
   // AppSlice
   const isOpfsAvailable = useStore((state) => state.isOpfsAvailable)
   const setAppPrefix = useStore((state) => state.setAppPrefix)
+
+  // Tracks the theme-change listener registered by onModelPath() so we
+  // can remove it before registering a new one on the next model load.
+  // Otherwise each prior listener stays in the registry, capturing its
+  // (now-disposed) viewer via closure and pinning it from GC. A ref
+  // (not module-level state) so two CadView mounts in the same process —
+  // tests, multi-pane layouts — don't stomp each other.
+  const previousThemeChangeCbRef = useRef(null)
 
   // IFCSlice
   const model = useStore((state) => state.model)
@@ -148,10 +151,10 @@ export default function CadView({
     if (isModelReady) {
       resetState()
     }
-    if (previousThemeChangeCb) {
-      theme.removeThemeChangeListener(previousThemeChangeCb)
+    if (previousThemeChangeCbRef.current) {
+      theme.removeThemeChangeListener(previousThemeChangeCbRef.current)
     }
-    previousThemeChangeCb = initViewerCb
+    previousThemeChangeCbRef.current = initViewerCb
     initViewerCb(undefined, theme)
     theme.addThemeChangeListener(initViewerCb)
   }

--- a/src/Containers/CadView.jsx
+++ b/src/Containers/CadView.jsx
@@ -190,6 +190,27 @@ export default function CadView({
       return
     }
 
+    // Past the early returns — we're actually going to load. The in-flight
+    // guard sits HERE (not at the effect-callback level) so two effect ticks
+    // whose onViewer would both return early — e.g. initial mount in
+    // Playwright where viewer is still null at the [auth]-effect's render —
+    // don't accidentally claim the slot and starve the eventual successful
+    // load from the [viewer] effect.
+    if (onViewerInFlightRef.current) {
+      debug().warn('CadView#onViewer: already in flight; skipping duplicate')
+      return
+    }
+    onViewerInFlightRef.current = true
+    try {
+      await onViewerInternal()
+    } finally {
+      onViewerInFlightRef.current = false
+    }
+  }
+
+
+  /** Inner load body — preconditions checked + in-flight flag managed by `onViewer`. */
+  async function onViewerInternal() {
     setIsModelReady(false)
 
     // define mesh colors for selected and preselected element
@@ -705,17 +726,14 @@ export default function CadView({
 
   /* eslint-disable react-hooks/exhaustive-deps */
   useEffect(() => {
-    if (!isViewerLoaded && !onViewerInFlightRef.current) {
+    if (!isViewerLoaded) {
       debug().log('Auth state changed. isAuthLoading:', isAuthLoading,
         'isAuthenticated:', isAuthenticated, 'isAuthResolved:', isAuthResolved)
       if (!isAuthLoading && isOpfsAvailable !== null && (!isAuthenticated || isAuthResolved)) {
-        onViewerInFlightRef.current = true
-        ;(async () => {
-          try {
-            await onViewer()
-          } finally {
-            onViewerInFlightRef.current = false
-          }
+        (async () => {
+          // onViewer's own in-flight guard dedupes when this races the
+          // [viewer]-effect during a mid-load auth resolution.
+          await onViewer()
         })()
       }
     }
@@ -732,18 +750,10 @@ export default function CadView({
 
   // Viewer changes in onModelPath (above)
   useEffect(() => {
-    if (onViewerInFlightRef.current) {
-      // The auth-state effect above already kicked off a load — skip so we
-      // don't run two `onViewer`s end-to-end (the Safari double-load).
-      return
-    }
-    onViewerInFlightRef.current = true
-    ;(async () => {
-      try {
-        await onViewer()
-      } finally {
-        onViewerInFlightRef.current = false
-      }
+    (async () => {
+      // onViewer's own in-flight guard dedupes when this races the
+      // [auth]-state effect during a mid-load auth resolution.
+      await onViewer()
     })()
   }, [viewer])
 

--- a/src/Containers/CadView.jsx
+++ b/src/Containers/CadView.jsx
@@ -85,6 +85,16 @@ export default function CadView({
   // tests, multi-pane layouts — don't stomp each other.
   const previousThemeChangeCbRef = useRef(null)
 
+  // Two useEffects below can each trigger `onViewer()` — the
+  // [viewer]-dep effect fires when `onModelPath` sets a new viewer, and the
+  // [isAuthLoading, …]-dep effect fires (with an `!isViewerLoaded` guard) so
+  // a model whose initial `onViewer` returned early on auth-not-ready
+  // retries once auth settles. If auth settles WHILE the first onViewer is
+  // mid-`loadModel`, `isViewerLoaded` is still false (it's only set at the
+  // end), so both fire end-to-end → double load. This in-flight ref
+  // dedupes overlapping calls; whichever effect tick wins, the other skips.
+  const onViewerInFlightRef = useRef(false)
+
   // IFCSlice
   const model = useStore((state) => state.model)
   const setIsModelLoading = useStore((state) => state.setIsModelLoading)
@@ -695,12 +705,17 @@ export default function CadView({
 
   /* eslint-disable react-hooks/exhaustive-deps */
   useEffect(() => {
-    if (!isViewerLoaded) {
+    if (!isViewerLoaded && !onViewerInFlightRef.current) {
       debug().log('Auth state changed. isAuthLoading:', isAuthLoading,
         'isAuthenticated:', isAuthenticated, 'isAuthResolved:', isAuthResolved)
       if (!isAuthLoading && isOpfsAvailable !== null && (!isAuthenticated || isAuthResolved)) {
-        (async () => {
-          await onViewer()
+        onViewerInFlightRef.current = true
+        ;(async () => {
+          try {
+            await onViewer()
+          } finally {
+            onViewerInFlightRef.current = false
+          }
         })()
       }
     }
@@ -717,8 +732,18 @@ export default function CadView({
 
   // Viewer changes in onModelPath (above)
   useEffect(() => {
-    (async () => {
-      await onViewer()
+    if (onViewerInFlightRef.current) {
+      // The auth-state effect above already kicked off a load — skip so we
+      // don't run two `onViewer`s end-to-end (the Safari double-load).
+      return
+    }
+    onViewerInFlightRef.current = true
+    ;(async () => {
+      try {
+        await onViewer()
+      } finally {
+        onViewerInFlightRef.current = false
+      }
     })()
   }, [viewer])
 

--- a/src/Containers/CadView.test.jsx
+++ b/src/Containers/CadView.test.jsx
@@ -156,6 +156,67 @@ describe('CadView', () => {
   })
 
 
+  // Regression: two useEffects in CadView can each kick off `onViewer()` —
+  // the [viewer]-dep effect (after `onModelPath` calls `setViewer`) and the
+  // [isAuthLoading, …]-dep effect (retries when auth resolves after an
+  // earlier early-return). Pre-fix, `isViewerLoaded` was only set at the
+  // END of `onViewer`, so an auth-resolve mid-`loadModel` left
+  // `isViewerLoaded` false and both effects ran end-to-end — the Safari
+  // double-load (1.5–2s apart). The in-flight ref dedupes overlapping
+  // calls; this test exercises the case where auth resolves WHILE the
+  // first load is mid-flight and asserts `downloadToOPFS` only fires once.
+  it('does not double-load when auth resolves mid-load (Safari race)', async () => {
+    // The bug pre-fix: two useEffects in CadView could each kick off
+    // `onViewer()` — the [viewer]-dep one after `setViewer`, and the
+    // [isAuthLoading, …]-dep one when auth settled. The second's
+    // `!isViewerLoaded` guard was insufficient because `isViewerLoaded`
+    // is only flipped AT THE END of `onViewer`; if auth resolved while
+    // the first load was still inside `loadModel`, both ran end-to-end.
+    //
+    // To exercise the race in jsdom (where everything finishes too fast
+    // for the natural flow to trip it), we hold the OPFS download mid-
+    // flight with a manual deferred Promise, flip the auth flag during
+    // that pause, then release the load and count the `downloadToOPFS`
+    // calls. Pre-fix this counts 2; with the in-flight ref it counts 1.
+    const OPFSUtils = jest.requireMock('../OPFS/utils')
+    OPFSUtils.downloadToOPFS.mockClear()
+    const originalImpl = OPFSUtils.downloadToOPFS.getMockImplementation()
+    let releaseLoad
+    const loadInFlight = new Promise((resolve) => {
+      releaseLoad = resolve
+    })
+    OPFSUtils.downloadToOPFS.mockImplementation(async (...args) => {
+      await loadInFlight
+      return originalImpl(...args)
+    })
+
+    const {result} = renderHook(() => useStore((state) => state))
+    await act(() => result.current.setIsOpfsAvailable(true))
+    await act(() => result.current.setModelPath({filepath: `/index.ifc`}))
+
+    render(<ShareMock><CadView installPrefix='' appPrefix='' pathPrefix=''/></ShareMock>)
+    await actAsyncFlush()
+
+    // First onViewer is now suspended inside downloadToOPFS, waiting on
+    // `loadInFlight`. Flip auth — pre-fix this fires the auth-effect's
+    // onViewer, which races the suspended one.
+    await act(() => {
+      result.current.setIsAuthResolved(true)
+    })
+    await actAsyncFlush()
+
+    // Release the suspended load. Now both pre-fix flows would proceed.
+    releaseLoad()
+    await waitFor(() => screen.getByTestId(aboutControlTestId))
+    await actAsyncFlush()
+
+    // Restore the mock for any subsequent tests.
+    OPFSUtils.downloadToOPFS.mockImplementation(originalImpl)
+
+    expect(OPFSUtils.downloadToOPFS).toHaveBeenCalledTimes(1)
+  })
+
+
   // Regression: the React effect `[selectedElements, selectedInstanceIds]`
   // dispatches `viewer.setInstanceSelection` whenever `selectedInstanceIds`
   // is non-empty. Pre-`ids.length > 0` guard, a stale `selectedInstanceIds`

--- a/src/OPFS/OPFS.worker.js
+++ b/src/OPFS/OPFS.worker.js
@@ -365,6 +365,52 @@ export async function computeGitBlobSha1FromFile(file) {
 
 
 /**
+ * Open a `FileSystemSyncAccessHandle`, with one self-healing retry if Safari
+ * refuses the first attempt with `InvalidStateError`.
+ *
+ * Safari's OPFS implementation can hold an internal handle reference to a
+ * file even across worker terminations / `clearOPFSCache()` calls, so a
+ * brand-new `createSyncAccessHandle()` against a file path the browser still
+ * thinks is "open" raises `InvalidStateError: The object is in an invalid
+ * state.` Removing the file (which forces Safari to drop the stale ref) and
+ * re-creating it usually clears the condition.
+ *
+ * @param {FileSystemDirectoryHandle} parentDirectory
+ * @param {FileSystemFileHandle} fileHandle - Pre-created file handle. Used
+ *   for the first attempt. If we have to recreate, `parentDirectory` +
+ *   `fileName` are how we get a fresh handle back.
+ * @param {string} fileName - Name to recreate the file under on retry.
+ * @return {Promise<{handle: FileSystemSyncAccessHandle, fileHandle: FileSystemFileHandle}>}
+ *   Updated `fileHandle` (different object if we recreated) and the open
+ *   sync access handle. Caller MUST close the access handle.
+ */
+async function openSyncAccessHandleWithRetry(parentDirectory, fileHandle, fileName) {
+  try {
+    const handle = await fileHandle.createSyncAccessHandle()
+    return {handle, fileHandle}
+  } catch (firstErr) {
+    const isInvalidState = firstErr && (
+      firstErr.name === 'InvalidStateError' ||
+      /invalid state/i.test(firstErr.message || ''))
+    if (!isInvalidState) {
+      throw firstErr
+    }
+    // Best-effort: drop Safari's stale internal reference by removing the
+    // entry, then recreate the file and try the handle once more.
+    try {
+      await parentDirectory.removeEntry(fileName)
+    } catch (_) {/* file may already be gone — that's fine */}
+    const freshHandle = await parentDirectory.getFileHandle(fileName, {create: true})
+    // If THIS throws too, we're out of options — let it propagate. The
+    // resilience fix in `Loader.js` will catch it and fall back to direct
+    // fetch so the user still gets their model.
+    const handle = await freshHandle.createSyncAccessHandle()
+    return {handle, fileHandle: freshHandle}
+  }
+}
+
+
+/**
  * Write temporary file to OPFS (Origin Private File System)
  *
  * @param {Response} response - The response from the request.
@@ -399,11 +445,15 @@ export async function writeTemporaryFileToOPFS(response, originalFilePath, _etag
 
   try {
     [modelDirectoryHandle, modelBlobFileHandle] = await writeFileToPath(opfsRoot, originalFilePath, _etag, null)
-    // Create FileSystemSyncAccessHandle on the file.
-    blobAccessHandle = await modelBlobFileHandle.createSyncAccessHandle()
+    // `openSyncAccessHandleWithRetry` handles Safari's stale-internal-ref
+    // case — InvalidStateError on a fresh file, even after clearOPFSCache().
+    // If the retry also fails, the throw propagates; the resilience fix in
+    // Loader.js catches it and falls back to direct fetch.
+    const opened = await openSyncAccessHandleWithRetry(
+      modelDirectoryHandle, modelBlobFileHandle, modelBlobFileHandle.name)
+    blobAccessHandle = opened.handle
+    modelBlobFileHandle = opened.fileHandle
   } catch (error) {
-    // If create succeeded but the handle didn't, close defensively so a
-    // retry isn't blocked by Safari's InvalidStateError on the leaked handle.
     if (blobAccessHandle) {
       try {
         await blobAccessHandle.close()
@@ -982,10 +1032,12 @@ export async function downloadModelToOPFS(objectUrl, commitHash, originalFilePat
     }
   }
   try {
-    // eslint-disable-next-line no-unused-vars
     [modelDirectoryHandle, modelBlobFileHandle] = await retrieveFileWithPath(branchFolderHandle, originalFilePath, commitHash, true)
-    // Create FileSystemSyncAccessHandle on the file.
-    blobAccessHandle = await modelBlobFileHandle.createSyncAccessHandle()
+    // Same Safari self-heal as in writeTemporaryFileToOPFS.
+    const opened = await openSyncAccessHandleWithRetry(
+      modelDirectoryHandle, modelBlobFileHandle, modelBlobFileHandle.name)
+    blobAccessHandle = opened.handle
+    modelBlobFileHandle = opened.fileHandle
   } catch (error) {
     if (blobAccessHandle) {
       try {

--- a/src/OPFS/OPFS.worker.js
+++ b/src/OPFS/OPFS.worker.js
@@ -384,10 +384,12 @@ export async function writeTemporaryFileToOPFS(response, originalFilePath, _etag
     [modelDirectoryHandle, modelBlobFileHandle] = await
     retrieveFileWithPathNew(opfsRoot, originalFilePath, _etag, null, false)
 
-    if (modelBlobFileHandle !== undefined) {
-      const blobFile = await modelBlobFileHandle.getFile()
-
-      self.postMessage({completed: true, event: 'download', file: blobFile})
+    if (modelBlobFileHandle !== undefined && modelBlobFileHandle !== null) {
+      // Caller is responsible for posting the terminal completed event after
+      // any rename/move. Posting an intermediate `download` event here would
+      // hand the caller a File reference that Safari invalidates as soon as
+      // the caller renames the underlying OPFS entry (WebKitBlobResource
+      // error 1 on the subsequent `arrayBuffer()`).
       return [modelDirectoryHandle, modelBlobFileHandle]
     }
   } catch (error) {
@@ -400,12 +402,22 @@ export async function writeTemporaryFileToOPFS(response, originalFilePath, _etag
     // Create FileSystemSyncAccessHandle on the file.
     blobAccessHandle = await modelBlobFileHandle.createSyncAccessHandle()
   } catch (error) {
+    // If create succeeded but the handle didn't, close defensively so a
+    // retry isn't blocked by Safari's InvalidStateError on the leaked handle.
+    if (blobAccessHandle) {
+      try {
+        await blobAccessHandle.close()
+      } catch (_) {/* idempotent */}
+    }
     const workerMessage = `Error getting file handle for ${originalFilePath}: ${error}`
     self.postMessage({error: workerMessage})
     return
   }
 
   if (!response.body) {
+    try {
+      await blobAccessHandle.close()
+    } catch (_) {/* idempotent */}
     throw new Error('ReadableStream not supported in this browser.')
   }
 
@@ -433,8 +445,6 @@ export async function writeTemporaryFileToOPFS(response, originalFilePath, _etag
         }
       } catch (error) {
         const workerMessage = `Error writing to ${response.headers.etag}: ${error}.`
-        // Close the access handle when done
-        await blobAccessHandle.close()
         self.postMessage({error: workerMessage})
         return
       }
@@ -452,24 +462,22 @@ export async function writeTemporaryFileToOPFS(response, originalFilePath, _etag
     }
 
     if (isDone) {
-      // close blob handle
-      await blobAccessHandle.close()
-      // if done, the file should be written. Signal the worker has completed.
-      try {
-        const blobFile = await modelBlobFileHandle.getFile()
-
-        self.postMessage({completed: true, event: 'download', file: blobFile})
-
-        return [modelDirectoryHandle, modelBlobFileHandle]
-      } catch (error) {
-        const workerMessage = `Error Getting file handle: ${error}.`
-        self.postMessage({error: workerMessage})
-        return
-      }
+      // Caller posts the terminal completed event after rename; see above.
+      return [modelDirectoryHandle, modelBlobFileHandle]
     }
   } catch (error) {
     reader.cancel()
     self.postMessage({error: error})
+  } finally {
+    // Always close the sync access handle. Leaking it leaves the OPFS file
+    // in a state Safari refuses subsequent createSyncAccessHandle() calls
+    // on (`InvalidStateError: The object is in an invalid state.`), which
+    // we were observing on the Sculpture model after any prior failed load.
+    if (blobAccessHandle) {
+      try {
+        await blobAccessHandle.close()
+      } catch (_) {/* idempotent */}
+    }
   }
 }
 
@@ -493,9 +501,8 @@ export async function writeTemporaryBase64BlobFileToOPFS(blob, originalFilePath,
     [modelDirectoryHandle, modelBlobFileHandle] = await retrieveFileWithPathNew(opfsRoot, originalFilePath, _etag, null, false)
 
     if (modelBlobFileHandle !== null) {
-      const blobFile = await modelBlobFileHandle.getFile()
-
-      self.postMessage({completed: true, event: 'download', file: blobFile})
+      // Caller posts the terminal completed event after rename; see the
+      // sibling note in writeTemporaryFileToOPFS for the Safari rationale.
       return [modelDirectoryHandle, modelBlobFileHandle]
     }
   } catch (error) {
@@ -511,18 +518,17 @@ export async function writeTemporaryBase64BlobFileToOPFS(blob, originalFilePath,
     const arrayBuffer = await blob.arrayBuffer()
     await blobAccessHandle.write(arrayBuffer, {at: 0})
 
-    const blobFile = await modelBlobFileHandle.getFile()
-
-    self.postMessage({completed: true, event: 'download', file: blobFile})
-
     return [modelDirectoryHandle, modelBlobFileHandle]
   } catch (error) {
     const workerMessage = `Error writing file handle for ${originalFilePath}: ${error}`
-    // Close the access handle when done
-    if (blobAccessHandle) {
-      await blobAccessHandle.close()
-    }
     self.postMessage({error: workerMessage})
+  } finally {
+    // Always close — see note in writeTemporaryFileToOPFS.
+    if (blobAccessHandle) {
+      try {
+        await blobAccessHandle.close()
+      } catch (_) {/* idempotent */}
+    }
   }
 }
 
@@ -579,6 +585,87 @@ export function base64ToBlob(base64, mimeType = 'application/octet-stream') {
 
 
 /**
+ * Fetch the latest commit hash, rename the OPFS entry to its final
+ * `<segment>.<shaHash>.<commitHash>` name, refresh the cache, and post a
+ * single terminal completed event with the post-rename File.
+ *
+ * Centralizes the "rename, then hand the caller a stable File" sequence
+ * that fixes Safari's WebKitBlobResource error 1: posting the pre-rename
+ * File and renaming afterwards invalidates that File's blob backing in
+ * WebKit, so `arrayBuffer()` on the caller side fails. Doing the rename
+ * before postMessage avoids the race entirely.
+ *
+ * If the commit-hash fetch or rename fails (e.g. offline, GitHub down,
+ * Safari rename glitch), we still post a `download` event with the
+ * original handle so the load completes — the user just doesn't get
+ * commit-pinning on this load.
+ *
+ * @param {FileSystemDirectoryHandle} modelDirectoryHandle
+ * @param {FileSystemFileHandle} modelBlobFileHandle Pre-rename handle.
+ * @param {string} originalFilePath
+ * @param {string} shaHash
+ * @param {string} cacheKey
+ * @param {string} owner
+ * @param {string} repo
+ * @param {string} branch
+ * @param {string} accessToken
+ * @param {number|null} fallbackLastModified Last-modified from cache, used
+ *   when rename succeeds but commit-date didn't come back (legacy cache rows).
+ */
+async function postFinalDownloadEventAfterRename(
+  modelDirectoryHandle,
+  modelBlobFileHandle,
+  originalFilePath,
+  shaHash,
+  cacheKey,
+  owner,
+  repo,
+  branch,
+  accessToken,
+  fallbackLastModified) {
+  let finalFileHandle = modelBlobFileHandle
+  let renamed = false
+  let lastModifiedGithub = fallbackLastModified
+
+  try {
+    const commitResult = await fetchLatestCommitHash(
+      ghApiBase(accessToken), owner, repo, originalFilePath, accessToken, branch)
+    const _commitHash = commitResult && commitResult.hash
+    const _commitDate = commitResult && commitResult.date
+
+    if (_commitHash !== null && _commitHash !== undefined) {
+      const pathSegments = safePathSplit(originalFilePath)
+      const lastSegment = pathSegments[pathSegments.length - 1]
+      const newFileName = `${lastSegment}.${shaHash}.${_commitHash}`
+      const newResult = await renameFileInOPFS(modelDirectoryHandle, modelBlobFileHandle, newFileName)
+
+      if (newResult !== null) {
+        const mockResponse = generateMockResponse(shaHash)
+        await CacheModule.updateCacheRaw(cacheKey, mockResponse, _commitHash, _commitDate)
+        finalFileHandle = newResult
+        renamed = true
+        if (_commitDate !== undefined && _commitDate !== null) {
+          lastModifiedGithub = _commitDate
+        }
+      }
+    }
+  } catch (_) {
+    // Fall through: post the un-renamed file. Don't fail the load over a
+    // GitHub commits-API hiccup or a Safari OPFS rename glitch — the user
+    // can still view the model, they just won't get commit-pinning.
+  }
+
+  const finalFile = await finalFileHandle.getFile()
+  self.postMessage({
+    completed: true,
+    event: renamed ? 'renamed' : 'download',
+    file: finalFile,
+    lastModifiedGithub: lastModifiedGithub,
+  })
+}
+
+
+/**
  * Write base64 model to OPFS (Origin Private File System)
  *
  * @param {string} content - The content to write to the file.
@@ -631,32 +718,22 @@ export async function writeBase64Model(content, shaHash, originalFilePath, owner
       }
 
       if (modelBlobFileHandle !== null ) {
-        // Display model
-        const blobFile = await modelBlobFileHandle.getFile()
-
-        self.postMessage({completed: true, event: (commitHash === null ) ? 'download' : 'exists', file: blobFile})
-
         if (commitHash !== null) {
+          // Commit hash already known — file in OPFS is at its final name.
+          // Single terminal event.
+          const blobFile = await modelBlobFileHandle.getFile()
+          self.postMessage({completed: true, event: 'exists', file: blobFile})
           return
         }
-        // get commit hash
-        const _commitHash = await fetchLatestCommitHash(ghApiBase(accessToken), owner, repo, originalFilePath, accessToken, branch)
 
-        if (_commitHash !== null) {
-          const pathSegments = safePathSplit(originalFilePath)
-          const lastSegment = pathSegments[pathSegments.length - 1]
-          const newFileName = `${lastSegment}.${shaHash}.${_commitHash}`
-          const newResult = await renameFileInOPFS(modelDirectoryHandle, modelBlobFileHandle, newFileName)
-
-          if (newResult !== null) {
-            const mockResponse = generateMockResponse(shaHash)
-            // Update cache with new data
-            await CacheModule.updateCacheRaw(cacheKey, mockResponse, _commitHash)
-            const updatedBlobFile = await newResult.getFile()
-
-            self.postMessage({completed: true, event: 'renamed', file: updatedBlobFile})
-          }
-        }
+        // No commit hash — we'll fetch one and rename. Defer posting the
+        // terminal event until AFTER the rename so the File reference handed
+        // to the caller is the post-rename one (Safari invalidates the
+        // pre-rename File's blob backing → WebKitBlobResource error 1).
+        await postFinalDownloadEventAfterRename(
+          modelDirectoryHandle, modelBlobFileHandle,
+          originalFilePath, shaHash, cacheKey,
+          owner, repo, branch, accessToken, null /* lastModifiedGithub */)
       } else {
         // we don't have it stored and need to decode the base64 blob to file and write to OPFS
         const blob = base64ToBlob(content)
@@ -668,24 +745,13 @@ export async function writeBase64Model(content, shaHash, originalFilePath, owner
 
           await CacheModule.updateCacheRaw(cacheKey, mockResponse, null)
 
-          // get commit hash
-          const _commitHash = await fetchLatestCommitHash(ghApiBase(accessToken), owner, repo, originalFilePath, accessToken, branch)
-
-          if (_commitHash !== null) {
-            const pathSegments = safePathSplit(originalFilePath)
-            const lastSegment = pathSegments[pathSegments.length - 1]
-            const newFileName = `${lastSegment}.${shaHash}.${_commitHash}`
-            const newResult = await renameFileInOPFS(modelDirectoryHandle, modelBlobFileHandle, newFileName)
-
-            if (newResult !== null) {
-              // Update cache with new data
-              const clonedResponse = generateMockResponse(shaHash)
-              await CacheModule.updateCacheRaw(cacheKey, clonedResponse, _commitHash)
-              const updatedBlobFile = await newResult.getFile()
-
-              self.postMessage({completed: true, event: 'renamed', file: updatedBlobFile})
-            }
-          }
+          // Caller (us) now posts the terminal event after rename. The
+          // helper falls back to a `download` event with the original file
+          // if commit-hash fetch or rename fails.
+          await postFinalDownloadEventAfterRename(
+            modelDirectoryHandle, modelBlobFileHandle,
+            originalFilePath, shaHash, cacheKey,
+            owner, repo, branch, accessToken, null /* lastModifiedGithub */)
         }
       }
     } catch (error) {
@@ -757,33 +823,20 @@ export async function downloadModel(objectUrl, shaHash, originalFilePath, owner,
       }
 
       if (modelBlobFileHandle !== null ) {
-        // Display model
-        const blobFile = await modelBlobFileHandle.getFile()
-
-        self.postMessage({completed: true, event: (commitHash === null ) ? 'download' : 'exists', file: blobFile, lastModifiedGithub})
-
         if (commitHash !== null) {
+          // Commit hash already known — file in OPFS is at its final name,
+          // single terminal event.
+          const blobFile = await modelBlobFileHandle.getFile()
+          self.postMessage({completed: true, event: 'exists', file: blobFile, lastModifiedGithub})
           return
         }
-        // get commit hash
-        const {hash: _commitHash, date: _commitDate} =
-          await fetchLatestCommitHash(ghApiBase(accessToken), owner, repo, originalFilePath, accessToken, branch)
 
-        if (_commitHash !== null) {
-          const pathSegments = safePathSplit(originalFilePath)
-          const lastSegment = pathSegments[pathSegments.length - 1]
-          const newFileName = `${lastSegment}.${shaHash}.${_commitHash}`
-          const newResult = await renameFileInOPFS(modelDirectoryHandle, modelBlobFileHandle, newFileName)
-
-          if (newResult !== null) {
-            const mockResponse = generateMockResponse(shaHash)
-            // Update cache with new data
-            await CacheModule.updateCacheRaw(cacheKey, mockResponse, _commitHash, _commitDate)
-            const updatedBlobFile = await newResult.getFile()
-
-            self.postMessage({completed: true, event: 'renamed', file: updatedBlobFile, lastModifiedGithub: _commitDate})
-          }
-        }
+        // No commit hash yet — fetch and rename BEFORE posting the file.
+        // See postFinalDownloadEventAfterRename for the Safari rationale.
+        await postFinalDownloadEventAfterRename(
+          modelDirectoryHandle, modelBlobFileHandle,
+          originalFilePath, shaHash, cacheKey,
+          owner, repo, branch, accessToken, lastModifiedGithub)
       } else {
         // we don't have it and need to fetch
         const result = await fetchRGHUC(objectUrl)
@@ -791,33 +844,25 @@ export async function downloadModel(objectUrl, shaHash, originalFilePath, owner,
         if (result !== null) {
           [modelDirectoryHandle, modelBlobFileHandle] = await writeTemporaryFileToOPFS(result, cacheKey, shaHash, onProgress)
 
-          const mockResponse = generateMockResponse(shaHash)
+          if (modelBlobFileHandle) {
+            const mockResponse = generateMockResponse(shaHash)
+            await CacheModule.updateCacheRaw(cacheKey, mockResponse, null)
 
-          await CacheModule.updateCacheRaw(cacheKey, mockResponse, null)
-
-          // get commit hash
-          const {hash: _commitHash, date: _commitDate} =
-          await fetchLatestCommitHash(ghApiBase(accessToken), owner, repo, originalFilePath, accessToken, branch)
-
-          if (_commitHash !== null) {
-            const pathSegments = safePathSplit(originalFilePath)
-            const lastSegment = pathSegments[pathSegments.length - 1]
-            const newFileName = `${lastSegment}.${shaHash}.${_commitHash}`
-            const newResult = await renameFileInOPFS(modelDirectoryHandle, modelBlobFileHandle, newFileName)
-
-            if (newResult !== null) {
-              // Update cache with new data
-              const clonedResponse = generateMockResponse(shaHash)
-              await CacheModule.updateCacheRaw(cacheKey, clonedResponse, _commitHash, _commitDate)
-              const updatedBlobFile = await newResult.getFile()
-
-              self.postMessage({completed: true, event: 'renamed', file: updatedBlobFile, lastModifiedGithub: _commitDate})
-              return
-            }
+            await postFinalDownloadEventAfterRename(
+              modelDirectoryHandle, modelBlobFileHandle,
+              originalFilePath, shaHash, cacheKey,
+              owner, repo, branch, accessToken, lastModifiedGithub)
           }
         }
       }
     } catch (error) {
+      // Don't leave the listener hanging — surface the error so the caller's
+      // promise rejects instead of waiting forever for a terminal event.
+      // (Pre-fix this swallowed silently, which was fine when there was no
+      // single-terminal-event contract; with the new contract, the listener
+      // relies on either a `completed` or an `error` message.)
+      const workerMessage = `Error in downloadModel for ${cacheKey}: ${error}`
+      self.postMessage({error: workerMessage})
       return
     }
 
@@ -942,6 +987,11 @@ export async function downloadModelToOPFS(objectUrl, commitHash, originalFilePat
     // Create FileSystemSyncAccessHandle on the file.
     blobAccessHandle = await modelBlobFileHandle.createSyncAccessHandle()
   } catch (error) {
+    if (blobAccessHandle) {
+      try {
+        await blobAccessHandle.close()
+      } catch (_) {/* idempotent */}
+    }
     const workerMessage = `Error getting file handle for ${originalFilePath}: ${error}`
     self.postMessage({error: workerMessage})
     return
@@ -950,6 +1000,9 @@ export async function downloadModelToOPFS(objectUrl, commitHash, originalFilePat
   const response = await fetch(objectUrl)
 
   if (!response.body) {
+    try {
+      await blobAccessHandle.close()
+    } catch (_) {/* idempotent */}
     throw new Error('ReadableStream not supported in this browser.')
   }
 
@@ -977,8 +1030,6 @@ export async function downloadModelToOPFS(objectUrl, commitHash, originalFilePat
         }
       } catch (error) {
         const workerMessage = `Error writing to ${commitHash}: ${error}.`
-        // Close the access handle when done
-        await blobAccessHandle.close()
         self.postMessage({error: workerMessage})
         return
       }
@@ -1000,8 +1051,12 @@ export async function downloadModelToOPFS(objectUrl, commitHash, originalFilePat
     }
 
     if (isDone) {
-      // close blob handle
-      await blobAccessHandle.close()
+      // Close before getFile() so Safari isn't holding a write lock when we
+      // hand the File back. (Idempotent — the finally block is the safety net
+      // for the error paths above; this is the happy-path close.)
+      try {
+        await blobAccessHandle.close()
+      } catch (_) {/* idempotent */}
       // if done, the file should be written. Write the metadata and signal the worker has completed.
       try {
         const blobFile = await modelBlobFileHandle.getFile()
@@ -1016,6 +1071,14 @@ export async function downloadModelToOPFS(objectUrl, commitHash, originalFilePat
   } catch (error) {
     reader.cancel()
     self.postMessage({error: error})
+  } finally {
+    // Always close the sync access handle. See writeTemporaryFileToOPFS for
+    // the rationale (Safari InvalidStateError on subsequent loads if leaked).
+    if (blobAccessHandle) {
+      try {
+        await blobAccessHandle.close()
+      } catch (_) {/* idempotent */}
+    }
   }
 }
 
@@ -1241,6 +1304,16 @@ export async function writeModelToOPFSFromFile(modelFile, objectKey, originalFil
   } catch (error) {
     const workerMessage = `Error getting file handle for ${originalFilePath}: ${error}`
     self.postMessage({error: workerMessage})
+  } finally {
+    // writeFileToHandle closes the handle on success, but bails without
+    // closing if its own try fails — and there's no close at all if create
+    // succeeded but writeFileToHandle never ran (an await above threw).
+    // Defensive close so Safari doesn't refuse later loads of the same path.
+    if (blobAccessHandle) {
+      try {
+        await blobAccessHandle.close()
+      } catch (_) {/* idempotent */}
+    }
   }
 }
 
@@ -1574,20 +1647,26 @@ export async function writeModelToOPFS(objectUrl, objectKey) {
 
     const fileArrayBuffer = await fileBuffer.arrayBuffer()
 
+    let blobAccessHandle = null
     try {
       // Create FileSystemSyncAccessHandle on the file.
-      const blobAccessHandle = await modelBlobFileHandle.createSyncAccessHandle()
+      blobAccessHandle = await modelBlobFileHandle.createSyncAccessHandle()
 
       // Write buffer at the beginning of the file
       await blobAccessHandle.write(fileArrayBuffer, {at: 0})
-      // Close the access handle when done
-      await blobAccessHandle.close()
 
       self.postMessage({completed: true, event: 'write', fileName: objectKey})
     } catch (error) {
       const workerMessage = `Error writing to ${objectKey}: ${error}.`
       self.postMessage({error: workerMessage})
       return
+    } finally {
+      // See writeTemporaryFileToOPFS for the Safari rationale.
+      if (blobAccessHandle) {
+        try {
+          await blobAccessHandle.close()
+        } catch (_) {/* idempotent */}
+      }
     }
   } catch (error) {
     const workerMessage = `Error writing object URL to file: ${error}`
@@ -1664,14 +1743,13 @@ export async function writeFileToOPFS(objectUrl, fileName) {
 
     const fileArrayBuffer = await fileBuffer.arrayBuffer()
 
+    let accessHandle = null
     try {
       // Create FileSystemSyncAccessHandle on the file.
-      const accessHandle = await newFileHandle.createSyncAccessHandle()
+      accessHandle = await newFileHandle.createSyncAccessHandle()
 
       // Write buffer at the beginning of the file
       const writeSize = await accessHandle.write(fileArrayBuffer, {at: 0})
-      // Close the access handle when done
-      await accessHandle.close()
 
       if (writeSize > 0) {
         self.postMessage({completed: true, event: 'write', fileName: fileName})
@@ -1683,6 +1761,13 @@ export async function writeFileToOPFS(objectUrl, fileName) {
       const workerMessage = `Error writing to ${fileName}: ${error}.`
       self.postMessage({error: workerMessage})
       return
+    } finally {
+      // See writeTemporaryFileToOPFS for the Safari rationale.
+      if (accessHandle) {
+        try {
+          await accessHandle.close()
+        } catch (_) {/* idempotent */}
+      }
     }
   } catch (error) {
     const workerMessage = `Error writing object URL to file: ${error}`

--- a/src/OPFS/OPFS.worker.js
+++ b/src/OPFS/OPFS.worker.js
@@ -612,7 +612,7 @@ export function base64ToBlob(base64, mimeType = 'application/octet-stream') {
  * @param {number|null} fallbackLastModified Last-modified from cache, used
  *   when rename succeeds but commit-date didn't come back (legacy cache rows).
  */
-async function postFinalDownloadEventAfterRename(
+export async function postFinalDownloadEventAfterRename(
   modelDirectoryHandle,
   modelBlobFileHandle,
   originalFilePath,

--- a/src/OPFS/OPFS.worker.test.js
+++ b/src/OPFS/OPFS.worker.test.js
@@ -531,3 +531,110 @@ test('fetchLatestCommitHash throws when no commits returned', async () => {
     worker.fetchLatestCommitHash('https://api.github.com', 'owner', 'repo', 'model.ifc', '', 'main'),
   ).rejects.toThrow('No commits found')
 })
+
+
+// ------------------------------------------------------------
+// postFinalDownloadEventAfterRename tests
+//
+// Helper underlies the Safari rename-race fix: rename the OPFS entry BEFORE
+// posting the File so the caller's `.arrayBuffer()` doesn't fault on an
+// invalidated blob backing. Three paths to cover: rename success, commits-
+// API failure (fallback to original handle), and rename failure (same
+// fallback, different cause).
+// ------------------------------------------------------------
+
+test('postFinalDownloadEventAfterRename posts `renamed` with the post-rename file on success', async () => {
+  const ISO_DATE = '2022-09-22T10:30:27Z'
+  const EPOCH_MS = new Date(ISO_DATE).getTime()
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: true,
+    json: jest.fn().mockResolvedValue([{sha: 'commit123', commit: {author: {date: ISO_DATE}}}]),
+  })
+
+  const fileHandle = await rootDir.getFileHandle('model.ifc.sha1.temporary', {create: true})
+  fileHandle.data = new Uint8Array(Buffer.from('hello'))
+
+  await worker.postFinalDownloadEventAfterRename(
+    rootDir, fileHandle,
+    'model.ifc', 'sha1', 'cacheKey',
+    'owner', 'repo', 'main', '', null,
+  )
+
+  // The point of the helper: hand back the POST-rename File, with the commit
+  // date attached. Pre-fix we posted the pre-rename File which Safari then
+  // invalidated on the rename.
+  expect(self.postMessage).toHaveBeenCalledTimes(1)
+  const msg = self.postMessage.mock.calls[0][0]
+  expect(msg.completed).toBe(true)
+  expect(msg.event).toBe('renamed')
+  expect(msg.file).toBeInstanceOf(File)
+  expect(msg.file.name).toBe('model.ifc.sha1.commit123')
+  expect(msg.lastModifiedGithub).toBe(EPOCH_MS)
+})
+
+test('postFinalDownloadEventAfterRename falls back to `download` with the original file when commits API fails', async () => {
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: false,
+    statusText: 'Forbidden',
+    json: jest.fn().mockResolvedValue([]),
+  })
+
+  const fileHandle = await rootDir.getFileHandle('model.ifc.sha1.temporary', {create: true})
+  fileHandle.data = new Uint8Array(Buffer.from('hello'))
+  const FALLBACK_MS = 1234567890000
+
+  await worker.postFinalDownloadEventAfterRename(
+    rootDir, fileHandle,
+    'model.ifc', 'sha1', 'cacheKey',
+    'owner', 'repo', 'main', '', FALLBACK_MS,
+  )
+
+  // We resolve with the un-renamed file so the load completes; user just
+  // doesn't get commit-pinning on this load. The lastModified falls back to
+  // whatever the cache gave us (callers pass it from the cache headers).
+  expect(self.postMessage).toHaveBeenCalledTimes(1)
+  const msg = self.postMessage.mock.calls[0][0]
+  expect(msg.completed).toBe(true)
+  expect(msg.event).toBe('download')
+  expect(msg.file).toBeInstanceOf(File)
+  expect(msg.file.name).toBe('model.ifc.sha1.temporary')
+  expect(msg.lastModifiedGithub).toBe(FALLBACK_MS)
+})
+
+test('postFinalDownloadEventAfterRename falls back to `download` when rename throws', async () => {
+  const ISO_DATE = '2022-09-22T10:30:27Z'
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: true,
+    json: jest.fn().mockResolvedValue([{sha: 'commit123', commit: {author: {date: ISO_DATE}}}]),
+  })
+
+  const fileHandle = await rootDir.getFileHandle('model.ifc.sha1.temporary', {create: true})
+  fileHandle.data = new Uint8Array(Buffer.from('hello'))
+  // Force the rename path to throw — `renameFileInOPFS` prefers `move()` when
+  // available; an unconditional throw exercises the helper's outer catch.
+  // eslint-disable-next-line require-await
+  fileHandle.move = jest.fn(async () => {
+    throw new Error('move blew up')
+  })
+  // Block the stream-copy fallback too, so `renameFileInOPFS` raises.
+  // eslint-disable-next-line require-await
+  rootDir.getFileHandle = jest.fn(async (name, opts) => {
+    if (name === 'model.ifc.sha1.commit123' && opts && opts.create === true) {
+      throw new Error('cannot create destination')
+    }
+    throw new Error('not found')
+  })
+
+  await worker.postFinalDownloadEventAfterRename(
+    rootDir, fileHandle,
+    'model.ifc', 'sha1', 'cacheKey',
+    'owner', 'repo', 'main', '', null,
+  )
+
+  expect(self.postMessage).toHaveBeenCalledTimes(1)
+  const msg = self.postMessage.mock.calls[0][0]
+  expect(msg.event).toBe('download')
+  // Fallback File comes from the ORIGINAL handle, not the (failed) rename.
+  expect(msg.file).toBeInstanceOf(File)
+  expect(msg.file.name).toBe('model.ifc.sha1.temporary')
+})

--- a/src/OPFS/utils.js
+++ b/src/OPFS/utils.js
@@ -184,59 +184,82 @@ export function writeBase64Model(
   branch,
   setOpfsFile) {
   assertDefined(content, shaHash, originalFilePath, accessToken, owner, repo, branch, setOpfsFile)
+  return awaitTerminalWorkerEvent(
+    () => opfsWriteBase64Model(content, shaHash, originalFilePath, owner, repo, branch, accessToken),
+    {setOpfsFile})
+}
+
+
+/**
+ * Subscribe to the OPFS worker's single-terminal-event protocol and return a
+ * Promise that resolves with the final File (or rejects on `{error}`).
+ *
+ * The worker emits exactly one terminal `completed` event per request —
+ * `exists`, `renamed`, or `download` (the last is the commit-hash / rename
+ * fallback path; we still resolve with the un-renamed File so the load
+ * completes). Progress events (`progressEvent: true`) are forwarded to
+ * `onProgress` and don't terminate the listener.
+ *
+ * Extracted from the duplicate listeners in `downloadModel` /
+ * `writeBase64Model` so the protocol contract lives in one place.
+ *
+ * @param {Function} kickoff Invokes the corresponding `opfsService` entry
+ *   point. Called after the listener is wired up so we don't miss the
+ *   first message.
+ * @param {object} hooks
+ * @param {Function} hooks.setOpfsFile Called with the resolved File.
+ * @param {Function} [hooks.onProgress] Called on each progress update.
+ * @param {Function} [hooks.onLastModifiedGithub] Called once with the commit
+ *   epoch ms if the terminal event carries it.
+ * @return {Promise<File>}
+ */
+function awaitTerminalWorkerEvent(kickoff, {setOpfsFile, onProgress, onLastModifiedGithub}) {
   return new Promise((resolve, reject) => {
     const workerRef = initializeWorker()
-    if (workerRef !== null) {
-      // See the listener in downloadModel below for the protocol details —
-      // same single-terminal-event flow, same legacy-tolerance.
-      let downloadSeen = false
-      let waitingForTerminal = false
-      let pendingDownloadEvent = null
-      const finishWith = (event) => {
-        workerRef.removeEventListener('message', listener)
-        const file = event.data.file
-        if (file instanceof File) {
-          setOpfsFile(file)
-        } else if (typeof Blob !== 'undefined' && file instanceof Blob) {
-          setOpfsFile(file)
-        } else {
-          debug().error('Retrieved object is not of type File.')
-        }
-        resolve(file)
-      }
-      const listener = (event) => {
-        if (event.data.error) {
-          debug().error('Error from worker:', event.data.error)
-          workerRef.removeEventListener('message', listener)
-          reject(new Error(event.data.error))
-        } else if (event.data.completed) {
-          if (event.data.event === 'download' && !downloadSeen) {
-            downloadSeen = true
-            waitingForTerminal = true
-            pendingDownloadEvent = event
-            debug().warn('Worker finished downloading file')
-            Promise.resolve().then(() => {
-              if (waitingForTerminal && pendingDownloadEvent) {
-                waitingForTerminal = false
-                finishWith(pendingDownloadEvent)
-                pendingDownloadEvent = null
-              }
-            })
-            return
-          }
-          if (event.data.event === 'exists') {
-            debug().warn('Commit exists in OPFS.')
-          }
-          waitingForTerminal = false
-          pendingDownloadEvent = null
-          finishWith(event)
-        }
-      }
-      workerRef.addEventListener('message', listener)
-    } else {
+    if (workerRef === null) {
       reject(new Error('Worker initialization failed'))
+      return
     }
-    opfsWriteBase64Model(content, shaHash, originalFilePath, owner, repo, branch, accessToken)
+    const listener = (event) => {
+      if (event.data.error) {
+        debug().error('Error from worker:', event.data.error)
+        workerRef.removeEventListener('message', listener)
+        reject(new Error(event.data.error))
+        return
+      }
+      if (event.data.progressEvent) {
+        if (onProgress) {
+          onProgress({
+            lengthComputable: event.data.contentLength !== 0,
+            contentLength: event.data.contentLength,
+            receivedLength: event.data.receivedLength,
+          })
+        }
+        return
+      }
+      if (!event.data.completed) {
+        return
+      }
+      // Terminal event. Log the variant for diagnostics, then resolve.
+      if (event.data.event === 'download') {
+        debug().warn('Worker finished downloading file')
+      } else if (event.data.event === 'exists') {
+        debug().warn('Commit exists in OPFS.')
+      }
+      if (event.data.lastModifiedGithub && onLastModifiedGithub) {
+        onLastModifiedGithub(event.data.lastModifiedGithub)
+      }
+      workerRef.removeEventListener('message', listener)
+      const file = event.data.file
+      if (file instanceof File) {
+        setOpfsFile(file)
+      } else {
+        debug().error('Retrieved object is not of type File.')
+      }
+      resolve(file)
+    }
+    workerRef.addEventListener('message', listener)
+    kickoff()
   })
 }
 
@@ -267,85 +290,9 @@ export function downloadModel(
   onProgress,
   onLastModifiedGithub = null) {
   assertDefined(objectUrl, shaHash, originalFilePath, accessToken, owner, repo, branch, setOpfsFile, onProgress)
-  return new Promise((resolve, reject) => {
-    const workerRef = initializeWorker()
-    if (workerRef !== null) {
-      // Listener for messages from the worker.
-      //
-      // The worker now emits exactly one terminal completed event per call
-      // (`exists`, `renamed`, or — when the post-download commit-hash fetch
-      // or rename failed and we fell back to the un-renamed handle —
-      // `download`). The legacy two-event sequence (`download` followed by
-      // `renamed`) is still tolerated for tests and any classic-worker
-      // callers: we treat the first `download` as intermediate and wait for
-      // a follow-up terminal event, but if no follow-up arrives in the
-      // next microtask we accept the `download` AS terminal so the load
-      // never hangs.
-      let downloadSeen = false
-      let waitingForTerminal = false
-      let pendingDownloadEvent = null
-      const finishWith = (event) => {
-        workerRef.removeEventListener('message', listener)
-        const file = event.data.file
-        if (file instanceof File) {
-          setOpfsFile(file)
-        } else if (typeof Blob !== 'undefined' && file instanceof Blob) {
-          // In jest tests File ≡ Blob — accept the Blob path.
-          setOpfsFile(file)
-        } else {
-          debug().error('Retrieved object is not of type File.')
-        }
-        resolve(file)
-      }
-      const listener = (event) => {
-        if (event.data.error) {
-          debug().error('Error from worker:', event.data.error)
-          workerRef.removeEventListener('message', listener)
-          reject(new Error(event.data.error))
-        } else if (event.data.progressEvent) {
-          if (onProgress) {
-            onProgress({
-              lengthComputable: event.data.contentLength !== 0,
-              contentLength: event.data.contentLength,
-              receivedLength: event.data.receivedLength,
-            })
-          }
-        } else if (event.data.completed) {
-          if (event.data.lastModifiedGithub && onLastModifiedGithub) {
-            onLastModifiedGithub(event.data.lastModifiedGithub)
-          }
-          if (event.data.event === 'download' && !downloadSeen) {
-            // Legacy two-event flow: hold this event in case it's
-            // intermediate. If a follow-up `renamed`/`exists` doesn't arrive
-            // in the next microtask, treat the `download` AS terminal so the
-            // load doesn't hang (commit-hash-fallback path).
-            downloadSeen = true
-            waitingForTerminal = true
-            pendingDownloadEvent = event
-            debug().warn('Worker finished downloading file')
-            Promise.resolve().then(() => {
-              if (waitingForTerminal && pendingDownloadEvent) {
-                waitingForTerminal = false
-                finishWith(pendingDownloadEvent)
-                pendingDownloadEvent = null
-              }
-            })
-            return
-          }
-          if (event.data.event === 'exists') {
-            debug().warn('Commit exists in OPFS.')
-          }
-          waitingForTerminal = false
-          pendingDownloadEvent = null
-          finishWith(event)
-        }
-      }
-      workerRef.addEventListener('message', listener)
-    } else {
-      reject(new Error('Worker initialization failed'))
-    }
-    opfsDownloadModel(objectUrl, shaHash, originalFilePath, owner, repo, branch, accessToken, !!(onProgress))
-  })
+  return awaitTerminalWorkerEvent(
+    () => opfsDownloadModel(objectUrl, shaHash, originalFilePath, owner, repo, branch, accessToken, !!(onProgress)),
+    {setOpfsFile, onProgress, onLastModifiedGithub})
 }
 
 /**

--- a/src/OPFS/utils.js
+++ b/src/OPFS/utils.js
@@ -187,28 +187,49 @@ export function writeBase64Model(
   return new Promise((resolve, reject) => {
     const workerRef = initializeWorker()
     if (workerRef !== null) {
-      // Listener for messages from the worker
+      // See the listener in downloadModel below for the protocol details —
+      // same single-terminal-event flow, same legacy-tolerance.
+      let downloadSeen = false
+      let waitingForTerminal = false
+      let pendingDownloadEvent = null
+      const finishWith = (event) => {
+        workerRef.removeEventListener('message', listener)
+        const file = event.data.file
+        if (file instanceof File) {
+          setOpfsFile(file)
+        } else if (typeof Blob !== 'undefined' && file instanceof Blob) {
+          setOpfsFile(file)
+        } else {
+          debug().error('Retrieved object is not of type File.')
+        }
+        resolve(file)
+      }
       const listener = (event) => {
         if (event.data.error) {
           debug().error('Error from worker:', event.data.error)
-          workerRef.removeEventListener('message', listener) // Remove the event listener
+          workerRef.removeEventListener('message', listener)
           reject(new Error(event.data.error))
         } else if (event.data.completed) {
-          if (event.data.event === 'download') {
+          if (event.data.event === 'download' && !downloadSeen) {
+            downloadSeen = true
+            waitingForTerminal = true
+            pendingDownloadEvent = event
             debug().warn('Worker finished downloading file')
-          } else if (event.data.event === 'exists') {
+            Promise.resolve().then(() => {
+              if (waitingForTerminal && pendingDownloadEvent) {
+                waitingForTerminal = false
+                finishWith(pendingDownloadEvent)
+                pendingDownloadEvent = null
+              }
+            })
+            return
+          }
+          if (event.data.event === 'exists') {
             debug().warn('Commit exists in OPFS.')
           }
-          const file = event.data.file
-          if (event.data.event === 'renamed' || event.data.event === 'exists') {
-            workerRef.removeEventListener('message', listener) // Remove the event listener
-            if (file instanceof File) {
-              setOpfsFile(file)
-            } else {
-              debug().error('Retrieved object is not of type File.')
-            }
-          }
-          resolve(file) // Resolve the promise with the file
+          waitingForTerminal = false
+          pendingDownloadEvent = null
+          finishWith(event)
         }
       }
       workerRef.addEventListener('message', listener)
@@ -249,11 +270,37 @@ export function downloadModel(
   return new Promise((resolve, reject) => {
     const workerRef = initializeWorker()
     if (workerRef !== null) {
-      // Listener for messages from the worker
+      // Listener for messages from the worker.
+      //
+      // The worker now emits exactly one terminal completed event per call
+      // (`exists`, `renamed`, or — when the post-download commit-hash fetch
+      // or rename failed and we fell back to the un-renamed handle —
+      // `download`). The legacy two-event sequence (`download` followed by
+      // `renamed`) is still tolerated for tests and any classic-worker
+      // callers: we treat the first `download` as intermediate and wait for
+      // a follow-up terminal event, but if no follow-up arrives in the
+      // next microtask we accept the `download` AS terminal so the load
+      // never hangs.
+      let downloadSeen = false
+      let waitingForTerminal = false
+      let pendingDownloadEvent = null
+      const finishWith = (event) => {
+        workerRef.removeEventListener('message', listener)
+        const file = event.data.file
+        if (file instanceof File) {
+          setOpfsFile(file)
+        } else if (typeof Blob !== 'undefined' && file instanceof Blob) {
+          // In jest tests File ≡ Blob — accept the Blob path.
+          setOpfsFile(file)
+        } else {
+          debug().error('Retrieved object is not of type File.')
+        }
+        resolve(file)
+      }
       const listener = (event) => {
         if (event.data.error) {
           debug().error('Error from worker:', event.data.error)
-          workerRef.removeEventListener('message', listener) // Remove the event listener
+          workerRef.removeEventListener('message', listener)
           reject(new Error(event.data.error))
         } else if (event.data.progressEvent) {
           if (onProgress) {
@@ -261,27 +308,36 @@ export function downloadModel(
               lengthComputable: event.data.contentLength !== 0,
               contentLength: event.data.contentLength,
               receivedLength: event.data.receivedLength,
-            }) // Custom progress event
+            })
           }
         } else if (event.data.completed) {
-          if (event.data.event === 'download') {
-            debug().warn('Worker finished downloading file')
-          } else if (event.data.event === 'exists') {
-            debug().warn('Commit exists in OPFS.')
-          }
           if (event.data.lastModifiedGithub && onLastModifiedGithub) {
             onLastModifiedGithub(event.data.lastModifiedGithub)
           }
-          const file = event.data.file
-          if (event.data.event === 'renamed' || event.data.event === 'exists') {
-            workerRef.removeEventListener('message', listener) // Remove the event listener
-            if (file instanceof File) {
-              setOpfsFile(file)
-            } else {
-              debug().error('Retrieved object is not of type File.')
-            }
+          if (event.data.event === 'download' && !downloadSeen) {
+            // Legacy two-event flow: hold this event in case it's
+            // intermediate. If a follow-up `renamed`/`exists` doesn't arrive
+            // in the next microtask, treat the `download` AS terminal so the
+            // load doesn't hang (commit-hash-fallback path).
+            downloadSeen = true
+            waitingForTerminal = true
+            pendingDownloadEvent = event
+            debug().warn('Worker finished downloading file')
+            Promise.resolve().then(() => {
+              if (waitingForTerminal && pendingDownloadEvent) {
+                waitingForTerminal = false
+                finishWith(pendingDownloadEvent)
+                pendingDownloadEvent = null
+              }
+            })
+            return
           }
-          resolve(file) // Resolve the promise with the file
+          if (event.data.event === 'exists') {
+            debug().warn('Commit exists in OPFS.')
+          }
+          waitingForTerminal = false
+          pendingDownloadEvent = null
+          finishWith(event)
         }
       }
       workerRef.addEventListener('message', listener)

--- a/src/OPFS/utils.test.js
+++ b/src/OPFS/utils.test.js
@@ -159,7 +159,7 @@ describe('OPFS Test Suite', () => {
 
   describe('downloadModel', () => {
     it('should resolve with file when download completes', async () => {
-      const mockFile = new Blob(['dummy content'], {type: 'application/octet-stream'})
+      const mockFile = new File(['dummy content'], 'model.ifc', {type: 'application/octet-stream'})
       const mockWorker = {
         addEventListener: jest.fn((_, handler) => {
           process.nextTick(() => {
@@ -201,12 +201,14 @@ describe('OPFS Test Suite', () => {
     })
 
     it('should call onProgress with progress data', async () => {
+      // The worker now emits exactly one terminal completed event per call
+      // (`renamed`, `exists`, or — fallback — `download`). Progress events
+      // arrive before that as `progressEvent: true` messages.
       const mockWorker = {
         addEventListener: jest.fn((_, handler) => {
           process.nextTick(() => {
-            handler({data: {progressEvent: true, contentLength: 100, receivedLength: 50}}) // Simulate a progress update
-            handler({data: {completed: true, event: 'download', file: new Blob(['content'])}}) // Then download
-            handler({data: {completed: true, event: 'renamed', file: new Blob(['content'])}}) // Then complete
+            handler({data: {progressEvent: true, contentLength: 100, receivedLength: 50}})
+            handler({data: {completed: true, event: 'renamed', file: new File(['content'], 'model.ifc')}})
           })
         }),
         removeEventListener: jest.fn(),
@@ -236,7 +238,7 @@ describe('OPFS Test Suite', () => {
 
     it('calls onLastModifiedGithub when exists event carries the date', async () => {
       const EPOCH_MS = 1663842627000
-      const mockFile = new Blob(['content'], {type: 'application/octet-stream'})
+      const mockFile = new File(['content'], 'model.ifc', {type: 'application/octet-stream'})
       const mockWorker = {
         addEventListener: jest.fn((_, handler) => {
           process.nextTick(() => {
@@ -256,13 +258,15 @@ describe('OPFS Test Suite', () => {
       expect(onLastModifiedGithub).toHaveBeenCalledWith(EPOCH_MS)
     })
 
-    it('calls onLastModifiedGithub from deferred renamed event', async () => {
+    it('calls onLastModifiedGithub from a single renamed event', async () => {
+      // Replaces the old `download` + `renamed` two-event test. The worker's
+      // new contract is a single terminal event; if rename succeeded the
+      // commit date rides on the `renamed` message directly.
       const EPOCH_MS = 1663842627000
-      const mockFile = new Blob(['content'], {type: 'application/octet-stream'})
+      const mockFile = new File(['content'], 'model.ifc', {type: 'application/octet-stream'})
       const mockWorker = {
         addEventListener: jest.fn((_, handler) => {
           process.nextTick(() => {
-            handler({data: {completed: true, event: 'download', file: mockFile}})
             handler({data: {completed: true, event: 'renamed', file: mockFile, lastModifiedGithub: EPOCH_MS}})
           })
         }),
@@ -277,10 +281,37 @@ describe('OPFS Test Suite', () => {
       )
 
       expect(onLastModifiedGithub).toHaveBeenCalledWith(EPOCH_MS)
+      expect(onLastModifiedGithub).toHaveBeenCalledTimes(1)
+    })
+
+    it('resolves with the file even when only a download event arrives (commit-hash fallback)', async () => {
+      // Fallback path: commits API or rename failed, worker posted `download`
+      // as the terminal event with the un-renamed handle. Promise should
+      // resolve normally so the load doesn't hang.
+      const mockFile = new File(['content'], 'model.ifc', {type: 'application/octet-stream'})
+      const mockWorker = {
+        addEventListener: jest.fn((_, handler) => {
+          process.nextTick(() => {
+            handler({data: {completed: true, event: 'download', file: mockFile}})
+          })
+        }),
+        removeEventListener: jest.fn(),
+      }
+      OPFSService.initializeWorker.mockReturnValue(mockWorker)
+
+      const setOPFSFile = jest.fn()
+      const result = await downloadModel(
+        'objectUrl', 'shaHash', 'originalFilePath', 'accessToken',
+        'owner', 'repo', 'branch', setOPFSFile, jest.fn(),
+      )
+
+      expect(result).toBe(mockFile)
+      expect(setOPFSFile).toHaveBeenCalledWith(mockFile)
+      expect(mockWorker.removeEventListener).toHaveBeenCalledTimes(1)
     })
 
     it('does not call onLastModifiedGithub when no date in message', async () => {
-      const mockFile = new Blob(['content'], {type: 'application/octet-stream'})
+      const mockFile = new File(['content'], 'model.ifc', {type: 'application/octet-stream'})
       const mockWorker = {
         addEventListener: jest.fn((_, handler) => {
           process.nextTick(() => {

--- a/src/connections/loadFromSource.js
+++ b/src/connections/loadFromSource.js
@@ -97,6 +97,7 @@ async function writeAndOpen(download, fallbackName, provider, connection, onLoad
     const blobUrl = URL.createObjectURL(blob)
     const dotParts = filename.split('.')
     if (dotParts.length <= 1) {
+      URL.revokeObjectURL(blobUrl)
       throw new Error('Cannot extract filetype from filename')
     }
     const ext = dotParts[dotParts.length - 1]
@@ -108,10 +109,15 @@ async function writeAndOpen(download, fallbackName, provider, connection, onLoad
           if (event.data.error) {
             debug().error('loadFromSource: OPFS write error:', event.data.error)
             workerRef.removeEventListener('message', listener)
+            // Revoke once the worker is done with the URL. Without this,
+            // each load leaked a blob backing — Safari surfaces those as
+            // `WebKitBlobResource error 1` lines on every fresh load.
+            URL.revokeObjectURL(blobUrl)
             reject(new Error(event.data.error))
           } else if (event.data.completed && event.data.event === 'write') {
             debug().log('loadFromSource: OPFS write complete')
             workerRef.removeEventListener('message', listener)
+            URL.revokeObjectURL(blobUrl)
             onLoad(event.data.fileName)
             resolve()
           }
@@ -123,6 +129,7 @@ async function writeAndOpen(download, fallbackName, provider, connection, onLoad
         opfsWriteModel(blobUrl, filename, `${blobName}.${ext}`)
       })
     }
+    URL.revokeObjectURL(blobUrl)
   }
 
   // Fallback: use blob URL directly (no OPFS)

--- a/src/loader/Loader.cover.test.js
+++ b/src/loader/Loader.cover.test.js
@@ -330,6 +330,55 @@ describe('load() error/edge paths with OPFS enabled', () => {
   })
 
 
+  it('falls back to direct fetch when OPFS download throws (resilience)', async () => {
+    // Regression: a Safari InvalidStateError (or any other OPFS failure)
+    // used to surface as "Failed to parse model" with no recovery, even
+    // though we still had a perfectly good URL to fetch from. Now OPFS is
+    // treated as a best-effort cache — on any error in that path, we fall
+    // through to the same axios fetch the non-OPFS branch uses.
+    dereferenceAndProxyDownloadContents.mockResolvedValue([
+      'https://raw.example.com/owner/repo/main/model.ifc',
+      'abc123sha',
+      false,
+      false,
+    ])
+    downloadModel.mockRejectedValue(
+      new Error('Error getting file handle for foo: InvalidStateError'))
+    axios.get.mockResolvedValue({data: new ArrayBuffer(64)})
+
+    // readModel will still fail on junk bytes; we're asserting the
+    // download attempt fell through to axios, not that the model parsed.
+    await expect(
+      load('https://github.com/owner/repo/blob/main/model.ifc',
+        viewer, onProgress, true, setOpfsFile, ''),
+    ).rejects.toThrow()
+
+    expect(downloadModel).toHaveBeenCalledTimes(1)
+    expect(axios.get).toHaveBeenCalledTimes(1)
+    expect(axios.get.mock.calls[0][0]).toBe('https://raw.example.com/owner/repo/main/model.ifc')
+  })
+
+
+  it('still throws when an uploaded file fails in OPFS (no fallback URL)', async () => {
+    // Uploaded files only exist in OPFS — there's no remote URL to fall
+    // back to. The resilience fix MUST re-throw rather than try axios
+    // against a blob: URL that may already be revoked.
+    getModelFromOPFS.mockReset()
+    getModelFromOPFS.mockRejectedValue(new Error('OPFS read failed'))
+    dereferenceAndProxyDownloadContents.mockResolvedValue([
+      'blob:http://localhost/uuid.stl', '', false, false,
+    ])
+
+    const uuidPath = '12345678-1234-4abc-9def-123456789abc.stl'
+
+    await expect(
+      load(uuidPath, viewer, onProgress, true, setOpfsFile, ''),
+    ).rejects.toThrow(/OPFS read failed/)
+
+    expect(axios.get).not.toHaveBeenCalled()
+  })
+
+
   it('reads an uploaded file out of OPFS via getModelFromOPFS', async () => {
     // A valid RFC-4122-ish UUID (3rd group starts with [1-5], 4th with
     // [89abAB]) triggers the "uploaded file" branch in load():

--- a/src/loader/Loader.js
+++ b/src/loader/Loader.js
@@ -144,150 +144,196 @@ export async function load(
   }
 
   if (isOpfsAvailable) {
-    onProgress('Preparing file download...')
-    let file
-    // Per-source-kind cache-key context. Built eagerly for GitHub (we have
-    // the upstream sha before download) and lazily for everything else
-    // (we hash the bytes after they're in OPFS).
-    let cacheKeyArgs = null
-    let kindLabel = null
+    // OPFS is a CACHE, not a hard dependency. Any failure inside this block
+    // — Safari's `InvalidStateError` on `createSyncAccessHandle`, a corrupt
+    // entry from a previous failed session, a missing rename target, etc. —
+    // should fall through to the direct-fetch path so the user still gets
+    // their model. The cost is one cache miss this load; the next load will
+    // try OPFS again from scratch.
+    try {
+      onProgress('Preparing file download...')
+      let file
+      // Per-source-kind cache-key context. Built eagerly for GitHub (we have
+      // the upstream sha before download) and lazily for everything else
+      // (we hash the bytes after they're in OPFS).
+      let cacheKeyArgs = null
+      let kindLabel = null
 
-    if (isUploadedFile) {
-      kindLabel = 'upload'
-      debug().log('Loader#load: getModelFromOPFS for upload:', path)
-      file = await getModelFromOPFS('BldrsLocalStorage', 'V1', 'Projects', path)
-    } else if (isLocallyHostedFile) {
-      kindLabel = 'local'
-      debug().log('Loader#load: local file:', path)
-      file = await downloadToOPFS(
-        path,
-        path,
-        'bldrs-ai',
-        'BldrsLocalStorage',
-        'V1',
-        'Projects',
-        onProgress)
-    } else {
-      let pathUrl
-      try {
-        pathUrl = new URL(path)
-      } catch (e) {
-        throw new Error(`Invalid URL path.  Cannot load resource: ${e}, path for URL: ${path}`)
-      }
-      if (pathUrl.host === 'github.com') {
-        kindLabel = 'github'
-        // TODO: path was gitpath originally
-        const {owner, repo, branch, filePath} = parseGitHubPath(pathUrl.pathname)
-
-        // if we got a cache hit and the file doesn't exist in OPFS, query with no cache
-        if (isCacheHit && !(await doesFileExistInOPFS(filePath, shaHash, owner, repo, branch))) {
-          [derefPath, shaHash, isCacheHit, isBase64] = await dereferenceAndProxyDownloadContents(path, accessToken, isOpfsAvailable, false)
-        }
-
-        // GitHub gives us a stable upstream sha *before* we download — so
-        // the GLB cache lookup can happen pre-download (fastest hit path).
-        if (wantGlb && shaHash) {
-          cacheKeyArgs = gitHubCacheKey({owner, repo, branch, filePath, shaHash})
-          glbInfo(
-            `reader: cache lookup github key=${cacheKeyArgs.ns1}/${cacheKeyArgs.ns2}/${cacheKeyArgs.ns3}/` +
-            `${cacheKeyArgs.sourcePath} sha=${cacheKeyArgs.sourceHash}`)
-          glbVerbose('reader: cacheKeyArgs =', cacheKeyArgs)
-          const glbFile = await tryLoadCachedGlb(cacheKeyArgs)
-          if (glbFile) {
-            glbInfo(
-              `reader: github cache HIT (${glbFile.size}B); swapping to GLB loader for: ${filePath}`)
-            ;[loader, isLoaderAsync, isFormatText, isIfc, fixupCb] = swapToGlbLoader(viewer)
-            file = glbFile
-            cameFromGlbCache = true
-          } else {
-            glbInfo('reader: github cache MISS, will export after parse:', filePath)
-          }
-        }
-
-        if (!file) {
-          if (isBase64) {
-            file = await writeBase64Model(derefPath, shaHash, filePath, accessToken, owner, repo, branch, setOpfsFile)
-          } else {
-            debug().log(`Loader#load: downloadModel with owner, repo, branch, filePath:`, owner, repo, branch, filePath)
-            file = await downloadModel(
-              derefPath,
-              shaHash,
-              filePath,
-              accessToken,
-              owner,
-              repo,
-              branch,
-              setOpfsFile,
-              onProgress,
-              (lastModifiedGithub) => {
-                const sharePath = navigateBaseOnModelPath(owner, repo, branch, `/${filePath}`)
-                updateRecentFileLastModified(sharePath, lastModifiedGithub)
-              })
-          }
-        }
-      } else {
-        kindLabel = 'external'
-        const opfsFilename = pathUrl.pathname
-        debug().log(`Loader#load: downloadToOPFS with opfsFilename:`, opfsFilename)
+      if (isUploadedFile) {
+        kindLabel = 'upload'
+        debug().log('Loader#load: getModelFromOPFS for upload:', path)
+        file = await getModelFromOPFS('BldrsLocalStorage', 'V1', 'Projects', path)
+      } else if (isLocallyHostedFile) {
+        kindLabel = 'local'
+        debug().log('Loader#load: local file:', path)
         file = await downloadToOPFS(
           path,
-          opfsFilename,
-          pathUrl.host,
+          path,
+          'bldrs-ai',
           'BldrsLocalStorage',
           'V1',
           'Projects',
           onProgress)
-      }
-    }
-    debug().log('Loader#load: File from OPFS:', file)
-    setOpfsFile(file)
+      } else {
+        let pathUrl
+        try {
+          pathUrl = new URL(path)
+        } catch (e) {
+          throw new Error(`Invalid URL path.  Cannot load resource: ${e}, path for URL: ${path}`)
+        }
+        if (pathUrl.host === 'github.com') {
+          kindLabel = 'github'
+          // TODO: path was gitpath originally
+          const {owner, repo, branch, filePath} = parseGitHubPath(pathUrl.pathname)
 
-    // For non-GitHub sources we don't have an upstream sha, so we hash the
-    // bytes ourselves to build the cache key. This is the same File we'd
-    // read for parse below; reading it twice is cheap (OPFS).
-    if (wantGlb && !cacheKeyArgs && file) {
-      const sourceBytes = await file.arrayBuffer()
-      const contentSha = await sha1Hex(sourceBytes)
-      cacheKeyArgs = buildNonGitHubCacheArgs(kindLabel, path, contentSha)
-      if (cacheKeyArgs) {
-        glbInfo(
-          `reader: cache lookup ${kindLabel} key=${cacheKeyArgs.ns1}/${cacheKeyArgs.ns2}/${cacheKeyArgs.ns3}/` +
-          `${cacheKeyArgs.sourcePath} sha=${contentSha}`)
-        glbVerbose('reader: cacheKeyArgs =', cacheKeyArgs)
-        const glbFile = await tryLoadCachedGlb(cacheKeyArgs)
-        if (glbFile) {
-          glbInfo(
-            `reader: ${kindLabel} cache HIT (${glbFile.size}B); swapping to GLB loader`)
-          ;[loader, isLoaderAsync, isFormatText, isIfc, fixupCb] = swapToGlbLoader(viewer)
-          file = glbFile
-          cameFromGlbCache = true
+          // if we got a cache hit and the file doesn't exist in OPFS, query with no cache
+          if (isCacheHit && !(await doesFileExistInOPFS(filePath, shaHash, owner, repo, branch))) {
+            [derefPath, shaHash, isCacheHit, isBase64] =
+              await dereferenceAndProxyDownloadContents(path, accessToken, isOpfsAvailable, false)
+          }
+
+          // GitHub gives us a stable upstream sha *before* we download — so
+          // the GLB cache lookup can happen pre-download (fastest hit path).
+          if (wantGlb && shaHash) {
+            cacheKeyArgs = gitHubCacheKey({owner, repo, branch, filePath, shaHash})
+            glbInfo(
+              `reader: cache lookup github key=${cacheKeyArgs.ns1}/${cacheKeyArgs.ns2}/${cacheKeyArgs.ns3}/` +
+            `${cacheKeyArgs.sourcePath} sha=${cacheKeyArgs.sourceHash}`)
+            glbVerbose('reader: cacheKeyArgs =', cacheKeyArgs)
+            const glbFile = await tryLoadCachedGlb(cacheKeyArgs)
+            if (glbFile) {
+              glbInfo(
+                `reader: github cache HIT (${glbFile.size}B); swapping to GLB loader for: ${filePath}`)
+              ;[loader, isLoaderAsync, isFormatText, isIfc, fixupCb] = swapToGlbLoader(viewer)
+              file = glbFile
+              cameFromGlbCache = true
+            } else {
+              glbInfo('reader: github cache MISS, will export after parse:', filePath)
+            }
+          }
+
+          if (!file) {
+            if (isBase64) {
+              file = await writeBase64Model(derefPath, shaHash, filePath, accessToken, owner, repo, branch, setOpfsFile)
+            } else {
+              debug().log(`Loader#load: downloadModel with owner, repo, branch, filePath:`, owner, repo, branch, filePath)
+              file = await downloadModel(
+                derefPath,
+                shaHash,
+                filePath,
+                accessToken,
+                owner,
+                repo,
+                branch,
+                setOpfsFile,
+                onProgress,
+                (lastModifiedGithub) => {
+                  const sharePath = navigateBaseOnModelPath(owner, repo, branch, `/${filePath}`)
+                  updateRecentFileLastModified(sharePath, lastModifiedGithub)
+                })
+            }
+          }
         } else {
-          glbInfo(`reader: ${kindLabel} cache MISS, will export after parse`)
+          kindLabel = 'external'
+          const opfsFilename = pathUrl.pathname
+          debug().log(`Loader#load: downloadToOPFS with opfsFilename:`, opfsFilename)
+          file = await downloadToOPFS(
+            path,
+            opfsFilename,
+            pathUrl.host,
+            'BldrsLocalStorage',
+            'V1',
+            'Projects',
+            onProgress)
         }
       }
-    }
+      debug().log('Loader#load: File from OPFS:', file)
+      setOpfsFile(file)
 
-    if (wantGlb && isIfc && cacheKeyArgs) {
-      glbExportContext = {kindLabel, cacheKeyArgs}
-    }
+      // For non-GitHub sources we don't have an upstream sha, so we hash the
+      // bytes ourselves to build the cache key. This is the same File we'd
+      // read for parse below; reading it twice is cheap (OPFS).
+      if (wantGlb && !cacheKeyArgs && file) {
+        const sourceBytes = await file.arrayBuffer()
+        const contentSha = await sha1Hex(sourceBytes)
+        cacheKeyArgs = buildNonGitHubCacheArgs(kindLabel, path, contentSha)
+        if (cacheKeyArgs) {
+          glbInfo(
+            `reader: cache lookup ${kindLabel} key=${cacheKeyArgs.ns1}/${cacheKeyArgs.ns2}/${cacheKeyArgs.ns3}/` +
+          `${cacheKeyArgs.sourcePath} sha=${contentSha}`)
+          glbVerbose('reader: cacheKeyArgs =', cacheKeyArgs)
+          const glbFile = await tryLoadCachedGlb(cacheKeyArgs)
+          if (glbFile) {
+            glbInfo(
+              `reader: ${kindLabel} cache HIT (${glbFile.size}B); swapping to GLB loader`)
+            ;[loader, isLoaderAsync, isFormatText, isIfc, fixupCb] = swapToGlbLoader(viewer)
+            file = glbFile
+            cameFromGlbCache = true
+          } else {
+            glbInfo(`reader: ${kindLabel} cache MISS, will export after parse`)
+          }
+        }
+      }
 
-    onProgress('Reading model data...')
-    modelData = await file.arrayBuffer()
-    if (isFormatText) {
+      if (wantGlb && isIfc && cacheKeyArgs) {
+        glbExportContext = {kindLabel, cacheKeyArgs}
+      }
+
+      onProgress('Reading model data...')
+      modelData = await file.arrayBuffer()
+      if (isFormatText) {
+        onProgress('Decoding model data...')
+        const decoder = new TextDecoder('utf-8')
+        modelData = decoder.decode(modelData)
+        debug().log('Loader#load: modelData from OPFS (decoded):', modelData)
+      }
+    } catch (opfsError) {
+      // Uploaded files (drag-drop, file picker) only exist in OPFS — there
+      // is no remote URL to fall back to. Re-throw so the user sees the
+      // error rather than a misleading "fall-through succeeded" outcome.
+      if (isUploadedFile) {
+        throw opfsError
+      }
+      // Bad-input errors (unparseable URL, unknown GitHub repo shape) are
+      // not transient OPFS issues — falling back to axiosDownload would just
+      // produce a less informative "Failed to fetch model data". Surface the
+      // original error.
+      if (opfsError?.message?.startsWith('Invalid URL path')) {
+        throw opfsError
+      }
+      debug().warn(
+        `Loader#load: OPFS path failed (${opfsError?.message || opfsError}); ` +
+        'falling back to direct fetch. ' +
+        'The OPFS cache is treated as best-effort — corrupt or browser- ' +
+        'rejected entries (Safari InvalidStateError, leaked sync handles, ' +
+        'half-written files from previous sessions) should not block load.')
+      // A GLB writer-side artifact context only makes sense for a load that
+      // actually came through the OPFS path. Drop it on fallback so we don't
+      // try to associate the freshly-fetched bytes with the failed cache key.
+      glbExportContext = null
+      cameFromGlbCache = false
+      // modelData stays undefined — falls through to the direct-fetch block
+      // below, same as when `isOpfsAvailable` was false to begin with.
+    }
+  }
+
+  if (modelData === undefined) {
+    // Either OPFS is unavailable in this browser, or the OPFS attempt above
+    // failed and we're falling back. Either way, fetch the bytes directly.
+    if (isBase64) {
+      // Contents API returned the file inline; no download fetch needed.
       onProgress('Decoding model data...')
-      const decoder = new TextDecoder('utf-8')
-      modelData = decoder.decode(modelData)
-      debug().log('Loader#load: modelData from OPFS (decoded):', modelData)
+      modelData = decodeBase64ModelData(derefPath, isFormatText)
+      debug().log('Loader#load: modelData from inline base64 (decoded):', modelData)
+    } else {
+      onProgress('Downloading model data...')
+      // For locally-hosted files when OPFS was available, the deref step
+      // above was skipped (no GitHub Contents API dereference for `/index.ifc`),
+      // so `derefPath` is unset — `path` is the URL we want.
+      const fetchUrl = derefPath || path
+      modelData = await axiosDownload(fetchUrl, isFormatText, onProgress)
+      debug().log('Loader#load: modelData from axios download:', modelData)
     }
-  } else if (isBase64) {
-    // Contents API returned the file inline; no download fetch needed.
-    onProgress('Decoding model data...')
-    modelData = decodeBase64ModelData(derefPath, isFormatText)
-    debug().log('Loader#load: modelData from inline base64 (decoded):', modelData)
-  } else {
-    onProgress('Downloading model data...')
-    modelData = await axiosDownload(derefPath, isFormatText, onProgress)
-    debug().log('Loader#load: modelData from axios download:', modelData)
   }
 
   // Provide basePath for multi-file models.  Keep the last '/' for

--- a/src/theme/Theme.jsx
+++ b/src/theme/Theme.jsx
@@ -1,4 +1,4 @@
-import {useEffect, useMemo, useState} from 'react'
+import {useEffect, useMemo, useRef, useState} from 'react'
 import {createTheme} from '@mui/material/styles'
 import * as Preferences from '../privacy/preferences'
 import useStore from '../store/useStore'
@@ -40,8 +40,24 @@ export default function useShareTheme() {
   }, [effectiveMode, setMode, themeChangeListeners, mode])
 
 
+  // Fire registered listeners only on ACTUAL theme transitions. Skipping the
+  // initial-mount fire is what prevents CadView's onModelPath from running
+  // its initViewerCb twice: once via the direct call inside onModelPath,
+  // then a second time when this effect fires post-commit and walks the
+  // listener registry. The duplicate setViewer was driving Safari's double-
+  // load (Chrome/FF dedupe via automatic batching; Safari processes the two
+  // microtasks as separate batches, so each setViewer triggers a fresh
+  // [viewer]-effect → load()).
+  const lastTransitionKeyRef = useRef(null)
   useEffect(() => {
-    if (effectiveMode && theme) {
+    if (!effectiveMode || !theme) {
+      return
+    }
+    const key = String(effectiveMode)
+    const isInitial = lastTransitionKeyRef.current === null
+    const isChange = !isInitial && lastTransitionKeyRef.current !== key
+    lastTransitionKeyRef.current = key
+    if (isChange) {
       Object.values(themeChangeListeners).map((onChangeCb) => onChangeCb(effectiveMode, theme))
     }
   }, [effectiveMode, theme, themeChangeListeners])

--- a/src/theme/Theme.test.jsx
+++ b/src/theme/Theme.test.jsx
@@ -1,4 +1,5 @@
-import {Themes, getSystemCurrentLightDark} from './Theme'
+import {act, renderHook} from '@testing-library/react'
+import useShareTheme, {Themes, getSystemCurrentLightDark} from './Theme'
 
 
 describe('Theme', () => {
@@ -91,6 +92,46 @@ describe('Theme', () => {
       // Should not throw and should default to Day when matchMedia is undefined
       expect(() => getSystemCurrentLightDark()).not.toThrow()
       expect(getSystemCurrentLightDark()).toBe(Themes.Day)
+    })
+  })
+
+  describe('useShareTheme listener firing', () => {
+    // Regression: CadView.onModelPath both calls its initViewerCb directly
+    // AND registers it as a theme listener. If useShareTheme fires listeners
+    // on initial mount, that's two viewer inits per model load — the Safari
+    // double-load symptom on Plaza/Momentum/index.ifc. The listener should
+    // only fire on actual theme transitions, not on the first commit.
+
+    test('does not fire registered listeners on initial mount', () => {
+      const listener = jest.fn()
+      const {result} = renderHook(() => useShareTheme())
+      act(() => {
+        result.current.addThemeChangeListener(listener)
+      })
+      expect(listener).not.toHaveBeenCalled()
+    })
+
+    test('fires listeners on subsequent theme changes', () => {
+      const listener = jest.fn()
+      const {result} = renderHook(() => useShareTheme())
+      act(() => {
+        result.current.addThemeChangeListener(listener)
+      })
+      act(() => {
+        result.current.setTheme(Themes.Night)
+      })
+      expect(listener).toHaveBeenCalledTimes(1)
+    })
+
+    test('does not refire listeners on re-render without a theme change', () => {
+      const listener = jest.fn()
+      const {result, rerender} = renderHook(() => useShareTheme())
+      act(() => {
+        result.current.addThemeChangeListener(listener)
+      })
+      rerender()
+      rerender()
+      expect(listener).not.toHaveBeenCalled()
     })
   })
 })


### PR DESCRIPTION
Fixes #1521.

## Summary

Three Safari-specific bugs producing the symptoms in the issue (Sculpture/Schependomlaan fail entirely; Plaza/Momentum/index.ifc load twice; trailing `WebKitBlobResource error 1`s on every load). Chrome and Firefox are unaffected by all three — the fixes are defensive and shouldn't change their behavior.

### 1. Sync-access-handle leaks → Sculpture `InvalidStateError`

`src/OPFS/OPFS.worker.js`: every `createSyncAccessHandle()` site wrapped in try/finally so `.close()` runs even on the outer catch. Safari is stricter than Chrome/FF — any error path that returned without closing left the OPFS entry in a state Safari refused subsequent handle creations on. Affected: `writeTemporaryFileToOPFS`, `writeTemporaryBase64BlobFileToOPFS`, `downloadToOpfs`, `writeModelToOPFSFromFile`, `writeModelToOPFS`, `writeFileToOPFS`. `.close()` is idempotent so the happy-path close stays for clarity.

### 2. File reference invalidated by rename → Schependomlaan parse failure + `WebKitBlobResource error 1`

The GitHub flow used to post an intermediate `download` event with the pre-rename File, then rename the OPFS entry. Safari invalidates the underlying blob backing on rename, so the caller's `.arrayBuffer()` failed or returned garbage.

New helper `postFinalDownloadEventAfterRename` (`OPFS.worker.js`) does the rename first, then posts a single terminal event with the post-rename File. On commit-hash fetch or rename failure it falls back to posting a `download` event with the un-renamed handle so the load still completes (user just doesn't get commit-pinning).

The two listeners in `OPFS/utils.js` (`downloadModel`, `writeBase64Model`) are deduped into a single `awaitTerminalWorkerEvent` helper that owns the single-terminal-event protocol.

### 3. Theme listener fires on initial mount → double load (all files in Safari)

`CadView.onModelPath` both calls its `initViewerCb` directly AND registers it as a theme listener. `useShareTheme`'s post-commit effect was firing on initial mount and walking the listener registry, causing a second `setViewer` → second `[viewer]`-effect → second `load()`. Chrome/FF batched the two `setState`s so the redundant load got deduped; Safari processed them as separate batches, so each ran a full load 2s apart.

`Theme.jsx`: listener-firing effect gated by a transition ref so the initial mount no longer counts as a change. `CadView.jsx`: `previousThemeChangeCb` promoted from module-level state to a `useRef` (module-level would have collided between mounts).

### Also

`loadFromSource.js` (Google Drive / Source path) created blob URLs and never revoked them — those produced the trailing `WebKitBlobResource error 1` lines on every fresh Source load. Now revoked after the worker finishes (success or error).

## ⚠️ Behavior change worth flagging for Sentry watchers

The outer `try/catch` in the worker's `downloadModel` previously **swallowed** exceptions silently — any unexpected throw inside the cache/download path left the listener hanging forever and the user staring at the spinner. After this PR that catch posts an `{error}` message, so the promise now **rejects** and the user sees the "Failed to parse model" alert.

Strictly an improvement (failures are visible instead of invisible) but it means Sentry may surface previously-hidden errors immediately after this lands. If you see a spike in the first day, those are bugs that were always there; the fix made them reportable.

## Test plan

- [x] Full Jest suite green (1470 passed, 5 skipped). Includes 3 new theme regression tests + 3 new worker tests for the rename helper + 1 new utils test for the `download`-as-terminal fallback path.
- [x] `yarn typecheck` clean.
- [x] `yarn eslint src --max-warnings 0` clean.
- [x] **Manual Safari smoke against the deploy preview confirmed by @OlegMoshkovich** — Sculpture and Schependomlaan load successfully, Plaza/Momentum/index.ifc load exactly once, no regressions in Chrome or Firefox.