### PR TITLE
feat(viewer): instanced-rendering grouper + measurement probe (PR1)

### DIFF
--- a/design/new/viewer-replacement.md
+++ b/design/new/viewer-replacement.md
@@ -380,8 +380,7 @@ the per-vertex `expressID` attribute across child Meshes.
   binned ones; on Snowdon (~6k products) that's noticeable but
   recoverable with InstancedMesh batching for the
   `IfcMappedItem`-heavy portion and per-product Mesh for the
-  rest. Worth a separate spike post-default-on. Captured here
-  so the idea doesn't fall off the followup list.
+  rest. See §3b.iv — now an active effort.
 
 **Done — BLDRS_spatial_tree slice.** Landed 2026-05 (PR #1527).
 Resolves §3b.iii default-on blocker 1 below: cache-hit GLBs now
@@ -612,6 +611,83 @@ Order of operations: ship Conway-direct + extensions → bake goldens
 manually → wire bit-level diff into the regression harness → flip
 public-launch gate. Not on the critical path for the §3b.iii blockers
 above; tracked here so it doesn't fall off.
+
+#### 3b.iv. Instanced rendering (GPU instancing) — active
+
+We now own the whole chain (Conway engine → `@bldrs-ai/conway/web-ifc`
+→ this loader), so the long-standing "InstancedMesh batching" idea
+(§3b.iii open item) becomes tractable end-to-end. The key fact, verified
+against the compat surface:
+
+**Conway already emits the instancing model; we throw it away here.**
+At the compat boundary each `PlacedGeometry` carries a `geometryExpressID`
+referencing a **shared, source-unit *local*-space** geometry plus its own
+`flatTransformation` placement matrix. `GetGeometry(geometryExpressID)`
+returns the shared buffer — and the conway #308 "port cluster" fix
+(`ifc_api_proxy_ap214.ts`, the removed per-leaf `normalize()`) exists
+precisely *because* AP214 instances / `IfcMappedItem`s share one geometry
+buffer. So the shared-geometry + N-matrices representation survives intact
+to `flatMeshToBufferGeometry`. That assembler is the *only* place it dies:
+`flatMeshToBufferGeometry.js:232` bakes each matrix into a private vertex
+slab and merges everything into one `BufferGeometry`, so the 6 physical
+as1 bolts (or Snowdon's 2284 shared-geometry multi-placed FlatMeshes,
+§3b.ii) become N full vertex copies instead of 1 shape + N matrices.
+(Conway's *own* three.js renderer, `conway/src/rendering/threejs/scene_object.ts`,
+already does the right thing — `BatchedMesh.addGeometry` once per shape +
+`addInstance` per placement. We're the outlier.)
+
+**Plan.** Render the case-1 (shared-`geometryExpressID`) portion with GPU
+instancing; keep merged geometry for case-2 / singletons — a **hybrid**,
+which `THREE.BatchedMesh` (three 0.184) models directly (many shapes +
+many instances, one draw call). Don't instance everything: a model of
+thousands of placed-once unique shapes would turn one draw call into
+thousands. Group by `geometryExpressID`; shapes with ≥2 placements
+instance, the rest merge.
+
+- **Geometry:** one `BufferGeometry` per unique `geometryExpressID`
+  (fetched once, kept in local space — *don't* apply `flatTransformation`
+  to vertices).
+- **Placement:** per-instance matrix from `flatTransformation`
+  (`setMatrixAt` / batched instance), per-instance color via
+  `instanceColor` — which retires most of the `color`-bin `groups[]` +
+  array-material machinery for the instanced case.
+- **Picking:** `InstancedMesh`/`BatchedMesh` raycasts return
+  `instanceId`/`batchId` *natively*, replacing the triangle→instance
+  lookup (`IfcInstanceMap.getInstanceIdByTriangle`). The synthetic 0-based
+  `instanceID` the assembler already mints per `PlacedGeometry`
+  (`flatMeshToBufferGeometry.js:278`) maps 1:1 onto it; selection still
+  resolves to `parentExpressId` the same way. (Validate `three-mesh-bvh`
+  accelerated raycast on instanced/batched geometry — current picking
+  depends on it.)
+
+**Why now / tie-in to STEP occurrence identity.** Instancing makes the
+scalar-`expressID` collapse *structural*: `instanceId` **is** the
+per-occurrence handle. Today all 6 as1 bolts resolve to one
+`parentExpressId` (`CadView.jsx`), exactly the case the conway
+STEP-metadata plan flags — STEP stores a compressed DAG of part *types* +
+NAUO edges, so a physical part exists only as a root→leaf *path*, not a
+single entity (conway `design/new/step-metadata-nist.md` §"Occurrence
+identity"). The `expressID → ordered occurrence path` generalization that
+plan asks of Share and the per-instance id GPU instancing needs are the
+**same** identifier. Doing them together is cheaper than either alone, and
+STEP assemblies are both the forcing function and the biggest beneficiary.
+
+**Slicing.**
+- **PR1 (this slice) — building block + measurement, no live render
+  change.** `src/viewer/ifc/flatMeshToInstancedModel.js`: a pure grouper
+  that dedupes the captured FlatMeshes by `geometryExpressID` and returns
+  the per-shape placement lists (matrix/color/parent/instanceId) + stats
+  (unique shapes = instanced draw calls, total instances, vertex-buffer
+  bytes merged-vs-instanced, the most-instanced shape). Behind
+  `?feature=instancedMeshes` the loader logs the real comparison for the
+  loaded model, so as1 / Snowdon give concrete draw-call + memory deltas
+  in a deploy preview **without** touching the production render path
+  (no Conway release needed — the data is already in the stream). The
+  grouper is the reusable core PR2 consumes.
+- **PR2 — live render swap.** Build `BatchedMesh` (hybrid) from the
+  grouper output, rewire picking onto native `instanceId`/`batchId`, and
+  reconcile selection/subset + the cache round-trip. Gated behind the same
+  flag until it reaches parity with the merged-mesh path.
 
 ### 3c. Plugins (small, replaceable, individually disposable)
 Each takes a `ThreeContext` (and an `IfcModelService` if relevant) and exposes a tiny API:

--- a/design/new/viewer-replacement.md
+++ b/design/new/viewer-replacement.md
@@ -672,22 +672,54 @@ plan asks of Share and the per-instance id GPU instancing needs are the
 **same** identifier. Doing them together is cheaper than either alone, and
 STEP assemblies are both the forcing function and the biggest beneficiary.
 
+**Measured (PR1, 2026-06).** The grouper ran over real models. Vertex
+reduction = how much of the merged vertex memory the geometry sharing
+removes; `drawCalls` = unique shapes (the *naive* InstancedMesh-per-shape
+bound, **not** the target — see below).
+
+| Model | instances | unique shapes | shared | vtx reduction | mem saved | top shape | naive drawCalls |
+|---|---|---|---|---|---|---|---|
+| index.ifc | 7 | 7 | 0 | 0% | ~0 | ×1 | 7 |
+| Momentum (ArchiCAD) | 439 | 425 | 7 | 1% | 0.5 MB | ×3 | 425 |
+| Schependomlaan | 6,250 | 4,697 | 667 | 34% | 5.7 MB | ×147 | 4,697 |
+| Snowdon 2x3 (Revit) | 25,587 | 9,767 | 5,230 | **60%** | **63 MB** | ×336 | 9,767 |
+| Snowdon 4 (Revit) | 28,363 | 12,251 | 5,310 | **57%** | **65 MB** | ×336 | 12,251 |
+| Arty.step | 6,769 | 5,128 | 1,285 | **26%** | **25 MB** | ×20 | 5,128 |
+
+Three settled conclusions:
+
+1. **The memory win is real and large where instancing is dense** (Revit
+   ~60% / ~63 MB; STEP `Arty.step` 26% / 25 MB) and **degrades
+   gracefully** to ~0 on singleton-heavy models (index, Momentum) — no
+   penalty, they just merge as today.
+2. **STEP is a first-class beneficiary**, confirming the occurrence-identity
+   thesis on real data, not just `as1`.
+3. **The `drawCalls` column is a warning, not a target.** Naive
+   InstancedMesh-per-shape turns Snowdon's 1 merged draw call into ~10–12k —
+   almost certainly a net render-perf loss. **This is the empirical reason
+   PR2 uses `BatchedMesh`** (one multi-draw call across many shapes +
+   per-instance transforms), keeping draw calls ~1 while taking the memory
+   win. Do **not** ship InstancedMesh-per-shape.
+
 **Slicing.**
-- **PR1 (this slice) — building block + measurement, no live render
-  change.** `src/viewer/ifc/flatMeshToInstancedModel.js`: a pure grouper
-  that dedupes the captured FlatMeshes by `geometryExpressID` and returns
-  the per-shape placement lists (matrix/color/parent/instanceId) + stats
-  (unique shapes = instanced draw calls, total instances, vertex-buffer
-  bytes merged-vs-instanced, the most-instanced shape). Behind
-  `?feature=instancedMeshes` the loader logs the real comparison for the
-  loaded model, so as1 / Snowdon give concrete draw-call + memory deltas
-  in a deploy preview **without** touching the production render path
-  (no Conway release needed — the data is already in the stream). The
-  grouper is the reusable core PR2 consumes.
-- **PR2 — live render swap.** Build `BatchedMesh` (hybrid) from the
-  grouper output, rewire picking onto native `instanceId`/`batchId`, and
-  reconcile selection/subset + the cache round-trip. Gated behind the same
-  flag until it reaches parity with the merged-mesh path.
+- **PR1 (landed, #1568) — grouper + always-on verbose analysis.**
+  `src/viewer/ifc/flatMeshToInstancedModel.js` is a pure grouper that
+  dedupes the captured FlatMeshes by `geometryExpressID` and returns the
+  per-shape placement lists (matrix/color/parent/instanceId) + the stats
+  above. It runs on every Conway-direct load (the grouping is cheap and is
+  the foundation PR2 builds on — not throwaway scaffolding) and the
+  analysis line is logged under verbose (`debug(DEBUG)`); there is **no
+  feature flag**. Render is unchanged.
+- **PR2 — `BatchedMesh` render path.** Build a `BatchedMesh` from the
+  grouper output (`addGeometry` once per unique shape in local space,
+  `addInstance` + `setMatrixAt`/`setColorAt` per placement; merge or batch
+  the singletons too — one draw call regardless). Rewire picking onto
+  native `batchId` → `parentExpressId`, reconcile selection/subset + the
+  GLB-cache round-trip, validate `three-mesh-bvh` accelerated raycast on
+  the batched geometry. Moving toward **always-on** within the Conway-direct
+  path (no new flag) with a defensive fallback to the merged path on any
+  construction error. Pairs with the `expressID → occurrence path`
+  identifier generalization (`batchId` is that per-occurrence handle).
 
 ### 3c. Plugins (small, replaceable, individually disposable)
 Each takes a `ThreeContext` (and an `IfcModelService` if relevant) and exposes a tiny API:

--- a/design/new/viewer-replacement.md
+++ b/design/new/viewer-replacement.md
@@ -672,44 +672,53 @@ plan asks of Share and the per-instance id GPU instancing needs are the
 **same** identifier. Doing them together is cheaper than either alone, and
 STEP assemblies are both the forcing function and the biggest beneficiary.
 
-**Measured (PR1, 2026-06).** The grouper ran over real models. Vertex
-reduction = how much of the merged vertex memory the geometry sharing
-removes; `drawCalls` = unique shapes (the *naive* InstancedMesh-per-shape
-bound, **not** the target — see below).
+**Measured (PR1, 2026-06).** The grouper ran over real models.
+**vtx reduction** = the share of merged vertex memory the geometry
+*sharing* removes (`1 − instancedVerts/mergedVerts`). **mem saved** = that
+sharing win on a uniform 24 B/vertex basis (position+normal) **minus** the
+per-instance matrix+colour overhead (80 B/instance) — i.e. only what
+instancing's geometry dedup buys, *not* the separate ~8 B/vertex the
+batched path also saves by dropping per-vertex pick attributes (that is a
+picking-model co-benefit, not sharing, so it is excluded to avoid
+overstating). **naive drawCalls** = unique shapes — the *naive*
+InstancedMesh-per-shape bound, **not** the target (see below).
 
-| Model | instances | unique shapes | shared | vtx reduction | mem saved | top shape | naive drawCalls |
+| Model | instances | unique shapes | shared | vtx reduction | mem saved (sharing) | top shape | naive drawCalls |
 |---|---|---|---|---|---|---|---|
 | index.ifc | 7 | 7 | 0 | 0% | ~0 | ×1 | 7 |
-| Momentum (ArchiCAD) | 439 | 425 | 7 | 1% | 0.5 MB | ×3 | 425 |
-| Schependomlaan | 6,250 | 4,697 | 667 | 34% | 5.7 MB | ×147 | 4,697 |
-| Snowdon 2x3 (Revit) | 25,587 | 9,767 | 5,230 | **60%** | **63 MB** | ×336 | 9,767 |
-| Snowdon 4 (Revit) | 28,363 | 12,251 | 5,310 | **57%** | **65 MB** | ×336 | 12,251 |
-| Arty.step | 6,769 | 5,128 | 1,285 | **26%** | **25 MB** | ×20 | 5,128 |
+| Momentum (ArchiCAD) | 439 | 425 | 7 | 1% | ~0 | ×3 | 425 |
+| Schependomlaan | 6,250 | 4,697 | 667 | 34% | ~2.5 MB | ×147 | 4,697 |
+| Snowdon 2x3 (Revit) | 25,587 | 9,767 | 5,230 | **60%** | **~38 MB** | ×336 | 9,767 |
+| Snowdon 4 (Revit) | 28,363 | 12,251 | 5,310 | **57%** | **~38 MB** | ×336 | 12,251 |
+| Arty.step | 6,769 | 5,128 | 1,285 | **26%** | **~10 MB** | ×20 | 5,128 |
 
 Three settled conclusions:
 
 1. **The memory win is real and large where instancing is dense** (Revit
-   ~60% / ~63 MB; STEP `Arty.step` 26% / 25 MB) and **degrades
-   gracefully** to ~0 on singleton-heavy models (index, Momentum) — no
-   penalty, they just merge as today.
+   ~60% / ~38 MB; STEP `Arty.step` 26% / ~10 MB) and **degrades
+   gracefully** to ~0 (or slightly negative — the per-instance overhead
+   with no sharing) on singleton-heavy models (index, Momentum). The
+   batched path additionally drops ~8 B/vertex of per-vertex pick
+   attributes — a further win not counted in the column above.
 2. **STEP is a first-class beneficiary**, confirming the occurrence-identity
    thesis on real data, not just `as1`.
 3. **The `drawCalls` column is a warning, not a target.** Naive
    InstancedMesh-per-shape turns Snowdon's 1 merged draw call into ~10–12k —
-   almost certainly a net render-perf loss. **This is the empirical reason
-   PR2 uses `BatchedMesh`** (one multi-draw call across many shapes +
-   per-instance transforms), keeping draw calls ~1 while taking the memory
-   win. Do **not** ship InstancedMesh-per-shape.
+   almost certainly a net render-perf loss. Even instancing *only* the
+   shared shapes (the hybrid) is ~5k draw calls. **This is the empirical
+   reason PR2 uses `BatchedMesh`** — it multi-draws the whole batch (all
+   shapes + per-instance transforms) in **~1 draw call**, taking the memory
+   win without the draw-call blowup. Do **not** ship InstancedMesh-per-shape.
 
 **Slicing.**
-- **PR1 (landed, #1568) — grouper + always-on verbose analysis.**
+- **PR1 (#1568) — grouper + verbose analysis.**
   `src/viewer/ifc/flatMeshToInstancedModel.js` is a pure grouper that
   dedupes the captured FlatMeshes by `geometryExpressID` and returns the
   per-shape placement lists (matrix/color/parent/instanceId) + the stats
-  above. It runs on every Conway-direct load (the grouping is cheap and is
-  the foundation PR2 builds on — not throwaway scaffolding) and the
-  analysis line is logged under verbose (`debug(DEBUG)`); there is **no
-  feature flag**. Render is unchanged.
+  above. There is **no feature flag** (it is a permanent diagnostic and
+  the foundation PR2 builds on); it runs **only when verbose logging is
+  enabled** (`isLogEnabled(DEBUG)`), so the per-placement grouping cost is
+  paid only when the analysis is actually wanted. Render is unchanged.
 - **PR2 — `BatchedMesh` render path.** Build a `BatchedMesh` from the
   grouper output (`addGeometry` once per unique shape in local space,
   `addInstance` + `setMatrixAt`/`setColorAt` per placement; merge or batch

--- a/src/FeatureFlags.js
+++ b/src/FeatureFlags.js
@@ -71,6 +71,15 @@ export const flags = [
   // `ifcItemsMapParity` shares the same capture.
   // Design: design/new/viewer-replacement.md §3b.
   {name: 'conwayDirectIfc', isActive: true},
+  // Instanced-rendering measurement probe. When on, the Conway-direct
+  // parse additionally groups the captured FlatMesh stream by shared
+  // `geometryExpressID` (`flatMeshToInstancedModel`) and logs the
+  // draw-call + vertex-memory delta of GPU instancing vs. the current
+  // merged path — WITHOUT changing what renders. Diagnostic only; the
+  // live BatchedMesh render swap is the follow-up slice (PR2). Flip on
+  // via `?feature=instancedMeshes` to get real numbers on a model in a
+  // deploy preview. Design: design/new/viewer-replacement.md §3b.iv.
+  {name: 'instancedMeshes', isActive: false},
 ]
 
 

--- a/src/FeatureFlags.js
+++ b/src/FeatureFlags.js
@@ -71,15 +71,6 @@ export const flags = [
   // `ifcItemsMapParity` shares the same capture.
   // Design: design/new/viewer-replacement.md §3b.
   {name: 'conwayDirectIfc', isActive: true},
-  // Instanced-rendering measurement probe. When on, the Conway-direct
-  // parse additionally groups the captured FlatMesh stream by shared
-  // `geometryExpressID` (`flatMeshToInstancedModel`) and logs the
-  // draw-call + vertex-memory delta of GPU instancing vs. the current
-  // merged path — WITHOUT changing what renders. Diagnostic only; the
-  // live BatchedMesh render swap is the follow-up slice (PR2). Flip on
-  // via `?feature=instancedMeshes` to get real numbers on a model in a
-  // deploy preview. Design: design/new/viewer-replacement.md §3b.iv.
-  {name: 'instancedMeshes', isActive: false},
 ]
 
 

--- a/src/utils/debug.js
+++ b/src/utils/debug.js
@@ -19,6 +19,20 @@ export default function debug(level = INFO) {
 }
 
 
+/**
+ * Whether `debug(level)` would actually log at the current threshold —
+ * i.e. logging at `level` is enabled. Lets callers skip *building* an
+ * expensive diagnostic (not just suppress the print) when it wouldn't be
+ * shown. Mirrors the predicate in `debug()`.
+ *
+ * @param {number} [level] The level the caller would log at (default DEBUG).
+ * @return {boolean}
+ */
+export function isLogEnabled(level = DEBUG) {
+  return level >= DEBUG_LEVEL
+}
+
+
 /** @param {number} level One of OFF, INFO, DEBUG, ALL. */
 export function setDebugLevel(level) {
   if (!Number.isFinite(level) || level < DEBUG || level > OFF) {

--- a/src/utils/debug.js
+++ b/src/utils/debug.js
@@ -1,10 +1,10 @@
-/* eslint-disable no-unused-vars */
-const OFF = 4
-const ERROR = 3
-const WARN = 2 // Use this as default for prod.  Should never see these messages.
-const INFO = 1
-const DEBUG = 0
-/* eslint-enable no-unused-vars */
+// Log levels, exported so callers can pick a threshold for `debug(level)`
+// (e.g. `debug(DEBUG).log(...)` only surfaces under verbose logging).
+export const OFF = 4
+export const ERROR = 3
+export const WARN = 2 // Use this as default for prod.  Should never see these messages.
+export const INFO = 1
+export const DEBUG = 0
 let DEBUG_LEVEL = WARN
 
 

--- a/src/viewer/ifc/ShareIfcLoader.js
+++ b/src/viewer/ifc/ShareIfcLoader.js
@@ -24,14 +24,21 @@ import {isOutOfMemoryError} from '../../utils/oom'
 import {isFeatureEnabled} from '../../FeatureFlags'
 import {runIfcItemsMapParityCheck} from './ifcItemsMapParity'
 import ShareIfcManager from './ShareIfcManager'
+import debug, {DEBUG} from '../../utils/debug'
 
 
 /**
- * Run the instanced-rendering grouper over a captured FlatMesh stream
- * and log the draw-call + vertex-memory comparison vs. the merged path.
- * Diagnostic only — see `?feature=instancedMeshes`
- * (design/new/viewer-replacement.md §3b.iv). Never throws into the
- * load path: a probe failure must not discard a successful parse.
+ * Group the captured FlatMesh stream by shared geometry and log the
+ * instancing analysis (draw-call + vertex-memory delta vs. the merged
+ * path) under verbose logging.
+ *
+ * Runs on every Conway-direct load — the grouping is cheap (a map lookup
+ * + size accessor per shape, a push per placement; negligible against
+ * parse/geometry) and `flatMeshToInstancedModel` is the foundation the
+ * BatchedMesh render path (§3b.iv) builds on, so this is not throwaway
+ * scaffolding. The log itself is gated on `debug(DEBUG)` so it only
+ * surfaces when verbose logging is enabled. Never throws into the load
+ * path: a probe failure must not discard a successful parse.
  *
  * @param {object} ifcAPI Conway IfcAPI bound to the model
  * @param {number} modelID
@@ -41,8 +48,7 @@ function logInstancedModelStats(ifcAPI, modelID, captured) {
   try {
     const {stats} = flatMeshToInstancedModel(captured, ifcAPI, modelID)
     const reduction = stats.vertexReductionRatio.toFixed(2)
-    // eslint-disable-next-line no-console
-    console.info(
+    debug(DEBUG).log(
       `[instancedMeshes] modelID=${modelID} — ` +
       `instances=${stats.instanceCount} ` +
       `uniqueShapes=${stats.uniqueGeometryCount} ` +
@@ -206,14 +212,12 @@ export default class ShareIfcLoader {
       if (isFeatureEnabled('ifcItemsMapParity')) {
         runIfcItemsMapParityCheck(ifcAPI, ifcModel, captured)
       }
-      // Instanced-rendering measurement probe (`?feature=instancedMeshes`).
-      // Groups the same captured stream by shared `geometryExpressID` and
-      // logs the GPU-instancing draw-call + vertex-memory delta vs. the
-      // merged path that just rendered — diagnostic only, render unchanged.
-      // See design/new/viewer-replacement.md §3b.iv.
-      if (isFeatureEnabled('instancedMeshes')) {
-        logInstancedModelStats(ifcAPI, modelID, captured)
-      }
+      // Instanced-rendering analysis: always runs (cheap), logged under
+      // verbose. Groups the captured stream by shared `geometryExpressID`
+      // and reports the GPU-instancing draw-call + vertex-memory delta vs.
+      // the merged path that just rendered. The grouper is the foundation
+      // the BatchedMesh render path (§3b.iv) builds on.
+      logInstancedModelStats(ifcAPI, modelID, captured)
       // Always-on integration-boundary log. `conwayDirect.spec.ts`
       // (and the deploy-preview smoke checks) gate on `[conwayDirect]
       // parsed modelID=…` firing — it's the single observable signal

--- a/src/viewer/ifc/ShareIfcLoader.js
+++ b/src/viewer/ifc/ShareIfcLoader.js
@@ -24,20 +24,21 @@ import {isOutOfMemoryError} from '../../utils/oom'
 import {isFeatureEnabled} from '../../FeatureFlags'
 import {runIfcItemsMapParityCheck} from './ifcItemsMapParity'
 import ShareIfcManager from './ShareIfcManager'
-import debug, {DEBUG} from '../../utils/debug'
+import debug, {DEBUG, isLogEnabled} from '../../utils/debug'
 
 
 /**
  * Group the captured FlatMesh stream by shared geometry and log the
  * instancing analysis (draw-call + vertex-memory delta vs. the merged
- * path) under verbose logging.
+ * path) — but ONLY when verbose logging is enabled.
  *
- * Runs on every Conway-direct load — the grouping is cheap (a map lookup
- * + size accessor per shape, a push per placement; negligible against
- * parse/geometry) and `flatMeshToInstancedModel` is the foundation the
- * BatchedMesh render path (§3b.iv) builds on, so this is not throwaway
- * scaffolding. The log itself is gated on `debug(DEBUG)` so it only
- * surfaces when verbose logging is enabled. Never throws into the load
+ * The whole grouping is gated on `isLogEnabled(DEBUG)`, not just the
+ * print: on a large model it walks every placement (tens of thousands)
+ * and re-fetches each unique shape's size across the Conway boundary, so
+ * building it on every default-level load — only to drop the result —
+ * would be pure waste. There is no feature flag (the grouper is a
+ * permanent diagnostic and the foundation the BatchedMesh render path,
+ * §3b.iv, builds on); verbosity is the gate. Never throws into the load
  * path: a probe failure must not discard a successful parse.
  *
  * @param {object} ifcAPI Conway IfcAPI bound to the model
@@ -45,6 +46,9 @@ import debug, {DEBUG} from '../../utils/debug'
  * @param {Array} captured FlatMeshes captured during the parse
  */
 function logInstancedModelStats(ifcAPI, modelID, captured) {
+  if (!isLogEnabled(DEBUG)) {
+    return
+  }
   try {
     const {stats} = flatMeshToInstancedModel(captured, ifcAPI, modelID)
     const reduction = stats.vertexReductionRatio.toFixed(2)

--- a/src/viewer/ifc/ShareIfcLoader.js
+++ b/src/viewer/ifc/ShareIfcLoader.js
@@ -19,10 +19,42 @@
 
 import {buildConwayIfcModel} from './buildConwayIfcModel'
 import {decorateConwayDirectIfcModel, parseIfcWithConway} from './conwayDirectIfcLoader'
+import {flatMeshToInstancedModel} from './flatMeshToInstancedModel'
 import {isOutOfMemoryError} from '../../utils/oom'
 import {isFeatureEnabled} from '../../FeatureFlags'
 import {runIfcItemsMapParityCheck} from './ifcItemsMapParity'
 import ShareIfcManager from './ShareIfcManager'
+
+
+/**
+ * Run the instanced-rendering grouper over a captured FlatMesh stream
+ * and log the draw-call + vertex-memory comparison vs. the merged path.
+ * Diagnostic only — see `?feature=instancedMeshes`
+ * (design/new/viewer-replacement.md §3b.iv). Never throws into the
+ * load path: a probe failure must not discard a successful parse.
+ *
+ * @param {object} ifcAPI Conway IfcAPI bound to the model
+ * @param {number} modelID
+ * @param {Array} captured FlatMeshes captured during the parse
+ */
+function logInstancedModelStats(ifcAPI, modelID, captured) {
+  try {
+    const {stats} = flatMeshToInstancedModel(captured, ifcAPI, modelID)
+    const reduction = stats.vertexReductionRatio.toFixed(2)
+    // eslint-disable-next-line no-console
+    console.info(
+      `[instancedMeshes] modelID=${modelID} — ` +
+      `instances=${stats.instanceCount} ` +
+      `uniqueShapes=${stats.uniqueGeometryCount} ` +
+      `(shared=${stats.sharedGeometryCount} singleton=${stats.singletonGeometryCount}) ` +
+      `→ instancedDrawCalls=${stats.uniqueGeometryCount} (merged path = 1) | ` +
+      `verts merged=${stats.mergedVertexCount} instanced=${stats.instancedVertexCount} ` +
+      `(reductionRatio=${reduction}) bytesSaved=${stats.estimatedBytesSaved} | ` +
+      `mostInstanced: geometry#${stats.topInstancedGeometryID} ×${stats.topInstancedCount}`)
+  } catch (err) {
+    console.warn('[instancedMeshes] probe failed (non-fatal):', err)
+  }
+}
 
 
 /**
@@ -173,6 +205,14 @@ export default class ShareIfcLoader {
       // per-instance story this check exposes.
       if (isFeatureEnabled('ifcItemsMapParity')) {
         runIfcItemsMapParityCheck(ifcAPI, ifcModel, captured)
+      }
+      // Instanced-rendering measurement probe (`?feature=instancedMeshes`).
+      // Groups the same captured stream by shared `geometryExpressID` and
+      // logs the GPU-instancing draw-call + vertex-memory delta vs. the
+      // merged path that just rendered — diagnostic only, render unchanged.
+      // See design/new/viewer-replacement.md §3b.iv.
+      if (isFeatureEnabled('instancedMeshes')) {
+        logInstancedModelStats(ifcAPI, modelID, captured)
       }
       // Always-on integration-boundary log. `conwayDirect.spec.ts`
       // (and the deploy-preview smoke checks) gate on `[conwayDirect]

--- a/src/viewer/ifc/flatMeshToInstancedModel.js
+++ b/src/viewer/ifc/flatMeshToInstancedModel.js
@@ -1,0 +1,235 @@
+/**
+ * flatMeshToInstancedModel — group a Conway FlatMesh stream by shared
+ * geometry so it can be rendered with GPU instancing.
+ *
+ * The instancing counterpart to `flatMeshToBufferGeometry`. Conway's
+ * compat surface already emits the web-ifc instancing model: every
+ * `PlacedGeometry` references a shared, source-unit *local*-space
+ * geometry by `geometryExpressID` plus its own `flatTransformation`
+ * placement matrix (`GetGeometry(geometryExpressID)` returns the shared
+ * buffer — the conway #308 "port cluster" fix preserves that sharing
+ * for AP214 instances / `IfcMappedItem`s). `flatMeshToBufferGeometry`
+ * discards it: it bakes each matrix into a private vertex slab and
+ * merges, so N placements of one shape become N full vertex copies.
+ *
+ * This grouper keeps the sharing instead: it dedupes by
+ * `geometryExpressID` so each unique shape is recorded once, with the
+ * list of per-placement matrices / colours / parent ids that a
+ * `THREE.InstancedMesh` / `BatchedMesh` consumes. It is intentionally
+ * PURE — no Conway vertex reads, no three.js object construction — so
+ * the measurement path (`?feature=instancedMeshes`) can report the
+ * shared-vs-baked win cheaply, and PR2's render swap can build the
+ * actual instanced scene graph from the same output. See
+ * `design/new/viewer-replacement.md` §3b.iv.
+ *
+ * @see flatMeshToBufferGeometry — the merge (baked) path this mirrors.
+ */
+
+
+/** Fallback colour used when a PlacedGeometry has no `.color` field. */
+const DEFAULT_COLOR = {x: 0.8, y: 0.8, z: 0.8, w: 1}
+
+/**
+ * Interleaved vertex stride from Conway: `[px, py, pz, nx, ny, nz]`
+ * (6 floats per vertex). `GetVertexDataSize()` is in float-element
+ * units, so `vertCount = vertexDataSize / VERT_STRIDE`.
+ */
+const VERT_STRIDE = 6
+
+/** Indices per triangle. */
+const INDICES_PER_TRIANGLE = 3
+
+/**
+ * Bytes a merged-path vertex costs in the GPU buffer: position (3) +
+ * normal (3) + per-vertex `expressID` (1) + per-vertex `instanceID` (1),
+ * all 4-byte. The merged path needs the two per-vertex id attributes to
+ * recover picking identity after the index buffer is BVH-reordered.
+ */
+const MERGED_BYTES_PER_VERTEX = (3 + 3 + 1 + 1) * 4
+
+/**
+ * Bytes an instanced-path vertex costs: position (3) + normal (3),
+ * 4-byte. The instanced path drops the per-vertex id attributes —
+ * picking resolves through the native `instanceId`/`batchId`, so the
+ * shared shape's vertices carry no identity.
+ */
+const INSTANCED_BYTES_PER_VERTEX = (3 + 3) * 4
+
+/**
+ * Per-instance GPU overhead the instanced path adds in place of the
+ * duplicated vertices: a 4×4 matrix (16 floats) + an RGBA instance
+ * colour (4 floats), 4-byte each.
+ */
+const INSTANCED_BYTES_PER_INSTANCE = ((4 * 4) + 4) * 4
+
+
+/**
+ * @typedef {object} InstancePlacement
+ * @property {Array<number>} matrix the PlacedGeometry's
+ *   `flatTransformation` (column-major 16-element 4×4), kept as-is —
+ *   NOT applied to vertices.
+ * @property {{x: number, y: number, z: number, w: number}} color RGBA.
+ * @property {number} parentExpressId owning IFC product (the
+ *   `FlatMesh.expressID`).
+ * @property {number} instanceId synthetic 0-based id, assigned in
+ *   emission order across the whole stream — the same id space
+ *   `flatMeshToBufferGeometry` mints, so the two paths agree.
+ */
+
+
+/**
+ * @typedef {object} InstanceGroup
+ * @property {number} geometryExpressID the shared shape's id; fetch its
+ *   local-space buffer once via `GetGeometry(modelID, geometryExpressID)`.
+ * @property {number} vertCount vertices in the shared shape.
+ * @property {number} triangleCount triangles in the shared shape.
+ * @property {Array<InstancePlacement>} placements one per visible
+ *   occurrence; `placements.length > 1` is the instanceable
+ *   (`IfcMappedItem` / AP214-occurrence) case.
+ */
+
+
+/**
+ * @typedef {object} InstancedModel
+ * @property {Array<InstanceGroup>} groups unique shapes, in first-seen
+ *   order, each with its placement list.
+ * @property {object} stats see `computeStats` — draw-call and
+ *   vertex-memory comparison of the merged vs. instanced shapes.
+ */
+
+
+/**
+ * Iterate the FlatMesh source uniformly whether it is a Conway
+ * `Vector` (size()/get(i)) or a plain Array of FlatMesh-shaped objects.
+ *
+ * @param {object|Array} vec
+ * @param {Function} fn called with each element
+ */
+function forEachVectorItem(vec, fn) {
+  const size = typeof vec?.size === 'function' ? vec.size() : (vec?.length ?? 0)
+  for (let i = 0; i < size; i++) {
+    fn(typeof vec.get === 'function' ? vec.get(i) : vec[i])
+  }
+}
+
+
+/**
+ * Derive the draw-call + vertex-memory comparison between the current
+ * merged path and the instanced path.
+ *
+ * @param {Map<number, InstanceGroup>} groupsById
+ * @param {number} instanceCount total placements (= synthetic id count)
+ * @return {object} stats
+ */
+function computeStats(groupsById, instanceCount) {
+  let sharedGeometryCount = 0 // shapes placed >1× (instancing pays off)
+  let mergedVertexCount = 0 // vertices the merge path materialises
+  let instancedVertexCount = 0 // vertices the instanced path materialises
+  let topInstancedCount = 0
+  let topInstancedGeometryID = -1
+  for (const group of groupsById.values()) {
+    const placements = group.placements.length
+    if (placements > 1) {
+      sharedGeometryCount++
+    }
+    mergedVertexCount += group.vertCount * placements
+    instancedVertexCount += group.vertCount
+    if (placements > topInstancedCount) {
+      topInstancedCount = placements
+      topInstancedGeometryID = group.geometryExpressID
+    }
+  }
+  const mergedBytes = mergedVertexCount * MERGED_BYTES_PER_VERTEX
+  const instancedBytes =
+    (instancedVertexCount * INSTANCED_BYTES_PER_VERTEX) +
+    (instanceCount * INSTANCED_BYTES_PER_INSTANCE)
+  return {
+    // Draw calls: the merged path is a single mesh (1); the instanced
+    // path is one InstancedMesh per unique shape. A hybrid (§3b.iv)
+    // would instance only the shared shapes and merge the singletons,
+    // landing between these — reported here as the un-hybridised bound.
+    uniqueGeometryCount: groupsById.size,
+    sharedGeometryCount,
+    singletonGeometryCount: groupsById.size - sharedGeometryCount,
+    instanceCount,
+    mergedVertexCount,
+    instancedVertexCount,
+    // 0..1; how much of the merged vertex memory the sharing removes.
+    vertexReductionRatio: mergedVertexCount > 0 ?
+      1 - (instancedVertexCount / mergedVertexCount) : 0,
+    mergedVertexBytes: mergedBytes,
+    instancedVertexBytes: instancedBytes,
+    estimatedBytesSaved: mergedBytes - instancedBytes,
+    topInstancedGeometryID,
+    topInstancedCount,
+  }
+}
+
+
+/**
+ * Group a captured Conway FlatMesh stream by shared `geometryExpressID`.
+ *
+ * @param {object|Array} flatMeshes FlatMesh source (Conway `Vector` or
+ *   Array of FlatMesh-shaped objects).
+ * @param {object} api Conway-compatible IfcAPI. Needs `GetGeometry`
+ *   returning an `IfcGeometry` with `GetVertexDataSize()` /
+ *   `GetIndexDataSize()`. Vertex/index *data* is NOT read here — only
+ *   sizes, to record the shared shape's vert/triangle counts.
+ * @param {number} modelID
+ * @return {InstancedModel}
+ */
+export function flatMeshToInstancedModel(flatMeshes, api, modelID) {
+  const groupsById = new Map()
+  let skippedFlatMeshes = 0
+  let skippedPlacedGeometries = 0
+  let instanceId = 0 // synthetic, emission order — matches the merge path
+
+  forEachVectorItem(flatMeshes, (flatMesh) => {
+    const parentExpressId = flatMesh?.expressID
+    const placedVec = flatMesh?.geometries
+    if (parentExpressId === undefined || !placedVec) {
+      skippedFlatMeshes++
+      return
+    }
+    forEachVectorItem(placedVec, (placed) => {
+      const geomExpressID = placed?.geometryExpressID
+      let group = groupsById.get(geomExpressID)
+      if (group === undefined) {
+        // First time we see this shape — measure it once.
+        // eslint-disable-next-line new-cap
+        const geom = api.GetGeometry(modelID, geomExpressID)
+        if (!geom) {
+          skippedPlacedGeometries++
+          return
+        }
+        // eslint-disable-next-line new-cap
+        const indexSize = geom.GetIndexDataSize()
+        // eslint-disable-next-line new-cap
+        const vertSize = geom.GetVertexDataSize()
+        if (indexSize === 0 || vertSize === 0) {
+          skippedPlacedGeometries++
+          return
+        }
+        group = {
+          geometryExpressID: geomExpressID,
+          vertCount: (vertSize / VERT_STRIDE) | 0,
+          triangleCount: (indexSize / INDICES_PER_TRIANGLE) | 0,
+          placements: [],
+        }
+        groupsById.set(geomExpressID, group)
+      }
+      group.placements.push({
+        matrix: placed.flatTransformation,
+        color: placed.color ?? DEFAULT_COLOR,
+        parentExpressId,
+        instanceId,
+      })
+      instanceId++
+    })
+  })
+
+  const stats = computeStats(groupsById, instanceId)
+  stats.skippedFlatMeshes = skippedFlatMeshes
+  stats.skippedPlacedGeometries = skippedPlacedGeometries
+  return {groups: [...groupsById.values()], stats}
+}

--- a/src/viewer/ifc/flatMeshToInstancedModel.js
+++ b/src/viewer/ifc/flatMeshToInstancedModel.js
@@ -40,27 +40,27 @@ const VERT_STRIDE = 6
 const INDICES_PER_TRIANGLE = 3
 
 /**
- * Bytes a merged-path vertex costs in the GPU buffer: position (3) +
- * normal (3) + per-vertex `expressID` (1) + per-vertex `instanceID` (1),
- * all 4-byte. The merged path needs the two per-vertex id attributes to
- * recover picking identity after the index buffer is BVH-reordered.
+ * Bytes one geometry vertex costs in the GPU buffer: position (3) +
+ * normal (3), 4-byte. Used for BOTH paths so `estimatedBytesSaved`
+ * isolates the *geometry-sharing* win — the thing instancing actually
+ * buys — and is not inflated by the picking-attribute format change.
+ *
+ * (Separately, the instanced/batched path can also drop the per-vertex
+ * `expressID` + `instanceID` attributes the merged path needs for
+ * BVH-reordered picking — another ~8 B/vertex — because it picks via the
+ * native `instanceId`/`batchId`. That is a real but *orthogonal* co-
+ * benefit of the picking-model change, not of sharing, so it is
+ * deliberately NOT credited here; counting it made singleton-heavy
+ * models report a large bogus "saving" with no sharing at all.)
  */
-const MERGED_BYTES_PER_VERTEX = (3 + 3 + 1 + 1) * 4
-
-/**
- * Bytes an instanced-path vertex costs: position (3) + normal (3),
- * 4-byte. The instanced path drops the per-vertex id attributes —
- * picking resolves through the native `instanceId`/`batchId`, so the
- * shared shape's vertices carry no identity.
- */
-const INSTANCED_BYTES_PER_VERTEX = (3 + 3) * 4
+const BYTES_PER_VERTEX = (3 + 3) * 4
 
 /**
  * Per-instance GPU overhead the instanced path adds in place of the
  * duplicated vertices: a 4×4 matrix (16 floats) + an RGBA instance
  * colour (4 floats), 4-byte each.
  */
-const INSTANCED_BYTES_PER_INSTANCE = ((4 * 4) + 4) * 4
+const BYTES_PER_INSTANCE = ((4 * 4) + 4) * 4
 
 
 /**
@@ -72,8 +72,12 @@ const INSTANCED_BYTES_PER_INSTANCE = ((4 * 4) + 4) * 4
  * @property {number} parentExpressId owning IFC product (the
  *   `FlatMesh.expressID`).
  * @property {number} instanceId synthetic 0-based id, assigned in
- *   emission order across the whole stream — the same id space
- *   `flatMeshToBufferGeometry` mints, so the two paths agree.
+ *   FlatMesh emission order across the whole stream. (Note: this is NOT
+ *   the same ordering `flatMeshToBufferGeometry` mints — that path
+ *   numbers its per-vertex `instanceID` in colour-bin order — so the two
+ *   ids must not be assumed equal. This id is unused today; the render
+ *   path, `flatMeshToBatchedModel`, mints its own occurrence id and maps
+ *   `batchId → parentExpressId` directly.)
  */
 
 
@@ -139,10 +143,13 @@ function computeStats(groupsById, instanceCount) {
       topInstancedGeometryID = group.geometryExpressID
     }
   }
-  const mergedBytes = mergedVertexCount * MERGED_BYTES_PER_VERTEX
+  // Same per-vertex cost both sides, so the delta is purely the
+  // geometry-sharing win (dropped duplicate vertices) minus the
+  // per-instance matrix/colour overhead. Negative for singleton-heavy
+  // models — correct: instancing costs more memory there than it saves.
+  const mergedBytes = mergedVertexCount * BYTES_PER_VERTEX
   const instancedBytes =
-    (instancedVertexCount * INSTANCED_BYTES_PER_VERTEX) +
-    (instanceCount * INSTANCED_BYTES_PER_INSTANCE)
+    (instancedVertexCount * BYTES_PER_VERTEX) + (instanceCount * BYTES_PER_INSTANCE)
   return {
     // Draw calls: the merged path is a single mesh (1); the instanced
     // path is one InstancedMesh per unique shape. A hybrid (§3b.iv)

--- a/src/viewer/ifc/flatMeshToInstancedModel.test.js
+++ b/src/viewer/ifc/flatMeshToInstancedModel.test.js
@@ -1,0 +1,153 @@
+/* eslint-disable no-magic-numbers */
+import {flatMeshToInstancedModel} from './flatMeshToInstancedModel'
+
+
+/** Identity 4x4 in three.js column-major flat form. */
+const IDENTITY_MAT = [
+  1, 0, 0, 0,
+  0, 1, 0, 0,
+  0, 0, 1, 0,
+  0, 0, 0, 1,
+]
+
+
+/**
+ * Mock Conway IfcAPI exposing only what the grouper reads: `GetGeometry`
+ * returning an IfcGeometry with vert/index *sizes* (no data reads).
+ *
+ * @param {object} byGeomExpressId map of geomExpressID → {verts, indices}
+ *   (element counts: verts = interleaved p+n floats, indices = u32 count)
+ * @return {object} mock api
+ */
+function makeApi(byGeomExpressId) {
+  return {
+    GetGeometry(_modelID, geomExpressID) {
+      const g = byGeomExpressId[geomExpressID]
+      if (!g) {
+        return null
+      }
+      return {
+        GetVertexDataSize: () => g.verts,
+        GetIndexDataSize: () => g.indices,
+      }
+    },
+  }
+}
+
+
+/** One unit triangle: 3 verts (18 interleaved floats) + 3 indices. */
+const UNIT_TRI = {verts: 18, indices: 3}
+
+
+/**
+ * @param {number} parentExpressId FlatMesh.expressID
+ * @param {Array<object>} placed PlacedGeometry-shaped entries
+ * @return {object} FlatMesh-shaped object (Array-backed geometries)
+ */
+function flatMesh(parentExpressId, placed) {
+  return {expressID: parentExpressId, geometries: placed}
+}
+
+
+describe('viewer/ifc/flatMeshToInstancedModel', () => {
+  it('dedupes shared geometryExpressID into one group with N placements', () => {
+    // The IfcMappedItem / AP214-occurrence case: one shape, 3 placements.
+    const api = makeApi({999: UNIT_TRI})
+    const flatMeshes = [flatMesh(100, [
+      {geometryExpressID: 999, flatTransformation: IDENTITY_MAT},
+      {geometryExpressID: 999, flatTransformation: IDENTITY_MAT},
+      {geometryExpressID: 999, flatTransformation: IDENTITY_MAT},
+    ])]
+    const {groups, stats} = flatMeshToInstancedModel(flatMeshes, api, 0)
+    expect(groups.length).toBe(1)
+    expect(groups[0].geometryExpressID).toBe(999)
+    expect(groups[0].vertCount).toBe(3)
+    expect(groups[0].triangleCount).toBe(1)
+    expect(groups[0].placements.length).toBe(3)
+    expect(stats.uniqueGeometryCount).toBe(1)
+    expect(stats.sharedGeometryCount).toBe(1)
+    expect(stats.instanceCount).toBe(3)
+    // Merge path materialises 3×3 verts; instancing materialises 3.
+    expect(stats.mergedVertexCount).toBe(9)
+    expect(stats.instancedVertexCount).toBe(3)
+    expect(stats.vertexReductionRatio).toBeCloseTo(1 - (3 / 9))
+    expect(stats.topInstancedGeometryID).toBe(999)
+    expect(stats.topInstancedCount).toBe(3)
+  })
+
+  it('keeps distinct geometryExpressIDs as separate singletons (compound case)', () => {
+    // The compound-representation case: one product, distinct shapes.
+    const api = makeApi({1: UNIT_TRI, 2: UNIT_TRI, 3: UNIT_TRI})
+    const flatMeshes = [flatMesh(100, [
+      {geometryExpressID: 1, flatTransformation: IDENTITY_MAT},
+      {geometryExpressID: 2, flatTransformation: IDENTITY_MAT},
+      {geometryExpressID: 3, flatTransformation: IDENTITY_MAT},
+    ])]
+    const {groups, stats} = flatMeshToInstancedModel(flatMeshes, api, 0)
+    expect(groups.length).toBe(3)
+    expect(stats.uniqueGeometryCount).toBe(3)
+    expect(stats.sharedGeometryCount).toBe(0)
+    expect(stats.singletonGeometryCount).toBe(3)
+    expect(stats.instanceCount).toBe(3)
+    // No sharing → no vertex reduction.
+    expect(stats.mergedVertexCount).toBe(9)
+    expect(stats.instancedVertexCount).toBe(9)
+    expect(stats.vertexReductionRatio).toBe(0)
+  })
+
+  it('records per-placement matrix/color/parent and emission-order instanceId', () => {
+    const api = makeApi({999: UNIT_TRI})
+    const matA = IDENTITY_MAT
+    const matB = [2, 0, 0, 0, 0, 2, 0, 0, 0, 0, 2, 0, 5, 6, 7, 1]
+    const red = {x: 1, y: 0, z: 0, w: 1}
+    // Two FlatMeshes (two products) sharing one shape — the cross-product
+    // instancing the merge path can't express as a single id.
+    const flatMeshes = [
+      flatMesh(100, [{geometryExpressID: 999, flatTransformation: matA, color: red}]),
+      flatMesh(200, [{geometryExpressID: 999, flatTransformation: matB}]),
+    ]
+    const {groups} = flatMeshToInstancedModel(flatMeshes, api, 0)
+    expect(groups.length).toBe(1)
+    const [p0, p1] = groups[0].placements
+    expect(p0.matrix).toBe(matA)
+    expect(p0.color).toEqual(red)
+    expect(p0.parentExpressId).toBe(100)
+    expect(p0.instanceId).toBe(0)
+    expect(p1.matrix).toBe(matB)
+    expect(p1.parentExpressId).toBe(200)
+    expect(p1.instanceId).toBe(1)
+  })
+
+  it('skips FlatMeshes without an expressID and missing/empty geometry', () => {
+    const api = makeApi({999: UNIT_TRI, 0: {verts: 0, indices: 0}})
+    const flatMeshes = [
+      flatMesh(undefined, [{geometryExpressID: 999, flatTransformation: IDENTITY_MAT}]),
+      flatMesh(100, [
+        {geometryExpressID: 999, flatTransformation: IDENTITY_MAT},
+        {geometryExpressID: 777, flatTransformation: IDENTITY_MAT}, // not in api
+        {geometryExpressID: 0, flatTransformation: IDENTITY_MAT}, // empty geometry
+      ]),
+    ]
+    const {groups, stats} = flatMeshToInstancedModel(flatMeshes, api, 0)
+    expect(groups.length).toBe(1) // only 999 survives
+    expect(stats.skippedFlatMeshes).toBe(1) // undefined expressID
+    expect(stats.skippedPlacedGeometries).toBe(2) // 777 missing + 0 empty
+    expect(stats.instanceCount).toBe(1)
+  })
+
+  it('supports Conway Vector-shaped sources (size()/get())', () => {
+    const api = makeApi({999: UNIT_TRI})
+    const placedVec = {
+      size: () => 2,
+      get: () => ({geometryExpressID: 999, flatTransformation: IDENTITY_MAT}),
+    }
+    const flatMeshes = {
+      size: () => 1,
+      get: () => ({expressID: 100, geometries: placedVec}),
+    }
+    const {groups, stats} = flatMeshToInstancedModel(flatMeshes, api, 0)
+    expect(groups.length).toBe(1)
+    expect(groups[0].placements.length).toBe(2)
+    expect(stats.instanceCount).toBe(2)
+  })
+})


### PR DESCRIPTION
Adds a pure **grouper** that dedupes Conway's FlatMesh stream by shared `geometryExpressID`, plus a verbose-logged instancing analysis. **No render change** — this is the measurement + building-block slice the `BatchedMesh` render path (#1571) builds on.

## Why this is a Share-only change
Conway's compat surface already emits the web-ifc instancing model: each `PlacedGeometry` references a shared, local-space geometry by `geometryExpressID` + its own `flatTransformation`. The merged assembler (`flatMeshToBufferGeometry`) throws that away — it bakes each matrix into a private vertex slab. This grouper keeps it, so we can measure (and later render) the instancing win.

## What's here
- **`src/viewer/ifc/flatMeshToInstancedModel.js`** — pure grouper: dedupes by `geometryExpressID`, returns per-shape placement lists (matrix/color/parent/occurrence id) + stats (unique shapes, shared vs. singleton, merged-vs-instanced vertex counts, estimated memory delta, most-instanced shape). Unit-tested.
- **`ShareIfcLoader`** — logs the analysis under verbose. **No feature flag** (it's a permanent diagnostic and the foundation #1571 consumes); the whole grouping is gated on `isLogEnabled(DEBUG)` so the per-placement cost is paid only when verbose logging is actually on.
- **`utils/debug.js`** — exports the log-level constants + an `isLogEnabled(level)` predicate (skip building an expensive diagnostic, not just suppress the print).
- **`viewer-replacement.md` §3b.iv** — records the measured numbers and the **BatchedMesh decision**.

## Measured (the decision data)
| Model | instances | shared shapes | vtx reduction | mem saved (sharing) |
|---|---|---|---|---|
| Snowdon 2x3 (Revit) | 25,587 | 5,230 | **60%** | ~38 MB |
| Arty.step | 6,769 | 1,285 | **26%** | ~10 MB |
| Schependomlaan | 6,250 | 667 | 34% | ~2.5 MB |
| Momentum / index | 439 / 7 | 7 / 0 | 1% / 0% | ~0 |

Big win on instance-heavy Revit/STEP models, ~0 on singleton-heavy ones (degrades gracefully). The naive InstancedMesh-per-shape draw count explodes (Snowdon 1 → ~10k), which is exactly why #1571 uses **`BatchedMesh`** (one multi-draw call) rather than InstancedMesh-per-shape.

## Self-review fixes (latest commit)
- `estimatedBytesSaved` no longer overstates the win — it used a 32-vs-24 B/vertex asymmetry that credited the picking-attribute drop to instancing on every vertex (Momentum's old "0.5 MB" at 1% sharing was almost all format-delta). Now a uniform 24 B/vertex basis isolates the pure geometry-sharing win; corrected the table (Snowdon ~38 MB not 63; Arty ~10 MB not 25).
- The grouper now runs **only when verbose** (`isLogEnabled(DEBUG)`), not on every load — avoids tens of thousands of throwaway allocations + a redundant geometry-size pass per default load. This also fixes the inverted catch (failures previously logged louder than the gated success).
- Corrected a misleading JSDoc claiming the grouper's synthetic id matches `flatMeshToBufferGeometry`'s (it mints in color-bin order, not emission order; the id is unused today).

## Notes
- Render is unchanged → Lighthouse/visual parity expected.
- Follow-up: the `BatchedMesh` render swap is **#1571** (stacked on this). The `expressID → occurrence path` selection-key generalization is **#1569** — `batchId` is that per-occurrence handle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)