### PR TITLE
Security: API Key Transmitted Without Encryption in Transit Description

### DIFF
--- a/src/Components/Bot/openRouterClient.ts
+++ b/src/Components/Bot/openRouterClient.ts
@@ -14,6 +14,9 @@ export async function askLLM({
 }: AskLlmOptions): Promise<string> {
   const openrouterBaseUrl = process.env.OPENROUTER_BASE_URL
   assertDefined(openrouterBaseUrl, 'OPENROUTER_BASE_URL is required')
+  if (!openrouterBaseUrl.startsWith('https://')) {
+    throw new Error('OPENROUTER_BASE_URL must use HTTPS')
+  }
   const url = `${openrouterBaseUrl}/api/v1/chat/completions`
 
   const body = {


### PR DESCRIPTION
## Summary

Security: API Key Transmitted Without Encryption in Transit Description

## Problem

**Severity**: `Medium` | **File**: `src/Components/Bot/openRouterClient.ts:L1`

In openRouterClient.ts, the API key is sent in the Authorization header. While this is standard practice, the code fetches from a configurable base URL (process.env.OPENROUTER_BASE_URL) without validating that HTTPS is used. If an attacker can manipulate the environment variable or perform a man-in-the-middle attack, the API key could be exposed.

## Solution

Validate that the base URL uses HTTPS before making requests. Implement certificate pinning or strict HTTPS enforcement for API calls that include authentication credentials.

## Changes

- `src/Components/Bot/openRouterClient.ts` (modified)