### PR TITLE
viewer-replacement Phase 5a: flip `conwayDirectIfc` + `glb` default-on

### DIFF
--- a/design/new/viewer-replacement.md
+++ b/design/new/viewer-replacement.md
@@ -565,12 +565,16 @@ neither compressor touches.
 
 **Default-on gating:** isolate routing done; spatial tree done;
 element properties done; compression unblocked. **No remaining
-blockers** — `conwayDirectIfc` flag is ready to flip default-on as
-a follow-up slice.
+blockers** — `conwayDirectIfc` flag flipped default-on **2026-05**.
 
 1. ~~Portable IFC spatial hierarchy~~ — **done** (PR #1527).
-2. ~~Portable IFC properties / property sets~~ — **done** (this PR).
-3. ~~Compression-safe per-element IDs (BLDRS_face_ids)~~ — **done** (this PR).
+2. ~~Portable IFC properties / property sets~~ — **done** (PR #1528).
+3. ~~Compression-safe per-element IDs (BLDRS_face_ids)~~ — **done** (PR #1528).
+4. ~~Flip the flag default-on~~ — **done** (this PR).
+   Pairs with `glb` (cache writer/reader) also default-on. Together:
+   first-load runs Conway-direct geometry + per-instance picking and
+   schedules a post-parse GLB writer; subsequent loads of the same
+   source hit the cache and bypass wit-three's IFC parser entirely.
 
 Issues / comments can be done later (post-prod-flip).
 
@@ -822,12 +826,60 @@ Each phase ends with `yarn lint && yarn test && yarn test-flows` green and a wor
   recompile).
 
 ### Phase 5 — drop `web-ifc-viewer` and bump `three`
-- Remove `web-ifc-viewer-1.0.209-bldrs-7.tgz` and the `web-ifc-viewer` dep.
-- Remove the nested `web-ifc-three` (gone with it).
-- Bump `three` to current stable. Update `@types/three` to match.
-- Hand-fix the small set of API drifts in `src/`: `outputColorSpace`, raycaster signatures, `BufferGeometryUtils.mergeVertices` import path, etc. (see §6).
-- Update `tools/esbuild` config — no more wasm copy from `web-ifc/`; only Conway's wasm.
-- Update `__mocks__/web-ifc-viewer.js` → `__mocks__/ShareViewer.js`.
+
+**Slice 5a — flag default-on (done 2026-05).** This PR. Flips
+`conwayDirectIfc` and `glb` to `isActive: true`; removes the
+now-dead `if (isFeatureEnabled('conwayDirectIfc'))` branches in
+`Loader.js`. Production cache-hit loads now bypass wit-three's IFC
+parser entirely; cache-miss loads still call `this.loader.parse(...)`
+(wit-three's `IFCLoader.parse`) and then swap the rendered geometry
+for the Conway-direct assembler's output.
+
+**Slice 5b — Conway-direct parse (todo).** The cache-miss path
+still goes through wit-three's `IFCLoader.parse` purely to drive
+Conway under the hood, then we throw away its assembled geometry
+and rebuild with our Conway-direct assembler. Cleanest replacement:
+
+```js
+const modelID = ifcAPI.OpenModel(new Uint8Array(buffer))
+const captured = []
+ifcAPI.StreamAllMeshes(modelID, (fm) => captured.push(fm))
+const {mesh: ifcModel} = buildConwayIfcModel(captured, ifcAPI, modelID)
+ifcModel.modelID = modelID
+// property reads route through ifcAPI.properties.* directly
+```
+
+Conway's adapter exposes the full property + spatial surface natively
+(`properties.getItemProperties`, `properties.getSpatialStructure`,
+`properties.getAllItemsOfType`) — the wit-three `ifcManager` wrapper
+is decorative on top. Lifting the parse out of wit-three removes the
+last load-path dep on the fork.
+
+**Slice 5c — ShareViewer composition (todo).** Today
+`ShareViewer extends IfcViewerAPI`. Replacing the `extends` with
+composition needs to stand up the same property surface
+(`this.IFC`, `this.context`, `this.clipper`) from scratch using the
+existing local plugins (`ThreeContext`, `Clipper`, `Selector`,
+`Picker`, `Highlighter`, `Isolator`, `Postprocessor`) plus a new
+`IfcManager`-shaped wrapper around the Conway IfcAPI (Slice 5b's
+surface). Once `ShareViewer` no longer inherits from the fork, the
+fork dep can be dropped from `package.json` and the
+`threeJsmCompatPlugin` esbuild rewrites in `tools/esbuild/plugins.js`
+can go with it.
+
+**Slice 5d — three / postprocessing / three-mesh-bvh bumps (todo).**
+After 5b+5c land — drop the fork pin, bump `three` to current stable,
+update `@types/three` to match, drop the `threeJsmCompatPlugin` rewrites,
+drop the `BLDRS_face_ids` per-vertex fallback's wit-three checks, etc.
+
+**Slice 5e — wasm + build scripts (todo).** Drop
+`build-share-copy-wasm-webifc`, `USE_WEBIFC_SHIM`, and
+`isWebIfcShimEnabled` from `tools/esbuild`. The `webIfcShimAliasPlugin`
+goes away — there are no more `web-ifc` imports to alias.
+
+**Slice 5f — mocks (todo).** Rename `__mocks__/web-ifc-viewer.js` →
+`__mocks__/ShareViewer.js`; update the three test files that
+`jest.mock('web-ifc-viewer')` to mock the new path.
 
 ### Phase 6 — cleanup
 - Remove the feature flag from Phase 3.

--- a/src/FeatureFlags.js
+++ b/src/FeatureFlags.js
@@ -17,7 +17,10 @@ export const flags = [
   // GLB runtime artifact pipeline (design/new/glb-model-sharing.md).
   // `glb` enables both the writer (post-IFC-parse cache warm-up) and the
   // reader (skip-IFC-when-GLB-cached fast path in Loader.js).
-  {name: 'glb', isActive: false},
+  // Default-on as of the Phase-5 prep landing — cache-hit GLB loads
+  // bypass wit-three entirely (spatial tree + properties + per-element
+  // picking all round-trip through BLDRS_* glTF extensions).
+  {name: 'glb', isActive: true},
   // DRACO compression for cached GLBs. Applies to BOTH write and read:
   // writer pipes the GLTFExporter output through @gltf-transform's
   // draco() transform; reader wires DRACOLoader into the GLTFLoader.
@@ -59,10 +62,15 @@ export const flags = [
   //     through the IFC→GLB→IFC cache automatically (GLTFExporter's
   //     `_INSTANCEID` rename + reader-side restore + capability
   //     inference + cache-hit IfcInstanceMap reconstruction).
-  // Test-phase flag — not yet on by default. Implies (turns on) the
-  // StreamAllMeshes capture wrapper; `ifcItemsMapParity` shares the
-  // same capture. Design: design/new/viewer-replacement.md §3b.
-  {name: 'conwayDirectIfc', isActive: false},
+  // Default-on as of the Phase-5 prep landing. The Conway-direct
+  // geometry assembler + per-instance picking are the production
+  // rendering path; live IFC parses still run wit-three to drive the
+  // FlatMesh stream (geometry is then replaced by the Conway-direct
+  // build). Cache-hit GLB loads bypass wit-three entirely.
+  // Implies (turns on) the StreamAllMeshes capture wrapper;
+  // `ifcItemsMapParity` shares the same capture.
+  // Design: design/new/viewer-replacement.md §3b.
+  {name: 'conwayDirectIfc', isActive: true},
 ]
 
 

--- a/src/FeatureFlags.test.js
+++ b/src/FeatureFlags.test.js
@@ -19,13 +19,27 @@ describe('FeatureFlags', () => {
     })
   })
 
-  it('declares glb and glbDraco flags, both inactive by default', () => {
+  it('declares glb active by default and glbDraco off (sub-option)', () => {
+    // glb went default-on in the Phase-5 prep landing — cache-hit GLB
+    // loads bypass wit-three entirely. glbDraco stays opt-in because
+    // compression adds 100-300ms per cache write and the size win
+    // varies by model; users opt in via `?feature=glbDraco`.
     const glb = flags.find((f) => f.name === 'glb')
     const glbDraco = flags.find((f) => f.name === 'glbDraco')
     expect(glb).toBeDefined()
-    expect(glb.isActive).toBe(false)
+    expect(glb.isActive).toBe(true)
     expect(glbDraco).toBeDefined()
     expect(glbDraco.isActive).toBe(false)
+  })
+
+  it('declares conwayDirectIfc active by default', () => {
+    // The Conway-direct geometry assembler + per-instance picking is
+    // the production rendering path. Off-switching is via a code change
+    // (no URL escape hatch); the wit-three fallback is on its way out
+    // entirely in the follow-up fork-removal slice.
+    const conwayDirect = flags.find((f) => f.name === 'conwayDirectIfc')
+    expect(conwayDirect).toBeDefined()
+    expect(conwayDirect.isActive).toBe(true)
   })
 
   describe('isFeatureEnabled', () => {
@@ -44,14 +58,15 @@ describe('FeatureFlags', () => {
     })
 
     it('returns false for an isActive: false flag when URL has no feature param', () => {
-      expect(isFeatureEnabled('glb')).toBe(false)
+      // glbDraco stays off by default (opt-in compression sub-option).
       expect(isFeatureEnabled('glbDraco')).toBe(false)
+      expect(isFeatureEnabled('glbMeshopt')).toBe(false)
     })
 
     it('enables a flag listed in ?feature=', () => {
-      window.location.search = '?feature=glb'
-      expect(isFeatureEnabled('glb')).toBe(true)
-      expect(isFeatureEnabled('glbDraco')).toBe(false)
+      window.location.search = '?feature=glbDraco'
+      expect(isFeatureEnabled('glbDraco')).toBe(true)
+      expect(isFeatureEnabled('glbMeshopt')).toBe(false)
     })
 
     it('enables multiple flags via comma-separated ?feature=', () => {

--- a/src/loader/Loader.installConwayDirectGeometry.test.js
+++ b/src/loader/Loader.installConwayDirectGeometry.test.js
@@ -314,14 +314,17 @@ describe('loader/installConwayDirectGeometry', () => {
   it('safely no-ops on an empty FlatMesh capture (defensive guard)', () => {
     const ifcModel = makeIfcModel()
     const placeholderGeom = ifcModel.geometry
-    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+    // Now logged at info level (was warn) — the empty-capture branch is
+    // hit by test harnesses whose IfcAPI mock omits StreamAllMeshes, not
+    // a real runtime failure. Still asserted: the log fires + says why.
+    const infoSpy = jest.spyOn(console, 'info').mockImplementation(() => {})
     installConwayDirectGeometry({}, ifcModel, [])
     // Geometry unchanged, no swap happened, no crash.
     expect(ifcModel.geometry).toBe(placeholderGeom)
     expect(ifcModel.instanceMap).toBeUndefined()
     expect(ifcModel.capabilities.ifcSubsets).toBe(true)
-    expect(warnSpy).toHaveBeenCalledWith(expect.stringMatching(/no FlatMesh capture/))
-    warnSpy.mockRestore()
+    expect(infoSpy).toHaveBeenCalledWith(expect.stringMatching(/no FlatMesh capture/))
+    infoSpy.mockRestore()
   })
 
   it('emits a stats log line with vertex / triangle counts and Conway-vs-wit comparison', () => {

--- a/src/loader/Loader.js
+++ b/src/loader/Loader.js
@@ -1228,16 +1228,14 @@ function newIfcLoader(viewer) {
         USE_FAST_BOOLS: true,
       })
 
-      // Phase-3 prep: capture Conway's FlatMesh stream during the live
-      // parse so the diagnostics below can read the original
-      // per-instance data without a second StreamAllMeshes walk.
-      // See runIfcItemsMapParityCheck for why a second walk is unsafe.
-      // Both flags share the capture wrapper.
-      const captureEnabled = isFeatureEnabled('ifcItemsMapParity') ||
-        isFeatureEnabled('conwayDirectIfc')
-      const parityCapture = captureEnabled ?
-        installFlatMeshCapture(this.loader.ifcManager.ifcAPI) :
-        null
+      // Capture Conway's FlatMesh stream during the live parse so the
+      // Conway-direct install (and the `ifcItemsMapParity` diagnostic,
+      // when enabled) can read the original per-instance data without a
+      // second StreamAllMeshes walk. See runIfcItemsMapParityCheck for
+      // why a second walk is unsafe. `installFlatMeshCapture` no-ops
+      // gracefully when the IfcAPI doesn't expose StreamAllMeshes (test
+      // mocks, alternative parsers).
+      const parityCapture = installFlatMeshCapture(this.loader.ifcManager.ifcAPI)
 
       if (onProgress) {
         onProgress('Parsing model geometry...')
@@ -1246,7 +1244,7 @@ function newIfcLoader(viewer) {
       try {
         ifcModel = await this.loader.parse(buffer, onProgress)
       } finally {
-        parityCapture?.restore()
+        parityCapture.restore()
       }
       this.addIfcModel(ifcModel)
 
@@ -1285,24 +1283,22 @@ function newIfcLoader(viewer) {
         onProgress('Model loaded successfully!')
       }
 
-      // Phase-3 prep: parallel-run the new IfcItemsMap populators
-      // against the live model and log the diff. Diagnostic only —
-      // no behavior change. Toggle via `?feature=ifcItemsMapParity`.
-      // See design/new/viewer-replacement.md §3b.ii for the
-      // per-vertex-vs-per-instance story this check exposes.
-      if (isFeatureEnabled('ifcItemsMapParity') && parityCapture) {
+      // Parallel-run the new IfcItemsMap populators against the live
+      // model and log the diff. Diagnostic only — no behavior change.
+      // Toggle via `?feature=ifcItemsMapParity`. See
+      // design/new/viewer-replacement.md §3b.ii for the per-vertex-vs-
+      // per-instance story this check exposes.
+      if (isFeatureEnabled('ifcItemsMapParity')) {
         runIfcItemsMapParityCheck(
           this.loader.ifcManager.ifcAPI, ifcModel, parityCapture.captured)
       }
-      // Phase-3 cut-over: replace web-ifc-three's geometry with the
-      // Conway-direct merged buffer + attach an IfcInstanceMap. The
-      // IFC manager (properties, spatial tree, typed search) stays —
-      // only the rendered triangles + the picking source of truth
-      // change. Toggle via `?feature=conwayDirectIfc`.
-      if (isFeatureEnabled('conwayDirectIfc') && parityCapture) {
-        installConwayDirectGeometry(
-          this.loader.ifcManager.ifcAPI, ifcModel, parityCapture.captured)
-      }
+      // Replace wit-three's rendered geometry with the Conway-direct
+      // merged buffer + per-instance picking map. The IFC manager
+      // (properties, spatial tree, typed search) stays in place —
+      // only the rendered triangles + picking source of truth change.
+      // Defensive against empty captures (see installConwayDirectGeometry).
+      installConwayDirectGeometry(
+        this.loader.ifcManager.ifcAPI, ifcModel, parityCapture.captured)
 
       return ifcModel
     } catch (err) {

--- a/src/loader/Loader.js
+++ b/src/loader/Loader.js
@@ -256,25 +256,41 @@ export async function load(
       // For non-GitHub sources we don't have an upstream sha, so we hash the
       // bytes ourselves to build the cache key. This is the same File we'd
       // read for parse below; reading it twice is cheap (OPFS).
+      //
+      // Self-contained try/catch: if the hash or cache lookup fails (e.g.
+      // `window.crypto.subtle` absent in some jsdom test envs, OPFS sync-
+      // handle hiccup partway through the lookup), we must NOT lose the
+      // file we already downloaded. Falling through to the outer catch
+      // would discard `file` and force an axios refetch, which then fails
+      // under tests that don't mock the outbound URL. The user-visible
+      // behavior on this failure path is "cache miss" — exactly what we'd
+      // do anyway if the lookup returned null.
       if (wantGlb && !cacheKeyArgs && file) {
-        const sourceBytes = await file.arrayBuffer()
-        const contentSha = await sha1Hex(sourceBytes)
-        cacheKeyArgs = buildNonGitHubCacheArgs(kindLabel, path, contentSha)
-        if (cacheKeyArgs) {
-          glbInfo(
-            `reader: cache lookup ${kindLabel} key=${cacheKeyArgs.ns1}/${cacheKeyArgs.ns2}/${cacheKeyArgs.ns3}/` +
-          `${cacheKeyArgs.sourcePath} sha=${contentSha}`)
-          glbVerbose('reader: cacheKeyArgs =', cacheKeyArgs)
-          const glbFile = await tryLoadCachedGlb(cacheKeyArgs)
-          if (glbFile) {
+        try {
+          const sourceBytes = await file.arrayBuffer()
+          const contentSha = await sha1Hex(sourceBytes)
+          cacheKeyArgs = buildNonGitHubCacheArgs(kindLabel, path, contentSha)
+          if (cacheKeyArgs) {
             glbInfo(
-              `reader: ${kindLabel} cache HIT (${glbFile.size}B); swapping to GLB loader`)
-            ;[loader, isLoaderAsync, isFormatText, isIfc, fixupCb] = swapToGlbLoader(viewer)
-            file = glbFile
-            cameFromGlbCache = true
-          } else {
-            glbInfo(`reader: ${kindLabel} cache MISS, will export after parse`)
+              `reader: cache lookup ${kindLabel} key=${cacheKeyArgs.ns1}/${cacheKeyArgs.ns2}/${cacheKeyArgs.ns3}/` +
+            `${cacheKeyArgs.sourcePath} sha=${contentSha}`)
+            glbVerbose('reader: cacheKeyArgs =', cacheKeyArgs)
+            const glbFile = await tryLoadCachedGlb(cacheKeyArgs)
+            if (glbFile) {
+              glbInfo(
+                `reader: ${kindLabel} cache HIT (${glbFile.size}B); swapping to GLB loader`)
+              ;[loader, isLoaderAsync, isFormatText, isIfc, fixupCb] = swapToGlbLoader(viewer)
+              file = glbFile
+              cameFromGlbCache = true
+            } else {
+              glbInfo(`reader: ${kindLabel} cache MISS, will export after parse`)
+            }
           }
+        } catch (cacheLookupError) {
+          glbInfo(
+            `reader: ${kindLabel} cache lookup failed; treating as MISS and continuing:`,
+            cacheLookupError)
+          cacheKeyArgs = null
         }
       }
 
@@ -1359,6 +1375,19 @@ function newIfcLoader(viewer) {
  */
 function installFlatMeshCapture(ifcAPI) {
   const captured = []
+  // Defensive: not every IfcAPI exposes `StreamAllMeshes` (test stubs,
+  // future Conway versions, alternative parsers). The capture wrapper
+  // is purely additive — the parse below still works on the un-wrapped
+  // API. A no-op stub keeps the flag-on code path indistinguishable
+  // from the flag-off behavior the codebase relied on for years.
+  if (typeof ifcAPI?.StreamAllMeshes !== 'function') {
+    return {
+      captured,
+      restore: () => {
+        // no-op — nothing was wrapped, nothing to unwrap.
+      },
+    }
+  }
   const orig = ifcAPI.StreamAllMeshes.bind(ifcAPI)
   ifcAPI.StreamAllMeshes = function patchedStreamAllMeshes(modelID, cb) {
     return orig(modelID, (flatMesh) => {
@@ -1557,9 +1586,18 @@ function runIfcItemsMapParityCheck(ifcAPI, ifcModel, capturedFlatMeshes) {
 export function installConwayDirectGeometry(ifcAPI, ifcModel, capturedFlatMeshes) {
   try {
     if (!Array.isArray(capturedFlatMeshes) || capturedFlatMeshes.length === 0) {
-      console.warn(
+      // No-op when the capture wrapper saw zero FlatMeshes. Real causes:
+      // (a) the IfcAPI mock used in some test harnesses doesn't expose
+      // `StreamAllMeshes`, so `installFlatMeshCapture` returned its
+      // stub-and-no-op shape; (b) the parse completed but emitted no
+      // geometry (degenerate or empty IFC). Either way, leaving
+      // wit-three's rendered geometry in place is the right fallback;
+      // logged at info level so it stays discoverable in real prod
+      // logs without polluting tests.
+      // eslint-disable-next-line no-console
+      console.info(
         '[conwayDirect] no FlatMesh capture from parse — ' +
-        'skipping Conway-direct install')
+        'leaving wit-three geometry in place')
       return
     }
     const t0 = (typeof performance !== 'undefined' && performance.now) ?


### PR DESCRIPTION
## Summary

First of two PRs to land §3b.iii's "default-on gating" from
`design/new/viewer-replacement.md`. All four blockers (isolate routing,
spatial-tree extension, element-properties extension, compression-safe
per-element IDs) shipped in #1518/#1527/#1528 — this PR flips
`conwayDirectIfc` + `glb` to `isActive: true` and prunes the now-dead
conditional branches.

Effect on the production load flow:

- **Every IFC parse** now runs the Conway-direct geometry assembler
  (replacing wit-three's rendered triangles + materials) and the
  per-instance picking path (matches what was clicked; Shift expands
  to whole IFC element).
- **First load on any source kind** triggers the post-parse GLB
  writer; OPFS gets a Bldrs container keyed by source identity.
- **Subsequent loads** of the same source bypass wit-three's IFC
  parser entirely — spatial tree, element properties, and
  per-element picking all round-trip through the `BLDRS_spatial_tree`
  / `BLDRS_element_properties` / `BLDRS_face_ids` glTF extensions.

## What this PR is and isn't

**Is:** the slice that makes the new path live for every user without
any URL escape hatch. Production behavior changes; bundle size doesn't.

**Isn't:** the slice that removes `web-ifc-viewer` from the bundle. That
needs `ShareViewer` to stop `extends IfcViewerAPI`, which in turn needs
a Conway-direct parse path to replace `this.loader.parse(buffer)` (the
last hot-path wit consumer). Design doc §4 now breaks Phase 5 into
named slices (5a → 5f) so the next PR has a clear handoff. Slice 5b
(Conway-direct parse) is the central remaining technical step; Slice
5c (ShareViewer composition) is gated on it.

The reason 5b+5c didn't land here: they're a real architectural change
with subtle failure modes (parser-state coupling, coordination matrix
setup, BVH initialisation on the cache-miss path). Doing them
unattended overnight wasn't the right risk profile. The flag flip
alone is safe + tested + valuable on its own.

## Commit-by-commit

1. **`FeatureFlags: flip glb + conwayDirectIfc default-on`** — flips
   both flags + updates the FeatureFlags test for the new defaults.
   Adds two defensive guardrails alongside the flip:
   - Self-contained `try/catch` around the non-GitHub cache-lookup
     (`sha1Hex` + `buildNonGitHubCacheArgs` + `tryLoadCachedGlb`). A
     failure here used to bubble to the outer OPFS catch, discarding
     the already-downloaded file and forcing an axios refetch. Now
     logs + treats as MISS and continues.
   - `installFlatMeshCapture` no-ops gracefully when the IfcAPI
     doesn't expose `StreamAllMeshes` (test mocks). Otherwise the
     wrapper would throw `Cannot read properties of undefined
     (reading 'bind')` on every test using a minimal IfcAPI stub.
2. **`loader: drop dead conwayDirectIfc/parityCapture conditionals`**
   — removes `if (isFeatureEnabled('conwayDirectIfc'))` and the
   `captureEnabled ? ... : null` ternary. The capture wrapper now
   runs unconditionally on every IFC parse. `ifcItemsMapParity`
   stays opt-in (URL-only diagnostic flag).
3. **`docs/viewer-replacement: record default-on flag flip + slice
   out Phase 5`** — §3b.iii blocker list checks off the flag flip.
   §4 Phase 5 broken into named slices 5a → 5f.

## Test plan

- [x] `yarn lint` passes (eslint + typecheck)
- [x] `yarn test` passes — 1659 jest tests green
- [ ] Playwright (`yarn test-flows`) — could not run locally
      (no chromium download), will validate in CI
- [ ] Manual smoke: load a fresh IFC (cache MISS) and confirm
      Conway-direct geometry + per-instance picking + post-parse
      GLB writer fires
- [ ] Manual smoke: reload the same model (cache HIT) and confirm
      wit-three's IFC parse is skipped; spatial tree + properties
      + picking all still work
- [ ] Manual smoke: `Properties.cacheHit.spec.ts` is `test.fixme`'d
      due to `OPFS_IS_ENABLED: false` in `vars.playwright.js` — the
      cache-hit round-trip should still be validated manually on
      deploy preview (Snowdon, Schependomlaan)

https://claude.ai/code/session_01PfUQoU4d2PMTioyhtArijA

---
_Generated by [Claude Code](https://claude.ai/code/session_01PfUQoU4d2PMTioyhtArijA)_