### PR TITLE
sentry: filter anonymous-onerror injected-script noise (SHARE-152/153)

### DIFF
--- a/src/index/sentry.js
+++ b/src/index/sentry.js
@@ -11,7 +11,7 @@ import {version as pkgVersion} from '../../package.json'
  * Stack-frame URLs matching any of these patterns mark the event as
  * "third-party noise" — we drop them in `beforeSend` below before
  * they reach Sentry. We add to this list when triage finds a class
- * of events with no actionable first-party signal.
+ * of events whose stack identifies a script we can't action.
  *
  * Current entries:
  *
@@ -44,6 +44,67 @@ const THIRD_PARTY_NOISE_PATTERNS = [
 
 
 /*
+ * Whole-event shape heuristics for noise that can't be identified by
+ * a script URL — typically injected scripts from custom WebViews or
+ * userscripts where the browser only reports `<anonymous>` for the
+ * source. Each entry pairs a `match(event)` predicate with the GA
+ * event name fired on the first per-session detection.
+ *
+ * Current entries:
+ *
+ *   isAnonymousOnerrorEvent  →  gaEventName: 'anonymous_injected_error'
+ *     SHARE-152 and SHARE-153 (2 users / ~2,200 events combined,
+ *     same trace_id / IP / Chrome Mobile WebView 76 on a Pixel
+ *     Android 10) presented as `TypeError: Cannot read properties of
+ *     null (reading 'querySelector' | 'src')` with `mechanism: onerror`
+ *     and a single-frame stack `<anonymous>:1:60`. That's the
+ *     fingerprint of an injected script (likely a userscript in a
+ *     customized Android WebView) hitting our DOM with the wrong
+ *     selectors. We can't fix THEIR script; we can stop showing
+ *     ourselves as the culprit. The two issues share the same
+ *     trace_id because each tick of the injected script throws both
+ *     errors back-to-back.
+ */
+const HEURISTIC_NOISE_MATCHERS = [
+  {
+    match: isAnonymousOnerrorEvent,
+    gaEventName: 'anonymous_injected_error',
+  },
+]
+
+
+/**
+ * True when every frame of the top exception has no identifiable
+ * source AND the exception was caught via `window.onerror`. That's
+ * the signature of an injected/eval'd script from a third party we
+ * can't inspect — Chrome Mobile WebView userscripts, in-app browser
+ * helpers, malicious overlays, etc. Restricted to values[0] (the
+ * outermost catch) so a chained exception with a legitimate
+ * application-frame top doesn't get suppressed by a noise cause.
+ *
+ * @param {object} event Sentry event payload
+ * @return {boolean}
+ */
+function isAnonymousOnerrorEvent(event) {
+  const exception = event?.exception?.values?.[0]
+  if (!exception) {
+    return false
+  }
+  if (exception.mechanism?.type !== 'onerror') {
+    return false
+  }
+  const frames = exception.stacktrace?.frames
+  if (!Array.isArray(frames) || frames.length === 0) {
+    return false
+  }
+  return frames.every((frame) => {
+    const filename = frame?.filename
+    return !filename || filename === '<anonymous>' || filename === '<unknown>'
+  })
+}
+
+
+/*
  * Per-pattern "have we already reported this in this session?" flags.
  * Module-level so they persist across multiple beforeSend calls on
  * the same page load, and reset on full page reload (which is the
@@ -64,11 +125,13 @@ export function _resetSentryFilterStateForTests() {
 
 
 /**
- * Returns false for Sentry events whose stack is rooted in a script
- * we've marked as third-party noise (see THIRD_PARTY_NOISE_PATTERNS).
- * On the first detection per session for each pattern, fires the
- * configured GA event so the "this client has telemetry blocking"
- * statistic isn't lost when we drop the Sentry event.
+ * Returns false for Sentry events we've classified as third-party
+ * noise — either by stack-frame URL pattern
+ * (THIRD_PARTY_NOISE_PATTERNS) or by whole-event shape heuristic
+ * (HEURISTIC_NOISE_MATCHERS). On the first detection per session
+ * for each pattern / heuristic, fires the configured GA event so
+ * the "this client has X" statistic isn't lost when we drop the
+ * Sentry event.
  *
  * Exported so it can be unit-tested with synthetic events — the
  * `setupSentry` call below is one-shot and not test-friendly.
@@ -81,10 +144,11 @@ export function shouldSendSentryEvent(event) {
   if (!Array.isArray(exceptions) || exceptions.length === 0) {
     return true
   }
-  // Walk every exception in the chain (caused-by exceptions appear as
-  // additional entries in `values[]`), not just the top one — RUM
-  // beacons typically surface as a single exception, but a wrapped /
-  // chained exception with RUM as the cause should still be dropped.
+  // Filename-pattern pass: walk every exception in the chain
+  // (caused-by exceptions appear as additional entries in values[]),
+  // not just the top — RUM beacons typically surface as a single
+  // exception, but a wrapped / chained exception with RUM as the
+  // cause should still be dropped.
   for (const exception of exceptions) {
     const frames = exception?.stacktrace?.frames
     if (!Array.isArray(frames) || frames.length === 0) {
@@ -100,6 +164,15 @@ export function shouldSendSentryEvent(event) {
           return false
         }
       }
+    }
+  }
+  // Shape-heuristic pass: each matcher inspects the whole event
+  // (e.g. mechanism + stack shape). Cheaper after the URL pass
+  // because we've already excluded most matches.
+  for (const {match, gaEventName} of HEURISTIC_NOISE_MATCHERS) {
+    if (match(event)) {
+      emitOncePerSession(gaEventName)
+      return false
     }
   }
   return true

--- a/src/index/sentry.js
+++ b/src/index/sentry.js
@@ -65,12 +65,6 @@ const THIRD_PARTY_NOISE_PATTERNS = [
  *     trace_id because each tick of the injected script throws both
  *     errors back-to-back.
  */
-const HEURISTIC_NOISE_MATCHERS = [
-  {
-    match: isAnonymousOnerrorEvent,
-    gaEventName: 'anonymous_injected_error',
-  },
-]
 
 
 /**
@@ -102,6 +96,14 @@ function isAnonymousOnerrorEvent(event) {
     return !filename || filename === '<anonymous>' || filename === '<unknown>'
   })
 }
+
+
+const HEURISTIC_NOISE_MATCHERS = [
+  {
+    match: isAnonymousOnerrorEvent,
+    gaEventName: 'anonymous_injected_error',
+  },
+]
 
 
 /*

--- a/src/index/sentry.test.js
+++ b/src/index/sentry.test.js
@@ -273,6 +273,30 @@ describe('shouldSendSentryEvent — anonymous onerror heuristic (SHARE-152 / SHA
     expect(shouldSendSentryEvent(event)).toBe(true)
   })
 
+  /*
+   * The heuristic is intentionally restricted to values[0] — a
+   * chained exception with a legitimate first-party top frame
+   * should NOT be suppressed just because the cause happens to be
+   * an anonymous onerror. Locks the JSDoc-documented behavior in.
+   */
+  it('keeps chained exceptions where the wrapper is first-party even if the cause is anonymous-onerror', () => {
+    const event = {
+      exception: {
+        values: [
+          {
+            mechanism: {type: 'generic'},
+            stacktrace: {frames: [{filename: 'src/Containers/CadView.jsx'}]},
+          },
+          {
+            mechanism: {type: 'onerror'},
+            stacktrace: {frames: [{filename: '<anonymous>'}]},
+          },
+        ],
+      },
+    }
+    expect(shouldSendSentryEvent(event)).toBe(true)
+  })
+
   it('fires gtagEvent("anonymous_injected_error") on the first drop', () => {
     expect(shouldSendSentryEvent(anonymousOnerrorEvent('x'))).toBe(false)
     expect(gtagEvent).toHaveBeenCalledTimes(1)

--- a/src/index/sentry.test.js
+++ b/src/index/sentry.test.js
@@ -196,3 +196,108 @@ describe('shouldSendSentryEvent — once-per-session GA signal', () => {
     expect(shouldSendSentryEvent(rumEvent())).toBe(false)
   })
 })
+
+
+describe('shouldSendSentryEvent — anonymous onerror heuristic (SHARE-152 / SHARE-153)', () => {
+  /*
+   * Mirror the actual SHARE-152 / SHARE-153 event shape: mechanism
+   * `onerror`, single-frame stack at `<anonymous>:1:60`. Both issues
+   * shared the same trace_id from a single Chrome Mobile WebView 76
+   * device running an injected script that fails on our DOM.
+   */
+  const anonymousOnerrorEvent = (message) => ({
+    exception: {
+      values: [{
+        type: 'TypeError',
+        value: message,
+        mechanism: {type: 'onerror', handled: false},
+        stacktrace: {
+          frames: [{filename: '<anonymous>'}],
+        },
+      }],
+    },
+  })
+
+  it('drops events with mechanism=onerror and an all-anonymous stack', () => {
+    expect(shouldSendSentryEvent(
+      anonymousOnerrorEvent(`Cannot read properties of null (reading 'querySelector')`),
+    )).toBe(false)
+  })
+
+  it('drops when every frame is anonymous/unknown/missing, even with several frames', () => {
+    const event = {
+      exception: {
+        values: [{
+          mechanism: {type: 'onerror'},
+          stacktrace: {
+            frames: [
+              {filename: '<anonymous>'},
+              {filename: '<unknown>'},
+              {filename: null},
+              {/* missing */},
+            ],
+          },
+        }],
+      },
+    }
+    expect(shouldSendSentryEvent(event)).toBe(false)
+  })
+
+  it('keeps onerror events that have any first-party frame in the stack', () => {
+    const event = {
+      exception: {
+        values: [{
+          mechanism: {type: 'onerror'},
+          stacktrace: {
+            frames: [
+              {filename: '<anonymous>'},
+              {filename: 'src/Containers/CadView.jsx'},
+            ],
+          },
+        }],
+      },
+    }
+    expect(shouldSendSentryEvent(event)).toBe(true)
+  })
+
+  it('keeps anonymous-only stacks when the mechanism is NOT onerror', () => {
+    const event = {
+      exception: {
+        values: [{
+          // e.g. caught via Sentry.captureException directly, not via window.onerror
+          mechanism: {type: 'generic'},
+          stacktrace: {frames: [{filename: '<anonymous>'}]},
+        }],
+      },
+    }
+    expect(shouldSendSentryEvent(event)).toBe(true)
+  })
+
+  it('fires gtagEvent("anonymous_injected_error") on the first drop', () => {
+    expect(shouldSendSentryEvent(anonymousOnerrorEvent('x'))).toBe(false)
+    expect(gtagEvent).toHaveBeenCalledTimes(1)
+    expect(gtagEvent).toHaveBeenCalledWith('anonymous_injected_error', {})
+  })
+
+  it('does not re-fire gtagEvent on subsequent drops in the same session', () => {
+    shouldSendSentryEvent(anonymousOnerrorEvent('x'))
+    shouldSendSentryEvent(anonymousOnerrorEvent('y'))
+    shouldSendSentryEvent(anonymousOnerrorEvent('z'))
+    expect(gtagEvent).toHaveBeenCalledTimes(1)
+  })
+
+  it('tracks the two noise sources independently — RUM and anonymous each fire once', () => {
+    const rumEvent = {
+      exception: {
+        values: [{stacktrace: {frames: [{filename: '/.netlify/scripts/rum'}]}}],
+      },
+    }
+    shouldSendSentryEvent(rumEvent)
+    shouldSendSentryEvent(anonymousOnerrorEvent('x'))
+    shouldSendSentryEvent(rumEvent)
+    shouldSendSentryEvent(anonymousOnerrorEvent('y'))
+    expect(gtagEvent).toHaveBeenCalledTimes(2)
+    expect(gtagEvent).toHaveBeenCalledWith('netlify_rum_blocked', {})
+    expect(gtagEvent).toHaveBeenCalledWith('anonymous_injected_error', {})
+  })
+})


### PR DESCRIPTION
## Summary

- Triage of Share prod's next-noisiest pair — **SHARE-152** (`Cannot read properties of null (reading 'src')`) and **SHARE-153** (`Cannot read properties of null (reading 'querySelector')`) — found both issues are the same incident reported under two different missing-property errors. Same `trace_id` (`c3cba4052f…`), same IP (Shillong, India), same device (Pixel running Chrome Mobile WebView 76.0.3809 on Android 10), single-frame stack `<anonymous>:1:60` with `mechanism: onerror` — the fingerprint of an injected script from a custom WebView / userscript hitting our DOM with wrong selectors. Not our code; the page works.
- 2 users / ~2,200 events combined, but the per-user event multiplier (~550 each) makes it a meaningful triage drag. Same playbook as SHARE-K3 (PR #1538): filter at the SDK boundary, keep a per-session GA signal.
- K3's filter is filename-regex based; this class has no meaningful filename to match on. Extends the noise system with a second pass: `HEURISTIC_NOISE_MATCHERS`, a list of `{match, gaEventName}` entries where `match(event)` is a whole-event predicate. The `beforeSend` runs filename-pattern matches first (cheap), then heuristic matches.
- First heuristic: `isAnonymousOnerrorEvent`. True when `values[0].mechanism.type === 'onerror'` AND every frame's filename is empty/null/`<anonymous>`/`<unknown>`. Restricted to `values[0]` so a chained exception with a legitimate first-party top frame doesn't get suppressed by an anonymous cause.
- On first detection per page load, fires `gtagEvent('anonymous_injected_error', {})` — same once-per-session contract as the RUM signal.

## Expected effect

- **Sentry**: SHARE-152 and SHARE-153 stop accruing new events — dropped at the SDK boundary.
- **GA**: a new `anonymous_injected_error` event with one fire per affected session — the heuristic catches the whole "injected-script-from-WebView" class, not just the specific 1-device case.
- **App behavior**: unchanged. The injected script in the affected WebView keeps running and failing; we just stop being blamed for it in Sentry.

## Test plan

- [x] `yarn lint` + `yarn typecheck` clean.
- [x] **19 tests** in `src/index/sentry.test.js` (12 prior + 7 new). New cases: drops onerror + all-anonymous events; handles mixed null/undefined/missing filenames in multi-frame anonymous stacks; keeps onerror events that have any first-party frame; keeps anonymous-only stacks when mechanism is NOT onerror; first drop fires `gtagEvent('anonymous_injected_error', {})`; subsequent drops don't re-fire; the two noise sources (RUM + anonymous) track independently — each gets one GA emission, not one combined.
- [x] Pre-commit hook (eslint + typecheck + full Jest suite) green.
- [ ] After deploy: confirm SHARE-152 + SHARE-153 event counts flatline and `anonymous_injected_error` appears in GA at the expected rate.

https://claude.ai/code/session_017qZZuG36veBdqnus3as6bx

---
_Generated by [Claude Code](https://claude.ai/code/session_017qZZuG36veBdqnus3as6bx)_