### PR TITLE
Disambiguate IFC and STEP formats in ISO-10303-21 headers

### DIFF
--- a/src/Filetype.js
+++ b/src/Filetype.js
@@ -161,7 +161,14 @@ export function analyzeHeaderStr(header) {
   } else if (header.match(/(^\s*#.*$)?(^\s*$)*^\s*v(\s+-?\d+(\.\d+)?){3}\s*$/m)) {
     return 'obj'
   } else if (header.includes('ISO-10303-21')) {
-    return 'ifc'
+    // IFC and STEP share the ISO-10303-21 (STEP physical file) envelope and,
+    // in this app, the same Conway loader. They differ only in their
+    // FILE_SCHEMA: IFC declares an IFC schema (IFC2X3 / IFC4 / IFC4X3 / ...),
+    // generic STEP declares an application protocol (AUTOMOTIVE_DESIGN,
+    // CONFIG_CONTROL_DESIGN, AP203/AP214/AP242, ...). Disambiguate so the
+    // upload/temp URL extension reflects the real format instead of always
+    // labeling part-21 files ".ifc".
+    return classifyStepFamily(header)
   } else if (header.match(/\s*(HEADER|COMPND|ORIGX1)/)) { // matches IFC & STEP, so put after
     return 'pdb'
   } else if (header.startsWith('solid') || header.includes('VCG')) {
@@ -173,6 +180,31 @@ export function analyzeHeaderStr(header) {
   } else {
     return null
   }
+}
+
+
+/**
+ * Classify an ISO-10303-21 (STEP physical file) header as IFC or generic
+ * STEP. We anchor on the FILE_SCHEMA entry's value rather than searching the
+ * whole header for "IFC", so an "IFC" substring elsewhere (e.g. a project
+ * name in FILE_NAME) doesn't cause a false IFC classification.
+ *
+ * IFC schema names always begin with "IFC" (IFC2X3, IFC4, IFC4X3, ...); any
+ * other schema is treated as generic STEP. If FILE_SCHEMA isn't present in
+ * the sniffed header window (e.g. an unusually long FILE_DESCRIPTION pushed
+ * it past the 1024-byte limit), default to 'ifc' — that preserves the prior
+ * behavior for the dominant format, and both types load through the same
+ * loader regardless.
+ *
+ * @param {string} header
+ * @return {string} 'ifc' or 'step'
+ */
+export function classifyStepFamily(header) {
+  const schemaMatch = header.match(/FILE_SCHEMA\s*\(\s*\(\s*'\s*([A-Za-z0-9_]+)/i)
+  if (schemaMatch === null) {
+    return 'ifc'
+  }
+  return /^IFC/i.test(schemaMatch[1]) ? 'ifc' : 'step'
 }
 
 

--- a/src/Filetype.test.js
+++ b/src/Filetype.test.js
@@ -89,6 +89,44 @@ describe('Filetype', () => {
       expect(analyzeHeaderStr(`ORIGX1      1.000000  0.000000  0.000000        0.00000`)).toBe('pdb')
     })
 
+    it('matches ifc header', () => {
+      const header = `ISO-10303-21;\n` +
+            `HEADER;\n` +
+            `FILE_DESCRIPTION((''),'2;1');\n` +
+            `FILE_NAME('model.ifc','',(''),(''),'','','');\n` +
+            `FILE_SCHEMA(('IFC4'));\n` +
+            `ENDSEC;\n`
+      expect(analyzeHeaderStr(header)).toBe('ifc')
+    })
+
+    it('matches step header as step, not ifc', () => {
+      const header = `ISO-10303-21;\n` +
+            `HEADER;\n` +
+            `FILE_DESCRIPTION((''),'2;1');\n` +
+            `FILE_NAME('part.step','',(''),(''),'','','');\n` +
+            `FILE_SCHEMA(('AUTOMOTIVE_DESIGN { 1 0 10303 214 1 1 1 1 }'));\n` +
+            `ENDSEC;\n`
+      expect(analyzeHeaderStr(header)).toBe('step')
+    })
+
+    it('does not misclassify step as ifc when the name contains "IFC"', () => {
+      // "IFC" appears in the FILE_NAME but the schema is a STEP AP, so the
+      // FILE_SCHEMA-anchored check must still resolve to step.
+      const header = `ISO-10303-21;\n` +
+            `HEADER;\n` +
+            `FILE_NAME('myIFCexport.stp','',(''),(''),'','','');\n` +
+            `FILE_SCHEMA(('CONFIG_CONTROL_DESIGN'));\n` +
+            `ENDSEC;\n`
+      expect(analyzeHeaderStr(header)).toBe('step')
+    })
+
+    it('defaults part-21 to ifc when FILE_SCHEMA is absent from the window', () => {
+      // FILE_SCHEMA truncated out of the sniffed header — fall back to the
+      // dominant format rather than mislabeling as step.
+      const header = `ISO-10303-21;\nHEADER;\nFILE_DESCRIPTION((''),'2;1');\n`
+      expect(analyzeHeaderStr(header)).toBe('ifc')
+    })
+
     it('matches stl header', () => {
       expect(analyzeHeaderStr(`solid smth`)).toBe('stl')
     })


### PR DESCRIPTION
## Summary

IFC and STEP files both use the ISO-10303-21 (STEP physical file) envelope format, making them indistinguishable by file signature alone. Previously, all ISO-10303-21 files were classified as IFC. This change adds proper disambiguation by examining the `FILE_SCHEMA` entry to correctly identify generic STEP files, ensuring upload/temp URL extensions reflect the actual format.

## Changes

- **`classifyStepFamily()` helper function**: New export that disambiguates ISO-10303-21 headers by anchoring on the `FILE_SCHEMA` value rather than searching the whole header for "IFC". IFC schema names always begin with "IFC" (IFC2X3, IFC4, IFC4X3, etc.); any other schema is treated as generic STEP. Defaults to 'ifc' if `FILE_SCHEMA` is absent from the sniffed header window (preserves prior behavior for the dominant format).

- **`analyzeHeaderStr()` refactor**: Changed ISO-10303-21 detection to call `classifyStepFamily()` instead of always returning 'ifc'. Includes detailed comments explaining the disambiguation strategy and why it's necessary.

- **Test coverage**: Four new test cases covering:
  - IFC header detection
  - STEP header detection (with AUTOMOTIVE_DESIGN schema)
  - False-positive prevention (IFC substring in FILE_NAME doesn't cause misclassification)
  - Graceful fallback when FILE_SCHEMA is truncated from the sniffed window

## Implementation Details

The regex `FILE_SCHEMA\s*\(\s*\(\s*'\s*([A-Za-z0-9_]+)/i` captures the first schema identifier, which is sufficient to distinguish IFC (always starts with "IFC") from application protocols like AUTOMOTIVE_DESIGN, CONFIG_CONTROL_DESIGN, AP203, AP214, AP242, etc. This approach is robust against "IFC" appearing elsewhere in the header (e.g., project names in FILE_NAME).

https://claude.ai/code/session_017xyADFCezZMbP1GzGoo1a8