### PR TITLE
Fix scene↔NavTree selection sync + element-path permalinks

### DIFF
--- a/design/roadmap.md
+++ b/design/roadmap.md
@@ -186,6 +186,14 @@ slice, and isolation controls expected of a BIM viewer.
   reset, <a href="https://github.com/bldrs-ai/Share/issues/1242" target="_blank" rel="noopener noreferrer">#1242</a> Access properties of selected element, <a href="https://github.com/bldrs-ai/Share/issues/1048" target="_blank" rel="noopener noreferrer">#1048</a> Navigate by hierarchy.
 - Open follow-up: NavTree on cache-hit GLB E2E spec (called out in
   `design/new/viewer-replacement.md` §3b.iii).
+- Regression fixed (viewer-replacement era): scene↔NavTree selection sync +
+  element-path permalinks. The default-on Conway-direct scene pick set store state
+  directly, bypassing the `selectItemsInScene` funnel — so a NavTree selection inherited
+  a stale per-instance highlight (scene stopped following the tree) and scene picks wrote
+  no permalink. Fixed by funnelling every selection source through `selectItemsInScene`
+  (now owns `selectedInstanceIds` + the URL path). Reactivated the `SynchronizedView` E2E
+  (was `describe.skip`). Stories: <a href="https://github.com/bldrs-ai/Share/issues/1046" target="_blank" rel="noopener noreferrer">#1046</a> (sync) +
+  <a href="https://github.com/bldrs-ai/Share/issues/1180" target="_blank" rel="noopener noreferrer">#1180</a> (permalinks).
 
 **Epic `view-110`: Cut planes** ✔
 *PDF View.3 — Cut sub-item ✔.*

--- a/src/Components/NavTree/SynchronizedView.spec.ts
+++ b/src/Components/NavTree/SynchronizedView.spec.ts
@@ -60,14 +60,21 @@ function getSelectedInstanceIds(page: Page): Promise<number[]> {
  * clicking labels in sequence reveals the next level — the same route the
  * IframeIntegration spec relies on. Leaves the `Together` leaves visible.
  *
+ * Clicks are scoped to the Navigation panel: unscoped `getByText('Bldrs')`
+ * also matches the `BLDRS.AI` page title (case-insensitive substring),
+ * tripping Playwright strict mode.
+ *
  * @param page Playwright page
+ * @return the Navigation panel locator, for scoping leaf clicks
  */
 async function openNavTreeToLeaves(page: Page) {
   await page.getByTestId('control-button-navigation').click()
-  await page.getByText('Bldrs').click()
-  await page.getByText('Build').click()
-  await page.getByText('Every').click()
-  await page.getByText('Thing').click()
+  const navPanel = page.getByTestId('SideDrawerPanel-Paper-Navigation')
+  await navPanel.getByText('Bldrs').click()
+  await navPanel.getByText('Build').click()
+  await navPanel.getByText('Every').click()
+  await navPanel.getByText('Thing').click()
+  return navPanel
 }
 
 
@@ -95,8 +102,8 @@ describe('View 100: Synchronized View and NavTree', () => {
   // The regressed direction: a NavTree click must drive the 3D scene.
   test('NavTree selection highlights the element in the scene and writes the element-path permalink', async ({page}) => {
     await visitHomepageWaitForModel(page)
-    await openNavTreeToLeaves(page)
-    await page.getByText('Together').first().click()
+    const navPanel = await openNavTreeToLeaves(page)
+    await navPanel.getByText('Together').first().click()
 
     // The tree click drove a selection into the store...
     await expect.poll(async () => (await getSelectedElements(page)).length).toBeGreaterThan(0)
@@ -118,7 +125,7 @@ describe('View 100: Synchronized View and NavTree', () => {
   // driving the scene.
   test('a NavTree selection clears a stale per-instance highlight from a prior scene pick', async ({page}) => {
     await visitHomepageWaitForModel(page)
-    await openNavTreeToLeaves(page)
+    const navPanel = await openNavTreeToLeaves(page)
 
     // Simulate the residue of a Conway-direct scene pick AFTER navigating
     // (the navigation clicks above would otherwise have cleared it).
@@ -127,7 +134,7 @@ describe('View 100: Synchronized View and NavTree', () => {
       (window as unknown as WindowWithStore).store?.getState().setSelectedInstanceIds([id])
     }, STALE_INSTANCE_ID)
 
-    await page.getByText('Together').first().click()
+    await navPanel.getByText('Together').first().click()
 
     // The selection funnel reset the per-instance highlight...
     await expect.poll(async () => (await getSelectedInstanceIds(page)).length).toBe(0)

--- a/src/Components/NavTree/SynchronizedView.spec.ts
+++ b/src/Components/NavTree/SynchronizedView.spec.ts
@@ -138,8 +138,11 @@ describe('View 100: Synchronized View and NavTree', () => {
   })
 
   // A scene pick is the other half of "set its path as part of the link":
-  // selecting in the scene must also produce a shareable permalink.
-  test('a scene pick writes the element-path permalink', async ({page}) => {
+  // selecting in the scene must also produce a shareable permalink — and
+  // the no-shift pick's per-instance highlight must survive the
+  // self-induced navigation (the location-watch effect must not re-select
+  // the element and reset selectedInstanceIds).
+  test('a no-shift scene pick writes the permalink and keeps the per-instance highlight', async ({page}) => {
     await visitHomepageWaitForModel(page)
 
     // index.ifc is fit-to-frame and centered, so a center double-click
@@ -149,6 +152,10 @@ describe('View 100: Synchronized View and NavTree', () => {
 
     await expect.poll(async () => (await getSelectedElements(page)).length).toBeGreaterThan(0)
     expect(page.url()).toMatch(/\/index\.ifc\/\d+/)
+    // The no-shift pick narrows the highlight to ONE PlacedGeometry; that
+    // restriction must not be widened back to the whole element by the
+    // navigation it just triggered.
+    await expect.poll(async () => (await getSelectedInstanceIds(page)).length).toBe(1)
   })
 
   // The reverse: opening a permalink pre-selects the element in both the

--- a/src/Components/NavTree/SynchronizedView.spec.ts
+++ b/src/Components/NavTree/SynchronizedView.spec.ts
@@ -1,73 +1,168 @@
-import {expect, test, Route} from '@playwright/test'
-import {readFile} from 'fs/promises'
-import path from 'path'
+import {expect, test, Page} from '@playwright/test'
 import {
   homepageSetup,
   setIsReturningUser,
   visitHomepageWaitForModel,
 } from '../../tests/e2e/utils'
 import {waitForModelReady} from '../../tests/e2e/models'
-import {expectScreen} from '../../tests/screens'
 
 
 const {beforeEach, describe} = test
 
+
+type StoreState = {
+  selectedElements: string[]
+  selectedInstanceIds: number[]
+  setSelectedInstanceIds: (ids: number[]) => void
+  viewer?: {getSelectedIds?: () => number[]}
+}
+type WindowWithStore = Window & {store?: {getState: () => StoreState}}
+
+
 /**
- * Migrated from cypress/e2e/view-100/synchronized-view-and-navtree.cy.js
+ * The parent-level selection the store currently holds (stringified
+ * expressIDs).
+ *
+ * @param page Playwright page
+ * @return selectedElements
+ */
+function getSelectedElements(page: Page): Promise<string[]> {
+  return page.evaluate(() =>
+    (window as unknown as WindowWithStore).store?.getState().selectedElements ?? [])
+}
+
+/**
+ * The expressIDs actually highlighted in the 3D scene, read straight off
+ * the viewer — the real proof the scene followed the selection.
+ *
+ * @param page Playwright page
+ * @return selected expressIDs in the scene
+ */
+function getSceneSelectedIds(page: Page): Promise<number[]> {
+  return page.evaluate(() =>
+    (window as unknown as WindowWithStore).store?.getState().viewer?.getSelectedIds?.() ?? [])
+}
+
+/**
+ * The Conway-direct per-instance highlight ids.
+ *
+ * @param page Playwright page
+ * @return selectedInstanceIds
+ */
+function getSelectedInstanceIds(page: Page): Promise<number[]> {
+  return page.evaluate(() =>
+    (window as unknown as WindowWithStore).store?.getState().selectedInstanceIds ?? [])
+}
+
+/**
+ * Walk the known index.ifc hierarchy down to its leaf elements. Selecting
+ * a node auto-expands its ancestor path (CadView's selection effect), so
+ * clicking labels in sequence reveals the next level — the same route the
+ * IframeIntegration spec relies on. Leaves the `Together` leaves visible.
+ *
+ * @param page Playwright page
+ */
+async function openNavTreeToLeaves(page: Page) {
+  await page.getByTestId('control-button-navigation').click()
+  await page.getByText('Bldrs').click()
+  await page.getByText('Build').click()
+  await page.getByText('Every').click()
+  await page.getByText('Thing').click()
+}
+
+
+/**
+ * Bidirectional scene ↔ NavTree selection sync + element-path permalinks.
+ *
+ * Migrated and de-screenshotted from
+ * cypress/e2e/view-100/synchronized-view-and-navtree.cy.js — it now
+ * asserts observable store + URL state (via `window.store`) instead of
+ * pixels, so it runs without golden images and pins the actual behaviour
+ * the bug touched rather than a rendering snapshot.
+ *
+ * Epic view-100 (3D + NavTree + Properties), story #1046 Synchronized
+ * View+NavTree. The permalink half is the selection slice of search-100
+ * #1180 (Permalinks).
  *
  * @see https://github.com/bldrs-ai/Share/issues/1046
  */
-describe.skip('View 100: Synchronized View and NavTree', () => {
+describe('View 100: Synchronized View and NavTree', () => {
   beforeEach(async ({page}) => {
     await homepageSetup(page)
     await setIsReturningUser(page.context())
   })
 
-  describe('User visits homepage, Open NavTree > select item', () => {
-    beforeEach(async ({page}) => {
-      await visitHomepageWaitForModel(page)
-      await page.getByTestId('control-button-navigation').click()
+  // The regressed direction: a NavTree click must drive the 3D scene.
+  test('NavTree selection highlights the element in the scene and writes the element-path permalink', async ({page}) => {
+    await visitHomepageWaitForModel(page)
+    await openNavTreeToLeaves(page)
+    await page.getByText('Together').first().click()
 
-      // Navigate through the tree structure
-      await page.getByText('Bldrs').click()
-      await page.getByText('Build').click()
-      await page.getByText('Every').click()
-      await page.getByText('Thing').click()
+    // The tree click drove a selection into the store...
+    await expect.poll(async () => (await getSelectedElements(page)).length).toBeGreaterThan(0)
+    const selected = await getSelectedElements(page)
 
-      // Click through multiple "Together" items
-      const togetherItems = page.getByText('Together')
-      for (let i = 0; i < 7; i++) {
-        await togetherItems.nth(i).click()
-      }
-    })
+    // ...the scene highlight followed it (nav → scene)...
+    await expect.poll(async () => (await getSceneSelectedIds(page)).length).toBeGreaterThan(0)
+    const sceneIds = (await getSceneSelectedIds(page)).map(String)
+    expect(sceneIds).toEqual(expect.arrayContaining([selected[0]]))
 
-    test('Item highlighted in tree and scene - Screen', async ({page}) => {
-      await expectScreen(page, 'SynchronizedView-item-highlighted.png')
-    })
+    // ...and the element path is now in the URL as a shareable permalink.
+    expect(page.url()).toMatch(/\/index\.ifc\/\d+/)
   })
 
-  describe('Visits permalink to selected element', () => {
-    beforeEach(async ({page}) => {
-      // TODO(pablo): root id selection doesn't work after search state working.  Also move this to a helper
-      await page.route('**/share/v/p/index.ifc/81/621', async (route: Route) => {
-        const fixturePath = path.resolve(process.cwd(), 'src/tests/fixtures/404.html')
-        const fixtureBuffer = await readFile(fixturePath)
+  // Regression for the reported bug: a per-instance highlight left behind
+  // by a prior scene pick must not survive a later NavTree selection.
+  // Pre-fix the stale `selectedInstanceIds` was re-applied over the new
+  // element, so the scene kept showing the old pick — the tree stopped
+  // driving the scene.
+  test('a NavTree selection clears a stale per-instance highlight from a prior scene pick', async ({page}) => {
+    await visitHomepageWaitForModel(page)
+    await openNavTreeToLeaves(page)
 
-        await route.fulfill({
-          status: 200,
-          body: fixtureBuffer,
-          headers: {'content-type': 'text/html'},
-        })
-      })
+    // Simulate the residue of a Conway-direct scene pick AFTER navigating
+    // (the navigation clicks above would otherwise have cleared it).
+    const STALE_INSTANCE_ID = 999999
+    await page.evaluate((id) => {
+      (window as unknown as WindowWithStore).store?.getState().setSelectedInstanceIds([id])
+    }, STALE_INSTANCE_ID)
 
-      await page.goto('/share/v/p/index.ifc/81/621')
-      await waitForModelReady(page)
-    })
+    await page.getByText('Together').first().click()
 
-    test('Item highlighted in scene - Screen', async ({page}) => {
-      // Check that nav-tree-root doesn't exist (no tree visible)
-      await expect(page.getByTestId('PanelBox-Navigation')).toHaveCount(0)
-      await expectScreen(page, 'SynchronizedView-permalink-highlighted.png')
-    })
+    // The selection funnel reset the per-instance highlight...
+    await expect.poll(async () => (await getSelectedInstanceIds(page)).length).toBe(0)
+    // ...so the scene reflects the newly-selected element, not the stale one.
+    const selected = await getSelectedElements(page)
+    const sceneIds = (await getSceneSelectedIds(page)).map(String)
+    expect(sceneIds).toEqual(expect.arrayContaining([selected[0]]))
+  })
+
+  // A scene pick is the other half of "set its path as part of the link":
+  // selecting in the scene must also produce a shareable permalink.
+  test('a scene pick writes the element-path permalink', async ({page}) => {
+    await visitHomepageWaitForModel(page)
+
+    // index.ifc is fit-to-frame and centered, so a center double-click
+    // lands on geometry. The Conway-direct pick routes through the same
+    // selection funnel as the NavTree, which writes the element path.
+    await page.locator('canvas').first().dblclick()
+
+    await expect.poll(async () => (await getSelectedElements(page)).length).toBeGreaterThan(0)
+    expect(page.url()).toMatch(/\/index\.ifc\/\d+/)
+  })
+
+  // The reverse: opening a permalink pre-selects the element in both the
+  // scene and the store (and, by extension, the NavTree, which renders
+  // from the same selectedElements).
+  test('opening an element permalink selects it in the scene and store', async ({page}) => {
+    // A known element path in the index.ifc fixture (shared with the
+    // Conway-direct and Properties permalink specs): parent 81, leaf 621.
+    const LEAF_ID = 621
+    await page.goto(`/share/v/p/index.ifc/81/${LEAF_ID}`)
+    await waitForModelReady(page)
+
+    await expect.poll(() => getSelectedElements(page)).toContain(`${LEAF_ID}`)
+    const sceneIds = await getSceneSelectedIds(page)
+    expect(sceneIds).toContain(LEAF_ID)
   })
 })

--- a/src/Containers/CadView.jsx
+++ b/src/Containers/CadView.jsx
@@ -724,8 +724,20 @@ export default function CadView({
     if (parts.length > 1) {
       debug().log('CadView#selectElementBasedOnUrlPath: have path', parts)
       const targetId = parseInt(parts[parts.length - 1])
-      const selectedInViewer = viewer.getSelectedIds()
-      if (isFinite(targetId) && !selectedInViewer.includes(targetId)) {
+      // Skip re-selecting when this element is already the active
+      // selection. We consult the store (selectItemsInScene updates it
+      // synchronously) and not only viewer.getSelectedIds(), because this
+      // also runs from the location-watch effect — which fires on the
+      // SELF-INDUCED navigation a selection just made, and runs BEFORE
+      // the selection effect has pushed the pick into the viewer, so
+      // getSelectedIds() is still stale. Without the store check the
+      // re-selection would funnel through selectItemsInScene again and
+      // reset selectedInstanceIds, widening a Conway per-instance scene
+      // pick to the whole element.
+      const alreadySelected =
+        useStore.getState().selectedElements.includes(`${targetId}`) ||
+        viewer.getSelectedIds().includes(targetId)
+      if (isFinite(targetId) && !alreadySelected) {
         selectItemsInScene([targetId], false)
       }
     }

--- a/src/Containers/CadView.jsx
+++ b/src/Containers/CadView.jsx
@@ -532,21 +532,24 @@ export default function CadView({
         if (!viewer.isolator.canBePickedInScene(parentExpressId)) {
           return
         }
-        // Always set parent expressID as the "selection" so the
-        // properties panel / nav tree / search highlight respond
-        // normally. The per-instance highlight is layered on top via
-        // selectedInstanceIds.
-        setSelectedElements([`${parentExpressId}`])
-        setSelectedInstanceIds(event.shiftKey ? [] : [instanceId])
+        // Route through selectItemsInScene (the single selection
+        // funnel) so a scene pick gets the same treatment as every
+        // other source: store update + element-path permalink in the
+        // URL. Previously this set the store directly and skipped the
+        // funnel, so scene selections never produced a shareable
+        // permalink. The parent expressID is always the "selection" so
+        // the properties panel / nav tree / search respond normally;
+        // `instanceIds` only narrows what the OutlineEffect draws.
+        // Shift = the whole IFC element (every instance) → no
+        // per-instance restriction; no-shift = just this PlacedGeometry.
+        const instanceIds = event.shiftKey ? [] : [instanceId]
+        selectItemsInScene([parentExpressId], true, instanceIds)
         return
       }
-      // Non-instance branch: clear any stale per-instance highlight
-      // so a Conway-click followed by a click on a non-Conway mesh
-      // doesn't leave the old single-instance subset stuck on the
-      // OutlineEffect.
-      if (Array.isArray(selectedInstanceIds) && selectedInstanceIds.length > 0) {
-        setSelectedInstanceIds([])
-      }
+      // Non-instance branch: elementSelection funnels through
+      // selectItemsInScene, which resets selectedInstanceIds, so a
+      // Conway pick followed by a click on a non-Conway mesh no longer
+      // leaves the old single-instance subset stuck on the OutlineEffect.
       if (mesh.expressID !== undefined) {
         elementSelection(viewer, elementsById, selectItemsInScene, event.shiftKey, mesh.expressID)
       } else {
@@ -652,12 +655,25 @@ export default function CadView({
 
 
   /**
-   * Pick the given items in the scene.
+   * Pick the given items in the scene. This is the single funnel for
+   * EVERY selection source — scene pick, NavTree click, search,
+   * keyboard, and URL/permalink — so it owns the full store-side
+   * selection contract: the parent-level `selectedElements`, the
+   * Conway-direct per-instance `selectedInstanceIds`, and (optionally)
+   * the element-path permalink in the URL. Routing every source
+   * through here is what keeps the scene and NavTree in sync in both
+   * directions.
    *
    * @param {Array} resultIDs Array of expressIDs
    * @param {boolean} updateNavigation Whether to update navigation
+   * @param {Array<number>} instanceIds Conway-direct per-instance highlight
+   *   restriction. Empty (the default) clears any prior per-instance
+   *   highlight — required so a selection arriving from a non-scene
+   *   source (NavTree, search, permalink) doesn't inherit the instance
+   *   subset left behind by an earlier scene pick. Only the Conway
+   *   scene-pick path passes a non-empty value.
    */
-  function selectItemsInScene(resultIDs, updateNavigation = true) {
+  function selectItemsInScene(resultIDs, updateNavigation = true, instanceIds = []) {
     // NOTE: we might want to compare with previous selection to avoid unnecessary updates
     if (!viewer) {
       return
@@ -666,6 +682,7 @@ export default function CadView({
       // Update The Component state
       const resIds = resultIDs.map((id) => `${id}`)
       setSelectedElements(resIds)
+      setSelectedInstanceIds(instanceIds)
       // Sets the url to the first selected element path.
       if (resultIDs.length > 0 && updateNavigation) {
         const firstId = resultIDs.slice(0, 1)
@@ -906,8 +923,18 @@ export default function CadView({
         <RootLandscape
           pathPrefix={pathPrefix}
           branch={modelPath.branch}
-          selectWithShiftClickEvents={(isShiftKeyDown, expressId) => {
-            elementSelection(viewer, elementsById, selectItemsInScene, isShiftKeyDown, expressId)
+          selectWithShiftClickEvents={(isShiftKeyDown, expressIdOrIds) => {
+            // The element-types tree passes an array (every element of a
+            // type) to select the group at once; the spatial tree and
+            // the scene pass a single expressID. elementSelection is
+            // single-id (shift toggle + descendants); the group case
+            // replaces the selection wholesale, like a search result, so
+            // it goes straight to the funnel with no permalink.
+            if (Array.isArray(expressIdOrIds)) {
+              selectItemsInScene(expressIdOrIds, false)
+            } else {
+              elementSelection(viewer, elementsById, selectItemsInScene, isShiftKeyDown, expressIdOrIds)
+            }
           }}
           deselectItems={deselectItems}
         />

--- a/src/Containers/CadView.test.jsx
+++ b/src/Containers/CadView.test.jsx
@@ -286,6 +286,43 @@ describe('CadView', () => {
   })
 
 
+  // Regression (nav→scene sync): `selectItemsInScene` is the single
+  // selection funnel and must own BOTH `selectedElements` and the
+  // Conway-direct per-instance `selectedInstanceIds`. Pre-fix only the
+  // scene-pick handler ever set/cleared `selectedInstanceIds`, so a
+  // selection arriving from any other source (NavTree click, search,
+  // keyboard deselect) left a STALE per-instance highlight behind that
+  // the `[selectedElements, selectedInstanceIds]` effect re-applied over
+  // the new/empty selection — the scene stopped following the tree.
+  // Deselecting via the funnel (Clear) must now also clear the instance
+  // highlight. Reuses the render + Clear mechanics of the unselect test.
+  it('deselect clears a stale per-instance highlight (funnel owns selectedInstanceIds)', async () => {
+    const testTree = makeTestTree()
+    const targetEltId = testTree.children[0].expressID
+    const STALE_INSTANCE_ID = 42
+    const {result} = renderHook(() => useStore((state) => state))
+    await act(() => {
+      result.current.setModelPath({filepath: `/index.ifc`})
+      result.current.setSelectedElement(targetEltId)
+      result.current.setSelectedElements([`${targetEltId}`])
+      // Simulate the residue of a prior Conway-direct scene pick.
+      result.current.setSelectedInstanceIds([STALE_INSTANCE_ID])
+    })
+
+    const {getByTestId} =
+      render(<ShareMock><CadView installPrefix='' appPrefix='' pathPrefix=''/></ShareMock>)
+
+    const eltGrp = getByTestId('element-group')
+    const clearSelection = within(eltGrp).getByTitle('Clear')
+    await act(async () => {
+      await fireEvent.click(clearSelection)
+    })
+    expect(result.current.selectedElements).toHaveLength(0)
+    expect(result.current.selectedInstanceIds).toHaveLength(0)
+    await actAsyncFlush()
+  })
+
+
   // TODO(nickcastel50): See Issue #956
   it.skip('renders and selects the element ID from URL', async () => {
     const mockCurrLocation = {...defaultLocationValue, pathname: '/index.ifc/89'}

--- a/src/Containers/selection.js
+++ b/src/Containers/selection.js
@@ -12,6 +12,17 @@ import {getDescendantExpressIds} from '../utils/TreeUtils'
  * @param {number} expressId the express id of the element
  */
 export function elementSelection(viewer, elementsById, selectItemsInScene, isShiftKeyDown, expressId) {
+  // NavTree click handlers pass `node.expressID.toString()` (a string)
+  // while scene picks pass a numeric `mesh.expressID`. Normalise to a
+  // number so the Set-membership test (shift toggle, below) and the
+  // isolator's numeric `Array.includes` checks behave identically
+  // regardless of which surface initiated the selection — otherwise a
+  // string id silently fails `selectedInViewer.has(expressId)` and
+  // `isolatedIds.includes(expressId)`.
+  expressId = Number(expressId)
+  if (!Number.isFinite(expressId)) {
+    return
+  }
   if (!viewer.isolator.canBePickedInScene(expressId)) {
     return
   }

--- a/src/Containers/selection.test.js
+++ b/src/Containers/selection.test.js
@@ -1,0 +1,76 @@
+import {elementSelection} from './selection'
+
+
+describe('elementSelection', () => {
+  // A tiny spatial tree: 1 ⊃ 2 ⊃ 3.
+  const leaf = {expressID: 3, children: []}
+  const mid = {expressID: 2, children: [leaf]}
+  const root = {expressID: 1, children: [mid]}
+  const elementsById = {1: root, 2: mid, 3: leaf}
+
+  /**
+   * Minimal viewer stub for the isolator + scene-selection surface
+   * elementSelection reads.
+   *
+   * @param {Array<number>} selectedIds currently selected in the scene
+   * @param {boolean} pickable whether canBePickedInScene returns true
+   * @return {object} viewer stub
+   */
+  function makeViewer(selectedIds = [], pickable = true) {
+    return {
+      isolator: {canBePickedInScene: jest.fn(() => pickable)},
+      getSelectedIds: jest.fn(() => [...selectedIds]),
+    }
+  }
+
+  it('selects a leaf element and updates navigation (non-shift)', () => {
+    const viewer = makeViewer()
+    const selectItemsInScene = jest.fn()
+    elementSelection(viewer, elementsById, selectItemsInScene, false, 3)
+    expect(selectItemsInScene).toHaveBeenCalledWith([3], true)
+  })
+
+  it('selects an element together with its descendants (non-shift)', () => {
+    const viewer = makeViewer()
+    const selectItemsInScene = jest.fn()
+    elementSelection(viewer, elementsById, selectItemsInScene, false, 2)
+    const [ids, updateNav] = selectItemsInScene.mock.calls[0]
+    expect(new Set(ids)).toEqual(new Set([2, 3]))
+    expect(updateNav).toBe(true)
+  })
+
+  // Regression: NavTree click handlers pass `node.expressID.toString()`
+  // (a string) while scene picks pass a numeric `mesh.expressID`. A
+  // string id must behave identically to the numeric one. Pre-fix the
+  // shift toggle did `Set<number>.has("2")` — always false — so
+  // shift-clicking an already-selected tree node RE-ADDED it instead of
+  // removing it. With the Number() normalisation the toggle deselects.
+  it('shift-clicking an already-selected element removes it — string id from NavTree', () => {
+    const viewer = makeViewer([2]) // 2 already selected in the scene
+    const selectItemsInScene = jest.fn()
+    elementSelection(viewer, elementsById, selectItemsInScene, true, '2')
+    expect(selectItemsInScene).toHaveBeenCalledWith([], false)
+  })
+
+  it('shift-clicking an unselected element adds it without updating navigation — string id', () => {
+    const viewer = makeViewer([])
+    const selectItemsInScene = jest.fn()
+    elementSelection(viewer, elementsById, selectItemsInScene, true, '3')
+    expect(selectItemsInScene).toHaveBeenCalledWith([3], false)
+  })
+
+  it('does nothing when the element cannot be picked in the scene', () => {
+    const viewer = makeViewer([], false)
+    const selectItemsInScene = jest.fn()
+    elementSelection(viewer, elementsById, selectItemsInScene, false, 2)
+    expect(selectItemsInScene).not.toHaveBeenCalled()
+  })
+
+  it('does nothing for a non-numeric id, without touching the isolator', () => {
+    const viewer = makeViewer()
+    const selectItemsInScene = jest.fn()
+    elementSelection(viewer, elementsById, selectItemsInScene, false, undefined)
+    expect(selectItemsInScene).not.toHaveBeenCalled()
+    expect(viewer.isolator.canBePickedInScene).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Problem

A regression from the viewer-replacement refactor: clicking an item in the **NavTree no longer selected/highlighted it in the 3D scene** (the forward direction, scene→NavTree, still worked), and **selecting in the scene didn't write a shareable element permalink**.

It's one architectural fault with two symptoms. Selection has several entry points (scene pick, NavTree click, search, keyboard, URL permalink). All of them funnel through `selectItemsInScene` **except** the Conway-direct scene pick (now default-on), which wrote `selectedElements` / `selectedInstanceIds` to the store directly:

- **NavTree→scene broken.** `selectItemsInScene` never owned `selectedInstanceIds`, so a per-instance highlight left behind by an earlier scene pick survived a NavTree/search selection. The `[selectedElements, selectedInstanceIds]` effect then re-applied the **stale** instance subset over the newly-selected element — the scene stopped following the tree. (Matches the report exactly: trying scene→nav first = works; then nav→scene = stale.)
- **No permalink on scene select.** Bypassing the funnel skipped the element-path URL update, so scene picks weren't shareable.

## Fix (well-factored)

Make `selectItemsInScene` the **single selection funnel**:
- it now owns **both** `selectedElements` and the Conway-direct `selectedInstanceIds` (+ the element-path URL), so every source resets the per-instance highlight consistently;
- the Conway scene pick routes through it — gaining the permalink and fixing both symptoms with the same change;
- the now-redundant manual instance-reset in the click handler is removed.

Plus two robustness fixes at the NavTree boundary:
- `elementSelection` normalises the NavTree's string `expressID` to a number, fixing shift-toggle (`Set<number>.has("id")`) and isolation-mode picking initiated from the tree;
- the element-types tree's group selection (an array of ids) is handled instead of silently dropped.

## Tests

- **`selection.test.js`** (new, unit): `elementSelection` id-coercion, shift add/remove, descendant selection, and bail guards. Red/green verified against the unfixed source.
- **`CadView.test.jsx`** (unit): deselect now clears a stale per-instance highlight — pins the funnel-owns-`selectedInstanceIds` contract.
- **`SynchronizedView.spec.ts`** (e2e): **reactivated** (was `describe.skip`) and rewritten to assert `window.store` + URL state instead of pixel screenshots — covers NavTree→scene + permalink, the stale-instance regression, scene→permalink, and permalink→selection.

Full pre-commit gate green locally (eslint + typecheck + 1738 jest tests).

## Requirements

Epic **view-100** (3D + NavTree + Properties). Stories #1046 (Synchronized View+NavTree) + #1180 (Permalinks) — both shipped earlier and regressed here; `design/roadmap.md` view-100 updated with the regression note.

https://claude.ai/code/session_01NJBw5yp2E48QA1ojoPs7Da

---
_Generated by [Claude Code](https://claude.ai/code/session_01NJBw5yp2E48QA1ojoPs7Da)_