### PR TITLE
Slice 5d.3: vendor IfcContext, drop new IfcViewerAPI() in ShareViewer

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -25,6 +25,31 @@ module.exports = {
         'no-empty-function': ['error', {allow: ['arrowFunctions']}],
       },
     },
+    // Vendored IfcContext family (`src/viewer/three/context/**`) — code
+    // copied from `web-ifc-viewer/dist/components/context/*` in slice
+    // 5d.3. Kept intentionally close to the upstream shape so future
+    // fork-side bug fixes are easy to re-apply; loosens jsdoc /
+    // magic-number / require-jsdoc rules that would otherwise force a
+    // massive cosmetic rewrite. The two intentional patches (Clock
+    // shim, light-intensity ×π, Postproduction stub) are inline.
+    {
+      files: ['src/viewer/three/context/**/*.js'],
+      rules: {
+        'require-jsdoc': 'off',
+        'no-magic-numbers': 'off',
+        'jsdoc/require-jsdoc': 'off',
+        'jsdoc/require-param-description': 'off',
+        'jsdoc/require-returns-description': 'off',
+        'jsdoc/require-returns': 'off',
+        'valid-jsdoc': 'off',
+        'max-len': 'off',
+        'no-console': 'off',
+        'no-mixed-operators': 'off',
+        'no-unused-expressions': 'off',
+        'no-var': 'off',
+        'no-shadow': 'off',
+      },
+    },
     // --- TS / TSX
     {
       files: ['*.ts', '*.tsx'],

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -48,6 +48,7 @@ module.exports = {
         'no-unused-expressions': 'off',
         'no-var': 'off',
         'no-shadow': 'off',
+        'no-tabs': 'off',
       },
     },
     // --- TS / TSX

--- a/__mocks__/web-ifc-viewer.js
+++ b/__mocks__/web-ifc-viewer.js
@@ -2,6 +2,33 @@ jest.mock('three')
 jest.mock('../src/viewer/three/IfcHighlighter')
 jest.mock('../src/viewer/three/IfcIsolator')
 jest.mock('../src/viewer/three/CustomPostProcessor')
+// Slice 5d.3: ShareViewer now instantiates `IfcContext` (vendored at
+// `src/viewer/three/context/`) and `makeForkIfc(ifcContext)` directly
+// (was `new IfcViewerAPI(options)`). The auto-mock-on-`from
+// 'web-ifc-viewer'`-import flow this file uses doesn't cover those
+// source modules; mock them here too. Load order is: ShareViewer.js
+// does `import 'web-ifc-viewer'` FIRST, which triggers this file
+// to load, which registers the jest.mock factories below. By the time
+// ShareViewer's later `import {IfcContext} from './three/context'`
+// resolves, the factory is registered and Jest uses it.
+//
+// The factories route through `globalThis` rather than capturing
+// `impl` / `legacyContextMock` directly because babel-plugin-jest-hoist
+// places the factory bodies in a separate lexical scope. Capturing the
+// consts produced a second `impl` reference and broke the singleton
+// invariant `viewer.IFC === __getShareViewerMockSingleton().IFC`.
+// Routing via `globalThis` ensures both this file's exports and the
+// factory closures resolve to the same backing objects.
+jest.mock('../src/viewer/three/context', () => ({
+  IfcContext: jest.fn().mockImplementation(
+    () => globalThis.__BLDRS_MOCK_LEGACY_CTX__),
+}))
+jest.mock('../src/viewer/three/forkIfcComposition', () => ({
+  makeForkIfc: jest.fn(() => ({
+    IFC: globalThis.__BLDRS_MOCK_IMPL__.IFC,
+    clipper: globalThis.__BLDRS_MOCK_IMPL__.clipper,
+  })),
+}))
 const ifcjsMock = jest.createMockFromModule('web-ifc-viewer')
 const ThreeContext = require('../src/viewer/three/ThreeContext').default
 
@@ -36,11 +63,15 @@ const legacyContextMock = {
   getClippingPlanes: jest.fn(() => {
     return []
   }),
-  getDomElement: jest.fn(() => ({
-    setAttribute: jest.fn(),
-    addEventListener: jest.fn(),
-    removeEventListener: jest.fn(),
-  })),
+  // Slice 5d.3: every ShareViewer instance now wraps the same
+  // legacyContextMock in its own ThreeContext, so reaching for
+  // `viewer.context.getDomElement` from one ShareViewer no longer
+  // affects another. Return a real `<div>` so callers that touch
+  // `.style.touchAction` (PlaceMark) or `.dispatchEvent` (drag-drop)
+  // see a usable DOM element straight from the singleton mock.
+  getDomElement: jest.fn(() => (typeof document !== 'undefined' ?
+    document.createElement('div') :
+    {setAttribute: () => {}, addEventListener: () => {}, removeEventListener: () => {}, style: {}})),
   getRenderer: jest.fn(),
   getScene: jest.fn(() => {
     return {
@@ -203,12 +234,55 @@ const impl = {
 const constructorMock = ifcjsMock.IfcViewerAPI
 constructorMock.mockImplementation(() => impl)
 
+// This file loads more than once per test run (auto-mock invocation
+// plus the explicit `import 'web-ifc-viewer'` from ShareViewer go
+// through separate module instances). Without dedup, each load builds
+// a new `impl` and stomps `globalThis.__BLDRS_MOCK_IMPL__`, so the
+// jest.mock factories at the top would resolve to a different `impl`
+// than `__getShareViewerMockSingleton()` returns — breaking the
+// invariant `viewer.IFC === singleton.IFC`. Keep only the first load's
+// impl/legacy on globalThis.
+if (!globalThis.__BLDRS_MOCK_IMPL__) {
+  globalThis.__BLDRS_MOCK_IMPL__ = impl
+  globalThis.__BLDRS_MOCK_LEGACY_CTX__ = legacyContextMock
+}
+
 
 /**
- * @return {object} The single mock instance of ShareViewer.
+ * Deferred accessors for the `jest.mock(...)` factories at the top of
+ * this file. The `mock` name prefix is required by babel-plugin-jest-
+ * hoist: the factory closures get hoisted above the `impl` /
+ * `legacyContextMock` const declarations, so they can't capture those
+ * consts directly — only `mock`-prefixed identifiers are allow-listed
+ * for out-of-scope reference. These function declarations ARE hoisted
+ * (JS function hoisting), and by the time a factory actually runs (when
+ * ShareViewer first requires `./three/context` etc.) the consts are
+ * populated.
+ *
+ * @return {object} the singleton mock `impl`.
+ */
+function mockGetImpl() {
+  return impl
+}
+
+
+/**
+ * @return {object} the raw fork-style IfcContext mock (pre-ThreeContext-wrap).
+ */
+function mockGetLegacyContext() {
+  return legacyContextMock
+}
+
+
+/**
+ * @return {object} The single mock instance of ShareViewer. Routes
+ *   through `globalThis.__BLDRS_MOCK_IMPL__` for the same load-dedup
+ *   reason as the jest.mock factories above (this file loads more than
+ *   once per test run; only the first load's `impl` lives on
+ *   globalThis, and we want every consumer to converge on it).
  */
 function __getShareViewerMockSingleton() {
-  return impl
+  return globalThis.__BLDRS_MOCK_IMPL__ ?? impl
 }
 
 

--- a/src/Components/Markers/MarkerControl.test.jsx
+++ b/src/Components/Markers/MarkerControl.test.jsx
@@ -111,10 +111,13 @@ describe('MarkerControl', () => {
   // need to move this after fixing that issue
   beforeEach(() => {
     viewer = new ShareViewer()
-    // Post-slice-5c: `_loadedModel` is a mock-side test helper that
-    // lives on the singleton impl (now reached via `_fork`), not on
-    // the ShareViewer instance.
-    viewer._fork._loadedModel.ifcManager.getSpatialStructure.mockReturnValue(makeTestTree())
+    // Slice 5d.3: `_loadedModel` lives on the singleton fork mock that
+    // `__mocks__/web-ifc-viewer.js` exposes via `__getShareViewerMockSingleton`.
+    // Pre-5d.3 this was reached via `viewer._fork`, but the `_fork`
+    // composition pointer is gone now that ShareViewer instantiates
+    // IfcContext + IfcManager + IfcClipper directly.
+    const {__getShareViewerMockSingleton: getSingleton} = require('web-ifc-viewer')
+    getSingleton()._loadedModel.ifcManager.getSpatialStructure.mockReturnValue(makeTestTree())
     viewer.context.getDomElement = jest.fn(() => {
       return document.createElement('div')
     })

--- a/src/Containers/CadView.test.jsx
+++ b/src/Containers/CadView.test.jsx
@@ -164,10 +164,13 @@ describe('CadView', () => {
   // TODO: `document.createElement` can't be used in testing-library directly, need to move this after fixing that issue
   beforeEach(() => {
     viewer = new ShareViewer()
-    // Post-slice-5c: `_loadedModel` is a mock-side test helper that
-    // lives on the singleton impl (now reached via `_fork`), not on
-    // the ShareViewer instance.
-    viewer._fork._loadedModel.ifcManager.getSpatialStructure.mockReturnValue(makeTestTree())
+    // Slice 5d.3: `_loadedModel` lives on the singleton fork mock that
+    // `__mocks__/web-ifc-viewer.js` exposes via `__getShareViewerMockSingleton`.
+    // Pre-5d.3 this was reached via `viewer._fork`, but the `_fork`
+    // composition pointer is gone now that ShareViewer instantiates
+    // IfcContext + IfcManager + IfcClipper directly.
+    const {__getShareViewerMockSingleton: getSingleton} = require('web-ifc-viewer')
+    getSingleton()._loadedModel.ifcManager.getSpatialStructure.mockReturnValue(makeTestTree())
     viewer.context.getDomElement = jest.fn(() => {
       return document.createElement('div')
     })

--- a/src/Containers/viewer.test.js
+++ b/src/Containers/viewer.test.js
@@ -237,16 +237,32 @@ describe('Containers/viewer', () => {
 
 
   describe('singleton fixture sanity', () => {
-    it('initViewer returns a ShareViewer wrapping the singleton fork mock', () => {
-      // Post-slice-5c: ShareViewer composes the fork instead of extending
-      // it. `viewer` is a ShareViewer; `viewer._fork` is the
-      // IfcViewerAPI mock singleton the rest of the tests share state
-      // through (e.g. `viewer.IFC === singleton.IFC` still holds because
-      // the constructor wires `this.IFC = this._fork.IFC`).
+    it('initViewer returns a ShareViewer that shares state with the singleton fork mock', () => {
+      // Slice 5d.3: ShareViewer no longer keeps a composite `_fork`
+      // reference — it instantiates `IfcContext` (vendored) +
+      // `IfcManager` + `IfcClipper` directly. The mock factories in
+      // `__mocks__/web-ifc-viewer.js` route those constructors through
+      // the singleton `impl`, so mutations to the singleton's IFC /
+      // clipper surface are observable on `viewer.IFC` /
+      // `viewer._forkClipper`. We can't use `.toBe(singleton.IFC)`
+      // because babel-plugin-jest-hoist places the `jest.mock(...,
+      // factory)` calls outside the module's lexical scope; the
+      // factory closes over a different `impl` binding than the one
+      // `__getShareViewerMockSingleton` returns. Sharing is verified
+      // structurally via a sentinel-property round trip instead.
       const viewer = initViewer('/share/v/p')
       const singleton = __getShareViewerMockSingleton()
-      expect(viewer._fork).toBe(singleton)
-      expect(viewer.IFC).toBe(singleton.IFC)
+      expect(viewer.IFC).toBeDefined()
+      expect(viewer._forkClipper).toBeDefined()
+      // Round-trip: mutating the singleton's IFC propagates to viewer.IFC
+      // (and vice versa) iff they're the same backing object.
+      const sentinel = Symbol('5d3-sanity')
+      singleton.IFC[sentinel] = 'shared'
+      expect(viewer.IFC[sentinel]).toBe('shared')
+      delete singleton.IFC[sentinel]
+      singleton.clipper[sentinel] = 'shared-clipper'
+      expect(viewer._forkClipper[sentinel]).toBe('shared-clipper')
+      delete singleton.clipper[sentinel]
     })
   })
 })

--- a/src/viewer/ShareViewer.js
+++ b/src/viewer/ShareViewer.js
@@ -1,4 +1,13 @@
-import {IfcViewerAPI} from 'web-ifc-viewer'
+// Load-order-critical: keep `web-ifc-viewer` as the FIRST import.
+// In Jest, the root manual mock `__mocks__/web-ifc-viewer.js`
+// auto-applies when this node-module is first imported, and it
+// registers `jest.mock()`s for our source modules (`./three/context`,
+// `./three/forkIfcComposition`, IfcHighlighter, …). Importing it first
+// guarantees those registrations land before the modules they mock are
+// pulled in below. In production this just loads the fork index (whose
+// subpaths we use via `forkIfcComposition` anyway), so it's a no-op
+// cost. See `__mocks__/web-ifc-viewer.js` for the full rationale.
+import 'web-ifc-viewer'
 import {BufferAttribute, BufferGeometry, ColorManagement, LinearSRGBColorSpace, Mesh} from 'three'
 import IfcViewsManager from '../Infrastructure/IfcElementsStyleManager'
 import IfcCustomViewSettings from '../Infrastructure/IfcCustomViewSettings'
@@ -8,6 +17,8 @@ import IfcIsolator from './three/IfcIsolator'
 import CustomPostProcessor from './three/CustomPostProcessor'
 import Selector from './three/Selector'
 import ShareIfcLoader from './ifc/ShareIfcLoader'
+import {IfcContext} from './three/context'
+import {makeForkIfc} from './three/forkIfcComposition'
 import ThreeContext from './three/ThreeContext'
 import debug from '../utils/debug'
 import {modelHasCapability} from './ShareModel'
@@ -67,22 +78,25 @@ const viewRules = {
 /**
  * ShareViewer — the top-level viewer facade for Bldrs Share.
  *
- * Slice 5c of design/new/viewer-replacement.md flipped this from
- * `extends IfcViewerAPI` to composition. The fork's `IfcViewerAPI` is
- * still instantiated internally (as `this._fork`) — we depend on it
- * for `IfcContext` (Scene/Camera/Renderer + render loop), `IfcManager`
- * (the parser / ifcAPI / property reads), and `IfcClipper` (IFC
- * clipping plane interaction) — but ShareViewer is no longer
- * `instanceof IfcViewerAPI`. Downstream code depends on this class,
- * not the fork. When the fork's pieces get replaced piece-by-piece in
- * later slices, `this._fork` shrinks until it can be deleted entirely
- * (the dep gets dropped from package.json then).
+ * Slice 5c flipped this from `extends IfcViewerAPI` to composition;
+ * slice 5d.3 dropped the `new IfcViewerAPI()` call too. ShareViewer
+ * now instantiates the three pieces it actually uses directly:
  *
- * Property surface (kept identical to pre-5c so consumers don't churn):
- *   - `this.IFC` — fork's IfcManager (selector, loader.ifcManager, …)
- *   - `this.context` — ThreeContext wrapping the fork's IfcContext
+ *   1. `IfcContext` — vendored at `src/viewer/three/context/` (was
+ *      `web-ifc-viewer/dist/components/context/context.js`).
+ *   2. `IfcManager` — still imported from `web-ifc-viewer` because
+ *      fork-side consumers (clipper / clipping-edges / fills / glTF)
+ *      reach into `IFC.loader.ifcManager.*` and would break without
+ *      the full wit-three surface. Replaced piecewise in later slices.
+ *   3. `IfcClipper` — still imported from `web-ifc-viewer`; the
+ *      clipper unification (5d.2) was explicitly deferred.
+ *
+ * Property surface (stable since slice 5c):
+ *   - `this.IFC` — standalone fork IfcManager
+ *   - `this.context` — ThreeContext wrapping our vendored IfcContext
  *   - `this.clipper` — local `Clipper` facade dispatching per-model
  *   - `this.selector` — local `Selector` facade over `IFC.selector`
+ *   - `this.ifcLoader` — `ShareIfcLoader` (Conway-direct IFC parse)
  *   - `this.isolator`, `this.highlighter`, `this.postProcessor`,
  *     `this.viewsManager` — local plugins constructed here.
  */
@@ -106,40 +120,47 @@ export class ShareViewer {
    * @param {object} options - Configuration options
    */
   constructor(options) {
-    // Composition (was `super(options)` before slice 5c). The fork
-    // viewer's constructor builds IfcContext, IfcManager, IfcClipper,
-    // plus a heap of components we never use (Grid, Axes, GLTF,
-    // ShadowDropper, Edges, DXF, PDF, SelectionWindow, …) — those
-    // bundle-cost stays put for now; subsequent slices replace the
-    // pieces we DO use and `_fork` shrinks. Held as a private member
-    // so `dispose()` can delegate fork teardown and tests can reach
-    // the same instance the singleton mock returns.
-    this._fork = new IfcViewerAPI(options)
-    this.IFC = this._fork.IFC
+    // Slice 5d.3: stop instantiating `new IfcViewerAPI(options)`. Build
+    // the three pieces we actually need ourselves:
+    //
+    //   1. `IfcContext` — vendored at `src/viewer/three/context/`
+    //      (was `web-ifc-viewer/dist/components/context/context.js`).
+    //      Owns the render loop, scene, camera, renderer, mouse,
+    //      raycaster, animator. Fork-side `IfcGrid` / `IfcAxes` /
+    //      `PlanManager` / `SectionFillManager` / `IfcDimensions` /
+    //      `Edges` / `ShadowDropper` / `EdgeProjector` / `DXFWriter` /
+    //      `PDFWriter` / `GLTFManager` / `SelectionWindow` — built but
+    //      unused before — are gone from the bundle.
+    //   2. `IfcManager` (still from `web-ifc-viewer` for now). Holds
+    //      `IFC.loader` (wit-three IFCLoader), `IFC.selector`,
+    //      `IFC.properties`, `IFC.units`. Fork-side clipper +
+    //      clipping-edges + fills + glTF still reach into
+    //      `IFC.loader.ifcManager.*` — fork dep stays until those
+    //      consumers are dropped or replaced.
+    //   3. `IfcClipper` (still from `web-ifc-viewer`). 5d.2 (the
+    //      clipper unification) was explicitly deferred — IFC users
+    //      keep the Q/W shortcut + click-drag UX until then.
+    //
+    // ThreeContext continues to wrap IfcContext (the consumer-facing
+    // surface — `getScene`, `getCameraControls`, `getNormalizedMouse…`,
+    // `setRenderUpdate`, …); only what it wraps changed (was fork
+    // node_modules IfcContext, now our vendored copy).
+    const ifcContext = new IfcContext(options)
+    this.context = new ThreeContext(ifcContext)
+    const {IFC, clipper: forkClipper} = makeForkIfc(ifcContext)
+    this.IFC = IFC
+    this._forkClipper = forkClipper
     // Slice 5d.1: install our `ShareIfcLoader` alongside the fork's
-    // IFCLoader (which stays at `viewer.IFC.loader`). The fork's
-    // IfcClipper / ClippingEdges / fills / plan-manager / glTF
-    // exporter all reach for `this.ifc.loader.ifcManager.{subsets,
-    // parser.optionalCategories, createSubset, state, …}` after
-    // construction — replacing `viewer.IFC.loader` would break them.
-    // Instead `viewer.ifcLoader` is a NEW top-level slot owned by
-    // ShareViewer; `Loader.js#findLoader` reads from there for the
-    // `case 'ifc'` arm. The Conway IfcAPI handle is sourced from the
-    // fork's IFCManager during this transitional slice; later slices
-    // instantiate Conway directly.
-    const conwayIfcAPI = this._fork.IFC.loader?.ifcManager?.ifcAPI
+    // IFCLoader (which stays at `viewer.IFC.loader`). Fork-side
+    // consumers (clipper / clipping-edges / fills / plan-manager /
+    // glTF) reach for `this.ifc.loader.ifcManager.{subsets, …}` —
+    // replacing `viewer.IFC.loader` would break them.
+    // `viewer.ifcLoader` is the new top-level slot;
+    // `Loader.js#findLoader` reads from there for `case 'ifc'`.
+    const conwayIfcAPI = this.IFC.loader?.ifcManager?.ifcAPI
     if (conwayIfcAPI) {
       this.ifcLoader = new ShareIfcLoader({ifcAPI: conwayIfcAPI, ifc: this.IFC})
     }
-    // Wrap the fork's `IfcContext` in our ThreeContext layer. The fork's
-    // IfcManager / IfcClipper retained their own private references to
-    // the original context inside `new IfcViewerAPI(...)`, so the
-    // wrapper here only affects `this.context.X` reads from our code.
-    // Guarded so mocks that pre-wrap (see __mocks__/web-ifc-viewer.js)
-    // don't get double-wrapped.
-    this.context = this._fork.context instanceof ThreeContext ?
-      this._fork.context :
-      new ThreeContext(this._fork.context)
     const renderer = this.context.getRenderer()
     // Partner to the top-level `ColorManagement.enabled = false`: that
     // disables the *input* side (auto sRGB→linear conversions on
@@ -167,12 +188,11 @@ export class ShareViewer {
     // for an IfcModelService-backed `Selection` plugin.
     this.selector = new Selector(this.IFC?.selector)
     // Clipper — §3c.iv slice 3 unified facade over the fork's
-    // `IfcClipper` + in-repo `GlbClipper`. The fork constructed an
-    // IfcClipper on `_fork.clipper`; we capture that as the IFC backing
-    // impl and wrap with our Clipper. Call-sites no longer branch on
-    // `viewer.IFC.type === 'glb'` — they call `viewer.clipper.X` and
-    // trust the plugin.
-    this._forkClipper = this._fork.clipper
+    // `IfcClipper` + in-repo `GlbClipper`. `this._forkClipper` is the
+    // IfcClipper instantiated above (5d.3 wired it standalone); the
+    // Clipper plugin wraps it as the IFC backing impl. Call-sites no
+    // longer branch on `viewer.IFC.type === 'glb'` — they call
+    // `viewer.clipper.X` and trust the plugin.
     this.clipper = new Clipper(this, this._forkClipper)
     this.viewsManager = new IfcViewsManager(this.IFC.loader.ifcManager.parser, viewRules[viewParameter])
   }
@@ -227,16 +247,22 @@ export class ShareViewer {
     } catch (e) {
       console.warn('clipper.dispose failed:', e)
     }
-    // Fork teardown. Stub out the clipper before delegating so
-    // `_fork.dispose()` doesn't double-dispose what `this.clipper`
-    // just tore down. IfcContext + IFC.dispose are the load-bearing
-    // pieces this delegation buys us.
-    if (this._fork) {
-      this._fork.clipper = {dispose: () => {/* already torn down */}}
+    // Slice 5d.3: with `new IfcViewerAPI(options)` gone, there's no
+    // composite-viewer dispose to delegate to. Tear down the three
+    // pieces we own directly. `this.clipper.dispose()` already called
+    // `_forkClipper.dispose()` above, so we don't repeat it here.
+    if (this.IFC) {
       try {
-        await this._fork.dispose?.()
+        await this.IFC.dispose?.()
       } catch (e) {
-        console.warn('_fork.dispose failed:', e)
+        console.warn('IFC.dispose failed:', e)
+      }
+    }
+    if (this.context) {
+      try {
+        this.context.dispose?.()
+      } catch (e) {
+        console.warn('context.dispose failed:', e)
       }
     }
   }

--- a/src/viewer/three/context/LiteEvent.js
+++ b/src/viewer/three/context/LiteEvent.js
@@ -1,0 +1,22 @@
+// -------------------------------------------------------------------------------------------
+// Credit to Jason Kleban: https://gist.github.com/JasonKleban/50cee44960c225ac1993c922563aa540
+// -------------------------------------------------------------------------------------------
+export class LiteEvent {
+  constructor() {
+    this.handlers = []
+    this.trigger = ((data) => {
+      // @ts-ignore
+      this.handlers.slice(0).forEach((h) => h(data))
+    })
+  }
+  on(handler) {
+    this.handlers.push(handler)
+  }
+  off(handler) {
+    this.handlers = this.handlers.filter((h) => h !== handler)
+  }
+  expose() {
+    return this
+  }
+}
+// # sourceMappingURL=LiteEvent.js.map

--- a/src/viewer/three/context/animator.js
+++ b/src/viewer/three/context/animator.js
@@ -1,0 +1,18 @@
+import gsap from 'gsap'
+
+
+export class Animator {
+  constructor() {
+    this.transformer = gsap
+  }
+  dispose() {
+    this.transformer = null
+  }
+  move(vector, transform, duration = 1, delay = 0) {
+    const x = transform.x
+    const y = transform.y
+    const z = transform.z
+    gsap.to(vector, {duration, delay, x, y, z})
+  }
+}
+// # sourceMappingURL=animator.js.map

--- a/src/viewer/three/context/base-types.js
+++ b/src/viewer/three/context/base-types.js
@@ -1,0 +1,49 @@
+// base-types — shared enums + IfcComponent base class for the vendored
+// IfcContext family. Lifted verbatim from
+// `web-ifc-viewer/dist/base-types.js` in slice 5d.3 (vendoring of
+// `web-ifc-viewer/dist/components/context/*` into
+// `src/viewer/three/context/`). Same shape; same NavigationModes
+// numeric constants (Orbit=0, FirstPerson=1, Plan=2) — kept stable so
+// the fork's IfcManager / IfcClipper (still imported from
+// `web-ifc-viewer`) interoperate with our context.
+
+
+/** @enum {number} */
+export const NavigationModes = Object.freeze({
+  Orbit: 0,
+  FirstPerson: 1,
+  Plan: 2,
+})
+
+
+/** @enum {number} */
+export const CameraProjections = Object.freeze({
+  Perspective: 0,
+  Orthographic: 1,
+})
+
+
+/**
+ * IfcComponent — base class for IfcContext sub-objects (IfcScene,
+ * IfcRenderer, IfcCamera, IfcRaycaster, etc.). The constructor
+ * registers `this` with the context's update list so the per-frame
+ * `updateAllComponents` loop calls `component.update(delta)`.
+ *
+ * Sub-classes that don't need per-frame work leave the default no-op
+ * `update`. Sub-classes that do (IfcRaycaster, OrbitControl) override it.
+ */
+export class IfcComponent {
+  /**
+   * @param {object} context the IfcContext owning this component.
+   */
+  constructor(context) {
+    context.addComponent(this)
+  }
+
+  /**
+   * @param {number} _delta seconds since the last frame.
+   */
+  update(_delta) {
+    // no-op default
+  }
+}

--- a/src/viewer/three/context/camera/camera.js
+++ b/src/viewer/three/context/camera/camera.js
@@ -1,0 +1,177 @@
+// IfcCamera — vendored from
+// `web-ifc-viewer/dist/components/context/camera/camera.js` in slice
+// 5d.3. Plan + FirstPerson nav modes are no-op stubs (we only use
+// Orbit) — the constructor still slots them so the existing
+// `setNavigationMode` API works, just silently.
+
+import {Box3, MathUtils, Matrix4, MOUSE, OrthographicCamera, PerspectiveCamera, Quaternion, Raycaster, Sphere, Spherical, Vector2, Vector3, Vector4} from 'three'
+import CameraControls from 'camera-controls'
+import {CameraProjections, IfcComponent, NavigationModes} from '../base-types'
+import {LiteEvent} from '../LiteEvent'
+import {FirstPersonControl} from './controls/first-person-control'
+import {OrbitControl} from './controls/orbit-control'
+import {ProjectionManager} from './projection-manager'
+import {PlanControl} from './controls/plan-control'
+
+
+const subsetOfTHREE = {
+  MOUSE,
+  Vector2,
+  Vector3,
+  Vector4,
+  Quaternion,
+  Matrix4,
+  Spherical,
+  Box3,
+  Sphere,
+  Raycaster,
+  MathUtils: {
+    DEG2RAD: MathUtils.DEG2RAD,
+    clamp: MathUtils.clamp,
+  },
+}
+const frustumSize = 50
+export class IfcCamera extends IfcComponent {
+  constructor(context) {
+    super(context)
+    this.onChange = new LiteEvent()
+    this.onChangeProjection = new LiteEvent()
+    this.previousUserInput = {}
+    this.context = context
+    const dims = this.context.getDimensions()
+    const aspect = dims.x / dims.y
+    this.perspectiveCamera = new PerspectiveCamera(45, aspect, 1, 2000)
+    this.orthographicCamera = new OrthographicCamera((frustumSize * aspect) / -2, (frustumSize * aspect) / 2, frustumSize / 2, frustumSize / -2, 0.1, 1000)
+    this.setupCameras()
+    CameraControls.install({THREE: subsetOfTHREE})
+    this.cameraControls = new CameraControls(this.perspectiveCamera, context.getDomElement())
+    this.navMode = {
+      [NavigationModes.Orbit]: new OrbitControl(this.context, this),
+      [NavigationModes.FirstPerson]: new FirstPersonControl(this.context, this),
+      [NavigationModes.Plan]: new PlanControl(this.context, this),
+    }
+    this.currentNavMode = this.navMode[NavigationModes.Orbit]
+    this.currentNavMode.toggle(true, {preventTargetAdjustment: true})
+    Object.values(this.navMode).forEach((mode) => {
+      mode.onChange.on(this.onChange.trigger)
+      mode.onChangeProjection.on(this.onChangeProjection.trigger)
+    })
+    this.projectionManager = new ProjectionManager(context, this)
+    this.setupControls()
+  }
+  dispose() {
+    this.perspectiveCamera.removeFromParent()
+    this.perspectiveCamera = null
+    this.orthographicCamera.removeFromParent()
+    this.orthographicCamera = null
+    this.cameraControls.dispose()
+    this.cameraControls = null
+    this.navMode = null
+    this.context = null
+    this.projectionManager = null
+  }
+  get projection() {
+    return this.projectionManager.projection
+  }
+  set projection(projection) {
+    this.projectionManager.projection = projection
+  }
+  /**
+   * @deprecated Use cameraControls instead.
+   */
+  get controls() {
+    return this.cameraControls
+  }
+  get activeCamera() {
+    return this.projectionManager.activeCamera
+  }
+  update(_delta) {
+    super.update(_delta)
+    if (this.cameraControls.enabled) {
+      this.cameraControls.update(_delta)
+    }
+  }
+  updateAspect(dims) {
+    if (!dims) {
+      dims = this.context.getDimensions()
+    }
+    this.perspectiveCamera.aspect = dims.x / dims.y
+    this.perspectiveCamera.updateProjectionMatrix()
+    this.setOrthoCameraAspect(dims)
+  }
+  /**
+   * @deprecated Use onChange.on() instead.
+   */
+  submitOnChange(action) {
+    this.onChange.on(action)
+  }
+  setNavigationMode(mode) {
+    if (this.currentNavMode.mode === mode) {
+      return
+    }
+    this.currentNavMode.toggle(false)
+    this.currentNavMode = this.navMode[mode]
+    this.currentNavMode.toggle(true)
+  }
+  toggleCameraControls(active) {
+    this.cameraControls.enabled = active
+  }
+  toggleProjection() {
+    const isOrto = this.projection === CameraProjections.Orthographic
+    this.projection = isOrto ? CameraProjections.Perspective : CameraProjections.Orthographic
+    this.onChangeProjection.trigger(this.activeCamera)
+  }
+  async targetItem(mesh) {
+    const center = this.context.getCenter(mesh)
+    await this.cameraControls.moveTo(center.x, center.y, center.z, true)
+  }
+  toggleUserInput(active) {
+    console.log(this.previousUserInput)
+    if (active) {
+      if (Object.keys(this.previousUserInput).length === 0) {
+        return
+      }
+      this.cameraControls.mouseButtons.left = this.previousUserInput.left
+      this.cameraControls.mouseButtons.right = this.previousUserInput.right
+      this.cameraControls.mouseButtons.middle = this.previousUserInput.middle
+      this.cameraControls.mouseButtons.wheel = this.previousUserInput.wheel
+    } else {
+      this.previousUserInput.left = this.cameraControls.mouseButtons.left
+      this.previousUserInput.right = this.cameraControls.mouseButtons.right
+      this.previousUserInput.middle = this.cameraControls.mouseButtons.middle
+      this.previousUserInput.wheel = this.cameraControls.mouseButtons.wheel
+      this.cameraControls.mouseButtons.left = 0
+      this.cameraControls.mouseButtons.right = 0
+      this.cameraControls.mouseButtons.middle = 0
+      this.cameraControls.mouseButtons.wheel = 0
+    }
+  }
+  setOrthoCameraAspect(dims) {
+    const aspect = dims.x / dims.y
+    this.orthographicCamera.left = (-frustumSize * aspect) / 2
+    this.orthographicCamera.right = (frustumSize * aspect) / 2
+    this.orthographicCamera.top = frustumSize / 2
+    this.orthographicCamera.bottom = -frustumSize / 2
+    this.orthographicCamera.updateProjectionMatrix()
+  }
+  // private setOrbitControls() {
+  //   this.setNavigationMode(NavigationModes.Orbit);
+  //   return this.currentNavMode as OrbitControl;
+  // }
+  setupCameras() {
+    this.setCameraPositionAndTarget(this.perspectiveCamera)
+  }
+  setCameraPositionAndTarget(camera) {
+    camera.position.z = 10
+    camera.position.y = 10
+    camera.position.x = 10
+    camera.lookAt(new Vector3(0, 0, 0))
+  }
+  setupControls() {
+    this.cameraControls.dampingFactor = 0.2
+    this.cameraControls.dollyToCursor = true
+    this.cameraControls.infinityDolly = true
+    this.cameraControls.setTarget(0, 0, 0)
+  }
+}
+// # sourceMappingURL=camera.js.map

--- a/src/viewer/three/context/camera/controls/first-person-control.js
+++ b/src/viewer/three/context/camera/controls/first-person-control.js
@@ -1,0 +1,47 @@
+// FirstPersonControl — no-op stub. The fork's IfcCamera constructor
+// instantiates one for `NavigationModes.FirstPerson`, but Bldrs Share
+// only uses `NavigationModes.Orbit` — we never call `setNavigationMode`
+// to switch to FirstPerson. Lifted from the fork in slice 5d.3 as a
+// shell so `camera.js`'s `navMode[NavigationModes.FirstPerson]` slot
+// still constructs (instead of breaking on a missing import).
+//
+// `onChange` / `onChangeProjection` are present so the
+// `Object.values(this.navMode).forEach((mode) => { mode.onChange.on(…)
+// })` loop in IfcCamera's constructor doesn't blow up.
+
+import {IfcComponent, NavigationModes} from '../../base-types'
+import {LiteEvent} from '../../LiteEvent'
+
+
+/**
+ * No-op FirstPerson nav mode. Toggle / fitModelToFrame are wired but
+ * intentionally do nothing — we never become the active nav mode.
+ */
+export class FirstPersonControl extends IfcComponent {
+  /**
+   * @param {object} context
+   * @param {object} _camera
+   */
+  constructor(context, _camera) {
+    super(context)
+    this.mode = NavigationModes.FirstPerson
+    this.enabled = false
+    this.onChange = new LiteEvent()
+    this.onChangeProjection = new LiteEvent()
+  }
+
+
+  /** @param {boolean} active */
+  toggle(active) {
+    this.enabled = active
+  }
+
+
+  /**
+   * Standard fit-model-to-frame shim. Never called — we only fit in
+   * Orbit mode.
+   */
+  fitModelToFrame() {
+    // no-op
+  }
+}

--- a/src/viewer/three/context/camera/controls/orbit-control.js
+++ b/src/viewer/three/context/camera/controls/orbit-control.js
@@ -1,0 +1,58 @@
+// OrbitControl — vendored from
+// `web-ifc-viewer/dist/components/context/camera/controls/orbit-control.js`
+// in slice 5d.3.
+
+import {Box3, Sphere, Vector3} from 'three'
+import {IfcComponent, NavigationModes} from '../../base-types'
+import {LiteEvent} from '../../LiteEvent'
+
+
+export class OrbitControl extends IfcComponent {
+  constructor(context, ifcCamera) {
+    super(context)
+    this.context = context
+    this.ifcCamera = ifcCamera
+    this.enabled = true
+    this.mode = NavigationModes.Orbit
+    this.onChange = new LiteEvent()
+    this.onUnlock = new LiteEvent()
+    this.onChangeProjection = new LiteEvent()
+    this.activateOrbitControls()
+  }
+  /**
+   * @deprecated Use cameraControls.getTarget.
+   */
+  get target() {
+    const target = new Vector3()
+    this.ifcCamera.cameraControls.getTarget(target)
+    return target
+  }
+  toggle(active) {
+    this.enabled = active
+    if (active) {
+      this.activateOrbitControls()
+    }
+  }
+  async fitModelToFrame() {
+    if (!this.enabled) {
+      return
+    }
+    const scene = this.context.getScene()
+    const box = new Box3().setFromObject(scene.children[scene.children.length - 1])
+    const sceneSize = new Vector3()
+    box.getSize(sceneSize)
+    const sceneCenter = new Vector3()
+    box.getCenter(sceneCenter)
+    const nearFactor = 0.5
+    const radius = Math.max(sceneSize.x, sceneSize.y, sceneSize.z) * nearFactor
+    const sphere = new Sphere(sceneCenter, radius)
+    await this.ifcCamera.cameraControls.fitToSphere(sphere, true)
+  }
+  activateOrbitControls() {
+    const controls = this.ifcCamera.cameraControls
+    controls.minDistance = 1
+    controls.maxDistance = 300
+    this.ifcCamera.cameraControls.truckSpeed = 2
+  }
+}
+// # sourceMappingURL=orbit-control.js.map

--- a/src/viewer/three/context/camera/controls/plan-control.js
+++ b/src/viewer/three/context/camera/controls/plan-control.js
@@ -1,0 +1,38 @@
+// PlanControl — no-op stub. Same rationale as `first-person-control.js`:
+// the fork's IfcCamera constructor instantiates one for
+// `NavigationModes.Plan` but we never activate it. Slot exists so
+// IfcCamera's `navMode[NavigationModes.Plan] = …` assignment + the
+// `Object.values(this.navMode).forEach(…)` event wire-up work.
+
+import {IfcComponent, NavigationModes} from '../../base-types'
+import {LiteEvent} from '../../LiteEvent'
+
+
+/**
+ * No-op Plan nav mode.
+ */
+export class PlanControl extends IfcComponent {
+  /**
+   * @param {object} context
+   * @param {object} _camera
+   */
+  constructor(context, _camera) {
+    super(context)
+    this.mode = NavigationModes.Plan
+    this.enabled = false
+    this.onChange = new LiteEvent()
+    this.onChangeProjection = new LiteEvent()
+  }
+
+
+  /** @param {boolean} active */
+  toggle(active) {
+    this.enabled = active
+  }
+
+
+  /** No-op fit. */
+  fitModelToFrame() {
+    // no-op
+  }
+}

--- a/src/viewer/three/context/camera/projection-manager.js
+++ b/src/viewer/three/context/camera/projection-manager.js
@@ -1,0 +1,86 @@
+// ProjectionManager — vendored from
+// `web-ifc-viewer/dist/components/context/camera/projection-manager.js`
+// in slice 5d.3.
+
+import {Vector3} from 'three'
+import CameraControls from 'camera-controls'
+import {CameraProjections, NavigationModes} from '../base-types'
+
+
+export class ProjectionManager {
+  constructor(context, ifcCamera) {
+    this.context = context
+    this.previousDistance = -1
+    this.cameras = ifcCamera
+    this.currentCamera = ifcCamera.perspectiveCamera
+    this.currentProjection = CameraProjections.Perspective
+  }
+  get activeCamera() {
+    return this.currentCamera
+  }
+  get projection() {
+    return this.currentProjection
+  }
+  set projection(projection) {
+    if (this.projection === projection) {
+      return
+    }
+    if (projection === CameraProjections.Orthographic) {
+      this.setOrthoCamera()
+    } else {
+      this.setPerspectiveCamera()
+    }
+  }
+  setOrthoCamera() {
+    // Matching orthographic camera to perspective camera
+    // Resource: https://stackoverflow.com/questions/48758959/what-is-required-to-convert-threejs-perspective-camera-to-orthographic
+    if (this.cameras.currentNavMode.mode === NavigationModes.FirstPerson) {
+      return
+    }
+    this.previousDistance = this.cameras.cameraControls.distance
+    this.cameras.cameraControls.distance = 200
+    const {width, height} = this.getDims()
+    this.setupOrthoCamera(height, width)
+    this.currentCamera = this.cameras.orthographicCamera
+    this.currentProjection = CameraProjections.Orthographic
+  }
+  getDims() {
+    const lineOfSight = new Vector3()
+    this.cameras.perspectiveCamera.getWorldDirection(lineOfSight)
+    const target = new Vector3()
+    this.cameras.cameraControls.getTarget(target)
+    const distance = target.clone().sub(this.cameras.perspectiveCamera.position)
+    const depth = distance.dot(lineOfSight)
+    const dims = this.context.getDimensions()
+    const aspect = dims.x / dims.y
+    const fov = this.cameras.perspectiveCamera.fov
+    const height = depth * 2 * Math.atan((fov * (Math.PI / 180)) / 2)
+    const width = height * aspect
+    return {width, height}
+  }
+  setupOrthoCamera(height, width) {
+    this.cameras.cameraControls.mouseButtons.wheel = CameraControls.ACTION.ZOOM
+    this.cameras.orthographicCamera.zoom = 1
+    this.cameras.orthographicCamera.left = width / -2
+    this.cameras.orthographicCamera.right = width / 2
+    this.cameras.orthographicCamera.top = height / 2
+    this.cameras.orthographicCamera.bottom = height / -2
+    this.cameras.orthographicCamera.updateProjectionMatrix()
+    this.cameras.orthographicCamera.position.copy(this.cameras.perspectiveCamera.position)
+    this.cameras.orthographicCamera.quaternion.copy(this.cameras.perspectiveCamera.quaternion)
+    this.cameras.cameraControls.camera = this.cameras.orthographicCamera
+  }
+  setPerspectiveCamera() {
+    this.cameras.cameraControls.mouseButtons.wheel = CameraControls.ACTION.DOLLY
+    this.cameras.perspectiveCamera.position.copy(this.cameras.orthographicCamera.position)
+    this.cameras.perspectiveCamera.quaternion.copy(this.cameras.orthographicCamera.quaternion)
+    this.cameras.perspectiveCamera.updateProjectionMatrix()
+    this.cameras.cameraControls.camera = this.cameras.perspectiveCamera
+    this.cameras.cameraControls.mouseButtons.wheel = CameraControls.ACTION.DOLLY
+    this.currentCamera = this.cameras.perspectiveCamera
+    this.currentProjection = CameraProjections.Perspective
+    this.cameras.cameraControls.distance = this.previousDistance
+    this.cameras.cameraControls.zoomTo(1)
+  }
+}
+// # sourceMappingURL=projection-manager.js.map

--- a/src/viewer/three/context/context.js
+++ b/src/viewer/three/context/context.js
@@ -1,0 +1,224 @@
+// IfcContext — vendored from
+// `web-ifc-viewer/dist/components/context/context.js` in slice 5d.3.
+// The `Clock` shim below replaces three's `Clock` (deprecated in r183)
+// — previously applied by `tools/esbuild/plugins.js#shimClock`. Class
+// is a constructor + `getDelta` only (all the IfcContext render loop
+// reads). `THREE.Timer` is not a drop-in replacement.
+
+import {Vector2, Vector3} from 'three'
+import {IfcCamera} from './camera/camera'
+import {IfcRaycaster} from './raycaster'
+import {IfcRenderer} from './renderer/renderer'
+import {IfcScene} from './scene'
+import {Animator} from './animator'
+import {IfcEvent, IfcEvents} from './ifcEvent'
+import {NavigationModes} from './base-types'
+import {IfcMouse} from './mouse'
+
+
+/**
+ * Drop-in shim for `THREE.Clock(true)` / `getDelta()`. Avoids the
+ * r183 deprecation warning without rewiring the render loop.
+ */
+class Clock {
+  constructor() {
+    this._last = performance.now()
+  }
+  getDelta() {
+    const now = performance.now()
+    const d = (now - this._last) / 1000
+    this._last = now
+    return d
+  }
+}
+
+
+export class IfcContext {
+  constructor(options) {
+    this.stats = null
+    this.isThisBeingDisposed = false
+    this.render = () => {
+      if (this.isThisBeingDisposed) {
+        return
+      }
+      if (this.stats) {
+        this.stats.begin()
+      }
+      const isWebXR = this.options.webXR || false
+      if (isWebXR) {
+        this.renderForWebXR()
+      } else {
+        requestAnimationFrame(this.render)
+      }
+      this.updateAllComponents()
+      if (this.stats) {
+        this.stats.end()
+      }
+    }
+    this.renderForWebXR = () => {
+      const newAnimationLoop = () => {
+        this.getRenderer().render(this.getScene(), this.getCamera())
+      }
+      this.getRenderer().setAnimationLoop(newAnimationLoop)
+    }
+    this.resize = () => {
+      this.updateAspect()
+    }
+    if (!options.container) {
+      throw new Error('Could not get container element!')
+    }
+    this.options = options
+    this.events = new IfcEvents()
+    this.items = this.newItems()
+    this.scene = new IfcScene(this)
+    this.renderer = new IfcRenderer(this)
+    this.mouse = new IfcMouse(this.renderer.renderer.domElement)
+    this.ifcCamera = new IfcCamera(this)
+    this.events.publish(IfcEvent.onCameraReady)
+    this.clippingPlanes = []
+    this.ifcCaster = new IfcRaycaster(this)
+    this.clock = new Clock(true)
+    this.ifcAnimator = new Animator()
+    this.setupWindowRescale()
+    this.render()
+  }
+  dispose() {
+    let _a; let _b; let _c
+    this.isThisBeingDisposed = true;
+    (_a = this.stats) === null || _a === void 0 ? void 0 : _a.dom.remove();
+    (_b = this.options.preselectMaterial) === null || _b === void 0 ? void 0 : _b.dispose();
+    (_c = this.options.selectMaterial) === null || _c === void 0 ? void 0 : _c.dispose()
+    this.options = null
+    this.items.components.length = 0
+    this.items.ifcModels.forEach((model) => {
+      model.removeFromParent()
+      if (model.geometry.boundsTree) {
+        model.geometry.disposeBoundsTree()
+      }
+      model.geometry.dispose()
+      if (Array.isArray(model.material)) {
+        model.material.forEach((mat) => mat.dispose())
+      } else {
+        model.material.dispose()
+      }
+    })
+    this.items.ifcModels.length = 0
+    this.items.pickableIfcModels.length = 0
+    this.items = null
+    this.ifcCamera.dispose()
+    this.ifcCamera = null
+    this.scene.dispose()
+    this.scene = null
+    this.renderer.dispose()
+    this.mouse = null
+    this.renderer = null
+    this.events.dispose()
+    this.events = null
+    this.ifcCaster.dispose()
+    this.ifcCaster = null
+    this.ifcAnimator.dispose()
+    this.ifcAnimator = null
+    this.clock = null
+    this.clippingPlanes.length = 0
+    this.unsetWindowRescale()
+  }
+  getScene() {
+    return this.scene.scene
+  }
+  getRenderer() {
+    return this.renderer.renderer
+  }
+  getRenderer2D() {
+    return this.renderer.renderer2D
+  }
+  getCamera() {
+    return this.ifcCamera.activeCamera
+  }
+  getIfcCamera() {
+    return this.ifcCamera
+  }
+  getDomElement() {
+    return this.getRenderer().domElement
+  }
+  getDomElement2D() {
+    return this.getRenderer2D().domElement
+  }
+  getContainerElement() {
+    return this.options.container
+  }
+  getDimensions() {
+    const element = this.getContainerElement()
+    return new Vector2(element.clientWidth, element.clientHeight)
+  }
+  getClippingPlanes() {
+    return this.clippingPlanes
+  }
+  getAnimator() {
+    return this.ifcAnimator
+  }
+  getCenter(mesh) {
+    mesh.geometry.computeBoundingBox()
+    if (!mesh.geometry.index) {
+      return new Vector3()
+    }
+    const indices = mesh.geometry.index.array
+    const position = mesh.geometry.attributes.position
+    const threshold = 20
+    let xCoords = 0
+    let yCoords = 0
+    let zCoords = 0
+    let counter = 0
+    for (let i = 0; i < indices.length || i < threshold; i++) {
+      xCoords += position.getX(indices[i])
+      yCoords += position.getY(indices[i])
+      zCoords += position.getZ(indices[i])
+      counter++
+    }
+    return new Vector3(xCoords / counter + mesh.position.x, yCoords / counter + mesh.position.y, zCoords / counter + mesh.position.z)
+  }
+
+  addComponent(component) {
+    this.items.components.push(component)
+  }
+  addClippingPlane(plane) {
+    this.clippingPlanes.push(plane)
+  }
+  removeClippingPlane(plane) {
+    const index = this.clippingPlanes.indexOf(plane)
+    this.clippingPlanes.splice(index, 1)
+  }
+  castRay(items) {
+    return this.ifcCaster.castRay(items)
+  }
+  castRayIfc() {
+    return this.ifcCaster.castRayIfc()
+  }
+  fitToFrame() {
+    this.ifcCamera.navMode[NavigationModes.Orbit].fitModelToFrame()
+  }
+  toggleCameraControls(active) {
+    this.ifcCamera.toggleCameraControls(active)
+  }
+  updateAspect() {
+    this.ifcCamera.updateAspect()
+    this.renderer.adjustRendererSize()
+  }
+  updateAllComponents() {
+    const delta = this.clock.getDelta()
+    this.items.components.forEach((component) => component.update(delta))
+  }
+  setupWindowRescale() {
+    window.addEventListener('resize', this.resize)
+  }
+  unsetWindowRescale() {
+    window.removeEventListener('resize', this.resize)
+  }
+  newItems() {
+    return {
+      components: [],
+      ifcModels: [],
+      pickableIfcModels: [],
+    }
+  }
+}
+// # sourceMappingURL=context.js.map

--- a/src/viewer/three/context/ifcEvent.js
+++ b/src/viewer/three/context/ifcEvent.js
@@ -1,0 +1,38 @@
+export var IfcEvent;
+(function(IfcEvent) {
+  IfcEvent['onCameraReady'] = 'onCameraReady'
+})(IfcEvent || (IfcEvent = {}))
+export class IfcEvents {
+  constructor() {
+    this.events = {
+      [IfcEvent.onCameraReady]: {
+        needsUpdate: false,
+        published: false,
+        actions: [],
+      },
+    }
+  }
+  dispose() {
+    this.events.onCameraReady.actions.length = 0
+    this.events = null
+  }
+  subscribe(event, action) {
+    this.events[event].actions.push(action)
+    this.events[event].needsUpdate = true
+    this.update(event)
+  }
+  publish(event) {
+    this.events[event].published = true
+    this.update(event)
+  }
+  update(event) {
+    if (this.events[event].needsUpdate && this.events[event].published) {
+      const actions = this.events[event].actions
+      for (let i = 0; i < actions.length; i++) {
+        actions[i]()
+      }
+      actions.length = 0
+    }
+  }
+}
+// # sourceMappingURL=ifcEvent.js.map

--- a/src/viewer/three/context/index.js
+++ b/src/viewer/three/context/index.js
@@ -1,0 +1,29 @@
+// Vendored IfcContext family — re-exports.
+//
+// Slice 5d.3 of design/new/viewer-replacement.md Phase 5. Replaces
+// `node_modules/web-ifc-viewer/dist/components/context/*`, which was
+// the last fork-side rendering anchor for `ShareViewer`. Source was
+// copied 1:1 from `web-ifc-viewer-1.0.209-bldrs-7.tgz`, then patched:
+//
+//   - `context.js`        — inline Clock shim (r183 deprecation)
+//   - `scene.js`          — light intensities × Math.PI (r157 lights)
+//   - `renderer/renderer.js` — Postproduction is now the local no-op
+//                              stub (we own postprocessing via
+//                              `CustomPostProcessor`)
+//   - `camera/controls/{first-person,plan}-control.js` — no-op stubs;
+//                              we only ever use Orbit
+//
+// Companion utility files: `base-types.js` (IfcComponent +
+// NavigationModes / CameraProjections enums) + `LiteEvent.js`
+// (small pub/sub used by IfcCamera + OrbitControl).
+
+export {IfcContext} from './context'
+export {IfcScene} from './scene'
+export {IfcRenderer} from './renderer/renderer'
+export {IfcCamera} from './camera/camera'
+export {IfcRaycaster} from './raycaster'
+export {IfcMouse} from './mouse'
+export {Animator} from './animator'
+export {IfcEvent, IfcEvents} from './ifcEvent'
+export {NavigationModes, CameraProjections, IfcComponent} from './base-types'
+export {LiteEvent} from './LiteEvent'

--- a/src/viewer/three/context/mouse.js
+++ b/src/viewer/three/context/mouse.js
@@ -1,0 +1,20 @@
+import {Vector2} from 'three'
+
+
+export class IfcMouse {
+  constructor(domElement) {
+    this.position = new Vector2()
+    this.rawPosition = new Vector2()
+    this.setupMousePositionUpdate(domElement)
+  }
+  setupMousePositionUpdate(domElement) {
+    domElement.onmousemove = (event) => {
+      this.rawPosition.x = event.clientX
+      this.rawPosition.y = event.clientY
+      const bounds = domElement.getBoundingClientRect()
+      this.position.x = ((event.clientX - bounds.left) / (bounds.right - bounds.left)) * 2 - 1
+      this.position.y = -((event.clientY - bounds.top) / (bounds.bottom - bounds.top)) * 2 + 1
+    }
+  }
+}
+// # sourceMappingURL=mouse.js.map

--- a/src/viewer/three/context/raycaster.js
+++ b/src/viewer/three/context/raycaster.js
@@ -1,0 +1,37 @@
+// IfcRaycaster — vendored from
+// `web-ifc-viewer/dist/components/context/raycaster.js` in slice 5d.3.
+
+import {Raycaster} from 'three'
+import {IfcComponent} from './base-types'
+
+
+export class IfcRaycaster extends IfcComponent {
+  constructor(context) {
+    super(context)
+    this.context = context
+    this.raycaster = new Raycaster()
+  }
+  dispose() {
+    this.raycaster = null
+    this.context = null
+  }
+  castRay(items) {
+    const camera = this.context.getCamera()
+    this.raycaster.setFromCamera(this.context.mouse.position, camera)
+    return this.raycaster.intersectObjects(items)
+  }
+  castRayIfc() {
+    const items = this.castRay(this.context.items.pickableIfcModels)
+    const filtered = this.filterClippingPlanes(items)
+    return filtered.length > 0 ? filtered[0] : null
+  }
+  filterClippingPlanes(objs) {
+    const planes = this.context.getClippingPlanes()
+    if (objs.length <= 0 || !planes || (planes === null || planes === void 0 ? void 0 : planes.length) <= 0) {
+      return objs
+    }
+    // const planes = this.clipper?.planes.map((p) => p.plane);
+    return objs.filter((elem) => planes.every((elem2) => elem2.distanceToPoint(elem.point) > 0))
+  }
+}
+// # sourceMappingURL=raycaster.js.map

--- a/src/viewer/three/context/renderer/custom-outline-pass.js
+++ b/src/viewer/three/context/renderer/custom-outline-pass.js
@@ -1,0 +1,211 @@
+import {Pass, FullScreenQuad} from 'three/examples/jsm/postprocessing/Pass'
+import {Color, MeshNormalMaterial, NearestFilter, RGBFormat, ShaderMaterial, Vector2, Vector4, WebGLRenderTarget} from 'three'
+// source: https://discourse.threejs.org/t/how-to-render-full-outlines-as-a-post-process-tutorial/22674
+// Follows the structure of
+// 		https://github.com/mrdoob/three.js/blob/master/examples/jsm/postprocessing/OutlinePass.js
+class CustomOutlinePass extends Pass {
+  constructor(resolution, scene, camera) {
+    super()
+    this.renderScene = scene
+    this.camera = camera
+    this.resolution = new Vector2(resolution.x, resolution.y)
+    // @ts-ignore
+    this.fsQuad = new FullScreenQuad(null)
+    this.fsQuad.material = this.createOutlinePostProcessMaterial()
+    // Create a buffer to store the normals of the scene onto
+    const normalTarget = new WebGLRenderTarget(this.resolution.x, this.resolution.y)
+    normalTarget.texture.format = RGBFormat
+    normalTarget.texture.minFilter = NearestFilter
+    normalTarget.texture.magFilter = NearestFilter
+    normalTarget.texture.generateMipmaps = false
+    normalTarget.stencilBuffer = false
+    this.normalTarget = normalTarget
+    this.normalOverrideMaterial = new MeshNormalMaterial()
+  }
+  dispose() {
+    this.normalTarget.dispose()
+    this.normalTarget = null
+    this.fsQuad.dispose()
+    this.fsQuad = null
+  }
+  setSize(width, height) {
+    this.normalTarget.setSize(width, height)
+    this.resolution.set(width * 2, height * 2)
+    // @ts-ignore
+    this.fsQuad.material.uniforms.screenSize.value.set(this.resolution.x, this.resolution.y, 1 / this.resolution.x, 1 / this.resolution.y)
+  }
+  render(renderer, writeBuffer, readBuffer) {
+    // Turn off writing to the depth buffer
+    // because we need to read from it in the subsequent passes.
+    const depthBufferValue = writeBuffer.depthBuffer
+    writeBuffer.depthBuffer = false
+    // 1. Re-render the scene to capture all normals in texture.
+    // Ideally we could capture this in the first render pass along with
+    // the depth texture.
+    renderer.setRenderTarget(this.normalTarget)
+    const overrideMaterialValue = this.renderScene.overrideMaterial
+    this.renderScene.overrideMaterial = this.normalOverrideMaterial
+    renderer.render(this.renderScene, this.camera)
+    this.renderScene.overrideMaterial = overrideMaterialValue
+    // @ts-ignore
+    this.fsQuad.material.uniforms.depthBuffer.value = readBuffer.depthTexture
+    // @ts-ignore
+    this.fsQuad.material.uniforms.normalBuffer.value = this.normalTarget.texture
+    // @ts-ignore
+    this.fsQuad.material.uniforms.sceneColorBuffer.value = readBuffer.texture
+    // 2. Draw the outlines using the depth texture and normal texture
+    // and combine it with the scene color
+    if (this.renderToScreen) {
+      // If this is the last effect, then renderToScreen is true.
+      // So we should render to the screen by setting target null
+      // Otherwise, just render into the writeBuffer that the next effect will use as its read buffer.
+      renderer.setRenderTarget(null)
+      this.fsQuad.render(renderer)
+    } else {
+      renderer.setRenderTarget(writeBuffer)
+      this.fsQuad.render(renderer)
+    }
+    // Reset the depthBuffer value so we continue writing to it in the next render.
+    writeBuffer.depthBuffer = depthBufferValue
+  }
+  get vertexShader() {
+    return `
+			varying vec2 vUv;
+			void main() {
+			  vUv = uv;
+			  gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+			}
+			`
+  }
+  get fragmentShader() {
+    return `
+			#include <packing>
+			// The above include imports "perspectiveDepthToViewZ"
+			// and other GLSL functions from ThreeJS we need for reading depth.
+			uniform sampler2D sceneColorBuffer;
+			uniform sampler2D depthBuffer;
+			uniform sampler2D normalBuffer;
+			uniform float cameraNear;
+  		uniform float cameraFar;
+  		uniform vec4 screenSize;
+      uniform vec3 outlineColor;
+      uniform vec4 multiplierParameters;
+      uniform int debugVisualize;
+
+			varying vec2 vUv;
+
+			// Helper functions for reading from depth buffer.
+			float readDepth (sampler2D depthSampler, vec2 coord) {
+				float fragCoordZ = texture2D(depthSampler, coord).x;
+				float viewZ = perspectiveDepthToViewZ( fragCoordZ, cameraNear, cameraFar );
+				return viewZToOrthographicDepth( viewZ, cameraNear, cameraFar );
+			}
+			float getLinearDepth(vec3 pos) {
+				return -(viewMatrix * vec4(pos, 1.0)).z;
+			}
+
+			float getLinearScreenDepth(sampler2D map) {
+		    	vec2 uv = gl_FragCoord.xy * screenSize.zw;
+		    	return readDepth(map,uv);
+			}
+			// Helper functions for reading normals and depth of neighboring pixels.
+			float getPixelDepth(int x, int y) {
+				// screenSize.zw is pixel size 
+				// vUv is current position
+				return readDepth(depthBuffer, vUv + screenSize.zw * vec2(x, y));
+			}
+			vec3 getPixelNormal(int x, int y) {
+				return texture2D(normalBuffer, vUv + screenSize.zw * vec2(x, y)).rgb;
+			}
+
+      float saturate(float num) {
+        return clamp(num, 0.0, 1.0);
+      }
+
+			void main() {
+				vec4 sceneColor = texture2D(sceneColorBuffer, vUv);
+				float depth = getPixelDepth(0, 0);
+				vec3 normal = getPixelNormal(0, 0);
+
+				// Get the difference between depth of neighboring pixels and current.
+				float depthDiff = 0.0;
+		  	depthDiff += abs(depth - getPixelDepth(1, 0));
+		  	depthDiff += abs(depth - getPixelDepth(-1, 0));
+		  	depthDiff += abs(depth - getPixelDepth(0, 1));
+		  	depthDiff += abs(depth - getPixelDepth(0, -1));
+
+		  	// Get the difference between normals of neighboring pixels and current
+		  	float normalDiff = 0.0;
+		  	normalDiff += distance(normal, getPixelNormal(1, 0));
+		  	normalDiff += distance(normal, getPixelNormal(0, 1));
+		  	normalDiff += distance(normal, getPixelNormal(0, 1));
+		  	normalDiff += distance(normal, getPixelNormal(0, -1));
+
+        normalDiff += distance(normal, getPixelNormal(1, 1));
+        normalDiff += distance(normal, getPixelNormal(1, -1));
+        normalDiff += distance(normal, getPixelNormal(-1, 1));
+        normalDiff += distance(normal, getPixelNormal(-1, -1));
+
+        // Apply multiplier & bias to each 
+        float depthBias = multiplierParameters.x;
+        float depthMultiplier = multiplierParameters.y;
+        float normalBias = multiplierParameters.z;
+        float normalMultiplier = multiplierParameters.w;
+
+        depthDiff = depthDiff * depthMultiplier;
+        depthDiff = saturate(depthDiff);
+        depthDiff = pow(depthDiff, depthBias);
+
+        normalDiff = normalDiff * normalMultiplier;
+        normalDiff = saturate(normalDiff);
+        normalDiff = pow(normalDiff, normalBias);
+
+
+		  	float outline = normalDiff + depthDiff;
+			
+		  	// Combine outline with scene color.
+		  	vec4 outlineColor = vec4(outlineColor, 1.0);
+		  	gl_FragColor = vec4(mix(sceneColor, outlineColor, outline));
+
+        // For debug visualization of the different inputs to this shader.
+        if (debugVisualize == 1) {
+          gl_FragColor = sceneColor;
+        }
+        if (debugVisualize == 2) {
+          gl_FragColor = vec4(vec3(depth), 1.0);
+        }
+        if (debugVisualize == 3) {
+          gl_FragColor = vec4(normal, 1.0);
+        }
+        if (debugVisualize == 4) {
+          gl_FragColor = vec4(vec3(outline * outlineColor), 1.0);
+        }
+			}
+			`
+  }
+  createOutlinePostProcessMaterial() {
+    return new ShaderMaterial({
+      uniforms: {
+        debugVisualize: {value: 0},
+        // @ts-ignore
+        sceneColorBuffer: {},
+        // @ts-ignore
+        depthBuffer: {},
+        // @ts-ignore
+        normalBuffer: {},
+        outlineColor: {value: new Color(0xffffff)},
+        // 4 scalar values packed in one uniform: depth multiplier, depth bias, and same for normals.
+        multiplierParameters: {value: new Vector4(1, 1, 1, 1)},
+        cameraNear: {value: this.camera.near},
+        cameraFar: {value: this.camera.far},
+        screenSize: {
+          value: new Vector4(this.resolution.x, this.resolution.y, 1 / this.resolution.x, 1 / this.resolution.y),
+        },
+      },
+      vertexShader: this.vertexShader,
+      fragmentShader: this.fragmentShader,
+    })
+  }
+}
+export {CustomOutlinePass}
+// # sourceMappingURL=custom-outline-pass.js.map

--- a/src/viewer/three/context/renderer/postproduction.js
+++ b/src/viewer/three/context/renderer/postproduction.js
@@ -1,69 +1,270 @@
-// Postproduction — no-op stub. The fork's `web-ifc-viewer` builds a
-// real `Postproduction` (EffectComposer + custom-outline-pass) on
-// IfcRenderer; the fork's `IfcClipper.set active(...)` toggles its
-// `.visible` field when clipping planes turn on/off. We don't use
-// fork's outline path — `CustomPostProcessor` (src/viewer/three/) is
-// our active postprocessing — so this stub only needs to satisfy the
-// surface IfcRenderer and IfcClipper poke at:
-//
-//   - `visible`              boolean toggle (IfcClipper writes it)
-//   - `setSize(w, h)`        called from IfcRenderer.adjustRendererSize
-//   - `dispose()`            called from IfcRenderer.dispose
-//   - `update()`             called from IfcRenderer.update (was the
-//                            outline render in the fork; no-op for us)
-//   - `htmlOverlay`          renderer reads this and appends to DOM
-//                            on construction — needs to be a real Element
-//                            (an empty `<div>` is enough; we never read
-//                            from it).
-//
-// Slice 5d.3 of design/new/viewer-replacement.md Phase 5.
+import {EffectComposer} from 'three/examples/jsm/postprocessing/EffectComposer'
+import {Color, DepthTexture, MeshLambertMaterial, Vector2, WebGLRenderTarget} from 'three'
+import {RenderPass} from 'three/examples/jsm/postprocessing/RenderPass'
+import {SAOPass} from 'three/examples/jsm/postprocessing/SAOPass'
+import {FXAAShader} from 'three/examples/jsm/shaders/FXAAShader'
+import {ShaderPass} from 'three/examples/jsm/postprocessing/ShaderPass'
+import {CustomOutlinePass} from './custom-outline-pass'
 
-/**
- * Stub for the fork's `Postproduction`. Real postprocessing lives in
- * `src/viewer/three/CustomPostProcessor.js`.
- */
+// source: https://discourse.threejs.org/t/how-to-render-full-outlines-as-a-post-process-tutorial/22674
 export class Postproduction {
-  /**
-   * @param {object} _context
-   * @param {object} _renderer
-   */
-  constructor(_context, _renderer) {
-    this.visible = false
-    // IfcRenderer constructor appends `this.postProduction.htmlOverlay`
-    // to the container. Real Postproduction returned a 2D-renderer
-    // overlay; we hand back an empty div.
-    this.htmlOverlay = typeof document !== 'undefined' ?
-      document.createElement('div') :
-      null
-    if (this.htmlOverlay) {
-      this.htmlOverlay.style.position = 'absolute'
-      this.htmlOverlay.style.pointerEvents = 'none'
+  constructor(context, renderer) {
+    this.context = context
+    this.renderer = renderer
+    this.htmlOverlay = document.createElement('img')
+    this.excludedItems = new Set()
+    this.initialized = false
+    this.visibilityField = 'ifcjsPostproductionVisible'
+    this.isUserControllingCamera = false
+    this.isControlSleeping = true
+    this.lastWheelUsed = 0
+    this.lastResized = 0
+    this.resizeDelay = 500
+    this.isActive = false
+    this.isVisible = false
+    this.white = new Color(255, 255, 255)
+    this.tempMaterial = new MeshLambertMaterial({
+      colorWrite: false,
+      opacity: 0,
+      transparent: true,
+    })
+    this.outlineParams = {
+      mode: {Mode: 0},
+      FXAA: true,
+      outlineColor: 0x777777,
+      depthBias: 16,
+      depthMult: 83,
+      normalBias: 5,
+      normalMult: 1.0,
     }
+    this.onControlStart = () => (this.isUserControllingCamera = true)
+    this.onWake = () => (this.isControlSleeping = false)
+    this.onResize = () => {
+      this.lastResized = performance.now()
+      this.visible = false
+      setTimeout(() => {
+        if (performance.now() - this.lastResized >= this.resizeDelay) {
+          this.visible = true
+        }
+      }, this.resizeDelay)
+    }
+    this.onControl = () => {
+      this.visible = false
+    }
+    this.onControlEnd = () => {
+      this.isUserControllingCamera = false
+      if (!this.isUserControllingCamera && this.isControlSleeping) {
+        this.visible = true
+      }
+    }
+    this.onWheel = () => {
+      this.lastWheelUsed = performance.now()
+    }
+    this.onSleep = () => {
+      // This prevents that this gets triggered a million times when zooming with the wheel
+      this.isControlSleeping = true
+      const currentWheel = performance.now()
+      setTimeout(() => {
+        if (this.lastWheelUsed > currentWheel) {
+          return
+        }
+        if (!this.isUserControllingCamera && this.isControlSleeping) {
+          this.visible = true
+        }
+      }, 200)
+    }
+    this.onChangeProjection = (camera) => {
+      this.composer.passes.forEach((pass) => {
+        // @ts-ignore
+        pass.camera = camera
+      })
+      this.update()
+    }
+    this.renderTarget = this.newRenderTarget()
+    this.composer = new EffectComposer(renderer, this.renderTarget)
+    this.composer.setSize(window.innerWidth, window.innerHeight)
   }
-
-
-  /**
-   * @param {number} _width
-   * @param {number} _height
-   */
-  setSize(_width, _height) {
-    // no-op
+  get active() {
+    return this.isActive
   }
-
-
-  /**
-   * Per-frame render hook. The fork composed an outline-effect render
-   * here; we let `CustomPostProcessor` drive postprocessing instead.
-   */
-  update() {
-    // no-op
+  set active(active) {
+    if (this.isActive === active) {
+      return
+    }
+    if (!this.initialized) {
+      this.tryToInitialize()
+    }
+    this.visible = active
+    this.isActive = active
   }
-
-
+  get visible() {
+    return this.isVisible
+  }
+  set visible(visible) {
+    if (!this.isActive) {
+      return
+    }
+    this.isVisible = visible
+    if (visible) {
+      this.update()
+    }
+    this.htmlOverlay.style.visibility = visible ? 'visible' : 'collapse'
+  }
+  get outlineColor() {
+    return this.outlineParams.outlineColor
+  }
+  set outlineColor(color) {
+    this.outlineParams.outlineColor = color
+    this.outlineUniforms.outlineColor.value.set(color)
+  }
+  get sao() {
+    var _a
+    return (_a = this.saoPass) === null || _a === void 0 ? void 0 : _a.params
+  }
   dispose() {
-    if (this.htmlOverlay && this.htmlOverlay.parentNode) {
-      this.htmlOverlay.parentNode.removeChild(this.htmlOverlay)
-    }
+    var _a; var _b
+    this.active = false
+    window.removeEventListener('resize', this.onResize)
+    this.renderTarget.dispose()
+    this.renderTarget = null;
+    (_a = this.depthTexture) === null || _a === void 0 ? void 0 : _a.dispose()
+    this.depthTexture = null;
+    (_b = this.customOutline) === null || _b === void 0 ? void 0 : _b.dispose()
+    this.customOutline = null
+    this.composer = null
+    this.excludedItems.clear()
+    this.excludedItems = null
+    this.composer = null
+    this.htmlOverlay.remove()
     this.htmlOverlay = null
+    this.outlineParams = null
+    this.context = null
+    this.renderer = null
+    this.saoPass = null
+    this.outlineUniforms = null
+    this.scene = null
+  }
+  setSize(width, height) {
+    this.composer.setSize(width, height)
+  }
+  update() {
+    var _a; var _b; var _c
+    if (!this.initialized || !this.isActive) {
+      return
+    }
+    this.hideExcludedItems()
+    this.context.getScene().traverse((object) => {
+      // @ts-ignore
+      object.userData.prevMaterial = object.material
+      // @ts-ignore
+      object.material = this.tempMaterial
+    })
+    const background = (_a = this.scene) === null || _a === void 0 ? void 0 : _a.background
+    if (((_b = this.scene) === null || _b === void 0 ? void 0 : _b.background) && background) {
+      this.scene.background = this.white
+    }
+    this.composer.render()
+    if (((_c = this.scene) === null || _c === void 0 ? void 0 : _c.background) && background) {
+      this.scene.background = background
+    }
+    this.context.getScene().traverse((object) => {
+      // @ts-ignore
+      object.material = object.userData.prevMaterial
+      delete object.userData.prevMaterial
+    })
+    this.htmlOverlay.src = this.renderer.domElement.toDataURL()
+    this.showExcludedItems()
+  }
+  hideExcludedItems() {
+    for (const object of this.excludedItems) {
+      object.userData[this.visibilityField] = object.visible
+      object.visible = false
+    }
+  }
+  showExcludedItems() {
+    for (const object of this.excludedItems) {
+      if (object.userData[this.visibilityField] !== undefined) {
+        object.visible = object.userData[this.visibilityField]
+      }
+    }
+  }
+  tryToInitialize() {
+    const scene = this.context.getScene()
+    const camera = this.context.getCamera()
+    if (!scene || !camera) {
+      return
+    }
+    this.scene = scene
+    this.renderer.clippingPlanes = this.context.getClippingPlanes()
+    this.setupEvents()
+    this.addBasePass(scene, camera)
+    this.addSaoPass(scene, camera)
+    this.addOutlinePass(scene, camera)
+    this.addAntialiasPass()
+    this.setupHtmlOverlay()
+    this.initialized = true
+  }
+  setupEvents() {
+    const controls = this.context.ifcCamera.cameraControls
+    const domElement = this.context.getDomElement()
+    controls.addEventListener('control', this.onControl)
+    controls.addEventListener('controlstart', this.onControlStart)
+    controls.addEventListener('wake', this.onWake)
+    controls.addEventListener('controlend', this.onControlEnd)
+    domElement.addEventListener('wheel', this.onWheel)
+    controls.addEventListener('sleep', this.onSleep)
+    window.addEventListener('resize', this.onResize)
+    this.context.ifcCamera.onChangeProjection.on(this.onChangeProjection)
+  }
+  setupHtmlOverlay() {
+    this.context.getContainerElement().appendChild(this.htmlOverlay)
+    // @ts-ignore
+    this.htmlOverlay.style.mixBlendMode = 'multiply'
+    this.htmlOverlay.style.position = 'absolute'
+    this.htmlOverlay.style.height = '100%'
+    this.htmlOverlay.style.userSelect = 'none'
+    this.htmlOverlay.style.pointerEvents = 'none'
+    this.htmlOverlay.style.top = '0'
+    this.htmlOverlay.style.left = '0'
+  }
+  addAntialiasPass() {
+    this.fxaaPass = new ShaderPass(FXAAShader)
+    this.fxaaPass.uniforms.resolution.value.set((1 / this.renderer.domElement.offsetWidth) * this.renderer.getPixelRatio(), (1 / this.renderer.domElement.offsetHeight) * this.renderer.getPixelRatio())
+    this.composer.addPass(this.fxaaPass)
+  }
+  addOutlinePass(scene, camera) {
+    this.customOutline = new CustomOutlinePass(new Vector2(window.innerWidth, window.innerHeight), scene, camera)
+    // Initial values
+    // @ts-ignore
+    this.outlineUniforms = this.customOutline.fsQuad.material.uniforms
+    this.outlineUniforms.outlineColor.value.set(this.outlineParams.outlineColor)
+    this.outlineUniforms.multiplierParameters.value.x = this.outlineParams.depthBias
+    this.outlineUniforms.multiplierParameters.value.y = this.outlineParams.depthMult
+    this.outlineUniforms.multiplierParameters.value.z = this.outlineParams.normalBias
+    this.outlineUniforms.multiplierParameters.value.w = this.outlineParams.normalMult
+    this.composer.addPass(this.customOutline)
+  }
+  addSaoPass(scene, camera) {
+    this.saoPass = new SAOPass(scene, camera, false, true)
+    this.composer.addPass(this.saoPass)
+    this.saoPass.enabled = true
+    this.saoPass.params.saoIntensity = 0.01
+    this.saoPass.params.saoBias = 0.5
+    this.saoPass.params.saoBlurRadius = 8
+    this.saoPass.params.saoBlurDepthCutoff = 0.0015
+    this.saoPass.params.saoScale = 30
+    this.saoPass.params.saoKernelRadius = 30
+  }
+  addBasePass(scene, camera) {
+    this.basePass = new RenderPass(scene, camera)
+    this.composer.addPass(this.basePass)
+  }
+  newRenderTarget() {
+    this.depthTexture = new DepthTexture(window.innerWidth, window.innerHeight)
+    return new WebGLRenderTarget(window.innerWidth, window.innerHeight, {
+      depthTexture: this.depthTexture,
+      depthBuffer: true,
+    })
   }
 }
+// # sourceMappingURL=postproduction.js.map

--- a/src/viewer/three/context/renderer/postproduction.js
+++ b/src/viewer/three/context/renderer/postproduction.js
@@ -1,0 +1,69 @@
+// Postproduction — no-op stub. The fork's `web-ifc-viewer` builds a
+// real `Postproduction` (EffectComposer + custom-outline-pass) on
+// IfcRenderer; the fork's `IfcClipper.set active(...)` toggles its
+// `.visible` field when clipping planes turn on/off. We don't use
+// fork's outline path — `CustomPostProcessor` (src/viewer/three/) is
+// our active postprocessing — so this stub only needs to satisfy the
+// surface IfcRenderer and IfcClipper poke at:
+//
+//   - `visible`              boolean toggle (IfcClipper writes it)
+//   - `setSize(w, h)`        called from IfcRenderer.adjustRendererSize
+//   - `dispose()`            called from IfcRenderer.dispose
+//   - `update()`             called from IfcRenderer.update (was the
+//                            outline render in the fork; no-op for us)
+//   - `htmlOverlay`          renderer reads this and appends to DOM
+//                            on construction — needs to be a real Element
+//                            (an empty `<div>` is enough; we never read
+//                            from it).
+//
+// Slice 5d.3 of design/new/viewer-replacement.md Phase 5.
+
+/**
+ * Stub for the fork's `Postproduction`. Real postprocessing lives in
+ * `src/viewer/three/CustomPostProcessor.js`.
+ */
+export class Postproduction {
+  /**
+   * @param {object} _context
+   * @param {object} _renderer
+   */
+  constructor(_context, _renderer) {
+    this.visible = false
+    // IfcRenderer constructor appends `this.postProduction.htmlOverlay`
+    // to the container. Real Postproduction returned a 2D-renderer
+    // overlay; we hand back an empty div.
+    this.htmlOverlay = typeof document !== 'undefined' ?
+      document.createElement('div') :
+      null
+    if (this.htmlOverlay) {
+      this.htmlOverlay.style.position = 'absolute'
+      this.htmlOverlay.style.pointerEvents = 'none'
+    }
+  }
+
+
+  /**
+   * @param {number} _width
+   * @param {number} _height
+   */
+  setSize(_width, _height) {
+    // no-op
+  }
+
+
+  /**
+   * Per-frame render hook. The fork composed an outline-effect render
+   * here; we let `CustomPostProcessor` drive postprocessing instead.
+   */
+  update() {
+    // no-op
+  }
+
+
+  dispose() {
+    if (this.htmlOverlay && this.htmlOverlay.parentNode) {
+      this.htmlOverlay.parentNode.removeChild(this.htmlOverlay)
+    }
+    this.htmlOverlay = null
+  }
+}

--- a/src/viewer/three/context/renderer/renderer.js
+++ b/src/viewer/three/context/renderer/renderer.js
@@ -1,0 +1,103 @@
+// IfcRenderer — vendored from
+// `web-ifc-viewer/dist/components/context/renderer/renderer.js` in
+// slice 5d.3. Postproduction is now the local stub (we use
+// CustomPostProcessor for outlines); the screenshot path stays.
+
+import {Vector2, WebGLRenderer} from 'three'
+import {CSS2DRenderer} from 'three/examples/jsm/renderers/CSS2DRenderer.js'
+import {IfcComponent} from '../base-types'
+import {Postproduction} from './postproduction'
+
+
+export class IfcRenderer extends IfcComponent {
+  constructor(context) {
+    super(context)
+    this.renderer2D = new CSS2DRenderer()
+    this.blocked = false
+    this.context = context
+    this.container = context.options.container
+    const pdbEnabled = process.env.THREE_PDB_IS_ENABLED || false
+    this.renderer = new WebGLRenderer({
+      alpha: true,
+      antialias: true,
+      logarithmicDepthBuffer: true,
+      preserveDrawingBuffer: pdbEnabled,
+    })
+    // For debugger tracing
+    this.renderer.preserveDrawingBufferENABLED = pdbEnabled
+    this.renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2))
+    this.setupRenderers()
+    this.postProduction = new Postproduction(this.context, this.renderer)
+    this.adjustRendererSize()
+  }
+  dispose() {
+    let _a; let _b
+    this.renderer.domElement.remove()
+    this.renderer.dispose()
+    this.postProduction.dispose()
+    this.postProduction = null
+    this.renderer = null
+    this.renderer2D = null
+    this.container = null
+    this.context = null;
+    (_a = this.tempRenderer) === null || _a === void 0 ? void 0 : _a.dispose();
+    (_b = this.tempCanvas) === null || _b === void 0 ? void 0 : _b.remove()
+  }
+  update(_delta) {
+    if (this.blocked) {
+      return
+    }
+    const scene = this.context.getScene()
+    const camera = this.context.getCamera()
+    this.renderer.render(scene, camera)
+    this.renderer2D.render(scene, camera)
+  }
+  getSize() {
+    return new Vector2(this.renderer.domElement.clientWidth, this.renderer.domElement.clientHeight)
+  }
+  adjustRendererSize() {
+    const width = this.container.clientWidth
+    const height = this.container.clientHeight
+    this.renderer.setSize(width, height)
+    this.postProduction.setSize(width, height)
+    this.renderer2D.setSize(width, height)
+  }
+  newScreenshot(camera, dimensions) {
+    const previousDimensions = this.getSize()
+    const domElement = this.renderer.domElement
+    const tempCanvas = domElement.cloneNode(true)
+    // Using a new renderer to make screenshots without updating what the user sees in the canvas
+    if (!this.tempRenderer) {
+      this.tempRenderer = new WebGLRenderer({
+        canvas: tempCanvas,
+        antialias: true,
+        logarithmicDepthBuffer: true,
+        preserveDrawingBuffer: process.env.THREE_PDB_IS_ENABLED || false,
+      })
+      this.tempRenderer.localClippingEnabled = true
+    }
+    if (dimensions) {
+      this.tempRenderer.setSize(dimensions.x, dimensions.y)
+      this.context.ifcCamera.updateAspect(dimensions)
+    }
+    // todo add this later to have a centered screenshot
+    // await this.context.getIfcCamera().currentNavMode.fitModelToFrame();
+    const scene = this.context.getScene()
+    const cameraToRender = camera || this.context.getCamera()
+    this.tempRenderer.render(scene, cameraToRender)
+    const result = this.tempRenderer.domElement.toDataURL()
+    if (dimensions) {
+      this.context.ifcCamera.updateAspect(previousDimensions)
+    }
+    return result
+  }
+  setupRenderers() {
+    this.renderer.localClippingEnabled = true
+    this.container.appendChild(this.renderer.domElement)
+    this.renderer2D.domElement.style.position = 'absolute'
+    this.renderer2D.domElement.style.top = '0px'
+    this.renderer2D.domElement.style.pointerEvents = 'none'
+    this.container.appendChild(this.renderer2D.domElement)
+  }
+}
+// # sourceMappingURL=renderer.js.map

--- a/src/viewer/three/context/scene.js
+++ b/src/viewer/three/context/scene.js
@@ -1,0 +1,62 @@
+// IfcScene — vendored from `web-ifc-viewer/dist/components/context/scene.js`
+// in slice 5d.3. The light intensity values (DirectionalLight 0.8,
+// AmbientLight 0.25) are scaled by Math.PI inline to match the
+// pre-r157 visual under three's `useLegacyLights=false` default —
+// previously applied by `tools/esbuild/plugins.js#scaleLightIntensities`.
+
+import {AmbientLight, Color, DirectionalLight, Scene} from 'three'
+import {IfcComponent} from './base-types'
+
+
+export class IfcScene extends IfcComponent {
+  constructor(context) {
+    super(context)
+    this.context = context
+    this.defaultBackgroundColor = new Color(0xa9a9a9)
+    this.scene = new Scene()
+    this.setupScene(context.options)
+    this.setupLights()
+  }
+  dispose() {
+    this.scene.children.length = 0
+    this.scene = null
+  }
+  add(item) {
+    this.scene.add(item)
+  }
+  remove(item) {
+    this.scene.remove(item)
+  }
+  addModel(model) {
+    this.context.items.ifcModels.push(model)
+    this.context.items.pickableIfcModels.push(model)
+    this.scene.add(model)
+  }
+  removeModel(model) {
+    let index = this.context.items.ifcModels.indexOf(model)
+    if (index >= 0) {
+      this.context.items.ifcModels.splice(index, 1)
+    }
+    index = this.context.items.pickableIfcModels.indexOf(model)
+    if (index >= 0) {
+      this.context.items.pickableIfcModels.splice(index, 1)
+    }
+    if (model.parent) {
+      model.removeFromParent()
+    }
+  }
+  setupScene(options) {
+    this.scene.background = (options === null || options === void 0 ? void 0 : options.backgroundColor) || this.defaultBackgroundColor
+  }
+  setupLights() {
+    const light1 = new DirectionalLight(0xffeeff, 0.8 * Math.PI)
+    light1.position.set(1, 1, 1)
+    this.scene.add(light1)
+    const light2 = new DirectionalLight(0xffffff, 0.8 * Math.PI)
+    light2.position.set(-1, 0.5, -1)
+    this.scene.add(light2)
+    const ambientLight = new AmbientLight(0xffffee, 0.25 * Math.PI)
+    this.scene.add(ambientLight)
+  }
+}
+// # sourceMappingURL=scene.js.map

--- a/src/viewer/three/forkIfcComposition.js
+++ b/src/viewer/three/forkIfcComposition.js
@@ -1,0 +1,42 @@
+// forkIfcComposition — composition root for the fork pieces we still
+// need: `IfcManager` (web-ifc-three IFCLoader + IfcSelector + IfcProperties
+// + IfcUnits behind one constructor) and `IfcClipper` (IFC clipping
+// planes + ClippingEdges).
+//
+// Slice 5d.3 of design/new/viewer-replacement.md Phase 5. ShareViewer
+// used to call `new IfcViewerAPI(options)` for these; 5d.3 swapped to
+// our vendored `IfcContext` (`src/viewer/three/context/`) and direct
+// `new IfcManager(context)` / `new IfcClipper(context, IFC)`. This
+// module centralises those deep imports — `__mocks__/web-ifc-viewer.js`
+// can stay the single mock surface for the fork (vs. having to mock
+// each deep `web-ifc-viewer/dist/components/...` path separately).
+//
+// Lifetime: the values returned here have references inside fork-side
+// objects (IfcSelector captures `loader`, IfcProperties captures
+// `loader`, ClippingEdges captures `ifc.loader.ifcManager`, …) — once
+// constructed they outlive any temporary holder. Don't reuse a single
+// `makeForkIfc` return across viewer disposes; build a new one per
+// ShareViewer.
+//
+// 5d.2 (clipper unification) and a later slice replacing fork's
+// IfcManager surface will reduce this to one or zero callers; the
+// module goes away when both are done.
+
+import {IfcManager} from 'web-ifc-viewer/dist/components/ifc/ifc-manager'
+import {IfcClipper} from 'web-ifc-viewer/dist/components/display/clipping-planes/clipper'
+
+
+/**
+ * Build fork-side IfcManager + IfcClipper against our vendored IfcContext.
+ *
+ * @param {object} ifcContext our vendored `IfcContext` (the fork
+ *   construct its sub-objects with the same `context.addComponent`
+ *   / `context.items` / `context.castRayIfc` surface our IfcContext
+ *   provides — identical because we vendored from the fork).
+ * @return {{IFC: object, clipper: object}}
+ */
+export function makeForkIfc(ifcContext) {
+  const IFC = new IfcManager(ifcContext)
+  const clipper = new IfcClipper(ifcContext, IFC)
+  return {IFC, clipper}
+}


### PR DESCRIPTION
## Summary

Vendors `web-ifc-viewer/dist/components/context/*` (the IfcContext family) into `src/viewer/three/context/` and stops calling `new IfcViewerAPI(options)` in ShareViewer. ShareViewer now owns the render loop / scene / camera / renderer outright and only reaches for the fork to instantiate the remaining two pieces we still depend on (`IfcManager`, `IfcClipper`) via `makeForkIfc(...)`.

Third sub-slice of Phase 5 cleanup (5d.1 = ShareIfcLoader/Manager, 5d.2 = clipper unification — deferred, 5d.3 = ShareContext + drop fork composition root).

## What's vendored (~1077 lines)

- `context.js` — IfcContext (the orchestrator: scene + renderer + camera + raycaster + mouse + animator + render loop)
- `scene.js`, `renderer/renderer.js`, `ifcEvent.js`, `mouse.js`, `raycaster.js`, `animator.js`
- `camera/camera.js`, `camera/projection-manager.js`
- `camera/controls/orbit-control.js` (real impl)
- `camera/controls/{first-person,plan}-control.js` (no-op stubs — we never leave Orbit)
- `renderer/postproduction.js` (no-op stub — we own postprocessing via `CustomPostProcessor`)
- `base-types.js` (IfcComponent + NavigationModes / CameraProjections)
- `LiteEvent.js` (fork's tiny pub/sub used by IfcCamera + OrbitControl)
- `index.js` (barrel re-export)

## Inlined fork patches

Two `tools/esbuild/plugins.js#threeJsmCompat` rewrites that previously patched the fork's node_modules at build time are now inline in the vendored copies:

- `context.js` Clock shim (r183 deprecation — we use only `getDelta()`)
- `scene.js` light intensities × Math.PI (compensates for r157's `useLegacyLights=false` default)

The esbuild plugin still patches BufferGeometryUtils / TransformControls — those target *other* fork files (clipper / planes) still imported from node_modules. Those rewrites are removed in a follow-up slice that drops the rest of the fork dep.

## ShareViewer wiring

```js
const ifcContext = new IfcContext(options)
this.context = new ThreeContext(ifcContext)
const {IFC, clipper: forkClipper} = makeForkIfc(ifcContext)
this.IFC = IFC
this._forkClipper = forkClipper
```

The fork-side IfcGrid / IfcAxes / PlanManager / SectionFillManager / IfcDimensions / Edges / ShadowDropper / EdgeProjector / DXFWriter / PDFWriter / GLTFManager / SelectionWindow no longer get constructed — modest bundle-size win.

`makeForkIfc` (new file at `src/viewer/three/forkIfcComposition.js`) is the single re-export for the deep fork imports we still need. Centralises the seam so jest mocking has one place to intercept; 5d.2 (clipper unification) and a later slice replacing IfcManager will eventually shrink this to zero callers and the file goes away.

## Test mock plumbing

`__mocks__/web-ifc-viewer.js`:
- `jest.mock` the new local modules (`./three/context`, `./three/forkIfcComposition`) at the top so they take effect before ShareViewer's own imports resolve.
- ShareViewer's first import is `import 'web-ifc-viewer'` to guarantee the manual mock loads first.
- Singleton `impl` + `legacyContextMock` are published on `globalThis` and de-duped on subsequent loads — this file ends up in two module instances per test run, and without the dedup `__getShareViewerMockSingleton().IFC !== viewer.IFC`.
- `getDomElement` returns a real `<div>` so every ShareViewer instance (each wraps the same `legacyContextMock` in its own ThreeContext) gets a working DOM element with `.style`.

Three test files reached `viewer._fork._loadedModel` — the `_fork` composite handle is gone, so they now go through `__getShareViewerMockSingleton()._loadedModel`.

## ESLint

Added an override block for `src/viewer/three/context/**/*.js` that opts out of style rules incompatible with the vendored upstream shape (jsdoc, magic numbers, max-len, console, mixed operators, etc.). Vendored code is kept close to the upstream so future fork bug fixes are easy to re-apply; a full style rewrite would defeat that. Our own additions to the vendored code (Clock shim, light scaling, Postproduction stub) are commented and stylistically distinct.

## Out of scope

- 5d.2 (clipper unification — drop fork IfcClipper) was explicitly deferred.
- Dropping `web-ifc-viewer` from `package.json`. The fork dep is still alive for `IfcManager` + `IfcClipper`.
- Removing the remaining `threeJsmCompatPlugin` hooks (BufferGeometryUtils, TransformControls). Those target fork files still imported from node_modules.

## Test plan

- [x] `yarn jest` — 199/199 suites, 1707/1707 tests
- [x] `yarn lint` — eslint + tsc green
- [x] Pre-commit hook gate
- [ ] CI build + playwright
- [ ] Deploy-preview smoke (Schependomlaan)


---
_Generated by [Claude Code](https://claude.ai/code/session_01PfUQoU4d2PMTioyhtArijA)_