### PR TITLE
Slice 5c: compose IfcViewerAPI instead of extending it

### DIFF
--- a/__mocks__/web-ifc-viewer.js
+++ b/__mocks__/web-ifc-viewer.js
@@ -96,6 +96,15 @@ const impl = {
     // IfcContext; only `viewer.context` is the ThreeContext wrapper.
     context: legacyContextMock,
     setWasmPath: jest.fn(),
+    // Post-slice-5c: ShareViewer.getProperties delegates to
+    // `this.IFC.getProperties`. Pre-5c the convenience method came
+    // from `IfcViewerAPI.prototype.getProperties` via `extends`, and
+    // the singleton mock shadowed it with the top-level
+    // `impl.getProperties` below — composition severs that shadow, so
+    // we mirror the production shape here too.
+    getProperties: jest.fn((modelId, eltId) => {
+      return loadedModel.ifcManager.getProperties(eltId)
+    }),
     selector: {
       unpickIfcItems: jest.fn(),
       selection: {

--- a/src/Components/Markers/MarkerControl.test.jsx
+++ b/src/Components/Markers/MarkerControl.test.jsx
@@ -111,7 +111,10 @@ describe('MarkerControl', () => {
   // need to move this after fixing that issue
   beforeEach(() => {
     viewer = new ShareViewer()
-    viewer._loadedModel.ifcManager.getSpatialStructure.mockReturnValue(makeTestTree())
+    // Post-slice-5c: `_loadedModel` is a mock-side test helper that
+    // lives on the singleton impl (now reached via `_fork`), not on
+    // the ShareViewer instance.
+    viewer._fork._loadedModel.ifcManager.getSpatialStructure.mockReturnValue(makeTestTree())
     viewer.context.getDomElement = jest.fn(() => {
       return document.createElement('div')
     })

--- a/src/Containers/CadView.test.jsx
+++ b/src/Containers/CadView.test.jsx
@@ -164,7 +164,10 @@ describe('CadView', () => {
   // TODO: `document.createElement` can't be used in testing-library directly, need to move this after fixing that issue
   beforeEach(() => {
     viewer = new ShareViewer()
-    viewer._loadedModel.ifcManager.getSpatialStructure.mockReturnValue(makeTestTree())
+    // Post-slice-5c: `_loadedModel` is a mock-side test helper that
+    // lives on the singleton impl (now reached via `_fork`), not on
+    // the ShareViewer instance.
+    viewer._fork._loadedModel.ifcManager.getSpatialStructure.mockReturnValue(makeTestTree())
     viewer.context.getDomElement = jest.fn(() => {
       return document.createElement('div')
     })
@@ -258,6 +261,12 @@ describe('CadView', () => {
   // The guard makes the effect skip `setInstanceSelection` when the
   // parent-level ids are empty. This test exercises that path.
   it('useEffect skips setInstanceSelection when selectedElements is empty', async () => {
+    // Post-slice-5c: ShareViewer composes the fork rather than extending
+    // it, so each `new ShareViewer()` is a fresh instance. Spy on the
+    // prototype so both the test's local `viewer` and CadView's own
+    // `initViewer()` instance route through the same Jest mock.
+    const setInstanceSelectionSpy = jest.spyOn(ShareViewer.prototype, 'setInstanceSelection')
+      .mockImplementation(() => {})
     const {result} = renderHook(() => useStore((state) => state))
     await act(() => result.current.setModelPath({filepath: `/index.ifc`}))
     render(<ShareMock><CadView installPrefix='' appPrefix='' pathPrefix=''/></ShareMock>)
@@ -266,11 +275,11 @@ describe('CadView', () => {
     // Set ONLY selectedInstanceIds — leave selectedElements at its
     // empty-array default. The effect runs on the dep change; the
     // guard should swallow it.
-    viewer.setInstanceSelection.mockClear()
+    setInstanceSelectionSpy.mockClear()
     const STALE_INSTANCE_ID = 42
     await act(() => result.current.setSelectedInstanceIds([STALE_INSTANCE_ID]))
     await actAsyncFlush()
-    expect(viewer.setInstanceSelection).not.toHaveBeenCalled()
+    expect(setInstanceSelectionSpy).not.toHaveBeenCalled()
   })
 
 
@@ -457,6 +466,12 @@ describe('CadView', () => {
 
 
   it('can highlight some elements based on state change', async () => {
+    // Post-slice-5c: ShareViewer composes the fork rather than extending
+    // it, so each `new ShareViewer()` is a fresh instance. Spy on the
+    // prototype so both the test's local `viewer` and CadView's own
+    // `initViewer()` instance route through the same Jest mock.
+    const preselectSpy = jest.spyOn(ShareViewer.prototype, 'preselectElementsByIds')
+      .mockImplementation(() => {})
     const highlightedIdsAsString = ['0', '1']
     const modelId = 0
     const elementCount = 2
@@ -470,8 +485,7 @@ describe('CadView', () => {
       result.current.setPreselectedElementIds(highlightedIdsAsString)
     })
     expect(result.current.preselectedElementIds).toHaveLength(elementCount)
-    expect(viewer.preselectElementsByIds)
-      .toHaveBeenLastCalledWith(modelId, highlightedIdsAsString)
+    expect(preselectSpy).toHaveBeenLastCalledWith(modelId, highlightedIdsAsString)
     await actAsyncFlush()
   })
 

--- a/src/Containers/viewer.test.js
+++ b/src/Containers/viewer.test.js
@@ -237,9 +237,16 @@ describe('Containers/viewer', () => {
 
 
   describe('singleton fixture sanity', () => {
-    it('initViewer returns the same singleton object the test mock exposes', () => {
+    it('initViewer returns a ShareViewer wrapping the singleton fork mock', () => {
+      // Post-slice-5c: ShareViewer composes the fork instead of extending
+      // it. `viewer` is a ShareViewer; `viewer._fork` is the
+      // IfcViewerAPI mock singleton the rest of the tests share state
+      // through (e.g. `viewer.IFC === singleton.IFC` still holds because
+      // the constructor wires `this.IFC = this._fork.IFC`).
       const viewer = initViewer('/share/v/p')
-      expect(viewer).toBe(__getShareViewerMockSingleton())
+      const singleton = __getShareViewerMockSingleton()
+      expect(viewer._fork).toBe(singleton)
+      expect(viewer.IFC).toBe(singleton.IFC)
     })
   })
 })

--- a/src/viewer/ShareViewer.js
+++ b/src/viewer/ShareViewer.js
@@ -64,13 +64,28 @@ const viewRules = {
 }
 /* eslint-disable jsdoc/no-undefined-types */
 /**
- * ShareViewer — the top-level viewer facade for Bldrs Share. Today still
- * extends `IfcViewerAPI` from the `web-ifc-viewer` fork; per
- * design/new/viewer-replacement.md §3, downstream code should depend on
- * this class rather than on the fork directly. When the fork is removed
- * (Phase 5), ShareViewer's surface stays — only its internals swap.
+ * ShareViewer — the top-level viewer facade for Bldrs Share.
+ *
+ * Slice 5c of design/new/viewer-replacement.md flipped this from
+ * `extends IfcViewerAPI` to composition. The fork's `IfcViewerAPI` is
+ * still instantiated internally (as `this._fork`) — we depend on it
+ * for `IfcContext` (Scene/Camera/Renderer + render loop), `IfcManager`
+ * (the parser / ifcAPI / property reads), and `IfcClipper` (IFC
+ * clipping plane interaction) — but ShareViewer is no longer
+ * `instanceof IfcViewerAPI`. Downstream code depends on this class,
+ * not the fork. When the fork's pieces get replaced piece-by-piece in
+ * later slices, `this._fork` shrinks until it can be deleted entirely
+ * (the dep gets dropped from package.json then).
+ *
+ * Property surface (kept identical to pre-5c so consumers don't churn):
+ *   - `this.IFC` — fork's IfcManager (selector, loader.ifcManager, …)
+ *   - `this.context` — ThreeContext wrapping the fork's IfcContext
+ *   - `this.clipper` — local `Clipper` facade dispatching per-model
+ *   - `this.selector` — local `Selector` facade over `IFC.selector`
+ *   - `this.isolator`, `this.highlighter`, `this.postProcessor`,
+ *     `this.viewsManager` — local plugins constructed here.
  */
-export class ShareViewer extends IfcViewerAPI {
+export class ShareViewer {
   // TODO: might be useful if we used a Set as well to handle large selections,
   // but for now array is more performant for small numbers
   _selectedExpressIds = []
@@ -90,17 +105,25 @@ export class ShareViewer extends IfcViewerAPI {
    * @param {object} options - Configuration options
    */
   constructor(options) {
-    super(options)
-    // Replace the fork's `IfcContext` reference on this.context with our
-    // layered wrapper. The fork's IfcManager / clipper / etc. were
-    // constructed in `super()` with the original IfcContext and keep
-    // their own private reference to it, so the fork side is unaffected.
-    // Our code reads `viewer.context.X` through the wrapper. Guarded so
-    // mocks that pre-wrap (see __mocks__/web-ifc-viewer.js) don't get
-    // double-wrapped.
-    if (!(this.context instanceof ThreeContext)) {
-      this.context = new ThreeContext(this.context)
-    }
+    // Composition (was `super(options)` before slice 5c). The fork
+    // viewer's constructor builds IfcContext, IfcManager, IfcClipper,
+    // plus a heap of components we never use (Grid, Axes, GLTF,
+    // ShadowDropper, Edges, DXF, PDF, SelectionWindow, …) — those
+    // bundle-cost stays put for now; subsequent slices replace the
+    // pieces we DO use and `_fork` shrinks. Held as a private member
+    // so `dispose()` can delegate fork teardown and tests can reach
+    // the same instance the singleton mock returns.
+    this._fork = new IfcViewerAPI(options)
+    this.IFC = this._fork.IFC
+    // Wrap the fork's `IfcContext` in our ThreeContext layer. The fork's
+    // IfcManager / IfcClipper retained their own private references to
+    // the original context inside `new IfcViewerAPI(...)`, so the
+    // wrapper here only affects `this.context.X` reads from our code.
+    // Guarded so mocks that pre-wrap (see __mocks__/web-ifc-viewer.js)
+    // don't get double-wrapped.
+    this.context = this._fork.context instanceof ThreeContext ?
+      this._fork.context :
+      new ThreeContext(this._fork.context)
     const renderer = this.context.getRenderer()
     // Partner to the top-level `ColorManagement.enabled = false`: that
     // disables the *input* side (auto sRGB→linear conversions on
@@ -124,27 +147,82 @@ export class ShareViewer extends IfcViewerAPI {
     // Selector — §3c.iv slice 1 facade over the fork's `IFC.selector`.
     // Every call-site that previously poked at `viewer.IFC.selector.X`
     // now routes through `viewer.selector.X` instead. Keeps the fork
-    // selector as the underlying impl until Phase 5 swaps it for an
-    // IfcModelService-backed `Selection` plugin.
+    // selector as the underlying impl until later in Phase 5 swaps it
+    // for an IfcModelService-backed `Selection` plugin.
     this.selector = new Selector(this.IFC?.selector)
     // Clipper — §3c.iv slice 3 unified facade over the fork's
-    // `IfcClipper` + in-repo `GlbClipper`. Replaces `viewer.clipper`
-    // (set by IfcViewerAPI's super() call) with one object that
-    // dispatches per-model. Call-sites no longer branch on
-    // `viewer.IFC.type === 'glb'` — they call `viewer.clipper.X`
-    // and trust the plugin. The fork's clipper is captured here
-    // before being overwritten so the IFC backing impl is preserved.
-    //
-    // Guard for the test-singleton path: __mocks__/web-ifc-viewer.js
-    // reuses one `impl` across every `new ShareViewer()` call. Without
-    // the `instanceof Clipper` check, the second construction would
-    // capture the *previous* Clipper plugin as `_forkClipper`, losing
-    // the underlying fork clipper.
-    if (!(this.clipper instanceof Clipper)) {
-      this._forkClipper = this.clipper
-      this.clipper = new Clipper(this, this._forkClipper)
-    }
+    // `IfcClipper` + in-repo `GlbClipper`. The fork constructed an
+    // IfcClipper on `_fork.clipper`; we capture that as the IFC backing
+    // impl and wrap with our Clipper. Call-sites no longer branch on
+    // `viewer.IFC.type === 'glb'` — they call `viewer.clipper.X` and
+    // trust the plugin.
+    this._forkClipper = this._fork.clipper
+    this.clipper = new Clipper(this, this._forkClipper)
     this.viewsManager = new IfcViewsManager(this.IFC.loader.ifcManager.parser, viewRules[viewParameter])
+  }
+
+
+  /**
+   * Tear down the composed viewer.
+   *
+   * Order matters: local plugins first (they hold direct refs to the
+   * fork's scene / IFC manager and would crash if those die first),
+   * then delegate to `_fork.dispose()` for IfcContext + IfcManager
+   * teardown (renderer.dispose, scene.dispose, IFC.dispose). The
+   * grid/axes/GLTF/etc. dispose chain inside the fork is no-op for our
+   * usage but cheap to leave running.
+   *
+   * `Containers/viewer.js#disposeViewer` already handles scene-traversal
+   * + renderer.forceContextLoss before calling this method; we don't
+   * double up on that work here.
+   *
+   * @return {Promise<void>}
+   */
+  async dispose() {
+    // Local plugins. Each is null-safe individually so partial-init
+    // teardown (e.g. constructor throw mid-build) still works.
+    try {
+      this.viewsManager?.dispose?.()
+    } catch (e) {
+      console.warn('viewsManager.dispose failed:', e)
+    }
+    try {
+      this.isolator?.dispose?.()
+    } catch (e) {
+      console.warn('isolator.dispose failed:', e)
+    }
+    try {
+      this.highlighter?.dispose?.()
+    } catch (e) {
+      console.warn('highlighter.dispose failed:', e)
+    }
+    try {
+      this.postProcessor?.dispose?.()
+    } catch (e) {
+      console.warn('postProcessor.dispose failed:', e)
+    }
+    // Clipper.dispose handles both the fork's IfcClipper (the IFC
+    // backing impl) and the GlbClipper (interaction handlers); we DO
+    // NOT call _forkClipper.dispose directly afterwards because
+    // _fork.dispose would call it again and the second call throws on
+    // a torn-down clipper.
+    try {
+      this.clipper?.dispose?.()
+    } catch (e) {
+      console.warn('clipper.dispose failed:', e)
+    }
+    // Fork teardown. Stub out the clipper before delegating so
+    // `_fork.dispose()` doesn't double-dispose what `this.clipper`
+    // just tore down. IfcContext + IFC.dispose are the load-bearing
+    // pieces this delegation buys us.
+    if (this._fork) {
+      this._fork.clipper = {dispose: () => {/* already torn down */}}
+      try {
+        await this._fork.dispose?.()
+      } catch (e) {
+        console.warn('_fork.dispose failed:', e)
+      }
+    }
   }
 
   /**
@@ -251,6 +329,23 @@ export class ShareViewer extends IfcViewerAPI {
 
     return elementIDs
   }
+
+  /**
+   * Fetch item properties. Carries over the deprecated convenience
+   * method from `IfcViewerAPI.getProperties` — `extends IfcViewerAPI`
+   * used to inherit this; post-slice-5c composition we re-publish it
+   * here so call-sites (`CadView.jsx#convertElement`) don't churn.
+   *
+   * @param {number} modelID
+   * @param {number} id Express ID.
+   * @param {boolean} [indirect] If true, also returns psets, qsets and type properties.
+   * @param {boolean} [recursive]
+   * @return {Promise<any>}
+   */
+  getProperties(modelID, id, indirect, recursive) {
+    return this.IFC.getProperties(modelID, id, indirect, recursive)
+  }
+
 
   /**
    * Loads the given IFC in the current scene.


### PR DESCRIPTION
## Summary

Slice 5c (first half) of Phase 5 in `design/new/viewer-replacement.md`. `ShareViewer` stops being `instanceof IfcViewerAPI` and instead holds the fork as `this._fork`. Same property surface (`this.IFC`, `this.context`, `this.clipper`, `this.selector`, `this.isolator`, `this.highlighter`, `this.postProcessor`, `this.viewsManager`) — downstream code in `src/Containers/`, `src/Components/`, `src/WidgetApi/` is unchanged.

Why this matters: while `extends IfcViewerAPI` is in place, the fork's pieces are pinned by the inheritance contract. With composition, follow-up slices can replace fork sub-components (IfcManager → ShareIfcManager, IfcClipper → unified Clipper, IfcContext → ShareContext) one at a time without churning every call-site.

## Architecture

```
class ShareViewer {
  constructor(options) {
    this._fork = new IfcViewerAPI(options)   // ← was super(options)
    this.IFC = this._fork.IFC                // legacy fork manager (unchanged)
    this.context = new ThreeContext(this._fork.context)
    this._forkClipper = this._fork.clipper
    this.clipper = new Clipper(this, this._forkClipper)
    // postProcessor, highlighter, isolator, selector, viewsManager — unchanged
  }

  async dispose() {
    // local plugins first, then await this._fork.dispose()
  }

  getProperties(modelID, id, indirect, recursive) {  // re-published (was inherited)
    return this.IFC.getProperties(modelID, id, indirect, recursive)
  }
}
```

The fork's heavyweight constructor still builds `Grid`, `Axes`, `GLTFManager`, `ShadowDropper`, `Edges`, `DXFWriter`, etc. — bundle cost is unchanged this slice. Bundle slimming comes later when we stop instantiating the fork's `IfcViewerAPI` and build only the pieces we need (`IfcContext`, `IfcManager`, `IfcClipper`).

## Test surface

The pre-5c mock pattern relied on prototype-shadowing through mock-assigned own properties (because `super()` returned the impl singleton, `this === impl`, ShareViewer.prototype methods were shadowed by `impl.X = jest.fn()`). With composition each `new ShareViewer()` is a distinct instance, so:

- **`viewer._fork` reaches the singleton** — `viewer.test.js`'s identity check + `_loadedModel` access in `CadView.test.jsx` and `MarkerControl.test.jsx` route through `viewer._fork`.
- **`jest.spyOn(ShareViewer.prototype, 'X')`** replaces `viewer.X = jest.fn()` for the two tests that asserted on `setInstanceSelection` / `preselectElementsByIds`. Same Jest mock, but installed on the prototype so both the test's local `viewer` and CadView's `initViewer()` viewer route through it.
- **`__mocks__/web-ifc-viewer.js`** — added `IFC.getProperties` to the mock impl so the new `ShareViewer.getProperties` delegation resolves in tests (production reaches it through the real `IfcManager`).

## Out of scope (follow-up slices)

- Build `ShareIfcManager` / `ShareIfcLoader` wrappers around Conway IfcAPI directly (the wrappers I committed to in scoping — kept for a focused follow-up so this PR stays minimal).
- Stop instantiating fork's `IfcViewerAPI` — instantiate `IfcContext`, `IfcManager`, `IfcClipper` directly from `web-ifc-viewer/dist/components` (drops `Grid`/`Axes`/`GLTF`/etc. from the bundle).
- Drop `web-ifc-viewer` from `package.json` + remove `threeJsmCompatPlugin` esbuild rewrites (slices 5d–5e).
- Rename `__mocks__/web-ifc-viewer.js` → `__mocks__/ShareViewer.js` (slice 5f).

## Test plan

- [x] `yarn jest --config tools/jest/jest.config.js` — 199 suites, 1707/1707 pass
- [x] `yarn lint` — eslint + tsc green
- [x] Pre-commit hook ran the full gate
- [ ] Playwright via CI on this branch
- [ ] Manual deploy-preview smoke (Schependomlaan + a GLB)


---
_Generated by [Claude Code](https://claude.ai/code/session_01PfUQoU4d2PMTioyhtArijA)_