### PR TITLE
Add setup script to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "url": "https://github.com/bldrs-ai/Share/issues"
   },
   "scripts": {
+    "setup": "yarn install",
     "build": "yarn build-conway",
     "build-prod": "SHARE_CONFIG=prod yarn build",
     "build-conway": "yarn clean && yarn build-share-conway",


### PR DESCRIPTION
## Summary
Add a convenience `setup` script to `package.json` that runs `yarn install` to streamline the initial project setup process.

## Changes
- Added `"setup": "yarn install"` script to the scripts section of `package.json`

## Rationale
This provides a documented, consistent entry point for developers to install dependencies, making the onboarding experience clearer and more discoverable compared to requiring knowledge of yarn commands.

https://claude.ai/code/session_01JiaruKYiJzttFsTELtU4Wx