### PR TITLE
Usage quotas 3/4: client layer — useQuota hook, limit dialog, badge

### DIFF
--- a/src/Components/Open/QuotaBadge.jsx
+++ b/src/Components/Open/QuotaBadge.jsx
@@ -1,0 +1,41 @@
+import React, {ReactElement} from 'react'
+import {Badge} from '@mui/material'
+import {TIERS} from '../../quota/quota'
+
+
+/** Show badge once this fraction of the quota is consumed */
+const SHOW_THRESHOLD = 1 / 2
+/** Switch badge to amber once this fraction is consumed */
+const WARN_THRESHOLD = 3 / 4
+
+
+/**
+ * Wraps children with a usage-quota badge on the Open toolbar button.
+ * Shown only when >= 50% of the quota is used; turns amber at >= 75%.
+ *
+ * @property {number} used Number of private models loaded this period
+ * @property {number} limit Maximum allowed for this tier
+ * @property {string} tier One of TIERS.*
+ * @property {ReactElement} children The button to wrap
+ * @return {ReactElement}
+ */
+export default function QuotaBadge({used, limit, tier, children}) {
+  if (tier === TIERS.PAID || limit === Infinity || used === 0) {
+    return children
+  }
+
+  const pct = used / limit
+  if (pct < SHOW_THRESHOLD) {
+    return children
+  }
+
+  return (
+    <Badge
+      badgeContent={`${used}/${limit}`}
+      color={pct >= WARN_THRESHOLD ? 'warning' : 'default'}
+      sx={{'& .MuiBadge-badge': {fontSize: '0.6rem', height: '16px', minWidth: '30px', right: -4, top: 4}}}
+    >
+      {children}
+    </Badge>
+  )
+}

--- a/src/Components/Open/QuotaLimitDialog.jsx
+++ b/src/Components/Open/QuotaLimitDialog.jsx
@@ -1,0 +1,91 @@
+import React, {ReactElement} from 'react'
+import {Button, Dialog, DialogActions, DialogContent, DialogTitle, Divider, Link, Stack, Typography} from '@mui/material'
+import {useAuth0} from '../../Auth0/Auth0Proxy'
+import {LIMITS, ROLLING_WINDOW_DAYS, TIERS} from '../../quota/quota'
+
+
+/**
+ * Modal shown when the user hits their usage quota.
+ * Anonymous users see both Subscribe and Sign up options.
+ * Free-tier users see only the Subscribe option.
+ *
+ * @property {string} tier One of TIERS.*
+ * @property {boolean} isOpen Controls dialog visibility
+ * @property {Function} onClose Called when the dialog should close
+ * @return {ReactElement}
+ */
+export default function QuotaLimitDialog({tier, isOpen, onClose}) {
+  const {loginWithRedirect, user} = useAuth0()
+
+  const handleSubscribe = () => {
+    onClose()
+    const email = user?.email ? `&userEmail=${encodeURIComponent(user.email)}` : ''
+    window.location.href = `/subscribe/?${email}`
+  }
+
+  const handleSignUp = () => {
+    onClose()
+    loginWithRedirect()
+  }
+
+  const isAnonymous = !tier || tier === TIERS.ANONYMOUS
+  const limitText = isAnonymous ?
+    `${LIMITS[TIERS.ANONYMOUS]} private models (lifetime)` :
+    `${LIMITS[TIERS.FREE]} private models in any rolling ${ROLLING_WINDOW_DAYS}-day window`
+
+  return (
+    <Dialog
+      open={isOpen}
+      onClose={onClose}
+      maxWidth='xs'
+      fullWidth
+      closeAfterTransition={false}
+    >
+      <DialogTitle sx={{pb: 1}}>Open more models</DialogTitle>
+      <DialogContent>
+        <Typography variant='body2' sx={{mb: 2}}>
+          You&apos;ve reached your limit of {limitText}.
+          {' '}<Link href='/share/quotas'>What counts as a load?</Link>
+        </Typography>
+        <Stack divider={<Divider/>} spacing={2}>
+          <Stack direction='row' alignItems='center' spacing={2}>
+            <Typography variant='body2' sx={{flex: 1}}>
+              Unlimited private models, priority loading, and team sharing.
+            </Typography>
+            <Button
+              onClick={handleSubscribe}
+              variant='contained'
+              color='accent'
+              sx={{textTransform: 'none', whiteSpace: 'nowrap'}}
+              data-testid='button-quota-subscribe'
+            >
+              Subscribe
+            </Button>
+          </Stack>
+          {isAnonymous && (
+            <Stack direction='row' alignItems='center' spacing={2}>
+              <Typography variant='body2' sx={{flex: 1}}>
+                Sign up free to open {LIMITS[TIERS.FREE]} private models per
+                rolling {ROLLING_WINDOW_DAYS} days and sync across devices.
+              </Typography>
+              <Button
+                onClick={handleSignUp}
+                variant='contained'
+                color='accent'
+                sx={{textTransform: 'none', whiteSpace: 'nowrap'}}
+                data-testid='button-quota-signup'
+              >
+                Sign up free
+              </Button>
+            </Stack>
+          )}
+        </Stack>
+      </DialogContent>
+      <DialogActions sx={{px: 3, pb: 2}}>
+        <Button onClick={onClose} sx={{textTransform: 'none'}}>
+          Not now
+        </Button>
+      </DialogActions>
+    </Dialog>
+  )
+}

--- a/src/FeatureFlags.js
+++ b/src/FeatureFlags.js
@@ -14,6 +14,15 @@ export const flags = [
   // land in identity-decoupling PR2.
   // See design/new/identity-decoupling-decisions.md.
   {name: 'githubAsSource', isActive: false},
+  // Usage quotas. The quota lib (src/quota), the record-load Netlify
+  // function, the useQuota hook and QuotaLimitDialog all ship
+  // unconditionally; this flag gates ENFORCEMENT. When off, useQuota
+  // reports unlimited capacity and record() is a no-op, so no load is
+  // ever counted or blocked and the QuotaBadge stays hidden. Off by
+  // default while quotas are validated against real Auth0 + public/private
+  // repos; enable per-session with `?feature=quotas`. Flip isActive to true
+  // to roll the limits out to everyone.
+  {name: 'quotas', isActive: false},
   // GLB runtime artifact pipeline (design/new/glb-model-sharing.md).
   // `glb` enables both the writer (post-IFC-parse cache warm-up) and the
   // reader (skip-IFC-when-GLB-cached fast path in Loader.js).

--- a/src/hooks/useQuota.js
+++ b/src/hooks/useQuota.js
@@ -1,0 +1,272 @@
+import {useState, useEffect, useCallback} from 'react'
+import {captureException} from '@sentry/react'
+import {useAuth0} from '../Auth0/Auth0Proxy'
+import useStore from '../store/useStore'
+import {isFeatureEnabled} from '../FeatureFlags'
+import {
+  TIERS,
+  LIMITS,
+  isQuotablePath,
+  isLocallyQuotable,
+  getTier,
+  pruneLoads,
+  loadQuota,
+  saveQuota,
+  recordLoad,
+  subscribeToQuota,
+} from '../quota/quota'
+
+
+const RECORD_LOAD_ENDPOINT = '/.netlify/functions/record-load'
+const HTTP_FORBIDDEN = 403
+
+
+// Stable no-ops returned when the `quotas` feature flag is off, so the hook's
+// shape is unchanged but every gate passes. Module-level keeps their identity
+// stable across renders. Not async (avoids require-await); callers `await`
+// the returned Promise.
+const passthroughCheck = () => ({allowed: true, used: 0, limit: Infinity, alreadyCounted: false})
+const passthroughRecord = () => Promise.resolve({allowed: true, used: 0, limit: Infinity, tier: TIERS.PAID, alreadyCounted: false})
+
+
+/**
+ * React hook for usage quota state.
+ *
+ * For authenticated users the server (record-load Netlify function) is the
+ * source of truth: every quotable load POSTs to it, the response is mirrored
+ * into OPFS, and the JWT is force-refreshed so other readers (BaseRoutes)
+ * see the same app_metadata.
+ *
+ * For anonymous users there is no server backstop — the hook relies on
+ * OPFS only, which is the explicit "lossy nudge to sign in" v1 trade-off.
+ *
+ * If the Netlify function is unreachable, the hook falls back to OPFS-only
+ * for that load and reports to Sentry. We degrade open rather than block
+ * legitimate users on an outage.
+ *
+ * @return {{
+ *   used: number,
+ *   limit: number,
+ *   tier: string,
+ *   hasCapacity: boolean,
+ *   check: Function,
+ *   record: Function,
+ * }}
+ */
+export default function useQuota() {
+  // isFeatureEnabled (not the useExistInFeature hook) reads window.location
+  // directly, so useQuota imposes no Router context on its consumers — it is
+  // rendered in containers that some tests mount without a router.
+  const quotasEnabled = isFeatureEnabled('quotas')
+  const {isAuthenticated, getAccessTokenSilently} = useAuth0()
+  const appMetadata = useStore((state) => state.appMetadata)
+  const tier = getTier(appMetadata, isAuthenticated)
+  const [quota, setQuota] = useState(null)
+
+  useEffect(() => {
+    let cancelled = false
+    loadQuota().then((raw) => {
+      if (cancelled) {
+        return
+      }
+      const next = {...raw, tier, loads: pruneLoads(raw.loads, tier)}
+      setQuota(next)
+      if (next.tier !== raw.tier || next.loads.length !== raw.loads.length) {
+        saveQuota(next)
+      }
+    })
+    const unsub = subscribeToQuota((q) => {
+      if (cancelled) {
+        return
+      }
+      setQuota({...q, tier})
+    })
+    return () => {
+      cancelled = true
+      unsub()
+    }
+  }, [tier])
+
+  const used = quota?.loads.length ?? 0
+  const limit = LIMITS[tier] !== undefined ? LIMITS[tier] : LIMITS[TIERS.FREE]
+
+  const check = useCallback((key) => {
+    if (!quota) {
+      return {allowed: true, used: 0, limit: Infinity, alreadyCounted: false}
+    }
+    if (tier === TIERS.PAID) {
+      return {allowed: true, used, limit, alreadyCounted: false}
+    }
+    if (key === null || !isQuotablePath(key)) {
+      return {allowed: true, used, limit, alreadyCounted: false}
+    }
+    const alreadyCounted = quota.loads.some((l) => l.key === key)
+    return {
+      allowed: alreadyCounted || used < limit,
+      used,
+      limit,
+      alreadyCounted,
+    }
+  }, [quota, used, limit, tier])
+
+  const record = useCallback(async (key) => {
+    if (!isQuotablePath(key)) {
+      return {allowed: true, used, limit, tier, alreadyCounted: false}
+    }
+
+    // Anonymous: OPFS only.
+    if (tier === TIERS.ANONYMOUS) {
+      if (!isLocallyQuotable(key)) {
+        return {allowed: true, used, limit, tier, alreadyCounted: false}
+      }
+      const updated = await recordLoad(key)
+      if (updated) {
+        setQuota((prev) => ({...(prev || updated), loads: updated.loads}))
+      }
+      const newUsed = updated?.loads.length ?? used
+      return {
+        allowed: newUsed <= limit,
+        used: newUsed,
+        limit,
+        tier,
+        alreadyCounted: false,
+      }
+    }
+
+    // Authenticated: server is authoritative.
+    let token
+    try {
+      token = await getAccessTokenSilently({
+        authorizationParams: {
+          audience: 'https://api.github.com/',
+          scope: 'openid profile email offline_access',
+        },
+      })
+    } catch (err) {
+      captureException(err)
+      return fallbackRecord(key, tier, limit, used, setQuota)
+    }
+
+    let response
+    try {
+      response = await fetch(RECORD_LOAD_ENDPOINT, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${token}`,
+        },
+        body: JSON.stringify({key}),
+      })
+    } catch (err) {
+      captureException(err)
+      return fallbackRecord(key, tier, limit, used, setQuota)
+    }
+
+    let data
+    try {
+      data = await response.json()
+    } catch {
+      data = {}
+    }
+
+    if (response.status === HTTP_FORBIDDEN) {
+      // Server denied — surface the limit dialog via the returned payload.
+      return {
+        allowed: false,
+        used: data.used ?? used,
+        limit: data.limit ?? limit,
+        tier: data.tier ?? tier,
+        alreadyCounted: false,
+      }
+    }
+
+    if (!response.ok) {
+      captureException(new Error(`record-load returned ${response.status}`))
+      return fallbackRecord(key, tier, limit, used, setQuota)
+    }
+
+    // Mirror server response into OPFS so the next mount has fresh state
+    // even if the server is briefly unreachable later.
+    if (Array.isArray(data.loads)) {
+      const updated = {tier: data.tier ?? tier, loads: data.loads}
+      saveQuota(updated)
+      setQuota(updated)
+    }
+
+    // Force-refresh the JWT so app_metadata readers (BaseRoutes etc.)
+    // see the bumped count on next read. Failure here is non-fatal —
+    // the hook's own state is already authoritative for the badge / dialog.
+    getAccessTokenSilently({
+      authorizationParams: {
+        audience: 'https://api.github.com/',
+        scope: 'openid profile email offline_access',
+      },
+      cacheMode: 'off',
+      useRefreshTokens: true,
+    }).catch((err) => captureException(err))
+
+    return {
+      allowed: data.allowed !== false,
+      used: data.used ?? used,
+      limit: data.limit ?? limit,
+      tier: data.tier ?? tier,
+      alreadyCounted: data.alreadyCounted === true,
+    }
+  }, [tier, limit, used, getAccessTokenSilently])
+
+  // Feature-gated: with the `quotas` flag off (the default) the hook reports
+  // unlimited capacity and record()/check() are no-ops, so every load site
+  // bypasses gating and the QuotaBadge (hidden when limit === Infinity) never
+  // shows. Enforcement is enabled per-session via `?feature=quotas`, or for
+  // everyone by flipping the flag's isActive in FeatureFlags.js. All hooks
+  // above run unconditionally, so this early return respects the rules of hooks.
+  if (!quotasEnabled) {
+    return {
+      used: 0,
+      limit: Infinity,
+      tier,
+      hasCapacity: true,
+      check: passthroughCheck,
+      record: passthroughRecord,
+    }
+  }
+
+  return {
+    used,
+    limit,
+    tier,
+    hasCapacity: tier === TIERS.PAID || used < limit,
+    check,
+    record,
+  }
+}
+
+
+/**
+ * Server unreachable — fall back to OPFS-only counting. Mirrors the
+ * anonymous code path but keeps the user's authenticated tier.
+ *
+ * @param {string} key Share path being loaded
+ * @param {string} tier User's quota tier
+ * @param {number} limit Per-tier load limit
+ * @param {number} used Current observed usage
+ * @param {Function} setQuota State setter for the hook's quota cache
+ * @return {Promise<{allowed:boolean,used:number,limit:number,tier:string,alreadyCounted:boolean}>}
+ */
+async function fallbackRecord(key, tier, limit, used, setQuota) {
+  if (!isLocallyQuotable(key)) {
+    return {allowed: true, used, limit, tier, alreadyCounted: false}
+  }
+  const updated = await recordLoad(key)
+  if (updated) {
+    setQuota((prev) => ({...(prev || updated), loads: updated.loads, tier}))
+  }
+  const newUsed = updated?.loads.length ?? used
+  return {
+    allowed: newUsed <= limit,
+    used: newUsed,
+    limit,
+    tier,
+    alreadyCounted: false,
+  }
+}

--- a/src/hooks/useQuota.test.js
+++ b/src/hooks/useQuota.test.js
@@ -1,0 +1,48 @@
+import {renderHook, waitFor} from '@testing-library/react'
+import {mockedUseAuth0, mockedUserLoggedOut} from '../__mocks__/authentication'
+import {isFeatureEnabled} from '../FeatureFlags'
+import useQuota from './useQuota'
+
+
+// Keep the real `flags` table; only stub the enforcement gate so each test
+// drives the flag directly.
+jest.mock('../FeatureFlags', () => ({
+  ...jest.requireActual('../FeatureFlags'),
+  isFeatureEnabled: jest.fn(),
+}))
+
+
+/**
+ * The `quotas` feature flag gates enforcement. These cover the gate itself;
+ * the per-tier / rolling-window correctness lives in src/quota/quota.test.js.
+ */
+describe('useQuota — quotas feature flag', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockedUseAuth0.mockReturnValue(mockedUserLoggedOut)
+  })
+
+  it('reports unlimited capacity and makes record() a no-op when the flag is off', async () => {
+    isFeatureEnabled.mockReturnValue(false)
+
+    const {result} = renderHook(() => useQuota())
+
+    expect(result.current.hasCapacity).toBe(true)
+    expect(result.current.limit).toBe(Infinity)
+    expect(result.current.used).toBe(0)
+
+    // A private GitHub path would normally be counted and could be blocked;
+    // with the flag off, record() resolves allowed without a server round-trip.
+    await expect(result.current.record('/share/v/gh/owner/repo/main/private.ifc'))
+      .resolves.toMatchObject({allowed: true})
+  })
+
+  it('enforces a finite per-tier limit when the flag is on', async () => {
+    isFeatureEnabled.mockReturnValue(true)
+
+    const {result} = renderHook(() => useQuota())
+
+    // Anonymous (logged-out) tier has a finite cap, so the gate is live.
+    await waitFor(() => expect(Number.isFinite(result.current.limit)).toBe(true))
+  })
+})

--- a/src/net/http.js
+++ b/src/net/http.js
@@ -8,6 +8,7 @@ export const HTTP_NOT_MODIFIED = 304
 
 export const HTTP_BAD_REQUEST = 400
 export const HTTP_AUTHORIZATION_REQUIRED = 401
+export const HTTP_FORBIDDEN = 403
 export const HTTP_NOT_FOUND = 404
 
 export const HTTP_INTERNAL_SERVER_ERROR = 500


### PR DESCRIPTION
## Usage quotas — PR 3 of 4 (supersedes #1494)

> ⏸️ **Paused — handoff (2026-08-07):** `main` has moved ~317 commits since the stack's base `845298d7`. Resume task list: **`design/new/quotas.md` §Status & remaining work** (in #1550's diff). Overlap for *this* PR: `src/FeatureFlags.js` (a flag entry added on main since) and `src/net/http.js` — both small, additive-vs-additive rebases.

Third of four stacked PRs re-landing #1494 on current `main`. **Based on #1551** (→ #1550 → `main`). These are the client primitives the load-site wiring (PR 4) consumes; nothing imports them yet, so this layer is additive. Design of record: `design/new/quotas.md` (PR 1).

> Diff shown against base `quota/2-server-enforcement`; retargets to `main` as the lower PRs merge.

### What this PR adds
`src/hooks/useQuota.js`:
- Authenticated users: awaits `record-load` on every load, mirrors the authoritative response into OPFS, force-refreshes the JWT so other readers observe the bumped count.
- Anonymous: OPFS-only via the core lib. Server unreachable / `5xx`: degrades to OPFS-only fallback rather than blocking. `403` = over-quota.
- Exposes `{tier, used, limit, hasCapacity, record}`.

`src/Components/Open/QuotaLimitDialog.jsx`: over-quota dialog (states the numeric limit + rolling-window phrasing, links to `/share/quotas`).
`src/Components/Open/QuotaBadge.jsx`: compact used/limit indicator (consumed by `OpenModelControl` in PR 4); hidden unless `limit` is finite and usage ≥ 50%.
`src/net/http.js`: `HTTP_FORBIDDEN` (403) added to the shared status constants.

### 🚩 Behind a feature flag (off by default)
Quotas touch every load path and need to bake, so enforcement is gated behind a **`quotas`** flag (`FeatureFlags.js`, `isActive: false`) — same "ship the scaffolding, flag the consumer surface" pattern as `sharing` / `githubAsSource`.

- `useQuota` reads it via **`isFeatureEnabled('quotas')`** — deliberately the `window.location` function, **not** the `useExistInFeature` hook, so `useQuota` imposes **no Router context** on its consumers (it's rendered in containers some tests mount without a router).
- **Flag off (default):** hook reports unlimited capacity, `record()`/`check()` are stable no-ops → every load site bypasses gating with no server round-trip, and the `QuotaBadge` stays hidden. Flag check sits after all hooks (rules-of-hooks safe).
- Enable per-session with `?feature=quotas`; flip `isActive: true` to roll out to everyone.
- `src/hooks/useQuota.test.js`: asserts the flag-off bypass and that a finite per-tier limit is in force when on.

> ⚠️ **Carried-over nit from #1494:** `useQuota` keeps a local `const HTTP_FORBIDDEN = 403` rather than importing the new shared one, so the `net/http.js` export isn't wired up yet. Left as-is to preserve #1494's reviewed bytes; trivial dedupe candidate.

### Verification
`yarn lint` clean · `yarn test` full suite green (on base `845298d7`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)