### PR TITLE
sentry: filter Netlify RUM noise + emit one GA signal per session (SHARE-K3)

### DIFF
--- a/src/index/sentry.js
+++ b/src/index/sentry.js
@@ -6,6 +6,59 @@ import {useLocation, useNavigationType, createRoutesFromChildren, matchRoutes} f
 import {version as pkgVersion} from '../../package.json'
 
 
+/*
+ * Stack-frame URLs matching any of these patterns mark the event as
+ * "third-party noise" — we drop them in `beforeSend` below before
+ * they reach Sentry. We add to this list when triage finds a class
+ * of events with no actionable first-party signal.
+ *
+ * Current entries:
+ *
+ *   /\/\.netlify\/scripts\/rum/
+ *     Netlify's RUM (Real User Monitoring) beacon, which POSTs to
+ *     ingesteer.services-prod.nsvcs.net. Ad-blockers, mobile
+ *     carriers in emerging markets, and corp proxies frequently
+ *     block that domain, surfacing here as
+ *     "TypeError: Failed to fetch" with mechanism: onunhandledrejection
+ *     and a stack rooted at /.netlify/scripts/rum. SHARE-K3 alone
+ *     was 7,118 users / 21,540 events of this — 94% Android, 99%
+ *     mobile — same emerging-markets demographic that blocks all
+ *     third-party telemetry. The page itself works; only Sentry
+ *     was noisy. Drop them upstream.
+ */
+const THIRD_PARTY_NOISE_PATTERNS = [
+  /\/\.netlify\/scripts\/rum/,
+]
+
+
+/**
+ * Returns false for Sentry events whose stack is rooted in a script
+ * we've marked as third-party noise (see THIRD_PARTY_NOISE_PATTERNS).
+ * Exported so it can be unit-tested with a synthetic event — the
+ * `setupSentry` call below is one-shot and not test-friendly.
+ *
+ * @param {object} event Sentry event payload
+ * @return {boolean} true to send, false to drop
+ */
+export function shouldSendSentryEvent(event) {
+  const frames = event?.exception?.values?.[0]?.stacktrace?.frames
+  if (!Array.isArray(frames) || frames.length === 0) {
+    return true
+  }
+  for (const frame of frames) {
+    if (typeof frame?.filename !== 'string') {
+      continue
+    }
+    for (const pattern of THIRD_PARTY_NOISE_PATTERNS) {
+      if (pattern.test(frame.filename)) {
+        return false
+      }
+    }
+  }
+  return true
+}
+
+
 /**
  * Setup Sentry for error tracking.
  */
@@ -19,6 +72,9 @@ export default function setupSentry() {
     // shipped it. Prefix with the project slug so the same Sentry org can
     // host multiple bldrs apps without release-tag collisions.
     release: `bldrs-share@${pkgVersion}`,
+    beforeSend(event) {
+      return shouldSendSentryEvent(event) ? event : null
+    },
     integrations: [
       reactRouterV6BrowserTracingIntegration({
         useEffect,

--- a/src/index/sentry.js
+++ b/src/index/sentry.js
@@ -77,18 +77,28 @@ export function _resetSentryFilterStateForTests() {
  * @return {boolean} true to send, false to drop
  */
 export function shouldSendSentryEvent(event) {
-  const frames = event?.exception?.values?.[0]?.stacktrace?.frames
-  if (!Array.isArray(frames) || frames.length === 0) {
+  const exceptions = event?.exception?.values
+  if (!Array.isArray(exceptions) || exceptions.length === 0) {
     return true
   }
-  for (const frame of frames) {
-    if (typeof frame?.filename !== 'string') {
+  // Walk every exception in the chain (caused-by exceptions appear as
+  // additional entries in `values[]`), not just the top one — RUM
+  // beacons typically surface as a single exception, but a wrapped /
+  // chained exception with RUM as the cause should still be dropped.
+  for (const exception of exceptions) {
+    const frames = exception?.stacktrace?.frames
+    if (!Array.isArray(frames) || frames.length === 0) {
       continue
     }
-    for (const {pattern, gaEventName} of THIRD_PARTY_NOISE_PATTERNS) {
-      if (pattern.test(frame.filename)) {
-        emitOncePerSession(gaEventName)
-        return false
+    for (const frame of frames) {
+      if (typeof frame?.filename !== 'string') {
+        continue
+      }
+      for (const {pattern, gaEventName} of THIRD_PARTY_NOISE_PATTERNS) {
+        if (pattern.test(frame.filename)) {
+          emitOncePerSession(gaEventName)
+          return false
+        }
       }
     }
   }

--- a/src/index/sentry.js
+++ b/src/index/sentry.js
@@ -1,6 +1,7 @@
 import {init, reactRouterV6BrowserTracingIntegration} from '@sentry/react'
 import {useEffect} from 'react'
 import {useLocation, useNavigationType, createRoutesFromChildren, matchRoutes} from 'react-router-dom'
+import {gtagEvent} from '../privacy/analytics'
 // Named import (rather than `import pkg from '../../package.json'`) so
 // esbuild can prune the rest of the JSON — we only care about `version`.
 import {version as pkgVersion} from '../../package.json'
@@ -24,17 +25,52 @@ import {version as pkgVersion} from '../../package.json'
  *     was 7,118 users / 21,540 events of this — 94% Android, 99%
  *     mobile — same emerging-markets demographic that blocks all
  *     third-party telemetry. The page itself works; only Sentry
- *     was noisy. Drop them upstream.
+ *     was noisy.
+ *
+ *     We can't make the RUM script stop trying (it keeps flushing
+ *     on every visibilitychange:hidden / pagehide), but we can stop
+ *     it from filling Sentry with one issue per flush. To avoid
+ *     losing the "this client has telemetry blocking" signal
+ *     entirely, the first detected RUM failure per session fires a
+ *     single GA `netlify_rum_blocked` event before dropping —
+ *     see emitOncePerSession() and shouldSendSentryEvent() below.
  */
 const THIRD_PARTY_NOISE_PATTERNS = [
-  /\/\.netlify\/scripts\/rum/,
+  {
+    pattern: /\/\.netlify\/scripts\/rum/,
+    gaEventName: 'netlify_rum_blocked',
+  },
 ]
+
+
+/*
+ * Per-pattern "have we already reported this in this session?" flags.
+ * Module-level so they persist across multiple beforeSend calls on
+ * the same page load, and reset on full page reload (which is the
+ * natural session boundary here — sessionStorage would persist them
+ * across reloads but adds storage failure modes for marginal benefit).
+ */
+const reportedNoiseSessions = new Set()
+
+
+/**
+ * Test-only reset for the per-session reported-noise flags. Tests
+ * that exercise the once-per-session contract need a way to clear
+ * state between cases without re-importing the module.
+ */
+export function _resetSentryFilterStateForTests() {
+  reportedNoiseSessions.clear()
+}
 
 
 /**
  * Returns false for Sentry events whose stack is rooted in a script
  * we've marked as third-party noise (see THIRD_PARTY_NOISE_PATTERNS).
- * Exported so it can be unit-tested with a synthetic event — the
+ * On the first detection per session for each pattern, fires the
+ * configured GA event so the "this client has telemetry blocking"
+ * statistic isn't lost when we drop the Sentry event.
+ *
+ * Exported so it can be unit-tested with synthetic events — the
  * `setupSentry` call below is one-shot and not test-friendly.
  *
  * @param {object} event Sentry event payload
@@ -49,13 +85,38 @@ export function shouldSendSentryEvent(event) {
     if (typeof frame?.filename !== 'string') {
       continue
     }
-    for (const pattern of THIRD_PARTY_NOISE_PATTERNS) {
+    for (const {pattern, gaEventName} of THIRD_PARTY_NOISE_PATTERNS) {
       if (pattern.test(frame.filename)) {
+        emitOncePerSession(gaEventName)
         return false
       }
     }
   }
   return true
+}
+
+
+/**
+ * Fire a GA event the first time per session it's requested, then
+ * suppress subsequent calls for the same name. Lets us preserve the
+ * "this client blocks third-party telemetry" signal without each
+ * blocked beacon becoming its own GA event too. Best-effort — GA
+ * itself may be blocked by the same client, and `gtagEvent` already
+ * handles `window.gtag === undefined`.
+ *
+ * @param {string|null|undefined} eventName
+ */
+function emitOncePerSession(eventName) {
+  if (!eventName || reportedNoiseSessions.has(eventName)) {
+    return
+  }
+  reportedNoiseSessions.add(eventName)
+  try {
+    gtagEvent(eventName, {})
+  } catch {
+    // GA not ready / consent declined / blocked — the Sentry drop
+    // happens regardless. Best-effort signal capture.
+  }
 }
 
 

--- a/src/index/sentry.test.js
+++ b/src/index/sentry.test.js
@@ -1,0 +1,89 @@
+import {shouldSendSentryEvent} from './sentry'
+
+
+describe('shouldSendSentryEvent', () => {
+  /*
+   * SHARE-K3 regression. Netlify's RUM beacon failing under an
+   * ad-blocker / carrier proxy produced 21,540 events / 7,118 users
+   * of "TypeError: Failed to fetch" with a stack rooted at
+   * /.netlify/scripts/rum. The shape below mirrors what Sentry's
+   * fetch instrumentation attached.
+   */
+  it('drops events whose stack is rooted in Netlify RUM', () => {
+    const event = {
+      exception: {
+        values: [{
+          type: 'TypeError',
+          value: 'Failed to fetch',
+          stacktrace: {
+            frames: [
+              {filename: '/.netlify/scripts/rum'},
+              {filename: '/.netlify/scripts/rum'},
+            ],
+          },
+        }],
+      },
+    }
+    expect(shouldSendSentryEvent(event)).toBe(false)
+  })
+
+  it('drops events when RUM appears anywhere in the stack, not just on top', () => {
+    const event = {
+      exception: {
+        values: [{
+          stacktrace: {
+            frames: [
+              {filename: 'src/some/first-party.js'},
+              {filename: 'https://bldrs.ai/.netlify/scripts/rum'},
+              {filename: 'node_modules/@sentry/core/src/utils-hoist/instrument/fetch.ts'},
+            ],
+          },
+        }],
+      },
+    }
+    expect(shouldSendSentryEvent(event)).toBe(false)
+  })
+
+  it('keeps events from first-party code', () => {
+    const event = {
+      exception: {
+        values: [{
+          type: 'Error',
+          value: 'Loader could not read model',
+          stacktrace: {
+            frames: [
+              {filename: 'src/Containers/CadView.jsx'},
+              {filename: 'src/loader/Loader.js'},
+            ],
+          },
+        }],
+      },
+    }
+    expect(shouldSendSentryEvent(event)).toBe(true)
+  })
+
+  it('keeps events with no stacktrace — no signal to filter on, default to send', () => {
+    expect(shouldSendSentryEvent({})).toBe(true)
+    expect(shouldSendSentryEvent({exception: {}})).toBe(true)
+    expect(shouldSendSentryEvent({exception: {values: []}})).toBe(true)
+    expect(shouldSendSentryEvent({exception: {values: [{stacktrace: {frames: []}}]}})).toBe(true)
+  })
+
+  it('tolerates frames with no filename', () => {
+    const event = {
+      exception: {
+        values: [{
+          stacktrace: {
+            frames: [
+              {filename: null},
+              {filename: undefined},
+              {/* missing filename */},
+              {filename: 'src/Containers/CadView.jsx'},
+            ],
+          },
+        }],
+      },
+    }
+    expect(shouldSendSentryEvent(event)).toBe(true)
+  })
+})

--- a/src/index/sentry.test.js
+++ b/src/index/sentry.test.js
@@ -1,4 +1,14 @@
-import {shouldSendSentryEvent} from './sentry'
+import {gtagEvent} from '../privacy/analytics'
+import {shouldSendSentryEvent, _resetSentryFilterStateForTests} from './sentry'
+
+
+jest.mock('../privacy/analytics', () => ({gtagEvent: jest.fn()}))
+
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  _resetSentryFilterStateForTests()
+})
 
 
 describe('shouldSendSentryEvent', () => {
@@ -85,5 +95,66 @@ describe('shouldSendSentryEvent', () => {
       },
     }
     expect(shouldSendSentryEvent(event)).toBe(true)
+  })
+})
+
+
+describe('shouldSendSentryEvent — once-per-session GA signal', () => {
+  const rumEvent = () => ({
+    exception: {
+      values: [{
+        stacktrace: {
+          frames: [{filename: '/.netlify/scripts/rum'}],
+        },
+      }],
+    },
+  })
+
+  /*
+   * The point of the GA emission isn't to spam — we want one signal
+   * per session that "this client blocks RUM", paired with dropping
+   * the Sentry events. The first drop fires gtagEvent; subsequent
+   * drops for the same pattern must be silent on the GA side too.
+   */
+  it('fires gtagEvent on the first drop of a third-party-noise event', () => {
+    expect(shouldSendSentryEvent(rumEvent())).toBe(false)
+    expect(gtagEvent).toHaveBeenCalledTimes(1)
+    expect(gtagEvent).toHaveBeenCalledWith('netlify_rum_blocked', {})
+  })
+
+  it('does not re-fire gtagEvent on subsequent drops of the same pattern', () => {
+    shouldSendSentryEvent(rumEvent())
+    shouldSendSentryEvent(rumEvent())
+    shouldSendSentryEvent(rumEvent())
+    expect(gtagEvent).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not fire gtagEvent for first-party events', () => {
+    const firstPartyEvent = {
+      exception: {
+        values: [{
+          stacktrace: {
+            frames: [{filename: 'src/Containers/CadView.jsx'}],
+          },
+        }],
+      },
+    }
+    expect(shouldSendSentryEvent(firstPartyEvent)).toBe(true)
+    expect(gtagEvent).not.toHaveBeenCalled()
+  })
+
+  it('refires gtagEvent after _resetSentryFilterStateForTests — proves test isolation works', () => {
+    shouldSendSentryEvent(rumEvent())
+    expect(gtagEvent).toHaveBeenCalledTimes(1)
+    _resetSentryFilterStateForTests()
+    shouldSendSentryEvent(rumEvent())
+    expect(gtagEvent).toHaveBeenCalledTimes(2)
+  })
+
+  it('still drops Sentry events when gtagEvent throws — best-effort GA capture', () => {
+    gtagEvent.mockImplementationOnce(() => {
+      throw new Error('gtag blew up')
+    })
+    expect(shouldSendSentryEvent(rumEvent())).toBe(false)
   })
 })

--- a/src/index/sentry.test.js
+++ b/src/index/sentry.test.js
@@ -96,6 +96,44 @@ describe('shouldSendSentryEvent', () => {
     }
     expect(shouldSendSentryEvent(event)).toBe(true)
   })
+
+  /*
+   * Sentry represents `caused by` chains as additional entries in
+   * `exception.values[]`. If the wrapping exception isn't third-party
+   * noise but the cause is, we should still drop — the wrapped error
+   * doesn't make the noise actionable.
+   */
+  it('drops events when the cause-chain has a RUM exception even if the top one does not', () => {
+    const event = {
+      exception: {
+        values: [
+          {
+            type: 'Error',
+            value: 'Wrapped failure',
+            stacktrace: {frames: [{filename: 'src/Containers/CadView.jsx'}]},
+          },
+          {
+            type: 'TypeError',
+            value: 'Failed to fetch',
+            stacktrace: {frames: [{filename: '/.netlify/scripts/rum'}]},
+          },
+        ],
+      },
+    }
+    expect(shouldSendSentryEvent(event)).toBe(false)
+  })
+
+  it('keeps events when every entry in the cause-chain is first-party', () => {
+    const event = {
+      exception: {
+        values: [
+          {stacktrace: {frames: [{filename: 'src/Containers/CadView.jsx'}]}},
+          {stacktrace: {frames: [{filename: 'src/loader/Loader.js'}]}},
+        ],
+      },
+    }
+    expect(shouldSendSentryEvent(event)).toBe(true)
+  })
 })
 
 


### PR DESCRIPTION
## Summary

- Triage of Share prod's #2 top-volume Sentry issue **SHARE-K3** ("TypeError: Failed to fetch", 21,540 events / 7,118 users) found the entire issue is **Netlify's RUM beacon** failing under client-side blocking — ad-blockers, mobile carriers in emerging markets, and corp proxies all routinely block `ingesteer.services-prod.nsvcs.net`. Stack frames are 100% inside `/.netlify/scripts/rum`, `mechanism: onunhandledrejection`, and Sentry's auto-fetch instrumentation caught the rejection as if it were our bug. 99% mobile, 94% Android — same demographic that blocks every third-party telemetry domain. The page itself works fine.
- We can't make the RUM script stop trying (it keeps flushing on every `visibilitychange:hidden` / `pagehide`), but we can stop it from filling Sentry **and** keep the "this client has telemetry blocking" statistic alive in GA.
- Adds a `beforeSend` hook in `Sentry.init` backed by a testable `shouldSendSentryEvent(event)` predicate. The predicate scans stack frames against a documented `THIRD_PARTY_NOISE_PATTERNS` list — currently a single entry pairing `/\/\.netlify\/scripts\/rum/` with the GA event name `netlify_rum_blocked`. New entries can be added with rationale as triage finds more unfixable third-party sources.
- On the first match per pattern per page load, `emitOncePerSession()` fires the paired GA event via the existing `gtagEvent` helper, then suppresses subsequent calls via a module-level `Set`. Sentry events are still dropped in every case — only the GA emission is throttled. `gtagEvent` already no-ops when `window.gtag` is missing or consent is declined; wrapped in try/catch anyway so a throwing analytics layer doesn't break the Sentry filter.
- Module-level state intentionally resets on full page reload (natural session boundary). `_resetSentryFilterStateForTests` exposes the reset for unit test isolation.

## Expected effect

- **Sentry**: SHARE-K3 stops accruing new events — dropped at the SDK boundary before they ever reach Sentry's ingest.
- **GA**: a new `netlify_rum_blocked` event with **one fire per affected session** — gives an actionable count of "how many users have telemetry blocking" without the per-flush spam we had in Sentry.
- **App behavior**: unchanged. RUM was fire-and-forget; users on blocked clients weren't seeing any UI impact, just unhandled rejections in the console (now still in the console, just not double-reported to Sentry).

## Test plan

- [x] `yarn lint` + `yarn typecheck` clean.
- [x] 10 unit tests in `src/index/sentry.test.js` — primary drop case, RUM-anywhere-in-stack, first-party stack passes through, missing/empty stacktraces default-to-send, frames without a filename tolerated, first drop fires `gtagEvent` with the right name, subsequent drops don't re-fire, first-party events don't fire at all, reset helper re-enables firing, `gtagEvent` throwing doesn't break the Sentry drop.
- [x] Pre-commit hook (eslint + typecheck + full Jest suite) green on both commits.
- [ ] After deploy: confirm SHARE-K3 event count flatlines and `netlify_rum_blocked` appears in GA at the expected rate.

https://claude.ai/code/session_017qZZuG36veBdqnus3as6bx

---
_Generated by [Claude Code](https://claude.ai/code/session_017qZZuG36veBdqnus3as6bx)_