### PR TITLE
AdSense site-verification script (Phase 1 of #1524)

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -53,5 +53,9 @@
       gtag('js', new Date());
       gtag('config', 'G-GRLNVMZRGW');
     </script>
+    <!-- AdSense site verification. Same body-after-bundle placement as gtag above so MSW takes control before the script's network requests fire in dev/test. design/new/ads.md captures why Auto ads stay OFF and which routes may carry ad slots. -->
+    <script async
+            src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-2372655610709687"
+            crossorigin="anonymous"></script>
   </body>
 </html>

--- a/src/AdSense.spec.ts
+++ b/src/AdSense.spec.ts
@@ -1,0 +1,21 @@
+import {expect, test} from '@playwright/test'
+import {homepageSetup} from './tests/e2e/utils'
+
+
+// Regression guard for AdSense site verification. If a future edit drops the
+// `<script>` tag from public/index.html, AdSense activation breaks silently
+// — no visible UI change, no test failure, no error logged. This test catches
+// that by asserting the browser fires the script request on `/` load. The
+// MSW handler in src/__mocks__/api-handlers.js fulfills the request with an
+// empty 200, so no live traffic occurs, but `page.on('request')` still fires
+// on attempt. See design/new/ads.md for the broader ad strategy.
+test('AdSense script is requested on page load', async ({page}) => {
+  await homepageSetup(page)
+  const adsenseRequest = page.waitForRequest(
+    (req) => req.url().includes('pagead2.googlesyndication.com/pagead/js/adsbygoogle.js'),
+    {timeout: 10_000},
+  )
+  await page.goto('/')
+  const req = await adsenseRequest
+  expect(req.url()).toContain('client=ca-pub-2372655610709687')
+})

--- a/src/__mocks__/api-handlers.js
+++ b/src/__mocks__/api-handlers.js
@@ -25,6 +25,7 @@ export function initHandlers(defines) {
   handlers.push(...subscribePageHandler())
   handlers.push(...stripePortalHandlers())
   handlers.push(...gaHandlers())
+  handlers.push(...adSenseHandlers())
   handlers.push(...apiHandlersOpenrouter(defines))
   handlers.push(...googleApisHandlers())
   // Pass through paths that are served by static assets or playwright fixtures
@@ -216,6 +217,35 @@ function gaHandlers() {
           headers: {'Content-Type': 'application/json'},
         },
       )
+    }),
+  ]
+}
+
+
+/**
+ * Mock to absorb AdSense traffic so no live requests escape tests.
+ *
+ * Both hosts must be intercepted: `googlesyndication.com` serves
+ * `adsbygoogle.js`, and once loaded the script chains follow-up requests to
+ * `doubleclick.net` for impression / measurement. Intercepting only
+ * googlesyndication would still leak doubleclick.
+ *
+ * See design/new/ads.md §"Test hermeticity" for why these hosts are not on
+ * the Playwright REAL_NETWORK_HOST_DENYLIST.
+ *
+ * @return {Array<object>} handlers
+ */
+function adSenseHandlers() {
+  return [
+    http.get('https://*.googlesyndication.com/*', () => {
+      return new Response('', {
+        status: HTTP_OK,
+        headers: {'Content-Type': 'application/javascript'},
+      })
+    }),
+
+    http.get('https://*.doubleclick.net/*', () => {
+      return new Response(null, {status: HTTP_OK})
     }),
   ]
 }

--- a/src/tests/e2e/utils.ts
+++ b/src/tests/e2e/utils.ts
@@ -9,23 +9,26 @@ import {resolve} from 'path'
  * @param page - Playwright page object
  */
 export function logNetworkCalls({page}: {page: Page}) {
-  const skipGoogleAnalyticsRequests = (req: Request) => {
-    if (new URL(req.url()).hostname.endsWith('googletagmanager.com') ||
-      new URL(req.url()).hostname.endsWith('google-analytics.com')) {
+  const skipAdAndAnalyticsRequests = (req: Request) => {
+    const hostname = new URL(req.url()).hostname
+    if (hostname.endsWith('googletagmanager.com') ||
+        hostname.endsWith('google-analytics.com') ||
+        hostname.endsWith('googlesyndication.com') ||
+        hostname.endsWith('doubleclick.net')) {
       return true
     }
     return false
   }
 
   page.on('request', (req: Request) => {
-    if (skipGoogleAnalyticsRequests(req)) {
+    if (skipAdAndAnalyticsRequests(req)) {
       return
     }
     console.warn(`➡️  ${req.method()} ${req.url()}`)
   })
 
   page.on('response', (res) => {
-    if (skipGoogleAnalyticsRequests(res.request() as Request)) {
+    if (skipAdAndAnalyticsRequests(res.request() as Request)) {
       return
     }
     const status = res.status()
@@ -50,11 +53,12 @@ export async function clearState(context: BrowserContext) {
  * Hosts whose traffic carries data the SPA reads or writes (model files,
  * GitHub API responses, auth tokens, AI completions). Reaching these from
  * a test is the leak we *must* fail on — it can paper over a broken mock
- * and produce non-hermetic results. Analytics / tracking script hosts
- * (googletagmanager, google-analytics) are deliberately NOT in this list:
- * MSW handles them, but on the first page navigation a `<script>` tag for
- * gtag may fire before MSW's service worker takes control, and a hard
- * abort there only breaks page init without protecting any data.
+ * and produce non-hermetic results. Ad / analytics / tracking script
+ * hosts (googletagmanager, google-analytics, googlesyndication,
+ * doubleclick) are deliberately NOT in this list: MSW handles them, but
+ * on the first page navigation a `<script>` tag for gtag or adsbygoogle
+ * may fire before MSW's service worker takes control, and a hard abort
+ * there only breaks page init without protecting any data.
  */
 const REAL_NETWORK_HOST_DENYLIST = [
   // Real GitHub


### PR DESCRIPTION
## Summary

- Phase 1 of [#1524](https://github.com/bldrs-ai/Share/issues/1524) (Ads on bldrs.ai). Closes #1523.
- Loads `adsbygoogle.js` so AdSense verifies and activates the publisher account. No `<ins>` slots yet — those land per-route in Phase 2.
- Script placed in `<body>` after the app bundle (matches the existing gtag pattern; same MSW-race rationale).
- MSW intercepts `*.googlesyndication.com` and `*.doubleclick.net` (the latter is required because `adsbygoogle.js` chains follow-up requests there once loaded).
- Renamed `skipGoogleAnalyticsRequests` → `skipAdAndAnalyticsRequests` in `src/tests/e2e/utils.ts`; extended the docstring on `REAL_NETWORK_HOST_DENYLIST` to cover the new hosts. Ad hosts are deliberately **not** on the denylist — see the comment.
- New `src/AdSense.spec.ts` asserts the browser issues the script request on `/` load, guarding against silent deletion of the `<script>` tag.

Design context: [`design/new/ads.md`](https://github.com/bldrs-ai/Share/blob/main/design/new/ads.md).

## Out-of-code follow-up (post-merge / post-deploy)

- AdSense dashboard → Settings → **Auto ads OFF** before approval. This keeps Google from injecting overlay/anchor/vignette units onto the 3D viewer.
- Approval typically takes days post-deploy.

## Test plan

- [x] `yarn eslint` clean on changed files
- [x] `yarn typecheck` clean
- [x] `yarn test` — 189/189 suites, 1473/1473 tests pass (re-run by pre-commit hook)
- [ ] `yarn test-flows src/AdSense.spec.ts` — could not run locally (sandbox blocks Playwright's chromium CDN); CI verifies
- [ ] Post-merge: DevTools Network on the deployed site shows `adsbygoogle.js` → 200, no console errors
- [ ] Post-merge: no visible ads on `/`, `/share/...`, `/about`, `/blog` (expected; no `<ins>` slots, Auto ads off)
- [ ] AdSense dashboard shows "site is ready" / activation status

https://claude.ai/code/session_01Px2hgZryxf3Fs1X9UsiMNH

---
_Generated by [Claude Code](https://claude.ai/code/session_01Px2hgZryxf3Fs1X9UsiMNH)_