### PR TITLE
Add BLDRS_spatial_tree glTF extension for cache-hit NavTree hydration

### DIFF
--- a/design/new/viewer-replacement.md
+++ b/design/new/viewer-replacement.md
@@ -398,6 +398,30 @@ before flipping the `conwayDirectIfc` flag default-on:
 
 Issues / comments can be done later (post-prod-flip).
 
+**Pre-public-launch (one of the last gates).** The regression-testing
+framework (headless 4-angle screenshots + perf timing) will be extended
+to do **GLB extract + bit-level data snapshot comparison**. Each model
+in the fixture corpus gets a manually-evaluated GLB extract as the
+golden artifact — schema-version-pinned, byte-stable across runs given
+the same Conway + GLTFExporter versions. The harness reads the cached
+artifact, decodes each `BLDRS_*` extension payload, and deep-diffs
+against the golden. Catches:
+
+- Extension-format drift (a writer change that quietly alters payload
+  layout, e.g. adding a field that gets serialised even though no
+  consumer reads it yet).
+- Geometry/material drift through the GLB cache round-trip (the BIN
+  chunk's bytes shift even when the visible scene is identical, e.g.
+  Conway emits geometry in a different order between versions).
+- Schema-bump bugs (a bump should invalidate everything; a bug where
+  it doesn't would surface as the golden still being readable when it
+  shouldn't be).
+
+Order of operations: ship Conway-direct + extensions → bake goldens
+manually → wire bit-level diff into the regression harness → flip
+public-launch gate. Not on the critical path for the §3b.iii blockers
+above; tracked here so it doesn't fall off.
+
 ### 3c. Plugins (small, replaceable, individually disposable)
 Each takes a `ThreeContext` (and an `IfcModelService` if relevant) and exposes a tiny API:
 

--- a/design/new/viewer-replacement.md
+++ b/design/new/viewer-replacement.md
@@ -383,18 +383,65 @@ the per-vertex `expressID` attribute across child Meshes.
   rest. Worth a separate spike post-default-on. Captured here
   so the idea doesn't fall off the followup list.
 
-**Default-on gating:** isolate routing now done. Remaining blockers
-before flipping the `conwayDirectIfc` flag default-on:
+**Done — BLDRS_spatial_tree slice.** Landed 2026-05 (PR #1527).
+Resolves §3b.iii default-on blocker 1 below: cache-hit GLBs now
+hydrate the NavTree without a live IFC parser.
 
-1. **Portable IFC spatial hierarchy** — NavTree currently sources
-   `getSpatialStructure(...)` from `viewer.IFC.loader.ifcManager`,
-   which only has parser state on cache-miss IFC parses. Cache-hit
-   GLB needs `BLDRS_spatial_tree` (see `design/new/glb-model-sharing.md`
-   §"Extensions") written at export and read back on cache-hit.
+- `src/loader/injectGlbExtensions.js` — GLB post-processor (parse →
+  splice extensions + bufferViews → re-serialise). Chosen over a
+  GLTFExporter plugin so geometry export stays untouched and the
+  extension wiring lives in one well-tested seam. Returns
+  `{bytes, stats}`; collision-safe (won't overwrite an existing
+  entry); synthesises a BIN chunk on input with none.
+- `src/loader/bldrsSpatialTree.js` — `BLDRS_spatial_tree` extension
+  codec. Writer-side `captureBldrsSpatialTree(ifcManager, modelID)`
+  whitelists `{expressID, type, Name, LongName, children}` (drops
+  parser internals, depth-bounded via `MAX_TREE_DEPTH=100`).
+  Reader-side `BldrsSpatialTreeReader` GLTFLoader plugin decompresses
+  on `afterRoot`, validates shape (object + numeric expressID),
+  attaches to `gltf.scene.userData.bldrsSpatialTree`. Guards on
+  out-of-range bufferView index and absent default scene.
+- `src/loader/Loader.js#convertToShareModel` — promotes
+  `userData.bldrsSpatialTree` to a model-level
+  `model.getSpatialStructure(modelID, withProperties)` closure on
+  cache-hit. Live IFC parses don't ship the extension and fall
+  through to the legacy `ifcManager` path.
+- `src/loader/Loader.js#parseBldrsGlbContainer` — bubbles
+  `gltf.scene.userData` up to the merged Group so downstream
+  consumers see extension data on the returned root.
+- `src/viewer/ShareModel.js#inferModelCapabilities` — flips
+  `capabilities.spatialStructure: true` when the userData payload
+  is present.
+- `src/Containers/CadView.jsx` — NavTree path discriminates on the
+  cache payload (`m.userData?.bldrsSpatialTree`). Method-existence
+  check would have collided with wit-three's prototype
+  `IFCModel.getSpatialStructure(): Promise<any>` (no args), silently
+  dropping `withProperties=true` on live IFC parses.
+- `src/loader/glbCacheKey.js` — schema bump `0.5.0` → `0.6.0` so
+  older cached artifacts read as miss; next miss rewrites with the
+  extension attached.
+
+Untrusted-input validation today is shape-only (object + numeric
+expressID + recursion-depth ceiling). Full validation per
+`design/new/glb-model-sharing.md` §"Validation and trust" — schema-
+version range, cross-reference integrity, size ceilings, HTML-strip
+on rendered strings — lands with the originator-side share flow
+(Phase 5+) when GLBs can arrive from arbitrary user browsers.
+File-header TODO points at the spec.
+
+**Default-on gating:** isolate routing done; spatial tree done.
+Remaining blockers before flipping the `conwayDirectIfc` flag
+default-on:
+
+1. ~~Portable IFC spatial hierarchy~~ — **done** (this slice).
 2. **Portable IFC properties / property sets** — ItemProperties
-   similarly currently sources from the ifcManager. Needs the
+   currently sources from the ifcManager. Needs the
    `BLDRS_element_properties` extension wired through the writer +
-   reader so the panel works on cache-hit too.
+   reader so the panel works on cache-hit too. Shape mirrors the
+   spatial-tree slice: capture at writer time, lazy-decompress on
+   first `model.getItemProperties` / `model.getPropertySets` call
+   (per glb-model-sharing.md the payload is large enough to want
+   lazy decode).
 
 Issues / comments can be done later (post-prod-flip).
 

--- a/src/Containers/CadView.jsx
+++ b/src/Containers/CadView.jsx
@@ -445,7 +445,14 @@ export default function CadView({
     // if we can't read the full model structure.
     let rootElt
     try {
-      rootElt = await m.ifcManager.getSpatialStructure(0, true)
+      // Prefer the model-level method when present — cache-hit GLBs that
+      // shipped a BLDRS_spatial_tree extension hydrate it via
+      // `Loader.js#convertToShareModel`. Falls back to the shared
+      // `ifcManager` path for live IFC parses (where the ifcManager
+      // still has live parser state). Once the cache covers every IFC
+      // load, the fallback goes away (along with the shared-manager shim).
+      const getTree = m.getSpatialStructure ?? m.ifcManager.getSpatialStructure?.bind(m.ifcManager)
+      rootElt = await getTree(0, true)
     } catch (e) {
       setAlert('Could not read full model structure.  Only model geometry will be available.')
       captureException(e, 'Could not read full model structure')

--- a/src/Containers/CadView.jsx
+++ b/src/Containers/CadView.jsx
@@ -451,8 +451,19 @@ export default function CadView({
       // `ifcManager` path for live IFC parses (where the ifcManager
       // still has live parser state). Once the cache covers every IFC
       // load, the fallback goes away (along with the shared-manager shim).
-      const getTree = m.getSpatialStructure ?? m.ifcManager.getSpatialStructure?.bind(m.ifcManager)
-      rootElt = await getTree(0, true)
+      //
+      // Method-style call (`m.getSpatialStructure(...)`) is intentional:
+      // `web-ifc-three.IFCModel` inherits a `getSpatialStructure` on its
+      // prototype that internally reads `this.ifcManager` — extracting it
+      // to a variable and calling bare loses the `this` binding and
+      // throws "Cannot read properties of undefined (reading 'ifcManager')".
+      // For the cache-hit GLB case the closure we attach is `this`-free
+      // and works either way.
+      if (m.getSpatialStructure) {
+        rootElt = await m.getSpatialStructure(0, true)
+      } else {
+        rootElt = await m.ifcManager.getSpatialStructure(0, true)
+      }
     } catch (e) {
       setAlert('Could not read full model structure.  Only model geometry will be available.')
       captureException(e, 'Could not read full model structure')

--- a/src/Containers/CadView.jsx
+++ b/src/Containers/CadView.jsx
@@ -445,21 +445,17 @@ export default function CadView({
     // if we can't read the full model structure.
     let rootElt
     try {
-      // Prefer the model-level method when present — cache-hit GLBs that
-      // shipped a BLDRS_spatial_tree extension hydrate it via
-      // `Loader.js#convertToShareModel`. Falls back to the shared
-      // `ifcManager` path for live IFC parses (where the ifcManager
-      // still has live parser state). Once the cache covers every IFC
-      // load, the fallback goes away (along with the shared-manager shim).
-      //
-      // Method-style call (`m.getSpatialStructure(...)`) is intentional:
-      // `web-ifc-three.IFCModel` inherits a `getSpatialStructure` on its
-      // prototype that internally reads `this.ifcManager` — extracting it
-      // to a variable and calling bare loses the `this` binding and
-      // throws "Cannot read properties of undefined (reading 'ifcManager')".
-      // For the cache-hit GLB case the closure we attach is `this`-free
-      // and works either way.
-      if (m.getSpatialStructure) {
+      // Cache-hit GLBs that shipped a BLDRS_spatial_tree extension
+      // hydrate a `getSpatialStructure(modelID, withProperties)` closure
+      // on the model via `Loader.js#convertToShareModel`. We can't just
+      // test `m.getSpatialStructure` because wit-three's IFCModel
+      // inherits a `getSpatialStructure(): Promise<any>` on its
+      // prototype that calls `this.ifcManager.getSpatialStructure(this.modelID)`
+      // — no `includeProperties` arg — so taking that branch on a live
+      // IFC parse silently drops the property data, leaving NavTree
+      // leaves nameless. Discriminate on the cache payload directly.
+      const cachedTree = m.userData?.bldrsSpatialTree
+      if (cachedTree) {
         rootElt = await m.getSpatialStructure(0, true)
       } else {
         rootElt = await m.ifcManager.getSpatialStructure(0, true)

--- a/src/loader/Loader.convertToShareModel.test.js
+++ b/src/loader/Loader.convertToShareModel.test.js
@@ -228,4 +228,44 @@ describe('Loader/convertToShareModel — Phase 2b.2 capability + subset wiring',
     // web-ifc-three's IFC.selector.pickIfcItemsByID instead.
     expect(mesh.createSubset).toBeUndefined()
   })
+
+  it('cache-hit BLDRS_spatial_tree hydrates a model-level getSpatialStructure closure', () => {
+    // Mirrors what the BldrsSpatialTreeReader plugin parks on the
+    // scene root: a JSON-decoded IFC tree on userData. convertToShareModel
+    // should promote it to a `model.getSpatialStructure(modelID, withProps)`
+    // closure so CadView's NavTree path can read it without going through
+    // the shared `viewer.IFC.loader.ifcManager` shim.
+    const mesh = new Mesh(new BufferGeometry())
+    mesh.userData.bldrsSpatialTree = {
+      expressID: 1,
+      type: 'IFCPROJECT',
+      Name: {value: 'Cached Project'},
+      children: [
+        {expressID: 2, type: 'IFCSITE', Name: {value: 'Site'}, children: []},
+      ],
+    }
+    convertToShareModel(mesh, makeViewerStub())
+    expect(typeof mesh.getSpatialStructure).toBe('function')
+    // The closure is sync-on-tree (no await internally) but signed as
+    // (modelID, withProperties) so it matches the legacy
+    // `ifcManager.getSpatialStructure` shape — the CadView caller awaits
+    // the result regardless. Pass the same args the live path uses.
+    const root = mesh.getSpatialStructure(0, true)
+    expect(root.expressID).toBe(1)
+    expect(root.Name.value).toBe('Cached Project')
+    expect(root.children).toHaveLength(1)
+  })
+
+  it('no BLDRS_spatial_tree on userData → no closure attached (live-IFC fallback path)', () => {
+    // Regression guard: an earlier iteration attached the closure
+    // unconditionally, which collided with `web-ifc-three.IFCModel`'s
+    // own prototype `getSpatialStructure(): Promise<any>` (no args).
+    // CadView discriminates on `userData.bldrsSpatialTree`; the model
+    // here must NOT carry a model-level method when the userData hook
+    // is absent.
+    const mesh = new Mesh(new BufferGeometry())
+    // userData.bldrsSpatialTree intentionally unset.
+    convertToShareModel(mesh, makeViewerStub())
+    expect(mesh.getSpatialStructure).toBeUndefined()
+  })
 })

--- a/src/loader/Loader.js
+++ b/src/loader/Loader.js
@@ -36,6 +36,7 @@ import {buildConwayIfcModel} from '../viewer/ifc/buildConwayIfcModel'
 import {instanceMapFromGeometry} from '../viewer/ifc/IfcInstanceMap'
 import {dereferenceAndProxyDownloadContents} from './urls'
 import BLDLoader from './BLDLoader'
+import {BldrsSpatialTreeReader} from './bldrsSpatialTree'
 import {ExtBldrsPropertiesPayload} from './ExtBldrsPropertiesPayload'
 import {exportAndCacheGlb} from './glbExport'
 import glbToThree from './glb'
@@ -494,12 +495,18 @@ export async function load(
   // when the `glb` feature flag is on. Failures are logged but never
   // thrown — the source is already on screen; this is cache warm-up only.
   // Design: design/new/glb-model-sharing.md §"Pipelines/A. Originator".
+  // `ifcManager` is captured from the live IFC parser state so the
+  // writer can pull `getSpatialStructure(...)` into a BLDRS_spatial_tree
+  // glTF extension — without that, cache-hit GLBs have no NavTree
+  // (the cache-hit path has no IFC parser). Non-IFC sources have no
+  // manager and the writer captures nothing; cache miss/hit both work.
   if (glbExportContext) {
     glbVerbose('writer: scheduling export, kind =', glbExportContext.kindLabel)
     exportAndCacheGlb({
       model,
       kindLabel: glbExportContext.kindLabel,
       cacheKeyArgs: glbExportContext.cacheKeyArgs,
+      ifcManager: viewer?.IFC?.loader?.ifcManager ?? null,
     })
   }
 
@@ -700,6 +707,23 @@ export function convertToShareModel(model, viewer) {
   model.ifcManager = viewer.IFC.loader.ifcManager
   model.ifcManager.getSpatialStructure = () => {
     return model
+  }
+
+  // Cache-hit hydration for BLDRS_spatial_tree. When the GLTFLoader
+  // plugin decoded the extension it parked the tree on
+  // `model.userData.bldrsSpatialTree`. Promote it to a model-level
+  // method so consumers (`Containers/CadView.jsx#onModel` etc.) can
+  // call `model.getSpatialStructure(modelID, withProperties)` and get
+  // the real IFC hierarchy without going through the (monkey-patched,
+  // shared-across-models) `viewer.IFC.loader.ifcManager` shim above.
+  // Live IFC parses miss this branch — they have no extension in their
+  // userData — and fall through to the legacy `ifcManager` path.
+  const spatialTree = model.userData?.bldrsSpatialTree
+  if (spatialTree) {
+    model.getSpatialStructure = (_modelID, _withProperties) => spatialTree
+    glbInfo(
+      'reader: hydrated NavTree from BLDRS_spatial_tree (' +
+      `root expressID=${spatialTree.expressID}, type=${spatialTree.type})`)
   }
   // Only override the manager's stock `getExpressId` for genuinely
   // unstructured models (OBJ / STL / direct .glb upload — no per-vertex
@@ -940,6 +964,7 @@ async function findLoader(pathname, viewer) {
 function newGltfLoader() {
   const loader = new GLTFLoader()
   loader.register((parser) => new ExtBldrsPropertiesPayload(parser))
+  loader.register((parser) => new BldrsSpatialTreeReader(parser))
   if (isFeatureEnabled('glbDraco')) {
     const dracoLoader = new DRACOLoader()
     dracoLoader.setDecoderPath('/static/js/draco/')
@@ -1587,6 +1612,16 @@ async function parseBldrsGlbContainer(loader, containerBytes) {
         reject(new Error(`Unhandled error parsing chunk ${i}: ${e}`))
       }
     })
+    // Bubble extension data parked on the chunk's scene by GLTFLoader
+    // plugins (`bldrsSpatialTree`, `bldrsPayload`, …) up to the merged
+    // wrapper. Otherwise `convertToShareModel` and
+    // `inferModelCapabilities` — which inspect `model.userData` on the
+    // root we return — would miss it. With multiple chunks the last
+    // one wins (per-chunk extensions clobber the merged userData in
+    // load order); today the writer only emits one chunk.
+    if (gltf.scene?.userData) {
+      Object.assign(merged.userData, gltf.scene.userData)
+    }
     if (gltf.scenes && gltf.scenes.length > 0) {
       for (const s of gltf.scenes) {
         merged.add(s)

--- a/src/loader/Loader.js
+++ b/src/loader/Loader.js
@@ -718,6 +718,14 @@ export function convertToShareModel(model, viewer) {
   // shared-across-models) `viewer.IFC.loader.ifcManager` shim above.
   // Live IFC parses miss this branch — they have no extension in their
   // userData — and fall through to the legacy `ifcManager` path.
+  //
+  // The closure ignores both arguments because a cache artifact holds
+  // exactly one model's tree (one IFC per GLB; modelID is always 0 in
+  // the consumer at CadView.jsx; properties are pre-serialised into
+  // the tree at writer time so `withProperties` has no run-time effect).
+  // Args are kept on the signature so the call shape matches
+  // `ifcManager.getSpatialStructure(modelID, withProperties)` — callers
+  // don't branch on which backend they're hitting.
   const spatialTree = model.userData?.bldrsSpatialTree
   if (spatialTree) {
     model.getSpatialStructure = (_modelID, _withProperties) => spatialTree

--- a/src/loader/bldrsSpatialTree.js
+++ b/src/loader/bldrsSpatialTree.js
@@ -1,0 +1,192 @@
+// BLDRS_spatial_tree GLTF extension — writer + reader.
+//
+// Carries the IFC spatial hierarchy (IfcProject → IfcSite → … → leaf
+// elements) inside the GLB cache artifact so the NavTree can render on
+// cache-hit without parsing the original IFC. Without this extension,
+// a re-visit to a cached model has no `viewer.IFC.loader.ifcManager`
+// parser state, `getSpatialStructure` returns nothing, and the NavTree
+// is empty. See design/new/viewer-replacement.md §3b.iii (the §"Default-on
+// gating" blocker this extension resolves) and
+// design/new/glb-model-sharing.md §"Extension catalogue".
+//
+// Wire shape (per node, recursive):
+//   {expressID, type, Name?, LongName?, children: [...]}
+//
+// `type` is preserved as the source emitted it (web-ifc-three returns
+// numeric IFC type IDs; Conway may return string names — both are
+// valid input to the existing NavTree consumer). `Name` / `LongName`
+// are kept in their IFC `{value: string}` shape rather than flattened
+// to bare strings so the consumer (`Containers/CadView.jsx` →
+// `Components/NavTree/...`) doesn't change.
+//
+// Extension JSON in glTF:
+//   extensionsUsed: ["BLDRS_spatial_tree", ...]
+//   extensions.BLDRS_spatial_tree: {compressed: true, bufferView: <int>}
+//   bufferViews[N] → gzipped JSON of the root tree node
+//
+// We never write this into `extensionsRequired` — a generic GLTF reader
+// should still be able to load the geometry; only the NavTree degrades.
+import * as pako from 'pako'
+import debug from '../utils/debug'
+
+
+export const BLDRS_SPATIAL_TREE_EXTENSION_NAME = 'BLDRS_spatial_tree'
+
+
+/**
+ * Walk a spatial-structure node and return a JSON-serializable copy
+ * with only the fields the NavTree consumer reads. Strips IFC parser
+ * internals (children with cycles back to parent, raw web-ifc handles,
+ * etc.) — anything we don't pluck explicitly is dropped.
+ *
+ * Idempotent: a node already produced by this function passes through
+ * unchanged. That property lets callers normalise once at capture and
+ * skip a defensive copy at read time.
+ *
+ * @param {object|null|undefined} node
+ * @return {object|null}
+ */
+function serializeNode(node) {
+  if (node === null || node === undefined || typeof node !== 'object') {
+    return null
+  }
+  const out = {
+    expressID: node.expressID,
+    type: node.type,
+  }
+  if (node.Name !== undefined) {
+    out.Name = node.Name
+  }
+  if (node.LongName !== undefined) {
+    out.LongName = node.LongName
+  }
+  if (Array.isArray(node.children) && node.children.length > 0) {
+    out.children = []
+    for (const child of node.children) {
+      const serialized = serializeNode(child)
+      if (serialized !== null) {
+        out.children.push(serialized)
+      }
+    }
+  } else {
+    out.children = []
+  }
+  return out
+}
+
+
+/**
+ * Capture the spatial structure for a model from an IfcManager-like
+ * source. Returns the JSON-ready tree, or `null` when no tree is
+ * available (the source has no parser state — common when the model
+ * itself came from a cached GLB and we're cache-roundtripping without
+ * re-parsing). Errors at the manager are logged and swallowed so a
+ * single missing tree never blocks the GLB write.
+ *
+ * @param {object|null|undefined} ifcManager IfcManager-like with
+ *   `getSpatialStructure(modelID, withProperties)`. Pass
+ *   `viewer.IFC.loader.ifcManager` from the live load path.
+ * @param {number} modelID
+ * @return {Promise<object|null>}
+ */
+export async function captureBldrsSpatialTree(ifcManager, modelID) {
+  if (!ifcManager || typeof ifcManager.getSpatialStructure !== 'function') {
+    return null
+  }
+  try {
+    const root = await ifcManager.getSpatialStructure(modelID, true)
+    if (!root || root.expressID === undefined) {
+      return null
+    }
+    return serializeNode(root)
+  } catch (e) {
+    debug().warn(
+      `[${BLDRS_SPATIAL_TREE_EXTENSION_NAME}] capture failed; ` +
+      `cache-hit NavTree will be empty for this model:`, e)
+    return null
+  }
+}
+
+
+/**
+ * GLTFLoader plugin that decodes the BLDRS_spatial_tree extension on
+ * read. Attaches the decoded tree to `gltf.scene.userData.bldrsSpatialTree`;
+ * `Loader.js#convertToShareModel` promotes it from there to
+ * `model.getSpatialStructure(modelID, withProperties)` + flips
+ * `capabilities.spatialStructure`.
+ *
+ * Register at GLTFLoader construction:
+ *   loader.register((parser) => new BldrsSpatialTreeReader(parser))
+ *
+ * Per the GLTFLoader plugin contract, `afterRoot(gltf)` returns the
+ * (possibly-modified) `gltf` object; the framework awaits the result
+ * before resolving the user's load promise.
+ */
+export class BldrsSpatialTreeReader {
+  /**
+   * @param {object} parser GLTFLoader parser passed at registration time
+   */
+  constructor(parser) {
+    this.name = BLDRS_SPATIAL_TREE_EXTENSION_NAME
+    this.parser = parser
+    this.spatialTree = null
+  }
+
+  /**
+   * Decompress with pako, trying gzip then deflate. Matches the
+   * fallback chain in ExtBldrsPropertiesPayload so older artifacts
+   * (deflate-encoded) keep working alongside current (gzip) ones.
+   *
+   * @param {Uint8Array} compressedData
+   * @return {string} the decoded JSON string
+   */
+  decompressData(compressedData) {
+    try {
+      return pako.ungzip(compressedData, {to: 'string'})
+    } catch (gzipErr) {
+      try {
+        return pako.inflate(compressedData, {to: 'string'})
+      } catch (deflateErr) {
+        console.error(`[${this.name}] pako failed (gzip & deflate)`, {gzipErr, deflateErr})
+        throw gzipErr
+      }
+    }
+  }
+
+  /**
+   * @param {object} gltf parsed GLTF object
+   * @return {Promise<object>} the same gltf object (per GLTFLoader extension contract)
+   */
+  async afterRoot(gltf) {
+    const json = this.parser.json
+    const ext = json.extensions?.[this.name]
+    if (!ext) {
+      return gltf
+    }
+
+    try {
+      let tree = null
+      if (ext.compressed && ext.bufferView !== undefined) {
+        const bv = json.bufferViews[ext.bufferView]
+        const bufferIndex = bv.buffer
+        const byteOffset = bv.byteOffset || 0
+        const byteLength = bv.byteLength
+        const arrayBuffer = await this.parser.getDependency('buffer', bufferIndex)
+        const compressed = new Uint8Array(arrayBuffer, byteOffset, byteLength)
+        const decompressed = this.decompressData(compressed)
+        tree = JSON.parse(decompressed)
+        debug().log(
+          `[${this.name}] decompressed tree (compressed ${compressed.byteLength}B → ` +
+          `decompressed ${decompressed.length}B)`)
+      } else if (ext.tree) {
+        // Forward-compat slot for an uncompressed inline-JSON variant.
+        tree = ext.tree
+      }
+      this.spatialTree = tree
+      gltf.scene.userData.bldrsSpatialTree = tree
+    } catch (e) {
+      console.error(`[${this.name}] failed to decode spatial tree:`, e)
+    }
+    return gltf
+  }
+}

--- a/src/loader/bldrsSpatialTree.js
+++ b/src/loader/bldrsSpatialTree.js
@@ -26,11 +26,33 @@
 //
 // We never write this into `extensionsRequired` — a generic GLTF reader
 // should still be able to load the geometry; only the NavTree degrades.
+//
+// TODO(viewer-replacement Phase 5+): when originator-side share lands
+// (design/new/glb-model-sharing.md §"Pipelines/A. Originator"), this
+// reader will be ingesting GLBs produced by arbitrary user browsers —
+// not just our own writer. At that point §"Validation and trust" of the
+// glb-model-sharing doc applies in full: schema-version range check,
+// cross-reference integrity (every `expressID` in the tree must exist
+// on some primitive's `_EXPRESS_ID` attribute), tree depth + size
+// ceilings, HTML-strip on `Name.value` / `LongName.value` at the
+// NavTree consumer (untrusted strings become DOM text). Today's
+// validation is minimal (shape + recursion-depth guard) because the
+// writer is in-browser and trusted; the full pass lands with the share
+// flow.
 import * as pako from 'pako'
-import debug from '../utils/debug'
+import {glbInfo, glbVerbose} from './glbLog'
 
 
 export const BLDRS_SPATIAL_TREE_EXTENSION_NAME = 'BLDRS_spatial_tree'
+
+// Bound on `serializeNode` / decoded-tree recursion. IFC spatial
+// hierarchies in the wild are shallow (IfcProject → Site → Building
+// → Storey → Space → element, ~6 levels typical, ~10 worst-case).
+// The ceiling exists to keep a malicious (deeply-nested) cached
+// artifact from blowing the JS stack on read — capture is bounded
+// symmetrically so a malformed live tree can't poison a cache write
+// either. Walks past this depth are truncated with a single warning.
+const MAX_TREE_DEPTH = 100
 
 
 /**
@@ -43,11 +65,19 @@ export const BLDRS_SPATIAL_TREE_EXTENSION_NAME = 'BLDRS_spatial_tree'
  * unchanged. That property lets callers normalise once at capture and
  * skip a defensive copy at read time.
  *
+ * Bounded by `MAX_TREE_DEPTH` recursion levels — sub-trees past the
+ * ceiling are dropped from `children`. Real IFCs sit ~6 levels deep;
+ * the ceiling exists for defense against an adversarial source.
+ *
  * @param {object|null|undefined} node
+ * @param {number} [depth]
  * @return {object|null}
  */
-function serializeNode(node) {
+function serializeNode(node, depth = 0) {
   if (node === null || node === undefined || typeof node !== 'object') {
+    return null
+  }
+  if (depth >= MAX_TREE_DEPTH) {
     return null
   }
   const out = {
@@ -63,7 +93,7 @@ function serializeNode(node) {
   if (Array.isArray(node.children) && node.children.length > 0) {
     out.children = []
     for (const child of node.children) {
-      const serialized = serializeNode(child)
+      const serialized = serializeNode(child, depth + 1)
       if (serialized !== null) {
         out.children.push(serialized)
       }
@@ -72,6 +102,31 @@ function serializeNode(node) {
     out.children = []
   }
   return out
+}
+
+
+/**
+ * Minimal shape check on a decoded extension payload. Catches the
+ * "the cache file is malformed / from a future schema / hostile"
+ * cases that the GLB sharing doc §"Validation and trust" lists; does
+ * NOT do the full cross-reference walk that lands in Phase 5+. Returns
+ * the input tree on pass, `null` on fail (caller treats null as
+ * "extension not usable; degrade to empty NavTree").
+ *
+ * @param {*} tree decoded extension payload
+ * @return {object|null}
+ */
+function validateDecodedTree(tree) {
+  if (tree === null || tree === undefined || typeof tree !== 'object') {
+    return null
+  }
+  if (Array.isArray(tree)) {
+    return null
+  }
+  if (typeof tree.expressID !== 'number') {
+    return null
+  }
+  return tree
 }
 
 
@@ -100,9 +155,9 @@ export async function captureBldrsSpatialTree(ifcManager, modelID) {
     }
     return serializeNode(root)
   } catch (e) {
-    debug().warn(
-      `[${BLDRS_SPATIAL_TREE_EXTENSION_NAME}] capture failed; ` +
-      `cache-hit NavTree will be empty for this model:`, e)
+    glbInfo(
+      `${BLDRS_SPATIAL_TREE_EXTENSION_NAME}: capture failed; ` +
+      'cache-hit NavTree will be empty for this model:', e)
     return null
   }
 }
@@ -147,7 +202,8 @@ export class BldrsSpatialTreeReader {
       try {
         return pako.inflate(compressedData, {to: 'string'})
       } catch (deflateErr) {
-        console.error(`[${this.name}] pako failed (gzip & deflate)`, {gzipErr, deflateErr})
+        glbInfo(
+          `${this.name}: pako failed (gzip & deflate)`, {gzipErr, deflateErr})
         throw gzipErr
       }
     }
@@ -167,6 +223,21 @@ export class BldrsSpatialTreeReader {
     try {
       let tree = null
       if (ext.compressed && ext.bufferView !== undefined) {
+        // Validate the bufferView index BEFORE dereferencing. A
+        // malformed (or hostile) cache file with an out-of-range index
+        // would throw `Cannot read properties of undefined (reading 'buffer')`
+        // from the next line. We surface the corruption explicitly and
+        // skip the decode so the caller degrades to empty-NavTree
+        // rather than failing the whole GLB parse.
+        if (!Array.isArray(json.bufferViews) ||
+            !Number.isInteger(ext.bufferView) ||
+            ext.bufferView < 0 ||
+            ext.bufferView >= json.bufferViews.length) {
+          glbInfo(
+            `${this.name}: extension references out-of-range bufferView ` +
+            `${ext.bufferView} (have ${json.bufferViews?.length ?? 0}); skipping`)
+          return gltf
+        }
         const bv = json.bufferViews[ext.bufferView]
         const bufferIndex = bv.buffer
         const byteOffset = bv.byteOffset || 0
@@ -175,17 +246,40 @@ export class BldrsSpatialTreeReader {
         const compressed = new Uint8Array(arrayBuffer, byteOffset, byteLength)
         const decompressed = this.decompressData(compressed)
         tree = JSON.parse(decompressed)
-        debug().log(
-          `[${this.name}] decompressed tree (compressed ${compressed.byteLength}B → ` +
+        glbVerbose(
+          `${this.name}: decompressed tree (compressed ${compressed.byteLength}B → ` +
           `decompressed ${decompressed.length}B)`)
       } else if (ext.tree) {
         // Forward-compat slot for an uncompressed inline-JSON variant.
         tree = ext.tree
       }
-      this.spatialTree = tree
-      gltf.scene.userData.bldrsSpatialTree = tree
+
+      // Minimal shape validation before publishing to consumers. See
+      // the file-header TODO for the full validation pass we owe once
+      // user-originated GLBs are in scope. `validateDecodedTree`
+      // returns `null` on fail; the consumer (`convertToShareModel`)
+      // checks `userData.bldrsSpatialTree` for truthiness so null is
+      // the right "extension present but unusable" signal.
+      const validated = validateDecodedTree(tree)
+      if (validated === null && tree !== null) {
+        glbInfo(
+          `${this.name}: decoded payload failed shape validation ` +
+          '(missing expressID or non-object); skipping')
+      }
+      this.spatialTree = validated
+
+      // `gltf.scene` is the default scene per glTF spec; legal to be
+      // absent when the file has multiple scenes and no `scene` index
+      // is set. Skip the attach in that case rather than crash —
+      // consumers see the missing userData as "no cached tree" and
+      // degrade to empty NavTree.
+      if (gltf.scene) {
+        gltf.scene.userData.bldrsSpatialTree = validated
+      } else {
+        glbInfo(`${this.name}: gltf has no default scene; cannot attach spatial tree`)
+      }
     } catch (e) {
-      console.error(`[${this.name}] failed to decode spatial tree:`, e)
+      glbInfo(`${this.name}: failed to decode spatial tree:`, e)
     }
     return gltf
   }

--- a/src/loader/bldrsSpatialTree.test.js
+++ b/src/loader/bldrsSpatialTree.test.js
@@ -165,7 +165,7 @@ describe('loader/bldrsSpatialTree', () => {
       const baseGlb = serializeGlb(
         {asset: {version: '2.0'}, buffers: [{byteLength: 4}]},
         new Uint8Array(4))
-      const withExt = injectGlbExtensions(baseGlb, [
+      const {bytes: withExt} = injectGlbExtensions(baseGlb, [
         {name: BLDRS_SPATIAL_TREE_EXTENSION_NAME, data: tree, compress: true},
       ])
 
@@ -193,6 +193,120 @@ describe('loader/bldrsSpatialTree', () => {
       expect(reader.name).toBe(BLDRS_SPATIAL_TREE_EXTENSION_NAME)
       expect(reader.name).toBe('BLDRS_spatial_tree')
     })
+
+    it('skips an out-of-range bufferView index without throwing', async () => {
+      // Hostile / malformed cache file: extension claims bufferView 99
+      // but only one bufferView exists. Without the guard, the next line
+      // would crash on `json.bufferViews[99].buffer`.
+      const json = {
+        asset: {version: '2.0'},
+        buffers: [{byteLength: 4}],
+        bufferViews: [{buffer: 0, byteOffset: 0, byteLength: 4}],
+        extensionsUsed: [BLDRS_SPATIAL_TREE_EXTENSION_NAME],
+        extensions: {
+          [BLDRS_SPATIAL_TREE_EXTENSION_NAME]: {compressed: true, bufferView: 99},
+        },
+      }
+      const reader = new BldrsSpatialTreeReader({
+        json,
+        getDependency: () => Promise.reject(new Error('should not be called')),
+      })
+      const gltf = {scene: {userData: {}}}
+      await expect(reader.afterRoot(gltf)).resolves.toBe(gltf)
+      expect(gltf.scene.userData.bldrsSpatialTree).toBeUndefined()
+      expect(reader.spatialTree).toBeNull()
+    })
+
+    it('skips a non-integer bufferView index without throwing', async () => {
+      const json = {
+        asset: {version: '2.0'},
+        buffers: [{byteLength: 4}],
+        bufferViews: [{buffer: 0, byteOffset: 0, byteLength: 4}],
+        extensions: {
+          [BLDRS_SPATIAL_TREE_EXTENSION_NAME]: {compressed: true, bufferView: 'one'},
+        },
+      }
+      const reader = new BldrsSpatialTreeReader({
+        json,
+        getDependency: () => Promise.reject(new Error('should not be called')),
+      })
+      await reader.afterRoot({scene: {userData: {}}})
+      expect(reader.spatialTree).toBeNull()
+    })
+
+    it('survives a gltf with no default scene (no attach, no throw)', async () => {
+      // Multi-scene glTF with no `scene` index is spec-legal. Without
+      // the null guard, `gltf.scene.userData = …` throws TypeError.
+      const tree = {expressID: 1, type: 'IFCPROJECT', children: []}
+      const baseGlb = serializeGlb(
+        {asset: {version: '2.0'}, buffers: [{byteLength: 4}]},
+        new Uint8Array(4))
+      const {bytes: withExt} = injectGlbExtensions(baseGlb, [
+        {name: BLDRS_SPATIAL_TREE_EXTENSION_NAME, data: tree, compress: true},
+      ])
+      const reader = new BldrsSpatialTreeReader(parserFromGlb(withExt))
+      const gltf = {/* no .scene */}
+      await expect(reader.afterRoot(gltf)).resolves.toBe(gltf)
+      // The decoded tree still hangs off the reader instance so callers
+      // with a non-standard glTF shape can still recover it.
+      expect(reader.spatialTree).toEqual(tree)
+    })
+
+    it('rejects a decoded payload that is not an object', async () => {
+      // Hostile cache file: the payload decodes to a JSON array (or
+      // a primitive). `validateDecodedTree` returns null; reader leaves
+      // the userData unset.
+      const baseGlb = serializeGlb(
+        {asset: {version: '2.0'}, buffers: [{byteLength: 4}]},
+        new Uint8Array(4))
+      const {bytes: withExt} = injectGlbExtensions(baseGlb, [
+        {name: BLDRS_SPATIAL_TREE_EXTENSION_NAME, data: [1, 2, 3]},
+      ])
+      const reader = new BldrsSpatialTreeReader(parserFromGlb(withExt))
+      const gltf = {scene: {userData: {}}}
+      await reader.afterRoot(gltf)
+      expect(gltf.scene.userData.bldrsSpatialTree).toBeNull()
+      expect(reader.spatialTree).toBeNull()
+    })
+
+    it('rejects a decoded payload missing expressID', async () => {
+      const baseGlb = serializeGlb(
+        {asset: {version: '2.0'}, buffers: [{byteLength: 4}]},
+        new Uint8Array(4))
+      const {bytes: withExt} = injectGlbExtensions(baseGlb, [
+        {name: BLDRS_SPATIAL_TREE_EXTENSION_NAME, data: {type: 'IFCPROJECT'}},
+      ])
+      const reader = new BldrsSpatialTreeReader(parserFromGlb(withExt))
+      const gltf = {scene: {userData: {}}}
+      await reader.afterRoot(gltf)
+      expect(reader.spatialTree).toBeNull()
+    })
+  })
+
+  describe('serialization depth ceiling', () => {
+    it('truncates a tree past MAX_TREE_DEPTH to keep the JS stack safe', async () => {
+      // Build a 150-level deep linear chain — past the 100-level
+      // ceiling. The capture should succeed (no throw) and the
+      // resulting tree should be truncated to MAX_TREE_DEPTH levels.
+      let node = {expressID: 999, type: 'IFCSPACE', children: []}
+      for (let i = 998; i >= 0; i--) {
+        node = {expressID: i, type: 'IFCSPACE', children: [node]}
+      }
+      const mgr = {getSpatialStructure: () => node}
+      const captured = await captureBldrsSpatialTree(mgr, 0)
+      expect(captured).not.toBeNull()
+      // Walk the resulting tree, count depth.
+      let depth = 0
+      let cursor = captured
+      while (cursor && cursor.children && cursor.children.length > 0) {
+        cursor = cursor.children[0]
+        depth++
+      }
+      // Depth is 0-based; root is depth 0. Past 100 levels we truncate
+      // by dropping the recursive `children` push. Exact terminal
+      // depth depends on whether the leaf is included; cap at 100.
+      expect(depth).toBeLessThanOrEqual(100)
+    })
   })
 
   describe('end-to-end: capture → inject → reader', () => {
@@ -215,7 +329,7 @@ describe('loader/bldrsSpatialTree', () => {
       const baseGlb = serializeGlb(
         {asset: {version: '2.0'}, buffers: [{byteLength: 4}]},
         new Uint8Array(4))
-      const withExt = injectGlbExtensions(baseGlb, [
+      const {bytes: withExt} = injectGlbExtensions(baseGlb, [
         {name: BLDRS_SPATIAL_TREE_EXTENSION_NAME, data: tree, compress: true},
       ])
 

--- a/src/loader/bldrsSpatialTree.test.js
+++ b/src/loader/bldrsSpatialTree.test.js
@@ -1,0 +1,242 @@
+/* eslint-disable no-magic-numbers */
+import {
+  BLDRS_SPATIAL_TREE_EXTENSION_NAME,
+  BldrsSpatialTreeReader,
+  captureBldrsSpatialTree,
+} from './bldrsSpatialTree'
+import {
+  injectGlbExtensions,
+  parseGlb,
+  serializeGlb,
+} from './injectGlbExtensions'
+
+
+describe('loader/bldrsSpatialTree', () => {
+  describe('captureBldrsSpatialTree', () => {
+    it('returns null when the ifcManager is missing', async () => {
+      expect(await captureBldrsSpatialTree(null, 0)).toBeNull()
+      expect(await captureBldrsSpatialTree(undefined, 0)).toBeNull()
+    })
+
+    it('returns null when the ifcManager has no getSpatialStructure', async () => {
+      expect(await captureBldrsSpatialTree({}, 0)).toBeNull()
+    })
+
+    it('returns null when getSpatialStructure resolves with no root', async () => {
+      const mgr = {getSpatialStructure: () => null}
+      expect(await captureBldrsSpatialTree(mgr, 0)).toBeNull()
+    })
+
+    it('returns null when the root has no expressID (malformed tree)', async () => {
+      const mgr = {getSpatialStructure: () => ({type: 'IFCPROJECT', children: []})}
+      expect(await captureBldrsSpatialTree(mgr, 0)).toBeNull()
+    })
+
+    it('returns null and swallows the error when the manager throws', async () => {
+      const mgr = {
+        getSpatialStructure: () => {
+          throw new Error('parser state gone')
+        },
+      }
+      // Suppress the debug().warn output during the test.
+      const origWarn = console.warn
+      console.warn = jest.fn()
+      try {
+        expect(await captureBldrsSpatialTree(mgr, 0)).toBeNull()
+      } finally {
+        console.warn = origWarn
+      }
+    })
+
+    it('serializes a minimal valid root', async () => {
+      const mgr = {
+        getSpatialStructure: () => ({
+          expressID: 1,
+          type: 'IFCPROJECT',
+          Name: {value: 'Project'},
+          children: [],
+        }),
+      }
+      expect(await captureBldrsSpatialTree(mgr, 0)).toEqual({
+        expressID: 1,
+        type: 'IFCPROJECT',
+        Name: {value: 'Project'},
+        children: [],
+      })
+    })
+
+    it('preserves nested children recursively', async () => {
+      const tree = {
+        expressID: 1,
+        type: 'IFCPROJECT',
+        Name: {value: 'P'},
+        children: [
+          {
+            expressID: 2,
+            type: 'IFCSITE',
+            Name: {value: 'S'},
+            children: [
+              {expressID: 3, type: 'IFCBUILDING', Name: {value: 'B'}, children: []},
+            ],
+          },
+        ],
+      }
+      const mgr = {getSpatialStructure: () => tree}
+      const captured = await captureBldrsSpatialTree(mgr, 0)
+      expect(captured).toEqual(tree)
+    })
+
+    it('strips fields not in the serialization whitelist', async () => {
+      // Real IfcManager output carries internal parser handles, parent
+      // backrefs, raw web-ifc result objects, etc. We intentionally drop
+      // anything not in the {expressID, type, Name, LongName, children}
+      // set so the cache payload stays small and JSON-safe.
+      const mgr = {
+        getSpatialStructure: () => ({
+          expressID: 1,
+          type: 'IFCPROJECT',
+          Name: {value: 'Project'},
+          LongName: {value: 'My Project'},
+          children: [],
+          // junk that should be dropped:
+          parent: {circular: true},
+          ifcAPIRef: () => null,
+          rawHandle: {_internal: true},
+        }),
+      }
+      const captured = await captureBldrsSpatialTree(mgr, 0)
+      expect(captured).toEqual({
+        expressID: 1,
+        type: 'IFCPROJECT',
+        Name: {value: 'Project'},
+        LongName: {value: 'My Project'},
+        children: [],
+      })
+      expect(captured.parent).toBeUndefined()
+      expect(captured.ifcAPIRef).toBeUndefined()
+      expect(captured.rawHandle).toBeUndefined()
+    })
+
+    it('threads the modelID through to getSpatialStructure', async () => {
+      const mgr = {
+        getSpatialStructure: jest.fn(() => ({
+          expressID: 1, type: 'IFCPROJECT', children: [],
+        })),
+      }
+      await captureBldrsSpatialTree(mgr, 42)
+      expect(mgr.getSpatialStructure).toHaveBeenCalledWith(42, true)
+    })
+  })
+
+  describe('BldrsSpatialTreeReader', () => {
+    /**
+     * Build a fake GLTFLoader `parser` over the supplied {json, bin}
+     * pair, sufficient for `afterRoot` to resolve its `getDependency`
+     * call. Mirrors how `ExtBldrsPropertiesPayload` is tested implicitly
+     * (via the live GLTFLoader); the simpler stub here keeps the test
+     * a unit of the extension's decode logic.
+     *
+     * @param {Uint8Array} glb
+     * @return {object}
+     */
+    function parserFromGlb(glb) {
+      const {json, bin} = parseGlb(glb)
+      const buffer = bin.buffer.slice(bin.byteOffset, bin.byteOffset + bin.byteLength)
+      return {
+        json,
+        getDependency: (kind, _index) => {
+          if (kind !== 'buffer') {
+            return Promise.reject(new Error(`unexpected dep kind ${kind}`))
+          }
+          return Promise.resolve(buffer)
+        },
+      }
+    }
+
+    it('decodes a tree round-tripped through injectGlbExtensions', async () => {
+      const tree = {
+        expressID: 1,
+        type: 'IFCPROJECT',
+        Name: {value: 'Project'},
+        children: [
+          {expressID: 2, type: 'IFCSITE', Name: {value: 'Site'}, children: []},
+        ],
+      }
+      const baseGlb = serializeGlb(
+        {asset: {version: '2.0'}, buffers: [{byteLength: 4}]},
+        new Uint8Array(4))
+      const withExt = injectGlbExtensions(baseGlb, [
+        {name: BLDRS_SPATIAL_TREE_EXTENSION_NAME, data: tree, compress: true},
+      ])
+
+      const reader = new BldrsSpatialTreeReader(parserFromGlb(withExt))
+      const gltf = {scene: {userData: {}}}
+      await reader.afterRoot(gltf)
+
+      expect(gltf.scene.userData.bldrsSpatialTree).toEqual(tree)
+      expect(reader.spatialTree).toEqual(tree)
+    })
+
+    it('is a no-op when the GLB has no BLDRS_spatial_tree extension', async () => {
+      const baseGlb = serializeGlb(
+        {asset: {version: '2.0'}, buffers: [{byteLength: 4}]},
+        new Uint8Array(4))
+      const reader = new BldrsSpatialTreeReader(parserFromGlb(baseGlb))
+      const gltf = {scene: {userData: {}}}
+      await reader.afterRoot(gltf)
+      expect(gltf.scene.userData.bldrsSpatialTree).toBeUndefined()
+      expect(reader.spatialTree).toBeNull()
+    })
+
+    it('reports its extension name', () => {
+      const reader = new BldrsSpatialTreeReader({json: {}})
+      expect(reader.name).toBe(BLDRS_SPATIAL_TREE_EXTENSION_NAME)
+      expect(reader.name).toBe('BLDRS_spatial_tree')
+    })
+  })
+
+  describe('end-to-end: capture → inject → reader', () => {
+    it('preserves the captured tree through write+read', async () => {
+      const mgr = {
+        getSpatialStructure: () => ({
+          expressID: 100,
+          type: 'IFCPROJECT',
+          Name: {value: 'E2E'},
+          LongName: {value: 'End to end project'},
+          children: [
+            {expressID: 200, type: 'IFCSITE', Name: {value: 'Site'}, children: []},
+            {expressID: 300, type: 'IFCBUILDING', Name: {value: 'Building'}, children: []},
+          ],
+        }),
+      }
+      const tree = await captureBldrsSpatialTree(mgr, 0)
+      expect(tree).not.toBeNull()
+
+      const baseGlb = serializeGlb(
+        {asset: {version: '2.0'}, buffers: [{byteLength: 4}]},
+        new Uint8Array(4))
+      const withExt = injectGlbExtensions(baseGlb, [
+        {name: BLDRS_SPATIAL_TREE_EXTENSION_NAME, data: tree, compress: true},
+      ])
+
+      const {json} = parseGlb(withExt)
+      expect(json.extensionsUsed).toContain(BLDRS_SPATIAL_TREE_EXTENSION_NAME)
+      expect(json.extensions[BLDRS_SPATIAL_TREE_EXTENSION_NAME]).toMatchObject({
+        compressed: true,
+      })
+
+      // Round-trip via the reader.
+      const buffer = parseGlb(withExt).bin.buffer.slice(
+        parseGlb(withExt).bin.byteOffset,
+        parseGlb(withExt).bin.byteOffset + parseGlb(withExt).bin.byteLength,
+      )
+      const reader = new BldrsSpatialTreeReader({
+        json,
+        getDependency: () => buffer,
+      })
+      const gltf = {scene: {userData: {}}}
+      await reader.afterRoot(gltf)
+      expect(gltf.scene.userData.bldrsSpatialTree).toEqual(tree)
+    })
+  })
+})

--- a/src/loader/glbCacheKey.js
+++ b/src/loader/glbCacheKey.js
@@ -15,6 +15,14 @@
 /**
  * Current Bldrs GLB artifact schema version. Bumped on any backwards-
  * incompatible change to the BLDRS_* extension contract or cache-key shape.
+ * 0.6.0 — added `BLDRS_spatial_tree` glTF extension carrying the IFC
+ *         spatial hierarchy. Cache-hit GLBs now hydrate the NavTree
+ *         without re-parsing the IFC (previously required the live
+ *         `viewer.IFC.loader.ifcManager` which only exists on cache-
+ *         miss IFC parses). Older artifacts read as a miss because the
+ *         schema version embeds in the filename; the next miss rewrites
+ *         with the extension attached. See
+ *         design/new/viewer-replacement.md §3b.iii default-on gating.
  * 0.5.0 — switched the writer from conway's GeometryAggregator to
  *         three.js GLTFExporter on the rendered IFCLoader model. Conway
  *         was filtering by CanonicalMeshType.BUFFER_GEOMETRY and
@@ -29,7 +37,7 @@
  * 0.2.0 — generalised cache key from GitHub-only (owner/repo/branch) to a
  *         per-source-kind 3-level namespace (ns1/ns2/ns3).
  */
-export const BLDRS_GLB_SCHEMA_VERSION = '0.5.0'
+export const BLDRS_GLB_SCHEMA_VERSION = '0.6.0'
 
 
 /**

--- a/src/loader/glbExport.js
+++ b/src/loader/glbExport.js
@@ -26,6 +26,10 @@
 // once the BLDRS_* extension story makes a custom writer worthwhile.
 import {GLTFExporter} from 'three/examples/jsm/exporters/GLTFExporter.js'
 import {writeGlbBytesToOPFS} from '../OPFS/utils'
+import {
+  BLDRS_SPATIAL_TREE_EXTENSION_NAME,
+  captureBldrsSpatialTree,
+} from './bldrsSpatialTree'
 import {glbCacheKey} from './glbCacheKey'
 import {
   activeGlbCompressionMode,
@@ -34,6 +38,7 @@ import {
 } from './glbCompress'
 import {packGlbChunks} from './glbContainer'
 import {glbInfo, glbVerbose} from './glbLog'
+import {injectGlbExtensions} from './injectGlbExtensions'
 
 
 /**
@@ -127,9 +132,16 @@ function silenceGltfExporterMaterialWarnings() {
  *   (e.g. 'github', 'local', 'upload', 'external'). Not used as a cache key.
  * @param {object} args.cacheKeyArgs Output of one of the sourceCacheKey
  *   adapters: {ns1, ns2, ns3, sourcePath, sourceHash}.
+ * @param {object} [args.ifcManager] IfcManager-like with
+ *   `getSpatialStructure(modelID, withProperties)` — typically
+ *   `viewer.IFC.loader.ifcManager`. When provided and the source is an
+ *   IFC parse with live parser state, the spatial structure is captured
+ *   and embedded as a `BLDRS_spatial_tree` extension so cache-hit GLBs
+ *   render their NavTree without re-parsing. Pass `null` for non-IFC
+ *   sources or when no live tree is available.
  * @return {Promise<boolean>}
  */
-export async function exportAndCacheGlb({model, kindLabel, cacheKeyArgs}) {
+export async function exportAndCacheGlb({model, kindLabel, cacheKeyArgs, ifcManager = null}) {
   const startMs = Date.now()
   try {
     const filePath = cacheKeyArgs.sourcePath
@@ -144,12 +156,26 @@ export async function exportAndCacheGlb({model, kindLabel, cacheKeyArgs}) {
       return false
     }
     glbVerbose('writer: GLTFExporter produced', rawBytes.byteLength, 'bytes')
+    // Capture BLDRS_* extension payloads from the live IFC parser state
+    // before it goes out of scope. We pass these through `injectGlbExtensions`
+    // even when null/empty — the helper is a no-op for an empty list, so
+    // the call-site stays unconditional.
+    const spatialTree = await captureBldrsSpatialTree(ifcManager, model?.modelID ?? 0)
+    const withExtensions = injectGlbExtensions(rawBytes, [
+      {name: BLDRS_SPATIAL_TREE_EXTENSION_NAME, data: spatialTree, compress: true},
+    ])
+    if (withExtensions !== rawBytes) {
+      glbVerbose(
+        'writer: injected extensions, +' +
+        `${withExtensions.byteLength - rawBytes.byteLength}B ` +
+        `(${withExtensions.injectGlbStats?.addedExtensions ?? 0} extension(s))`)
+    }
     // Use the *actual* compression mode (compressGlb may fall back to
     // null on encoder failure) so the cached artifact lands in the
     // matching schema slot. Otherwise a -draco / -meshopt suffix on
     // uncompressed bytes would mislead a reader running with the same
     // flag (it would expect compressed input on the next load).
-    const {bytes, mode} = await compressGlb(rawBytes, requestedMode)
+    const {bytes, mode} = await compressGlb(withExtensions, requestedMode)
     const schemaVer = schemaVersionFor(mode)
     const packed = packGlbChunks([bytes], mode)
     const key = glbCacheKey({...cacheKeyArgs, schemaVer})

--- a/src/loader/glbExport.js
+++ b/src/loader/glbExport.js
@@ -161,14 +161,13 @@ export async function exportAndCacheGlb({model, kindLabel, cacheKeyArgs, ifcMana
     // even when null/empty — the helper is a no-op for an empty list, so
     // the call-site stays unconditional.
     const spatialTree = await captureBldrsSpatialTree(ifcManager, model?.modelID ?? 0)
-    const withExtensions = injectGlbExtensions(rawBytes, [
+    const {bytes: withExtensions, stats: extStats} = injectGlbExtensions(rawBytes, [
       {name: BLDRS_SPATIAL_TREE_EXTENSION_NAME, data: spatialTree, compress: true},
     ])
-    if (withExtensions !== rawBytes) {
+    if (extStats.addedExtensions > 0) {
       glbVerbose(
-        'writer: injected extensions, +' +
-        `${withExtensions.byteLength - rawBytes.byteLength}B ` +
-        `(${withExtensions.injectGlbStats?.addedExtensions ?? 0} extension(s))`)
+        `writer: injected ${extStats.addedExtensions} extension(s), ` +
+        `+${withExtensions.byteLength - rawBytes.byteLength}B`)
     }
     // Use the *actual* compression mode (compressGlb may fall back to
     // null on encoder failure) so the cached artifact lands in the

--- a/src/loader/glbExport.test.js
+++ b/src/loader/glbExport.test.js
@@ -17,12 +17,18 @@ jest.mock('three/examples/jsm/exporters/GLTFExporter.js', () => ({
 
 // The real glbCompress lazy-imports @gltf-transform; in unit tests we
 // short-circuit it to a passthrough so the writer's behavior is testable
-// without standing up the wasm encoder pipeline.
+// without standing up the wasm encoder pipeline. The schemaVersionFor
+// mock reads through to the live `BLDRS_GLB_SCHEMA_VERSION` constant
+// (via `jest.requireActual`) so bumping the schema in `glbCacheKey.js`
+// doesn't break this mock.
 const mockActiveMode = jest.fn(() => null)
 const mockCompressGlb = jest.fn((bytes, mode) => Promise.resolve({bytes, mode: mode || null}))
 jest.mock('./glbCompress', () => ({
   activeGlbCompressionMode: () => mockActiveMode(),
-  schemaVersionFor: (mode) => (mode ? `0.5.0-${mode}` : '0.5.0'),
+  schemaVersionFor: (mode) => {
+    const {BLDRS_GLB_SCHEMA_VERSION: ver} = jest.requireActual('./glbCacheKey')
+    return mode ? `${ver}-${mode}` : ver
+  },
   compressGlb: (...args) => mockCompressGlb(...args),
 }))
 

--- a/src/loader/injectGlbExtensions.js
+++ b/src/loader/injectGlbExtensions.js
@@ -1,0 +1,283 @@
+// Post-process raw GLB bytes from GLTFExporter to inject custom
+// glTF top-level extensions whose payloads live in the binary chunk.
+//
+// We use GLTFExporter's output verbatim (geometry, materials, textures,
+// scene graph) and then splice in extra bufferViews + extension entries.
+// Going through this route — rather than writing a GLTFExporter plugin —
+// keeps the geometry-export path identical to what we ship today and
+// confines the extension write logic to one well-tested seam.
+//
+// Why "one seam, not a GLTFExporter plugin": GLTFExporter's plugin API
+// exposes per-{node,mesh,material} write hooks but its top-level extension
+// surface (`writer.extensionsUsed`, `writer.json.extensions`) is sparsely
+// documented and tightly coupled to write order — adding a bufferView from
+// a plugin requires reaching into `writer.processBufferView` after the
+// main parse, which is fragile across three.js versions. Post-processing
+// the canonical GLB wire format is version-stable.
+//
+// On-disk layout of a glTF 2.0 binary (".glb"), little-endian throughout:
+//   0..3   magic     u32  0x46546C67  "glTF"
+//   4..7   version   u32  2
+//   8..11  length    u32  total file length
+//   12..15 jChunkLen u32  byteLength of JSON chunk DATA (padded internally)
+//   16..19 jChunkTyp u32  0x4E4F534A  "JSON"
+//   20..   jChunkDat utf-8 JSON, padded with 0x20 (space) to multiple of 4
+//   ...    bChunkLen u32  byteLength of BIN chunk DATA (padded internally)
+//   +4     bChunkTyp u32  0x004E4942  "BIN\0"
+//   +8     bChunkDat raw  buffer bytes, padded with 0x00 to multiple of 4
+//
+// glTF requires `buffers[0].byteLength` to equal the BIN chunk's unpadded
+// data length — chunk-level zero padding does NOT count toward it. Each
+// new bufferView's `byteOffset` is set to a 4-byte boundary within the
+// buffer; the spec only requires alignment for accessor-typed bufferViews
+// but enforcing it everywhere keeps any future accessor reuse safe.
+import * as pako from 'pako'
+
+
+const GLB_MAGIC = 0x46546C67 // "glTF" LE
+const GLB_VERSION = 2
+const GLB_HEADER_BYTES = 12
+const CHUNK_HEADER_BYTES = 8
+const JSON_CHUNK_TYPE = 0x4E4F534A // "JSON" LE
+const BIN_CHUNK_TYPE = 0x004E4942 // "BIN\0" LE
+const HEX_RADIX = 16
+
+
+/**
+ * Round a byte length up to the next multiple of 4.
+ *
+ * @param {number} n
+ * @return {number}
+ */
+function pad4(n) {
+  return (n + 3) & ~3
+}
+
+
+/**
+ * Parse a GLB binary into its constituent JSON document + binary chunk.
+ * Throws when the input is not a well-formed GLB; callers wrap the call
+ * in try/catch when the input may be a non-GLB blob (e.g. our Bldrs
+ * container wrapper at a different layer).
+ *
+ * @param {Uint8Array} bytes
+ * @return {object} `{json: object, bin: Uint8Array|null}` — the BIN
+ *   chunk is null when the source GLB had no binary chunk (rare but
+ *   spec-legal; geometry-only-via-URI).
+ */
+export function parseGlb(bytes) {
+  if (!(bytes instanceof Uint8Array)) {
+    throw new TypeError('parseGlb: input must be a Uint8Array')
+  }
+  if (bytes.byteLength < GLB_HEADER_BYTES) {
+    throw new Error(`parseGlb: too short (${bytes.byteLength}B < header ${GLB_HEADER_BYTES}B)`)
+  }
+  const dv = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength)
+  const magic = dv.getUint32(0, true)
+  if (magic !== GLB_MAGIC) {
+    throw new Error(`parseGlb: bad magic 0x${magic.toString(HEX_RADIX)} (expected 0x${GLB_MAGIC.toString(HEX_RADIX)})`)
+  }
+  const version = dv.getUint32(4, true)
+  if (version !== GLB_VERSION) {
+    throw new Error(`parseGlb: unsupported version ${version} (expected ${GLB_VERSION})`)
+  }
+  const totalLen = dv.getUint32(8, true)
+  if (totalLen > bytes.byteLength) {
+    throw new Error(`parseGlb: header length ${totalLen} exceeds buffer ${bytes.byteLength}`)
+  }
+
+  // JSON chunk (required, must be first per spec).
+  let offset = GLB_HEADER_BYTES
+  const jLen = dv.getUint32(offset, true)
+  const jType = dv.getUint32(offset + 4, true)
+  if (jType !== JSON_CHUNK_TYPE) {
+    throw new Error(`parseGlb: first chunk is not JSON (got 0x${jType.toString(HEX_RADIX)})`)
+  }
+  const jStart = offset + CHUNK_HEADER_BYTES
+  const jEnd = jStart + jLen
+  const jsonText = new TextDecoder('utf-8').decode(bytes.subarray(jStart, jEnd))
+  // Strip trailing 0x20 padding before parsing (some decoders tolerate
+  // it, but JSON.parse on whitespace-after-EOF is implementation-
+  // specific in older runtimes).
+  const json = JSON.parse(jsonText.replace(/\s+$/, ''))
+  offset = jEnd
+
+  // BIN chunk (optional per spec; absent means embedded data URIs only).
+  let bin = null
+  if (offset < totalLen) {
+    const bLen = dv.getUint32(offset, true)
+    const bType = dv.getUint32(offset + 4, true)
+    if (bType !== BIN_CHUNK_TYPE) {
+      throw new Error(`parseGlb: second chunk is not BIN (got 0x${bType.toString(HEX_RADIX)})`)
+    }
+    const bStart = offset + CHUNK_HEADER_BYTES
+    // The authoritative data length is buffers[0].byteLength (per spec);
+    // bLen rounds up to a 4-byte chunk boundary. Slice to the authoritative
+    // length so we don't drag trailing zero padding into our new buffer.
+    const authLen = json?.buffers?.[0]?.byteLength ?? bLen
+    bin = bytes.subarray(bStart, bStart + authLen)
+  }
+
+  return {json, bin}
+}
+
+
+/**
+ * Serialize a {json, bin} pair into a GLB binary. Inverse of parseGlb.
+ *
+ * @param {object} json
+ * @param {Uint8Array|null} bin
+ * @return {Uint8Array}
+ */
+export function serializeGlb(json, bin) {
+  const jsonText = JSON.stringify(json)
+  // JSON chunk data is padded to 4 bytes with 0x20 (space); the GLB spec
+  // requires this so the chunk header that follows lands on alignment.
+  const jsonBytes = new TextEncoder().encode(jsonText)
+  const jsonPad = pad4(jsonBytes.length) - jsonBytes.length
+  const jsonChunkLen = jsonBytes.length + jsonPad
+
+  const hasBin = bin && bin.byteLength > 0
+  const binPad = hasBin ? pad4(bin.byteLength) - bin.byteLength : 0
+  const binChunkLen = hasBin ? bin.byteLength + binPad : 0
+
+  const totalLen = GLB_HEADER_BYTES +
+                   CHUNK_HEADER_BYTES + jsonChunkLen +
+                   (hasBin ? CHUNK_HEADER_BYTES + binChunkLen : 0)
+
+  const out = new Uint8Array(totalLen)
+  const dv = new DataView(out.buffer)
+  let p = 0
+  dv.setUint32(p, GLB_MAGIC, true); p += 4
+  dv.setUint32(p, GLB_VERSION, true); p += 4
+  dv.setUint32(p, totalLen, true); p += 4
+
+  // JSON chunk header + data + space padding.
+  dv.setUint32(p, jsonChunkLen, true); p += 4
+  dv.setUint32(p, JSON_CHUNK_TYPE, true); p += 4
+  out.set(jsonBytes, p); p += jsonBytes.length
+  for (let i = 0; i < jsonPad; i++) {
+    out[p++] = 0x20
+  }
+
+  // BIN chunk header + data + zero padding (zero-fill is implicit from
+  // Uint8Array init, no explicit loop needed).
+  if (hasBin) {
+    dv.setUint32(p, binChunkLen, true); p += 4
+    dv.setUint32(p, BIN_CHUNK_TYPE, true); p += 4
+    out.set(bin, p); p += bin.byteLength
+    p += binPad
+  }
+
+  return out
+}
+
+
+/**
+ * Inject one or more named top-level glTF extensions into a GLB. Each
+ * extension's payload is serialized to JSON (and optionally gzipped),
+ * appended to the GLB's binary chunk as a new bufferView, and recorded
+ * under the extension name with `{compressed, bufferView}` shape so the
+ * reader plugin can find it.
+ *
+ * On-disk shape per extension after injection:
+ *   json.extensions[name]      = {compressed: <bool>, bufferView: <int>}
+ *   json.extensionsUsed       += [name]   (idempotent)
+ *   json.bufferViews          += [{buffer: 0, byteOffset, byteLength}]
+ *   json.buffers[0].byteLength += pad4(payload bytes)
+ *
+ * The reader counterpart for each extension lives next to the writer
+ * helper that produces it (e.g. src/loader/bldrsSpatialTree.js exports
+ * both `captureBldrsSpatialTree` and `BldrsSpatialTreeReader`).
+ *
+ * Pass-through behavior: when `extensions` is empty (or every entry has
+ * `data: null/undefined`), the input bytes are returned unmodified — the
+ * caller can unconditionally route GLBs through this helper without
+ * paying a re-serialise cost when nothing is being injected.
+ *
+ * @param {Uint8Array} glbBytes
+ * @param {Array} extensions list of `{name: string, data: object|null|undefined, compress?: boolean}`
+ * @return {Uint8Array}
+ */
+export function injectGlbExtensions(glbBytes, extensions) {
+  const active = (extensions ?? []).filter((e) => e && e.data !== null && e.data !== undefined)
+  if (active.length === 0) {
+    return glbBytes
+  }
+
+  const {json, bin} = parseGlb(glbBytes)
+
+  // We always reference buffer 0 (the implicit GLB BIN chunk). If the
+  // input had no BIN chunk (geometry-only-via-URI is rare in practice
+  // but legal), we synthesise one. The buffers[] entry is similarly
+  // created on demand.
+  json.buffers = json.buffers ?? []
+  if (json.buffers.length === 0) {
+    json.buffers.push({byteLength: 0})
+  }
+  json.bufferViews = json.bufferViews ?? []
+  json.extensions = json.extensions ?? {}
+  json.extensionsUsed = json.extensionsUsed ?? []
+
+  // Lay out additions starting at the next 4-byte boundary after the
+  // existing buffer data. Each addition is itself padded to 4 bytes so
+  // subsequent bufferViews stay aligned. Track two cursors:
+  //   `nextOffset` — 4-aligned, where the *next* bufferView would start
+  //   `dataEnd`    — unpadded end of the *last* bufferView's data
+  // Both are needed downstream: `nextOffset` sizes the BIN chunk we
+  // hand to `serializeGlb`; `dataEnd` is the value written to
+  // `buffers[0].byteLength` (per glTF spec, the buffer's logical length
+  // is its data, not its alignment-padded extent — the chunk header
+  // carries the latter).
+  let nextOffset = pad4(json.buffers[0].byteLength)
+  let dataEnd = nextOffset
+  const additions = []
+  for (const {name, data, compress = true} of active) {
+    const jsonText = JSON.stringify(data)
+    const raw = new TextEncoder().encode(jsonText)
+    const payload = compress ? pako.gzip(raw) : raw
+    additions.push({name, payload, byteOffset: nextOffset, compressed: compress})
+    dataEnd = nextOffset + payload.byteLength
+    nextOffset += pad4(payload.byteLength)
+  }
+
+  // Build the new BIN at the padded size so trailing zeros stay inside
+  // the binary chunk; serializeGlb's chunk-level pad-to-4 then becomes
+  // a no-op rather than re-pad. Original data goes first; each addition
+  // lands at its assigned (4-aligned) offset, with intermediate padding
+  // bytes implicit zero from the Uint8Array init.
+  const oldLen = bin ? bin.byteLength : 0
+  const newBin = new Uint8Array(nextOffset)
+  if (bin) {
+    newBin.set(bin, 0)
+  }
+  for (const {payload, byteOffset} of additions) {
+    newBin.set(payload, byteOffset)
+  }
+
+  // Update JSON metadata. We point each new bufferView's byteLength at
+  // the payload (gzipped bytes), not the original JSON length — the
+  // reader decompresses by exactly this many bytes.
+  json.buffers[0].byteLength = dataEnd
+  for (const {name, payload, byteOffset, compressed} of additions) {
+    const bvIndex = json.bufferViews.length
+    json.bufferViews.push({
+      buffer: 0,
+      byteOffset,
+      byteLength: payload.byteLength,
+    })
+    json.extensions[name] = {compressed, bufferView: bvIndex}
+    if (!json.extensionsUsed.includes(name)) {
+      json.extensionsUsed.push(name)
+    }
+  }
+
+  // Telemetry hook for callers wanting to log the growth: report the
+  // delta on the return value.
+  const out = serializeGlb(json, newBin)
+  out.injectGlbStats = {
+    addedExtensions: additions.length,
+    addedBinBytes: nextOffset - oldLen,
+  }
+  return out
+}

--- a/src/loader/injectGlbExtensions.js
+++ b/src/loader/injectGlbExtensions.js
@@ -32,6 +32,7 @@
 // buffer; the spec only requires alignment for accessor-typed bufferViews
 // but enforcing it everywhere keeps any future accessor reuse safe.
 import * as pako from 'pako'
+import {glbInfo} from './glbLog'
 
 
 const GLB_MAGIC = 0x46546C67 // "glTF" LE
@@ -191,18 +192,32 @@ export function serializeGlb(json, bin) {
  * both `captureBldrsSpatialTree` and `BldrsSpatialTreeReader`).
  *
  * Pass-through behavior: when `extensions` is empty (or every entry has
- * `data: null/undefined`), the input bytes are returned unmodified — the
- * caller can unconditionally route GLBs through this helper without
- * paying a re-serialise cost when nothing is being injected.
+ * `data: null/undefined`), the input bytes are returned unmodified (and
+ * `stats.addedExtensions === 0`) — the caller can unconditionally route
+ * GLBs through this helper without paying a re-serialise cost when
+ * nothing is being injected.
+ *
+ * Collision behavior: an extension whose `name` is already present in
+ * `json.extensions` is **skipped** — we log a warning and leave the
+ * existing entry intact rather than overwrite (which would orphan the
+ * old bufferView in the file). Today's writer only injects on fresh
+ * GLTFExporter output so this branch is defensive; it matters once
+ * we start handling user-originated GLBs.
  *
  * @param {Uint8Array} glbBytes
  * @param {Array} extensions list of `{name: string, data: object|null|undefined, compress?: boolean}`
- * @return {Uint8Array}
+ * @return {{bytes: Uint8Array, stats: {addedExtensions: number, addedBinBytes: number, skippedNames: Array<string>}}}
+ *   `bytes` is the modified GLB (or the input unchanged in pass-through);
+ *   `stats` describes what changed so callers can log delta metrics
+ *   without inspecting the byte stream.
  */
 export function injectGlbExtensions(glbBytes, extensions) {
   const active = (extensions ?? []).filter((e) => e && e.data !== null && e.data !== undefined)
   if (active.length === 0) {
-    return glbBytes
+    return {
+      bytes: glbBytes,
+      stats: {addedExtensions: 0, addedBinBytes: 0, skippedNames: []},
+    }
   }
 
   const {json, bin} = parseGlb(glbBytes)
@@ -219,6 +234,30 @@ export function injectGlbExtensions(glbBytes, extensions) {
   json.extensions = json.extensions ?? {}
   json.extensionsUsed = json.extensionsUsed ?? []
 
+  // Filter out extensions whose name is already present in the JSON's
+  // `extensions` map. Overwriting would silently orphan the existing
+  // bufferView (still in the file, no entry references it) — that's a
+  // silent corruption path on round-tripping a GLB that already carried
+  // an earlier `BLDRS_*` payload. Surface it as a warning and skip.
+  const skippedNames = []
+  const toInject = []
+  for (const ext of active) {
+    if (json.extensions[ext.name] !== undefined) {
+      skippedNames.push(ext.name)
+      glbInfo(
+        `injectGlbExtensions: ${ext.name} already present; skipping ` +
+        '(overwriting would orphan the existing bufferView)')
+      continue
+    }
+    toInject.push(ext)
+  }
+  if (toInject.length === 0) {
+    return {
+      bytes: glbBytes,
+      stats: {addedExtensions: 0, addedBinBytes: 0, skippedNames},
+    }
+  }
+
   // Lay out additions starting at the next 4-byte boundary after the
   // existing buffer data. Each addition is itself padded to 4 bytes so
   // subsequent bufferViews stay aligned. Track two cursors:
@@ -232,7 +271,7 @@ export function injectGlbExtensions(glbBytes, extensions) {
   let nextOffset = pad4(json.buffers[0].byteLength)
   let dataEnd = nextOffset
   const additions = []
-  for (const {name, data, compress = true} of active) {
+  for (const {name, data, compress = true} of toInject) {
     const jsonText = JSON.stringify(data)
     const raw = new TextEncoder().encode(jsonText)
     const payload = compress ? pako.gzip(raw) : raw
@@ -272,12 +311,12 @@ export function injectGlbExtensions(glbBytes, extensions) {
     }
   }
 
-  // Telemetry hook for callers wanting to log the growth: report the
-  // delta on the return value.
-  const out = serializeGlb(json, newBin)
-  out.injectGlbStats = {
-    addedExtensions: additions.length,
-    addedBinBytes: nextOffset - oldLen,
+  return {
+    bytes: serializeGlb(json, newBin),
+    stats: {
+      addedExtensions: additions.length,
+      addedBinBytes: nextOffset - oldLen,
+      skippedNames,
+    },
   }
-  return out
 }

--- a/src/loader/injectGlbExtensions.test.js
+++ b/src/loader/injectGlbExtensions.test.js
@@ -86,23 +86,25 @@ describe('loader/injectGlbExtensions', () => {
   describe('injectGlbExtensions — no-op cases', () => {
     it('returns the input bytes unchanged when extensions list is empty', () => {
       const glb = makeMinimalGlb()
-      const out = injectGlbExtensions(glb, [])
-      expect(out).toBe(glb)
+      const {bytes, stats} = injectGlbExtensions(glb, [])
+      expect(bytes).toBe(glb)
+      expect(stats).toEqual({addedExtensions: 0, addedBinBytes: 0, skippedNames: []})
     })
 
     it('returns the input bytes unchanged when all entries have null data', () => {
       const glb = makeMinimalGlb()
-      const out = injectGlbExtensions(glb, [
+      const {bytes, stats} = injectGlbExtensions(glb, [
         {name: 'BLDRS_x', data: null},
         {name: 'BLDRS_y', data: undefined},
       ])
-      expect(out).toBe(glb)
+      expect(bytes).toBe(glb)
+      expect(stats.addedExtensions).toBe(0)
     })
 
     it('returns the input bytes unchanged when extensions is null/undefined', () => {
       const glb = makeMinimalGlb()
-      expect(injectGlbExtensions(glb, null)).toBe(glb)
-      expect(injectGlbExtensions(glb, undefined)).toBe(glb)
+      expect(injectGlbExtensions(glb, null).bytes).toBe(glb)
+      expect(injectGlbExtensions(glb, undefined).bytes).toBe(glb)
     })
   })
 
@@ -110,11 +112,11 @@ describe('loader/injectGlbExtensions', () => {
     it('appends a bufferView and extension entry with compressed payload', () => {
       const glb = makeMinimalGlb({binBytes: 16})
       const data = {hello: 'world', n: 42}
-      const out = injectGlbExtensions(glb, [
+      const {bytes} = injectGlbExtensions(glb, [
         {name: 'BLDRS_test', data, compress: true},
       ])
 
-      const parsed = parseGlb(out)
+      const parsed = parseGlb(bytes)
       expect(parsed.json.extensionsUsed).toContain('BLDRS_test')
       expect(parsed.json.extensions.BLDRS_test).toEqual({compressed: true, bufferView: 1})
 
@@ -136,10 +138,10 @@ describe('loader/injectGlbExtensions', () => {
 
     it('updates buffers[0].byteLength to cover the appended payload', () => {
       const glb = makeMinimalGlb({binBytes: 8})
-      const out = injectGlbExtensions(glb, [
+      const {bytes} = injectGlbExtensions(glb, [
         {name: 'BLDRS_test', data: {a: 1}, compress: true},
       ])
-      const parsed = parseGlb(out)
+      const parsed = parseGlb(bytes)
       const expectedMin = parsed.json.bufferViews[1].byteOffset +
                           parsed.json.bufferViews[1].byteLength
       expect(parsed.json.buffers[0].byteLength).toBe(expectedMin)
@@ -149,10 +151,10 @@ describe('loader/injectGlbExtensions', () => {
     it('supports an uncompressed payload', () => {
       const glb = makeMinimalGlb({binBytes: 4})
       const data = {raw: true}
-      const out = injectGlbExtensions(glb, [
+      const {bytes} = injectGlbExtensions(glb, [
         {name: 'BLDRS_test', data, compress: false},
       ])
-      const parsed = parseGlb(out)
+      const parsed = parseGlb(bytes)
       expect(parsed.json.extensions.BLDRS_test).toEqual({compressed: false, bufferView: 1})
       const bv = parsed.json.bufferViews[1]
       const payload = parsed.bin.subarray(bv.byteOffset, bv.byteOffset + bv.byteLength)
@@ -160,26 +162,26 @@ describe('loader/injectGlbExtensions', () => {
       expect(JSON.parse(text)).toEqual(data)
     })
 
-    it('annotates the output with injectGlbStats describing what changed', () => {
+    it('returns stats describing what changed', () => {
       const glb = makeMinimalGlb({binBytes: 8})
-      const out = injectGlbExtensions(glb, [
+      const {stats} = injectGlbExtensions(glb, [
         {name: 'BLDRS_test', data: {x: 1}},
       ])
-      expect(out.injectGlbStats).toBeDefined()
-      expect(out.injectGlbStats.addedExtensions).toBe(1)
-      expect(out.injectGlbStats.addedBinBytes).toBeGreaterThan(0)
+      expect(stats.addedExtensions).toBe(1)
+      expect(stats.addedBinBytes).toBeGreaterThan(0)
+      expect(stats.skippedNames).toEqual([])
     })
   })
 
   describe('injectGlbExtensions — multiple extensions', () => {
     it('lays out each new bufferView at a 4-aligned offset, in order', () => {
       const glb = makeMinimalGlb({binBytes: 4})
-      const out = injectGlbExtensions(glb, [
+      const {bytes} = injectGlbExtensions(glb, [
         {name: 'BLDRS_a', data: {a: 1}},
         {name: 'BLDRS_b', data: {b: 2}},
         {name: 'BLDRS_c', data: {c: 3}},
       ])
-      const parsed = parseGlb(out)
+      const parsed = parseGlb(bytes)
       expect(parsed.json.extensionsUsed).toEqual(
         expect.arrayContaining(['BLDRS_a', 'BLDRS_b', 'BLDRS_c']))
       const newBvs = parsed.json.bufferViews.slice(1)
@@ -193,6 +195,9 @@ describe('loader/injectGlbExtensions', () => {
     })
 
     it('does not duplicate names already in extensionsUsed', () => {
+      // Note this is a different shape from the "collision" case below:
+      // the name is in extensionsUsed but NOT in extensions{}, so the
+      // injection still runs and dedupes the extensionsUsed entry.
       const json = {
         asset: {version: '2.0'},
         buffers: [{byteLength: 4}],
@@ -200,11 +205,59 @@ describe('loader/injectGlbExtensions', () => {
         extensionsUsed: ['BLDRS_test'],
       }
       const glb = serializeGlb(json, new Uint8Array(4))
-      const out = injectGlbExtensions(glb, [
+      const {bytes} = injectGlbExtensions(glb, [
         {name: 'BLDRS_test', data: {x: 1}},
       ])
-      const parsed = parseGlb(out)
+      const parsed = parseGlb(bytes)
       expect(parsed.json.extensionsUsed.filter((n) => n === 'BLDRS_test')).toHaveLength(1)
+    })
+  })
+
+  describe('injectGlbExtensions — collision handling', () => {
+    it('skips an extension whose name is already in json.extensions, reports via stats', () => {
+      // Building a GLB that already carries an `extensions.BLDRS_test`
+      // entry. Re-injecting under the same name should NOT overwrite —
+      // that would silently orphan the existing bufferView, leaving a
+      // dead-data corruption path through cache round-trips. Instead we
+      // skip and surface the name via stats.skippedNames so the caller
+      // can log / metric.
+      const json = {
+        asset: {version: '2.0'},
+        buffers: [{byteLength: 4}],
+        bufferViews: [{buffer: 0, byteOffset: 0, byteLength: 4}],
+        extensionsUsed: ['BLDRS_test'],
+        extensions: {BLDRS_test: {compressed: true, bufferView: 0}},
+      }
+      const glb = serializeGlb(json, new Uint8Array(4))
+      const {bytes, stats} = injectGlbExtensions(glb, [
+        {name: 'BLDRS_test', data: {x: 999}},
+      ])
+      expect(stats.addedExtensions).toBe(0)
+      expect(stats.skippedNames).toEqual(['BLDRS_test'])
+      // Pass-through: existing entry untouched.
+      expect(bytes).toBe(glb)
+      const parsed = parseGlb(bytes)
+      expect(parsed.json.extensions.BLDRS_test).toEqual({compressed: true, bufferView: 0})
+    })
+
+    it('still injects siblings when one entry in the batch collides', () => {
+      const json = {
+        asset: {version: '2.0'},
+        buffers: [{byteLength: 4}],
+        bufferViews: [{buffer: 0, byteOffset: 0, byteLength: 4}],
+        extensionsUsed: ['BLDRS_a'],
+        extensions: {BLDRS_a: {compressed: true, bufferView: 0}},
+      }
+      const glb = serializeGlb(json, new Uint8Array(4))
+      const {bytes, stats} = injectGlbExtensions(glb, [
+        {name: 'BLDRS_a', data: {a: 1}}, // collides — skipped
+        {name: 'BLDRS_b', data: {b: 2}}, // fresh — injected
+      ])
+      expect(stats.addedExtensions).toBe(1)
+      expect(stats.skippedNames).toEqual(['BLDRS_a'])
+      const parsed = parseGlb(bytes)
+      expect(parsed.json.extensions.BLDRS_a).toEqual({compressed: true, bufferView: 0})
+      expect(parsed.json.extensions.BLDRS_b).toBeDefined()
     })
   })
 
@@ -212,10 +265,10 @@ describe('loader/injectGlbExtensions', () => {
     it('adds a BIN chunk if the source GLB has none', () => {
       const json = {asset: {version: '2.0'}}
       const glb = serializeGlb(json, null)
-      const out = injectGlbExtensions(glb, [
+      const {bytes} = injectGlbExtensions(glb, [
         {name: 'BLDRS_test', data: {x: 1}},
       ])
-      const parsed = parseGlb(out)
+      const parsed = parseGlb(bytes)
       expect(parsed.bin).not.toBeNull()
       expect(parsed.bin.byteLength).toBeGreaterThan(0)
       expect(parsed.json.buffers).toBeDefined()

--- a/src/loader/injectGlbExtensions.test.js
+++ b/src/loader/injectGlbExtensions.test.js
@@ -1,0 +1,227 @@
+/* eslint-disable no-magic-numbers */
+import * as pako from 'pako'
+import {
+  injectGlbExtensions,
+  parseGlb,
+  serializeGlb,
+} from './injectGlbExtensions'
+
+
+/**
+ * Build a minimal valid GLB (header + JSON chunk + BIN chunk). The JSON
+ * declares one buffer of `binBytes` length; the BIN chunk contains
+ * `binBytes` zero-bytes so the bufferView byteLength check downstream
+ * stays consistent with what GLTFExporter produces.
+ *
+ * @param {object} [opts]
+ * @param {number} [opts.binBytes] binary chunk data length (will be padded
+ *   internally to a 4-byte boundary).
+ * @param {Array} [opts.bufferViews] bufferViews JSON (default: one entry
+ *   covering the whole binary).
+ * @return {Uint8Array}
+ */
+function makeMinimalGlb({binBytes = 16, bufferViews} = {}) {
+  const json = {
+    asset: {version: '2.0'},
+    buffers: [{byteLength: binBytes}],
+    bufferViews: bufferViews ?? [{buffer: 0, byteOffset: 0, byteLength: binBytes}],
+  }
+  const bin = new Uint8Array(binBytes)
+  return serializeGlb(json, bin)
+}
+
+
+describe('loader/injectGlbExtensions', () => {
+  describe('parseGlb / serializeGlb roundtrip', () => {
+    it('round-trips a minimal GLB with JSON + BIN chunks', () => {
+      const json = {asset: {version: '2.0'}, buffers: [{byteLength: 8}]}
+      const bin = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8])
+      const glb = serializeGlb(json, bin)
+      const parsed = parseGlb(glb)
+      expect(parsed.json).toEqual(json)
+      expect(Array.from(parsed.bin)).toEqual([1, 2, 3, 4, 5, 6, 7, 8])
+    })
+
+    it('round-trips a JSON-only GLB (no BIN chunk)', () => {
+      const json = {asset: {version: '2.0'}}
+      const glb = serializeGlb(json, null)
+      const parsed = parseGlb(glb)
+      expect(parsed.json).toEqual(json)
+      expect(parsed.bin).toBeNull()
+    })
+
+    it('strips trailing chunk padding so JSON parses cleanly even with unaligned data length', () => {
+      // 5-byte JSON ("asset" only would be longer; use a 1-key obj).
+      // serializeGlb pads it to 8 bytes with spaces; parseGlb must
+      // strip the padding before JSON.parse.
+      const json = {x: 1}
+      const glb = serializeGlb(json, null)
+      const parsed = parseGlb(glb)
+      expect(parsed.json).toEqual({x: 1})
+    })
+
+    it('rejects a non-GLB blob (bad magic)', () => {
+      const bad = new Uint8Array(16)
+      bad[0] = 0x42 // "B" — not "g" of glTF
+      expect(() => parseGlb(bad)).toThrow(/bad magic/)
+    })
+
+    it('rejects too-short input', () => {
+      expect(() => parseGlb(new Uint8Array(4))).toThrow(/too short/)
+    })
+
+    it('rejects non-JSON first chunk', () => {
+      // Hand-build a GLB whose first chunk is BIN instead of JSON.
+      const buf = new Uint8Array(12 + 8)
+      const dv = new DataView(buf.buffer)
+      dv.setUint32(0, 0x46546C67, true) // magic "glTF"
+      dv.setUint32(4, 2, true) // version
+      dv.setUint32(8, buf.byteLength, true) // total length
+      dv.setUint32(12, 0, true) // chunk len
+      dv.setUint32(16, 0x004E4942, true) // chunk type "BIN\0"
+      expect(() => parseGlb(buf)).toThrow(/not JSON/)
+    })
+  })
+
+  describe('injectGlbExtensions — no-op cases', () => {
+    it('returns the input bytes unchanged when extensions list is empty', () => {
+      const glb = makeMinimalGlb()
+      const out = injectGlbExtensions(glb, [])
+      expect(out).toBe(glb)
+    })
+
+    it('returns the input bytes unchanged when all entries have null data', () => {
+      const glb = makeMinimalGlb()
+      const out = injectGlbExtensions(glb, [
+        {name: 'BLDRS_x', data: null},
+        {name: 'BLDRS_y', data: undefined},
+      ])
+      expect(out).toBe(glb)
+    })
+
+    it('returns the input bytes unchanged when extensions is null/undefined', () => {
+      const glb = makeMinimalGlb()
+      expect(injectGlbExtensions(glb, null)).toBe(glb)
+      expect(injectGlbExtensions(glb, undefined)).toBe(glb)
+    })
+  })
+
+  describe('injectGlbExtensions — single extension', () => {
+    it('appends a bufferView and extension entry with compressed payload', () => {
+      const glb = makeMinimalGlb({binBytes: 16})
+      const data = {hello: 'world', n: 42}
+      const out = injectGlbExtensions(glb, [
+        {name: 'BLDRS_test', data, compress: true},
+      ])
+
+      const parsed = parseGlb(out)
+      expect(parsed.json.extensionsUsed).toContain('BLDRS_test')
+      expect(parsed.json.extensions.BLDRS_test).toEqual({compressed: true, bufferView: 1})
+
+      // The new bufferView is appended after the existing one (index 1).
+      expect(parsed.json.bufferViews).toHaveLength(2)
+      const newBv = parsed.json.bufferViews[1]
+      expect(newBv.buffer).toBe(0)
+      // byteOffset should be 4-aligned and >= original binBytes.
+      expect(newBv.byteOffset % 4).toBe(0)
+      expect(newBv.byteOffset).toBeGreaterThanOrEqual(16)
+
+      // Decompress the payload at the bufferView's offset to verify
+      // the data made the round trip.
+      const payload = parsed.bin.subarray(
+        newBv.byteOffset, newBv.byteOffset + newBv.byteLength)
+      const json = pako.ungzip(payload, {to: 'string'})
+      expect(JSON.parse(json)).toEqual(data)
+    })
+
+    it('updates buffers[0].byteLength to cover the appended payload', () => {
+      const glb = makeMinimalGlb({binBytes: 8})
+      const out = injectGlbExtensions(glb, [
+        {name: 'BLDRS_test', data: {a: 1}, compress: true},
+      ])
+      const parsed = parseGlb(out)
+      const expectedMin = parsed.json.bufferViews[1].byteOffset +
+                          parsed.json.bufferViews[1].byteLength
+      expect(parsed.json.buffers[0].byteLength).toBe(expectedMin)
+      expect(parsed.bin.byteLength).toBe(expectedMin)
+    })
+
+    it('supports an uncompressed payload', () => {
+      const glb = makeMinimalGlb({binBytes: 4})
+      const data = {raw: true}
+      const out = injectGlbExtensions(glb, [
+        {name: 'BLDRS_test', data, compress: false},
+      ])
+      const parsed = parseGlb(out)
+      expect(parsed.json.extensions.BLDRS_test).toEqual({compressed: false, bufferView: 1})
+      const bv = parsed.json.bufferViews[1]
+      const payload = parsed.bin.subarray(bv.byteOffset, bv.byteOffset + bv.byteLength)
+      const text = new TextDecoder('utf-8').decode(payload)
+      expect(JSON.parse(text)).toEqual(data)
+    })
+
+    it('annotates the output with injectGlbStats describing what changed', () => {
+      const glb = makeMinimalGlb({binBytes: 8})
+      const out = injectGlbExtensions(glb, [
+        {name: 'BLDRS_test', data: {x: 1}},
+      ])
+      expect(out.injectGlbStats).toBeDefined()
+      expect(out.injectGlbStats.addedExtensions).toBe(1)
+      expect(out.injectGlbStats.addedBinBytes).toBeGreaterThan(0)
+    })
+  })
+
+  describe('injectGlbExtensions — multiple extensions', () => {
+    it('lays out each new bufferView at a 4-aligned offset, in order', () => {
+      const glb = makeMinimalGlb({binBytes: 4})
+      const out = injectGlbExtensions(glb, [
+        {name: 'BLDRS_a', data: {a: 1}},
+        {name: 'BLDRS_b', data: {b: 2}},
+        {name: 'BLDRS_c', data: {c: 3}},
+      ])
+      const parsed = parseGlb(out)
+      expect(parsed.json.extensionsUsed).toEqual(
+        expect.arrayContaining(['BLDRS_a', 'BLDRS_b', 'BLDRS_c']))
+      const newBvs = parsed.json.bufferViews.slice(1)
+      expect(newBvs).toHaveLength(3)
+      for (let i = 0; i < newBvs.length; i++) {
+        expect(newBvs[i].byteOffset % 4).toBe(0)
+        if (i > 0) {
+          expect(newBvs[i].byteOffset).toBeGreaterThan(newBvs[i - 1].byteOffset)
+        }
+      }
+    })
+
+    it('does not duplicate names already in extensionsUsed', () => {
+      const json = {
+        asset: {version: '2.0'},
+        buffers: [{byteLength: 4}],
+        bufferViews: [{buffer: 0, byteOffset: 0, byteLength: 4}],
+        extensionsUsed: ['BLDRS_test'],
+      }
+      const glb = serializeGlb(json, new Uint8Array(4))
+      const out = injectGlbExtensions(glb, [
+        {name: 'BLDRS_test', data: {x: 1}},
+      ])
+      const parsed = parseGlb(out)
+      expect(parsed.json.extensionsUsed.filter((n) => n === 'BLDRS_test')).toHaveLength(1)
+    })
+  })
+
+  describe('injectGlbExtensions — synthesises missing structures', () => {
+    it('adds a BIN chunk if the source GLB has none', () => {
+      const json = {asset: {version: '2.0'}}
+      const glb = serializeGlb(json, null)
+      const out = injectGlbExtensions(glb, [
+        {name: 'BLDRS_test', data: {x: 1}},
+      ])
+      const parsed = parseGlb(out)
+      expect(parsed.bin).not.toBeNull()
+      expect(parsed.bin.byteLength).toBeGreaterThan(0)
+      expect(parsed.json.buffers).toBeDefined()
+      expect(parsed.json.buffers[0].byteLength).toBe(parsed.bin.byteLength)
+      expect(parsed.json.bufferViews).toHaveLength(1)
+      expect(parsed.json.extensions.BLDRS_test).toBeDefined()
+    })
+  })
+})

--- a/src/viewer/ShareModel.js
+++ b/src/viewer/ShareModel.js
@@ -215,6 +215,16 @@ export function inferModelCapabilities(model, opts = {}) {
   if (hasPerVertexInstanceIds) {
     caps.instancePicking = true
   }
+  // BLDRS_spatial_tree extension hydration (cache-hit GLBs only).
+  // `Loader.js#convertToShareModel` reads `userData.bldrsSpatialTree`
+  // and attaches a `getSpatialStructure` method to the model. Flip the
+  // capability so the NavTree branches on this rather than format.
+  // Live IFC parses don't ship the extension and use the legacy
+  // `ifcManager` path; the format-based default already has
+  // spatialStructure on for them.
+  if (model.userData?.bldrsSpatialTree) {
+    caps.spatialStructure = true
+  }
   return caps
 }
 

--- a/src/viewer/ShareModel.test.js
+++ b/src/viewer/ShareModel.test.js
@@ -182,6 +182,27 @@ describe('viewer/ShareModel', () => {
       expect(caps.expressIdPicking).toBeUndefined()
       expect(caps.instancePicking).toBeUndefined()
     })
+
+    it('promotes spatialStructure when userData carries a BLDRS_spatial_tree payload', () => {
+      // Mirrors what `BldrsSpatialTreeReader#afterRoot` (the cache-hit
+      // path) attaches: a decoded IFC tree on the model's root userData.
+      // `Loader.js#convertToShareModel` then hangs `model.getSpatialStructure`
+      // off it. `inferModelCapabilities` doesn't need the consumer wiring
+      // to be in place to flip the flag — the presence of the payload
+      // alone is the signal.
+      const root = new Group()
+      root.userData.bldrsSpatialTree = {
+        expressID: 1, type: 'IFCPROJECT', Name: {value: 'P'}, children: [],
+      }
+      const caps = inferModelCapabilities(root)
+      expect(caps.spatialStructure).toBe(true)
+    })
+
+    it('leaves spatialStructure undefined when no BLDRS_spatial_tree is present', () => {
+      const root = new Group()
+      const caps = inferModelCapabilities(root)
+      expect(caps.spatialStructure).toBeUndefined()
+    })
   })
 
   describe('modelHasUnstructuredMeshClipper', () => {


### PR DESCRIPTION
## Summary

Implements a new `BLDRS_spatial_tree` glTF extension that embeds the IFC spatial hierarchy (IfcProject → IfcSite → … → leaf elements) into cached GLB artifacts. This allows the NavTree to render on cache-hit without re-parsing the original IFC file, resolving the "Default-on gating" blocker in the viewer-replacement design.

## Key Changes

- **New GLB post-processor (`injectGlbExtensions.js`)**: Parses raw GLB bytes from GLTFExporter, injects custom top-level extensions with payloads in the binary chunk, and re-serializes. Provides `parseGlb()`, `serializeGlb()`, and `injectGlbExtensions()` as stable, version-agnostic seams for extension injection without coupling to GLTFExporter's plugin API.

- **BLDRS_spatial_tree extension (`bldrsSpatialTree.js`)**: 
  - `captureBldrsSpatialTree()` — extracts and normalizes the spatial tree from an IfcManager, filtering to JSON-safe fields (expressID, type, Name, LongName, children).
  - `BldrsSpatialTreeReader` — GLTFLoader plugin that decompresses the extension payload on read and attaches it to `gltf.scene.userData.bldrsSpatialTree`.

- **Integration into export pipeline (`glbExport.js`)**: Passes `ifcManager` to the export context so the writer can capture the live spatial structure and inject it as a gzipped bufferView.

- **Cache-hit hydration (`Loader.js`, `ShareModel.js`)**: 
  - `convertToShareModel()` promotes `userData.bldrsSpatialTree` to a `getSpatialStructure()` method on the model.
  - `inferModelCapabilities()` flips the `spatialStructure` capability when the payload is present.
  - `CadView.jsx` prefers the model-level method over the live manager, so cache-hit models render their NavTree immediately.

- **Schema version bump (`glbCacheKey.js`)**: Incremented to 0.6.0 to mark the backwards-incompatible addition of the extension.

- **Comprehensive test coverage**: Unit tests for GLB round-tripping, extension injection (single/multiple, compressed/uncompressed), and end-to-end capture → inject → read flows.

## Implementation Details

- **Post-processing approach**: Rather than writing a GLTFExporter plugin (which couples to write order and internal APIs), the extension logic post-processes the canonical GLB wire format. This keeps the geometry-export path identical to today's and confines extension logic to one well-tested seam.

- **Binary layout**: Extensions are appended to the GLB's BIN chunk as new bufferViews at 4-byte-aligned offsets. The JSON metadata records `{compressed: bool, bufferView: index}` so readers can locate and decompress payloads.

- **Graceful degradation**: Non-IFC sources and cache-miss paths work unchanged. Cache-hit GLBs without the extension degrade to an empty NavTree (no error). Older cached artifacts (pre-0.6.0) continue to work; only new exports carry the extension.

- **Compression**: Payloads are gzipped by default (configurable) to keep cache artifacts compact. Readers support both gzip and deflate for forward/backward compatibility.

https://claude.ai/code/session_01NsqaNsVfhA8vGnY8SYfbXP