### PR TITLE
feat(viewer): BatchedMesh render path from the instancing grouper (PR2)

### DIFF
--- a/design/new/viewer-replacement.md
+++ b/design/new/viewer-replacement.md
@@ -765,6 +765,15 @@ Three settled conclusions:
     per-primitive geometry for `GLTFExporter`, no per-vertex `_EXPRESSID` for
     `BLDRS_face_ids`), so `exportAndCacheGlb` skips it and the model
     re-parses on the next load; a batched-aware GLB schema is future work.
+  - *Fit-to-frame.* `Loader.js#readModel` hoists a Group root's first child
+    geometry onto `model.geometry` ("generalize to multi-mesh" TODO). A
+    `BatchedMesh`'s `.geometry` is its packed buffer — every shape in
+    *un-instanced* local space — so for models whose shapes carry
+    building-scale local coords (Schependomlaan) that box is the whole site
+    (~830m), and `Box3.setFromObject` used it instead of recursing to the
+    instance-placed children, zooming the camera miles out. Fixed by skipping
+    `isBatchedMesh` children in that hoist (a batched Group has no single
+    representative geometry).
   - *Always-on* flip is deferred pending smoke-test of the flagged path.
 
 ### 3c. Plugins (small, replaceable, individually disposable)

--- a/design/new/viewer-replacement.md
+++ b/design/new/viewer-replacement.md
@@ -734,28 +734,38 @@ Three settled conclusions:
   `setColorAt(Vector4)`); >1 batch wraps in a `Group`. The occurrence-id
   space is global across both batches so selection is split-agnostic.
 
-  **Interaction follow-ups — landed (this slice).** The batched model now
-  drives the same selection / preselection / isolation call-sites the
-  merged paths use, by attaching a `createSubset` / `removeSubset` surface
-  (`src/viewer/ifc/batchedSubset.js`) that re-bakes the selected instances
-  (read back via `getMatrixAt` + the retained per-batch `instanceGeometry`)
-  into world-aligned subset Meshes carrying a synthetic per-vertex
-  `expressID`. Capabilities are `expressIdPicking` + `batchedPicking`, so
-  `ShareViewer.setSelection` / `highlightIfcItem` fall to the generic
-  `model.createSubset` branch and `IfcIsolator` works unchanged
-  (`visualElementsIds` is unioned from `instanceParents`). Selection
-  highlights every occurrence of the picked product — **per-occurrence
-  outline narrowing still needs `instancePicking`** and is the remaining
-  follow-up. `three-mesh-bvh` accelerated raycast is validated on
-  `BatchedMesh`: `ShareIfc` patches
-  `BatchedMesh.prototype.{computeBoundsTree,raycast}` and each batch builds
-  its per-geometry bounds trees; `acceleratedBatchedMeshRaycast` still emits
-  `intersection.batchId`, so the pick path is unaffected. **GLB cache:** a
-  `BatchedMesh` model is **not** GLB-cacheable yet (no per-primitive
-  geometry for `GLTFExporter`, no per-vertex `_EXPRESSID` for
-  `BLDRS_face_ids`), so `exportAndCacheGlb` skips it and the model
-  re-parses on the next load; a batched-aware GLB schema is future work.
-  **Always-on** flip is deferred pending smoke-test of the flagged path.
+  **Interaction follow-ups — landed (this slice).**
+
+  - *Selection + hover highlight (`src/viewer/ifc/batchedHighlight.js`).*
+    **Recolor, not overlay.** The merged paths highlight by dropping a
+    translucent subset Mesh into the scene coplanar with the source; that
+    only renders because the subset shares the source's *exact* vertex
+    buffer (pixel-identical depth, so it wins the depth test). A
+    `BatchedMesh` subset must be re-baked from independent CPU math, which
+    z-fights the opaque batch and vanishes — polygon-offset tuning never
+    made it robust. So the batched path recolors the *actual* instances via
+    `setColorAt` (the idiomatic BatchedMesh approach): two layers
+    (selection = sticky, preselection = hover) painted over each instance's
+    original colour, which is retained per-batch (`instanceColors`, alpha
+    included so glass stays glass). Selection covers every occurrence of the
+    picked product — **per-occurrence narrowing still needs `instancePicking`**
+    and is the remaining follow-up.
+  - *Isolate / hide (`src/viewer/ifc/batchedSubset.js`).* `IfcIsolator`
+    drives the batched model unchanged through a `createSubset` /
+    `removeSubset` surface that re-bakes the kept instances (`getMatrixAt` +
+    the retained `instanceGeometry`) into world-aligned subset Meshes
+    carrying a synthetic per-vertex `expressID` (so the isolated subset
+    stays pickable). `visualElementsIds` is unioned from `instanceParents`.
+  - *BVH picking.* `three-mesh-bvh` accelerated raycast validated on
+    `BatchedMesh`: `ShareIfc` patches
+    `BatchedMesh.prototype.{computeBoundsTree,raycast}` and each batch builds
+    its per-geometry bounds trees; `acceleratedBatchedMeshRaycast` still
+    emits `intersection.batchId`, so the pick path is unaffected.
+  - *GLB cache.* A `BatchedMesh` model is **not** GLB-cacheable yet (no
+    per-primitive geometry for `GLTFExporter`, no per-vertex `_EXPRESSID` for
+    `BLDRS_face_ids`), so `exportAndCacheGlb` skips it and the model
+    re-parses on the next load; a batched-aware GLB schema is future work.
+  - *Always-on* flip is deferred pending smoke-test of the flagged path.
 
 ### 3c. Plugins (small, replaceable, individually disposable)
 Each takes a `ThreeContext` (and an `IfcModelService` if relevant) and exposes a tiny API:

--- a/design/new/viewer-replacement.md
+++ b/design/new/viewer-replacement.md
@@ -719,16 +719,43 @@ Three settled conclusions:
   the foundation PR2 builds on); it runs **only when verbose logging is
   enabled** (`isLogEnabled(DEBUG)`), so the per-placement grouping cost is
   paid only when the analysis is actually wanted. Render is unchanged.
-- **PR2 — `BatchedMesh` render path.** Build a `BatchedMesh` from the
-  grouper output (`addGeometry` once per unique shape in local space,
-  `addInstance` + `setMatrixAt`/`setColorAt` per placement; merge or batch
-  the singletons too — one draw call regardless). Rewire picking onto
-  native `batchId` → `parentExpressId`, reconcile selection/subset + the
-  GLB-cache round-trip, validate `three-mesh-bvh` accelerated raycast on
-  the batched geometry. Moving toward **always-on** within the Conway-direct
-  path (no new flag) with a defensive fallback to the merged path on any
+- **PR2 (#1571) — `BatchedMesh` render path.** Build a `BatchedMesh` from
+  the grouper output (`addGeometry` once per unique shape in local space,
+  `addInstance` + `setMatrixAt`/`setColorAt` per placement; one draw call
+  regardless). Picking resolves on native `batchId` → `parentExpressId` via
+  the per-batch tables `buildBatchedConwayModel` attaches. Behind
+  `?feature=batchedMesh` with a defensive fallback to the merged path on any
   construction error. Pairs with the `expressID → occurrence path`
   identifier generalization (`batchId` is that per-occurrence handle).
+
+  **Transparency:** opaque and blended instances can't share one material
+  state, so placements are split by alpha into an opaque batch and a
+  transparent batch (`depthWrite:false`, per-instance RGBA via
+  `setColorAt(Vector4)`); >1 batch wraps in a `Group`. The occurrence-id
+  space is global across both batches so selection is split-agnostic.
+
+  **Interaction follow-ups — landed (this slice).** The batched model now
+  drives the same selection / preselection / isolation call-sites the
+  merged paths use, by attaching a `createSubset` / `removeSubset` surface
+  (`src/viewer/ifc/batchedSubset.js`) that re-bakes the selected instances
+  (read back via `getMatrixAt` + the retained per-batch `instanceGeometry`)
+  into world-aligned subset Meshes carrying a synthetic per-vertex
+  `expressID`. Capabilities are `expressIdPicking` + `batchedPicking`, so
+  `ShareViewer.setSelection` / `highlightIfcItem` fall to the generic
+  `model.createSubset` branch and `IfcIsolator` works unchanged
+  (`visualElementsIds` is unioned from `instanceParents`). Selection
+  highlights every occurrence of the picked product — **per-occurrence
+  outline narrowing still needs `instancePicking`** and is the remaining
+  follow-up. `three-mesh-bvh` accelerated raycast is validated on
+  `BatchedMesh`: `ShareIfc` patches
+  `BatchedMesh.prototype.{computeBoundsTree,raycast}` and each batch builds
+  its per-geometry bounds trees; `acceleratedBatchedMeshRaycast` still emits
+  `intersection.batchId`, so the pick path is unaffected. **GLB cache:** a
+  `BatchedMesh` model is **not** GLB-cacheable yet (no per-primitive
+  geometry for `GLTFExporter`, no per-vertex `_EXPRESSID` for
+  `BLDRS_face_ids`), so `exportAndCacheGlb` skips it and the model
+  re-parses on the next load; a batched-aware GLB schema is future work.
+  **Always-on** flip is deferred pending smoke-test of the flagged path.
 
 ### 3c. Plugins (small, replaceable, individually disposable)
 Each takes a `ThreeContext` (and an `IfcModelService` if relevant) and exposes a tiny API:

--- a/src/Containers/CadView.jsx
+++ b/src/Containers/CadView.jsx
@@ -521,9 +521,12 @@ export default function CadView({
       // keep the legacy Shift behavior unchanged.
       // BatchedMesh render path (`?feature=batchedMesh`): the raycast sets
       // `batchId` (the per-instance id); resolve it to the parent IFC
-      // product through the tables `buildBatchedConwayModel` attached. The
-      // synthetic occurrence id narrows the (deferred) per-instance outline,
-      // exactly like the merged path's instanceId.
+      // product through the tables `buildBatchedConwayModel` attached.
+      // Selection highlights every occurrence of that product (parent-level
+      // subset, via the model's `createSubset`). Per-occurrence narrowing
+      // would need `instancePicking`, which the batched model doesn't carry
+      // yet — so we pass no instanceIds (avoids a no-op `setInstanceSelection`
+      // + its warn). See design/new/viewer-replacement.md §3b.iv.
       if (mesh.isBatchedMesh && mesh.instanceParents) {
         const batchId = picked.batchId
         if (batchId === undefined || batchId < 0) {
@@ -533,8 +536,7 @@ export default function CadView({
         if (parentExpressId === undefined || !viewer.isolator.canBePickedInScene(parentExpressId)) {
           return
         }
-        const instanceIds = event.shiftKey ? [] : [mesh.instanceOccurrenceIds[batchId]]
-        selectItemsInScene([parentExpressId], true, instanceIds)
+        selectItemsInScene([parentExpressId], true, [])
         return
       }
       if (mesh.instanceMap) {

--- a/src/Containers/CadView.jsx
+++ b/src/Containers/CadView.jsx
@@ -506,8 +506,15 @@ export default function CadView({
       }
       const picked = pickedAll[0]
       const mesh = picked.object
-      // TODO(pablo): obsolete? needed this in h3 at some point
-      viewer.setHighlighted([mesh])
+      // TODO(pablo): obsolete? needed this in h3 at some point.
+      // A BatchedMesh must NOT reach the OutlineEffect: three auto-enables
+      // `USE_BATCHING` for it, but postprocessing's outline ShaderMaterial
+      // (DepthComparisonMaterial) predates BatchedMesh and omits the batching
+      // shader chunks, so its program fails to compile (`batchingMatrix`
+      // undeclared) and blanks the frame. The batched path highlights by
+      // recoloring instances (batchedHighlight) instead, so clear the outline
+      // rather than feed it the batch.
+      viewer.setHighlighted(mesh.isBatchedMesh ? null : [mesh])
       // Per-instance picking path (Conway-direct):
       //   no-shift = just this PlacedGeometry
       //   shift     = the whole IFC element (every instance)

--- a/src/Containers/CadView.jsx
+++ b/src/Containers/CadView.jsx
@@ -519,6 +519,24 @@ export default function CadView({
       // viewer-replacement work, so it wins the modifier slot. Models
       // without an instanceMap (today's wit-three path, GLB cache hit)
       // keep the legacy Shift behavior unchanged.
+      // BatchedMesh render path (`?feature=batchedMesh`): the raycast sets
+      // `batchId` (the per-instance id); resolve it to the parent IFC
+      // product through the tables `buildBatchedConwayModel` attached. The
+      // synthetic occurrence id narrows the (deferred) per-instance outline,
+      // exactly like the merged path's instanceId.
+      if (mesh.isBatchedMesh && mesh.instanceParents) {
+        const batchId = picked.batchId
+        if (batchId === undefined || batchId < 0) {
+          return
+        }
+        const parentExpressId = mesh.instanceParents[batchId]
+        if (parentExpressId === undefined || !viewer.isolator.canBePickedInScene(parentExpressId)) {
+          return
+        }
+        const instanceIds = event.shiftKey ? [] : [mesh.instanceOccurrenceIds[batchId]]
+        selectItemsInScene([parentExpressId], true, instanceIds)
+        return
+      }
       if (mesh.instanceMap) {
         const faceIdx = picked.faceIndex
         const instanceId = mesh.instanceMap.getInstanceIdByTriangle(faceIdx)

--- a/src/FeatureFlags.js
+++ b/src/FeatureFlags.js
@@ -71,6 +71,17 @@ export const flags = [
   // `ifcItemsMapParity` shares the same capture.
   // Design: design/new/viewer-replacement.md §3b.
   {name: 'conwayDirectIfc', isActive: true},
+  // BatchedMesh render path: render the Conway-direct geometry as a
+  // THREE.BatchedMesh (one geometry per shared shape + per-instance
+  // transforms) instead of the merged BufferGeometry — the ~60% vertex-
+  // memory win measured in §3b.iv, at ~1 draw call. Picking is native
+  // (`batchId`). Off by default as a deploy-preview *validation gate*
+  // (render/pick can't be exercised headlessly); once confirmed in a
+  // preview this flips to always-on within the Conway-direct path. 3D
+  // selection-outline / isolate / GLB-cache for the batched path are
+  // follow-ups. Flip on via `?feature=batchedMesh`.
+  // Design: design/new/viewer-replacement.md §3b.iv.
+  {name: 'batchedMesh', isActive: false},
 ]
 
 

--- a/src/loader/Loader.js
+++ b/src/loader/Loader.js
@@ -457,7 +457,13 @@ export async function load(
   // in the next block (cache-hit restoration); the createSubset
   // closure resolves them lazily at invoke time, so the attach-here-
   // populate-below order is fine.
-  if (model.capabilities.expressIdPicking && !model.capabilities.ifcSubsets) {
+  // BatchedMesh path excluded: its geometry carries no per-vertex `expressID`
+  // (IDs live in the per-batch `instanceParents` table), so the per-vertex
+  // `attachElementSubsets` would build empty subsets. `buildBatchedConwayModel`
+  // already attached the batch-aware `createSubset` (`attachBatchedSubsets`) —
+  // don't clobber it.
+  if (model.capabilities.expressIdPicking && !model.capabilities.ifcSubsets &&
+      !model.capabilities.batchedPicking) {
     const scene = typeof viewer.context?.getScene === 'function' ? viewer.context.getScene() : null
     if (model.capabilities.instancePicking) {
       attachInstanceMapSubsets(model, scene)

--- a/src/loader/Loader.js
+++ b/src/loader/Loader.js
@@ -1166,7 +1166,15 @@ export async function readModel(loader, modelData, basePath, isLoaderAsync, isIf
     // E.g. samba-dancing.fbx has Bones for child[0] and 2 meshes after
     for (let i = 0, n = model.children.length; i < n; i++) {
       const obj = model.children[i]
-      if (obj.geometry) {
+      // A `THREE.BatchedMesh`'s `.geometry` is its internal PACKED buffer —
+      // every shape in un-instanced local space (which, for models whose
+      // shapes carry building-scale local coords like Schependomlaan, spans
+      // the whole site, ~830m). Hoisting it onto the Group root makes
+      // `Box3.setFromObject` read that instead of recursing into the
+      // instance-placed children, so fit-to-frame zooms miles out. The
+      // batched Group has no single representative geometry — leave
+      // `model.geometry` undefined and let bounds recurse to the children.
+      if (obj.geometry && !obj.isBatchedMesh) {
         model.geometry = obj.geometry
         break
       }

--- a/src/loader/Loader.test.js
+++ b/src/loader/Loader.test.js
@@ -238,6 +238,28 @@ describe('Loader', () => {
       expect(result.geometry).toBe(meshChild.geometry)
     })
 
+    it('does not hoist a BatchedMesh child geometry onto the model root', async () => {
+      // A BatchedMesh's `.geometry` is its internal packed buffer (all shapes
+      // in un-instanced local space), so hoisting it onto a Group root makes
+      // Box3.setFromObject read those un-placed bounds instead of recursing to
+      // the instance-placed children — fit-to-frame then zooms miles out
+      // (Schependomlaan regression). The batched child must be skipped.
+      const batched = new Mesh(new BufferGeometry(), new Material())
+      batched.geometry.setAttribute('position', new BufferAttribute(new Float32Array([0, 0, 0]), 3))
+      batched.isBatchedMesh = true
+
+      const mockLoader = {
+        parse: jest.fn().mockReturnValue({
+          children: [batched],
+          isObject3D: true,
+        }),
+      }
+
+      const result = await readModel(mockLoader, 'test-data', './', false, false, null, null)
+
+      expect(result.geometry).toBeUndefined()
+    })
+
     it('logs warning when model has no geometry and children have no geometry', async () => {
       const mockLoader = {
         parse: jest.fn().mockReturnValue({

--- a/src/loader/glbExport.js
+++ b/src/loader/glbExport.js
@@ -144,6 +144,33 @@ function silenceGltfExporterMaterialWarnings() {
 
 
 /**
+ * True when the model root is, or contains, a `THREE.BatchedMesh`. Such
+ * models are produced by the Conway-direct instancing path and are not
+ * yet GLB-cacheable (see `exportAndCacheGlb`).
+ *
+ * @param {object} model Three.js root (Mesh / Group / Scene / BatchedMesh)
+ * @return {boolean}
+ */
+function modelHasBatchedMesh(model) {
+  if (!model) {
+    return false
+  }
+  if (model.isBatchedMesh) {
+    return true
+  }
+  let found = false
+  if (typeof model.traverse === 'function') {
+    model.traverse((obj) => {
+      if (obj.isBatchedMesh) {
+        found = true
+      }
+    })
+  }
+  return found
+}
+
+
+/**
  * Export the loaded model and write the resulting GLB (wrapped in the
  * Bldrs container) to OPFS at the cache key the reader will look for.
  * Fire-and-forget at the call site — any failure is logged but never
@@ -170,6 +197,17 @@ function silenceGltfExporterMaterialWarnings() {
 export async function exportAndCacheGlb({model, kindLabel, cacheKeyArgs, ifcManager = null}) {
   const startMs = Date.now()
   try {
+    // BatchedMesh render path (`?feature=batchedMesh`): a `THREE.BatchedMesh`
+    // has no standard per-primitive geometry/attributes for `GLTFExporter`
+    // to serialize, and it carries no per-vertex `_EXPRESSID` for the
+    // `BLDRS_face_ids` capture — a cached artifact would be empty or
+    // unpickable on read-back. Skip the cache write entirely; the model
+    // re-parses (fast, flag-gated) on the next load. A batched-aware GLB
+    // schema is future work (design/new/viewer-replacement.md §3b.iv).
+    if (modelHasBatchedMesh(model)) {
+      glbInfo('writer: skipped (BatchedMesh model is not GLB-cacheable yet)')
+      return false
+    }
     const filePath = cacheKeyArgs.sourcePath
     const requestedMode = activeGlbCompressionMode()
     glbInfo(

--- a/src/loader/glbExport.js
+++ b/src/loader/glbExport.js
@@ -40,6 +40,7 @@ import {
   BLDRS_SPATIAL_TREE_EXTENSION_NAME,
   captureBldrsSpatialTree,
 } from './bldrsSpatialTree'
+import {eachBatch} from '../viewer/ifc/batchedModel'
 import {glbCacheKey} from './glbCacheKey'
 import {
   activeGlbCompressionMode,
@@ -152,20 +153,10 @@ function silenceGltfExporterMaterialWarnings() {
  * @return {boolean}
  */
 function modelHasBatchedMesh(model) {
-  if (!model) {
-    return false
-  }
-  if (model.isBatchedMesh) {
-    return true
-  }
   let found = false
-  if (typeof model.traverse === 'function') {
-    model.traverse((obj) => {
-      if (obj.isBatchedMesh) {
-        found = true
-      }
-    })
-  }
+  eachBatch(model, () => {
+    found = true
+  })
   return found
 }
 

--- a/src/loader/glbExport.test.js
+++ b/src/loader/glbExport.test.js
@@ -152,6 +152,25 @@ describe('loader/glbExport', () => {
       expect(branch).toBe('main')
     })
 
+    it('skips a BatchedMesh model (not GLB-cacheable yet) without exporting', async () => {
+      const ok = await exportAndCacheGlb({model: {isBatchedMesh: true}, ...ctx})
+      expect(ok).toBe(false)
+      expect(mockExporterParse).not.toHaveBeenCalled()
+      expect(mockWriteGlbBytesToOPFS).not.toHaveBeenCalled()
+    })
+
+    it('skips a Group that contains a BatchedMesh', async () => {
+      const model = {
+        traverse: (fn) => {
+          fn({isBatchedMesh: false})
+          fn({isBatchedMesh: true})
+        },
+      }
+      const ok = await exportAndCacheGlb({model, ...ctx})
+      expect(ok).toBe(false)
+      expect(mockWriteGlbBytesToOPFS).not.toHaveBeenCalled()
+    })
+
     it('returns false (no throw) when the exporter produces no bytes', async () => {
       mockExporterParse.mockImplementation((_input, _onDone, onError) => onError(new Error('nope')))
       const ok = await exportAndCacheGlb({model: {}, ...ctx})

--- a/src/viewer/ShareModel.js
+++ b/src/viewer/ShareModel.js
@@ -51,6 +51,14 @@
  *     is meaningful. Set by Loader.js when the Conway-direct build
  *     (`?feature=conwayDirectIfc`) replaces the rendered geometry; the
  *     map lives on `model.instanceMap`.
+ * @property {boolean} batchedPicking
+ *     True when the model is a `THREE.BatchedMesh` (Conway-direct
+ *     `?feature=batchedMesh` path). Picking resolves via the per-batch
+ *     `instanceParents` table (`batchId → expressID`); selection / hover
+ *     highlight by recoloring instances (`batchedHighlight`), and
+ *     hide/isolate via `batchedSubset`. Mutually exclusive with
+ *     `ifcSubsets` (there's no web-ifc-three parser state to build subsets
+ *     from — routing selection through `pickByIds` would silently no-op).
  * @property {boolean} useIfcClipper
  *     Historical flag from when two cut-plane implementations co-existed
  *     (the fork's web-ifc clipper for IFC, the in-repo arrow-handle
@@ -79,6 +87,9 @@ export function capabilitiesForFormat(format) {
       // Off by default; Loader.js flips it on for the Conway-direct path
       // (after substituting geometry + attaching IfcInstanceMap).
       instancePicking: false,
+      // Off by default; `inferModelCapabilities` flips it on (and ifcSubsets
+      // off) when the rendered geometry is a decorated BatchedMesh.
+      batchedPicking: false,
       useIfcClipper: true,
     }
   }
@@ -103,6 +114,7 @@ function allOffCaps() {
     typedProperties: false,
     ifcSubsets: false,
     instancePicking: false,
+    batchedPicking: false,
     useIfcClipper: false,
   }
 }
@@ -186,7 +198,19 @@ export function inferModelCapabilities(model, opts = {}) {
   const instAttrName = opts.instanceAttrName ?? 'instanceID'
   let hasPerVertexElementIds = false
   let hasPerVertexInstanceIds = false
+  let hasBatchedInstances = false
   model.traverse((obj) => {
+    // BatchedMesh render path (`?feature=batchedMesh`): element IDs live in
+    // the per-batch `instanceParents` table, NOT on any vertex — so the
+    // per-vertex attribute checks below never fire and we'd otherwise keep
+    // the IFC format default (`ifcSubsets: true`, no `batchedPicking`),
+    // which routes ShareViewer.setSelection through web-ifc-three's
+    // `pickByIds` (no parser state → silent no-op → no highlight). Detect
+    // the decorated batch directly.
+    if (obj.isBatchedMesh && obj.instanceParents) {
+      hasBatchedInstances = true
+      return
+    }
     if (!obj.isMesh || !obj.geometry?.attributes) {
       return
     }
@@ -197,6 +221,13 @@ export function inferModelCapabilities(model, opts = {}) {
       hasPerVertexInstanceIds = true
     }
   })
+  if (hasBatchedInstances) {
+    // Parent-level picking (batchId → expressID) + in-place recolor
+    // highlight + batched isolation subsets. NOT web-ifc-three subsets.
+    caps.expressIdPicking = true
+    caps.batchedPicking = true
+    caps.ifcSubsets = false
+  }
   if (hasPerVertexElementIds) {
     caps.expressIdPicking = true
   }

--- a/src/viewer/ShareModel.test.js
+++ b/src/viewer/ShareModel.test.js
@@ -21,6 +21,9 @@ describe('viewer/ShareModel', () => {
         // off by default; Loader's Conway-direct path flips it on after
         // attaching an IfcInstanceMap.
         instancePicking: false,
+        // off by default; `inferModelCapabilities` flips it on (and ifcSubsets
+        // off) for the BatchedMesh render path.
+        batchedPicking: false,
         useIfcClipper: true,
       })
     })
@@ -138,6 +141,21 @@ describe('viewer/ShareModel', () => {
       expect(() => inferModelCapabilities(null)).not.toThrow()
       expect(inferModelCapabilities(null)).toEqual({})
       expect(inferModelCapabilities({})).toEqual({})
+    })
+
+    it('promotes batchedPicking (and clears ifcSubsets) for a decorated BatchedMesh', () => {
+      // A BatchedMesh carries no per-vertex expressID — IDs live in
+      // `instanceParents`. Without this, the model keeps the IFC format
+      // default (ifcSubsets:true, no batchedPicking) and setSelection routes
+      // through web-ifc-three's pickByIds → no highlight.
+      const batched = new Mesh(new BufferGeometry())
+      batched.isBatchedMesh = true
+      // eslint-disable-next-line no-magic-numbers
+      batched.instanceParents = new Uint32Array([100, 200])
+      const caps = inferModelCapabilities(batched)
+      expect(caps.batchedPicking).toBe(true)
+      expect(caps.expressIdPicking).toBe(true)
+      expect(caps.ifcSubsets).toBe(false)
     })
 
     /**

--- a/src/viewer/ShareViewer.js
+++ b/src/viewer/ShareViewer.js
@@ -892,8 +892,14 @@ export class ShareViewer {
       // BatchedMesh render path: recolor the hovered product's instances in
       // place (setColorAt). Coexists with — and paints over — the selection
       // recolor; cleared on cursor-leave by `_clearPreselectionForAllModels`.
-      const preMat = this.selector.getPreselectionMaterial()
-      applyBatchedPreselection(model, [id], preMat?.color)
+      // Dedup on the resolved id: `highlightIfcItem` fires per animation frame
+      // while the cursor rests, and a repaint re-uploads the colours texture —
+      // skip when the hovered product hasn't changed.
+      if (id !== this._lastBatchedPreselectId) {
+        this._lastBatchedPreselectId = id
+        const preMat = this.selector.getPreselectionMaterial()
+        applyBatchedPreselection(model, [id], preMat?.color)
+      }
     } else if (modelHasCapability(model, 'ifcSubsets')) {
       // Real-IFC path: web-ifc-three's preselection.pick handles
       // subset construction.
@@ -947,6 +953,8 @@ export class ShareViewer {
     // logic stays in one place instead of being split between
     // ShareViewer (Conway) and each model's `removeSubset` (legacy).
     this._clearConwayPreselectionSubsets()
+    // Reset the batched hover-dedup so re-entering the same product repaints.
+    this._lastBatchedPreselectId = undefined
     const models = this.IFC?.context?.items?.ifcModels
     if (!Array.isArray(models)) {
       return

--- a/src/viewer/ShareViewer.js
+++ b/src/viewer/ShareViewer.js
@@ -18,6 +18,12 @@ import {IfcContext} from './three/context'
 import ThreeContext from './three/ThreeContext'
 import debug from '../utils/debug'
 import {modelHasCapability} from './ShareModel'
+import {
+  applyBatchedPreselection,
+  applyBatchedSelection,
+  clearBatchedPreselection,
+  clearBatchedSelection,
+} from './ifc/batchedHighlight'
 
 
 // Minimum index-buffer capacity for the preselection pool. 256 u32
@@ -448,7 +454,10 @@ export class ShareViewer {
     if (toBeSelected.length === 0) {
       this.highlighter.setHighlighted(null)
       this._clearConwaySelectionSubsets()
-      if (modelHasCapability(model, 'ifcSubsets')) {
+      if (modelHasCapability(model, 'batchedPicking')) {
+        // Batched path recolors instances in place (no subset to remove).
+        clearBatchedSelection(model)
+      } else if (modelHasCapability(model, 'ifcSubsets')) {
         this.selector.unpick()
       } else if (typeof model.removeSubset === 'function') {
         model.removeSubset('selection')
@@ -478,6 +487,14 @@ export class ShareViewer {
           mesh.instanceMap.createSubsetMeshByParent(toBeSelected, {
             material: this.selector.getSelectionMaterial(),
           }))
+      } else if (modelHasCapability(model, 'batchedPicking')) {
+        // BatchedMesh render path: recolor the selected instances in place
+        // (setColorAt) rather than overlay a coplanar subset Mesh — see
+        // batchedHighlight.js for why the overlay approach can't render
+        // reliably on a BatchedMesh. Selection covers every occurrence of
+        // each requested product (per-occurrence narrowing is a follow-up).
+        const selMat = this.selector.getSelectionMaterial()
+        applyBatchedSelection(model, toBeSelected, selMat?.color)
       } else if (modelHasCapability(model, 'ifcSubsets')) {
         // Real-IFC path: web-ifc-three holds the parser state needed
         // by createSubset / SubsetCreator.
@@ -871,6 +888,12 @@ export class ShareViewer {
       // handler's no-shift semantic — hover preview should match what
       // a click would select.
       this._setConwayPreselectionFromHit(found.object, found.faceIndex)
+    } else if (modelHasCapability(model, 'batchedPicking')) {
+      // BatchedMesh render path: recolor the hovered product's instances in
+      // place (setColorAt). Coexists with — and paints over — the selection
+      // recolor; cleared on cursor-leave by `_clearPreselectionForAllModels`.
+      const preMat = this.selector.getPreselectionMaterial()
+      applyBatchedPreselection(model, [id], preMat?.color)
     } else if (modelHasCapability(model, 'ifcSubsets')) {
       // Real-IFC path: web-ifc-three's preselection.pick handles
       // subset construction.
@@ -929,7 +952,10 @@ export class ShareViewer {
       return
     }
     for (const m of models) {
-      if (typeof m?.removeSubset === 'function') {
+      if (modelHasCapability(m, 'batchedPicking')) {
+        // Batched path: undo the hover recolor (restores selection / original).
+        clearBatchedPreselection(m)
+      } else if (typeof m?.removeSubset === 'function') {
         m.removeSubset('preselection')
       }
     }

--- a/src/viewer/ShareViewer.js
+++ b/src/viewer/ShareViewer.js
@@ -1009,6 +1009,17 @@ export class ShareViewer {
    */
   getPickedItemId(picked) {
     const mesh = picked.object
+    // BatchedMesh path (`?feature=batchedMesh`): the parent IFC product id
+    // lives in the per-batch `instanceParents` table keyed by `batchId`,
+    // not on any vertex — there's no per-face expressID to read. Resolve it
+    // here so hover-preselection (highlightIfcItem) matches the click path.
+    if (mesh.isBatchedMesh && mesh.instanceParents) {
+      const batchId = picked.batchId
+      if (batchId === undefined || batchId < 0) {
+        return null
+      }
+      return mesh.instanceParents[batchId]
+    }
     if (!areDefinedAndNotNull(mesh.geometry, picked.faceIndex)) {
       return null
     }

--- a/src/viewer/ifc/ShareIfc.js
+++ b/src/viewer/ifc/ShareIfc.js
@@ -41,8 +41,14 @@
 // path; it deliberately does not await an Init that hasn't been kicked
 // off yet.
 
-import {BufferGeometry, Mesh} from 'three'
-import {acceleratedRaycast, computeBoundsTree, disposeBoundsTree} from 'three-mesh-bvh'
+import {BatchedMesh, BufferGeometry, Mesh} from 'three'
+import {
+  acceleratedRaycast,
+  computeBatchedBoundsTree,
+  computeBoundsTree,
+  disposeBatchedBoundsTree,
+  disposeBoundsTree,
+} from 'three-mesh-bvh'
 import {IfcAPI} from 'web-ifc'
 import ShareIfcManager from './ShareIfcManager'
 
@@ -62,6 +68,18 @@ import ShareIfcManager from './ShareIfcManager'
 BufferGeometry.prototype.computeBoundsTree = computeBoundsTree
 BufferGeometry.prototype.disposeBoundsTree = disposeBoundsTree
 Mesh.prototype.raycast = acceleratedRaycast
+
+// Same accelerated raycast for the Conway-direct BatchedMesh path. The
+// shared `acceleratedRaycast` dispatches on `this.isBatchedMesh` to
+// `acceleratedBatchedMeshRaycast`, which walks each instance's per-geometry
+// bounds tree (populated by `computeBatchedBoundsTree`) and still sets
+// `intersection.batchId` — the per-occurrence handle CadView reads to
+// resolve a pick. When a batch has no bounds trees built it falls back to
+// three's native BatchedMesh raycast (also batchId-bearing), so the patch
+// is safe even on batches we never call `computeBoundsTree()` on.
+BatchedMesh.prototype.computeBoundsTree = computeBatchedBoundsTree
+BatchedMesh.prototype.disposeBoundsTree = disposeBatchedBoundsTree
+BatchedMesh.prototype.raycast = acceleratedRaycast
 
 
 /**

--- a/src/viewer/ifc/ShareIfcLoader.js
+++ b/src/viewer/ifc/ShareIfcLoader.js
@@ -17,6 +17,7 @@
 // those were fields on the fork's IFCManager because parse was
 // attached to it. Now we own the loader so we hold direct refs.
 
+import {Box3, Vector3} from 'three'
 import {buildBatchedConwayModel} from './buildBatchedConwayModel'
 import {buildConwayIfcModel} from './buildConwayIfcModel'
 import {decorateConwayDirectIfcModel, parseIfcWithConway} from './conwayDirectIfcLoader'
@@ -204,6 +205,31 @@ export default class ShareIfcLoader {
 
       if (onProgress) {
         onProgress('Fitting model to frame...')
+      }
+      // TEMP diagnostic: fitModelToFrame frames `scene.children[last]` and
+      // applies matrixWorld. The batch boxes are healthy (~24m) yet Schep
+      // over-zooms, so log exactly what the fit consumes: is the model the
+      // last child, and every scene child's WORLD box size.
+      if (isFeatureEnabled('batchedMesh')) {
+        try {
+          const kids = scene?.children ?? []
+          const last = kids[kids.length - 1]
+          const mb = new Box3().setFromObject(ifcModel)
+          const msz = mb.getSize(new Vector3()).toArray().map((n) => n.toFixed(1))
+          const mc = mb.getCenter(new Vector3()).toArray().map((n) => n.toFixed(1))
+          // eslint-disable-next-line no-console
+          console.info(
+            `[batchedMesh] fitInput modelIsLast=${last === ifcModel} lastType=${last?.type} ` +
+            `modelWorldSize=${JSON.stringify(msz)} modelWorldCenter=${JSON.stringify(mc)} empty=${mb.isEmpty()}`)
+          kids.forEach((c, i) => {
+            const cb = new Box3().setFromObject(c)
+            const cs = cb.getSize(new Vector3()).toArray().map((n) => n.toFixed(1))
+            // eslint-disable-next-line no-console
+            console.info(`  child[${i}] type=${c.type} name="${c.name}" worldSize=${JSON.stringify(cs)} empty=${cb.isEmpty()}`)
+          })
+        } catch (e) {
+          console.warn('[batchedMesh] fitInput diag failed', e)
+        }
       }
       ifc.context.fitToFrame()
 

--- a/src/viewer/ifc/ShareIfcLoader.js
+++ b/src/viewer/ifc/ShareIfcLoader.js
@@ -167,7 +167,7 @@ export default class ShareIfcLoader {
       let buildStats
       if (isFeatureEnabled('batchedMesh')) {
         try {
-          const batched = buildBatchedConwayModel(captured, ifcAPI, modelID)
+          const batched = buildBatchedConwayModel(captured, ifcAPI, modelID, {scene})
           ifcModel = batched.model
           buildStats = batched.stats
         } catch (e) {

--- a/src/viewer/ifc/ShareIfcLoader.js
+++ b/src/viewer/ifc/ShareIfcLoader.js
@@ -17,7 +17,6 @@
 // those were fields on the fork's IFCManager because parse was
 // attached to it. Now we own the loader so we hold direct refs.
 
-import {Box3, Vector3} from 'three'
 import {buildBatchedConwayModel} from './buildBatchedConwayModel'
 import {buildConwayIfcModel} from './buildConwayIfcModel'
 import {decorateConwayDirectIfcModel, parseIfcWithConway} from './conwayDirectIfcLoader'
@@ -205,31 +204,6 @@ export default class ShareIfcLoader {
 
       if (onProgress) {
         onProgress('Fitting model to frame...')
-      }
-      // TEMP diagnostic: fitModelToFrame frames `scene.children[last]` and
-      // applies matrixWorld. The batch boxes are healthy (~24m) yet Schep
-      // over-zooms, so log exactly what the fit consumes: is the model the
-      // last child, and every scene child's WORLD box size.
-      if (isFeatureEnabled('batchedMesh')) {
-        try {
-          const kids = scene?.children ?? []
-          const last = kids[kids.length - 1]
-          const mb = new Box3().setFromObject(ifcModel)
-          const msz = mb.getSize(new Vector3()).toArray().map((n) => n.toFixed(1))
-          const mc = mb.getCenter(new Vector3()).toArray().map((n) => n.toFixed(1))
-          // eslint-disable-next-line no-console
-          console.info(
-            `[batchedMesh] fitInput modelIsLast=${last === ifcModel} lastType=${last?.type} ` +
-            `modelWorldSize=${JSON.stringify(msz)} modelWorldCenter=${JSON.stringify(mc)} empty=${mb.isEmpty()}`)
-          kids.forEach((c, i) => {
-            const cb = new Box3().setFromObject(c)
-            const cs = cb.getSize(new Vector3()).toArray().map((n) => n.toFixed(1))
-            // eslint-disable-next-line no-console
-            console.info(`  child[${i}] type=${c.type} name="${c.name}" worldSize=${JSON.stringify(cs)} empty=${cb.isEmpty()}`)
-          })
-        } catch (e) {
-          console.warn('[batchedMesh] fitInput diag failed', e)
-        }
       }
       ifc.context.fitToFrame()
 

--- a/src/viewer/ifc/ShareIfcLoader.js
+++ b/src/viewer/ifc/ShareIfcLoader.js
@@ -31,29 +31,33 @@ import debug, {DEBUG, WARN, isLogEnabled} from '../../utils/debug'
 /**
  * Group the captured FlatMesh stream by shared geometry and log the
  * instancing analysis (draw-call + vertex-memory delta vs. the merged
- * path) — but ONLY when verbose logging is enabled.
+ * path).
  *
- * The whole grouping is gated on `isLogEnabled(DEBUG)`, not just the
- * print: on a large model it walks every placement (tens of thousands)
+ * Normally the whole grouping is gated on `isLogEnabled(DEBUG)`, not just
+ * the print: on a large model it walks every placement (tens of thousands)
  * and re-fetches each unique shape's size across the Conway boundary, so
  * building it on every default-level load — only to drop the result —
  * would be pure waste. There is no feature flag (the grouper is a
  * permanent diagnostic and the foundation the BatchedMesh render path,
- * §3b.iv, builds on); verbosity is the gate. Never throws into the load
- * path: a probe failure must not discard a successful parse.
+ * §3b.iv, builds on); verbosity is the gate. `force` overrides the gate
+ * and logs at info level — used when `?feature=batchedMesh` is on so the
+ * operator running the eval sees the numbers without raising the log
+ * level. Never throws into the load path: a probe failure must not
+ * discard a successful parse.
  *
  * @param {object} ifcAPI Conway IfcAPI bound to the model
  * @param {number} modelID
  * @param {Array} captured FlatMeshes captured during the parse
+ * @param {boolean} [force] log at info level regardless of verbosity
  */
-function logInstancedModelStats(ifcAPI, modelID, captured) {
-  if (!isLogEnabled(DEBUG)) {
+function logInstancedModelStats(ifcAPI, modelID, captured, force = false) {
+  if (!force && !isLogEnabled(DEBUG)) {
     return
   }
   try {
     const {stats} = flatMeshToInstancedModel(captured, ifcAPI, modelID)
     const reduction = stats.vertexReductionRatio.toFixed(2)
-    debug(DEBUG).log(
+    const line =
       `[instancedMeshes] modelID=${modelID} — ` +
       `instances=${stats.instanceCount} ` +
       `uniqueShapes=${stats.uniqueGeometryCount} ` +
@@ -61,7 +65,13 @@ function logInstancedModelStats(ifcAPI, modelID, captured) {
       `→ instancedDrawCalls=${stats.uniqueGeometryCount} (merged path = 1) | ` +
       `verts merged=${stats.mergedVertexCount} instanced=${stats.instancedVertexCount} ` +
       `(reductionRatio=${reduction}) bytesSaved=${stats.estimatedBytesSaved} | ` +
-      `mostInstanced: geometry#${stats.topInstancedGeometryID} ×${stats.topInstancedCount}`)
+      `mostInstanced: geometry#${stats.topInstancedGeometryID} ×${stats.topInstancedCount}`
+    if (force) {
+      // eslint-disable-next-line no-console
+      console.info(line)
+    } else {
+      debug(DEBUG).log(line)
+    }
   } catch (err) {
     console.warn('[instancedMeshes] probe failed (non-fatal):', err)
   }
@@ -235,12 +245,12 @@ export default class ShareIfcLoader {
       if (isFeatureEnabled('ifcItemsMapParity')) {
         runIfcItemsMapParityCheck(ifcAPI, ifcModel, captured)
       }
-      // Instanced-rendering analysis: always runs (cheap), logged under
-      // verbose. Groups the captured stream by shared `geometryExpressID`
-      // and reports the GPU-instancing draw-call + vertex-memory delta vs.
-      // the merged path that just rendered. The grouper is the foundation
-      // the BatchedMesh render path (§3b.iv) builds on.
-      logInstancedModelStats(ifcAPI, modelID, captured)
+      // Instanced-rendering analysis: groups the captured stream by shared
+      // `geometryExpressID` and reports the GPU-instancing draw-call +
+      // vertex-memory delta. Logged under verbose normally; forced to info
+      // level when `?feature=batchedMesh` is on so the eval shows the
+      // numbers alongside what just rendered as a BatchedMesh.
+      logInstancedModelStats(ifcAPI, modelID, captured, isFeatureEnabled('batchedMesh'))
       // Always-on integration-boundary log. `conwayDirect.spec.ts`
       // (and the deploy-preview smoke checks) gate on `[conwayDirect]
       // parsed modelID=…` firing — it's the single observable signal

--- a/src/viewer/ifc/ShareIfcLoader.js
+++ b/src/viewer/ifc/ShareIfcLoader.js
@@ -17,6 +17,7 @@
 // those were fields on the fork's IFCManager because parse was
 // attached to it. Now we own the loader so we hold direct refs.
 
+import {buildBatchedConwayModel} from './buildBatchedConwayModel'
 import {buildConwayIfcModel} from './buildConwayIfcModel'
 import {decorateConwayDirectIfcModel, parseIfcWithConway} from './conwayDirectIfcLoader'
 import {flatMeshToInstancedModel} from './flatMeshToInstancedModel'
@@ -24,7 +25,7 @@ import {isOutOfMemoryError} from '../../utils/oom'
 import {isFeatureEnabled} from '../../FeatureFlags'
 import {runIfcItemsMapParityCheck} from './ifcItemsMapParity'
 import ShareIfcManager from './ShareIfcManager'
-import debug, {DEBUG, isLogEnabled} from '../../utils/debug'
+import debug, {DEBUG, WARN, isLogEnabled} from '../../utils/debug'
 
 
 /**
@@ -146,11 +147,29 @@ export default class ShareIfcLoader {
       if (onProgress) {
         onProgress('Building model...')
       }
-      const {mesh: ifcModel, stats: buildStats} = buildConwayIfcModel(
-        captured, ifcAPI, modelID)
       const scene = typeof ifc.context?.getScene === 'function' ?
         ifc.context.getScene() : null
-      decorateConwayDirectIfcModel(ifcModel, ifcAPI, modelID, {scene})
+
+      // BatchedMesh render path (`?feature=batchedMesh`, §3b.iv): render the
+      // deduped geometry as a THREE.BatchedMesh. Falls back to the merged
+      // path on any construction error so the flag can never break a load.
+      let ifcModel
+      let buildStats
+      if (isFeatureEnabled('batchedMesh')) {
+        try {
+          const batched = buildBatchedConwayModel(captured, ifcAPI, modelID)
+          ifcModel = batched.model
+          buildStats = batched.stats
+        } catch (e) {
+          debug(WARN).warn('batchedMesh build failed; falling back to merged path:', e)
+        }
+      }
+      if (ifcModel === undefined) {
+        const merged = buildConwayIfcModel(captured, ifcAPI, modelID)
+        ifcModel = merged.mesh
+        buildStats = merged.stats
+        decorateConwayDirectIfcModel(ifcModel, ifcAPI, modelID, {scene})
+      }
 
       ifc.addIfcModel(ifcModel)
 

--- a/src/viewer/ifc/batchedHighlight.js
+++ b/src/viewer/ifc/batchedHighlight.js
@@ -130,7 +130,10 @@ function setLayer(model, expressIds, color, layer) {
   const setKey = layer === 'pre' ? 'preSet' : 'selSet'
   const colorKey = layer === 'pre' ? 'preColor' : 'selColor'
   eachBatch(model, (mesh) => {
-    if (!mesh.instanceParents || typeof mesh.setColorAt !== 'function') {
+    // `instanceColors` is required: paint() restores a cleared instance to
+    // its original colour from it — without it, clearing would repaint every
+    // touched instance the default highlight colour. Skip rather than corrupt.
+    if (!mesh.instanceParents || !mesh.instanceColors || typeof mesh.setColorAt !== 'function') {
       return
     }
     const state = highlightState(mesh)

--- a/src/viewer/ifc/batchedHighlight.js
+++ b/src/viewer/ifc/batchedHighlight.js
@@ -21,9 +21,9 @@ import {Vector4} from 'three'
  * `preselection` (transient, hover). Preselection paints over selection;
  * removing either restores the layer beneath, ending at the instance's
  * original colour (kept in `mesh.instanceColors`, alpha included — so glass
- * stays glass). State lives on the BatchedMesh in non-enumerable-ish
- * `__sel*` / `__pre*` slots; isolate still uses the subset path
- * (`batchedSubset`) and is unaffected.
+ * stays glass). State lives in `mesh.userData.batchedHighlight` (layer sets +
+ * colours + a one-time parent→batchIds index); isolate still uses the subset
+ * path (`batchedSubset`) and is unaffected.
  *
  * @see batchedSubset — the isolation-subset sibling.
  * @see design/new/viewer-replacement.md §3b.iv
@@ -62,6 +62,37 @@ function eachBatch(model, fn) {
 
 
 /**
+ * Lazily create + cache this batch's highlight state under `userData`
+ * (matching the repo convention for custom mesh state, cf.
+ * `userData.sourceMesh`). Holds the two layer sets + colours and a one-time
+ * `parentIndex` (parent expressID → batchIds) so `setLayer` resolves a
+ * product's instances in O(matched) instead of scanning all N instances on
+ * every hover/selection.
+ *
+ * @param {object} mesh BatchedMesh carrying `instanceParents`
+ * @return {object} `{selSet, preSet, selColor, preColor, parentIndex}`
+ */
+function highlightState(mesh) {
+  let state = mesh.userData.batchedHighlight
+  if (!state) {
+    const parentIndex = new Map()
+    const parents = mesh.instanceParents
+    for (let b = 0; b < parents.length; b++) {
+      const list = parentIndex.get(parents[b])
+      if (list) {
+        list.push(b)
+      } else {
+        parentIndex.set(parents[b], [b])
+      }
+    }
+    state = {selSet: new Set(), preSet: new Set(), selColor: undefined, preColor: undefined, parentIndex}
+    mesh.userData.batchedHighlight = state
+  }
+  return state
+}
+
+
+/**
  * Repaint one instance to its current layered colour: preselection wins
  * over selection wins over the instance's original colour. Alpha always
  * comes from the original (keeps a highlighted glass pane translucent).
@@ -70,13 +101,14 @@ function eachBatch(model, fn) {
  * @param {number} batchId
  */
 function paint(mesh, batchId) {
+  const state = mesh.userData.batchedHighlight
   const orig = mesh.instanceColors?.[batchId]
   const a = orig?.w ?? 1
   let rgb
-  if (mesh.__preSet?.has(batchId)) {
-    rgb = mesh.__preColor ?? DEFAULT_HIGHLIGHT
-  } else if (mesh.__selSet?.has(batchId)) {
-    rgb = mesh.__selColor ?? DEFAULT_HIGHLIGHT
+  if (state?.preSet.has(batchId)) {
+    rgb = state.preColor ?? DEFAULT_HIGHLIGHT
+  } else if (state?.selSet.has(batchId)) {
+    rgb = state.selColor ?? DEFAULT_HIGHLIGHT
   } else {
     rgb = orig ? {r: orig.x, g: orig.y, b: orig.z} : DEFAULT_HIGHLIGHT
   }
@@ -95,23 +127,29 @@ function paint(mesh, batchId) {
  */
 function setLayer(model, expressIds, color, layer) {
   const ids = expressIds instanceof Set ? expressIds : new Set(expressIds ?? [])
-  const setKey = layer === 'pre' ? '__preSet' : '__selSet'
-  const colorKey = layer === 'pre' ? '__preColor' : '__selColor'
+  const setKey = layer === 'pre' ? 'preSet' : 'selSet'
+  const colorKey = layer === 'pre' ? 'preColor' : 'selColor'
   eachBatch(model, (mesh) => {
     if (!mesh.instanceParents || typeof mesh.setColorAt !== 'function') {
       return
     }
-    mesh[colorKey] = color ?? undefined
+    const state = highlightState(mesh)
+    state[colorKey] = color ?? undefined
+    // O(matched): walk the requested products' batchIds via the index, not
+    // all N instances.
     const next = new Set()
     if (color && ids.size > 0) {
-      for (let b = 0; b < mesh.instanceParents.length; b++) {
-        if (ids.has(mesh.instanceParents[b])) {
-          next.add(b)
+      for (const id of ids) {
+        const list = state.parentIndex.get(id)
+        if (list) {
+          for (const b of list) {
+            next.add(b)
+          }
         }
       }
     }
-    const prev = mesh[setKey] ?? new Set()
-    mesh[setKey] = next
+    const prev = state[setKey]
+    state[setKey] = next
     // Repaint every instance whose membership in this layer changed; paint()
     // resolves the layered colour from the still-current sets.
     for (const b of prev) {

--- a/src/viewer/ifc/batchedHighlight.js
+++ b/src/viewer/ifc/batchedHighlight.js
@@ -1,4 +1,5 @@
 import {Vector4} from 'three'
+import {eachBatch} from './batchedModel'
 
 
 /**
@@ -34,31 +35,6 @@ import {Vector4} from 'three'
 const DEFAULT_HIGHLIGHT = {r: 0, g: 0.8, b: 1}
 
 const _rgba = new Vector4()
-
-
-/**
- * Run `fn` for every `BatchedMesh` in a batched model (the mesh itself, or
- * each batch child of a two-batch Group).
- *
- * @param {object} model BatchedMesh or Group root
- * @param {Function} fn called with each BatchedMesh
- */
-function eachBatch(model, fn) {
-  if (!model) {
-    return
-  }
-  if (model.isBatchedMesh) {
-    fn(model)
-    return
-  }
-  if (typeof model.traverse === 'function') {
-    model.traverse((obj) => {
-      if (obj.isBatchedMesh) {
-        fn(obj)
-      }
-    })
-  }
-}
 
 
 /**
@@ -212,20 +188,6 @@ export function clearBatchedPreselection(model) {
 }
 
 
-/**
- * True when the model is, or contains, a decorated BatchedMesh (carries the
- * `instanceParents` table). Lets call-sites pick the recolor path without a
- * capability lookup.
- *
- * @param {object} model
- * @return {boolean}
- */
-export function isBatchedModel(model) {
-  let found = false
-  eachBatch(model, (mesh) => {
-    if (mesh.instanceParents) {
-      found = true
-    }
-  })
-  return found
-}
+// `isBatchedModel` moved to ./batchedModel; re-exported here so existing
+// call-sites (and tests) that import it from batchedHighlight keep working.
+export {isBatchedModel} from './batchedModel'

--- a/src/viewer/ifc/batchedHighlight.js
+++ b/src/viewer/ifc/batchedHighlight.js
@@ -1,0 +1,190 @@
+import {Vector4} from 'three'
+
+
+/**
+ * batchedHighlight — native per-instance selection / preselection highlight
+ * for the Conway-direct `THREE.BatchedMesh` render path, via `setColorAt`.
+ *
+ * Why recolor instead of an overlay subset: the merged paths highlight by
+ * dropping a translucent subset Mesh into the scene, coplanar with the
+ * source. That relies on the subset sharing the source's *exact* vertex
+ * buffer so the two surfaces get pixel-identical depth and the overlay
+ * reliably wins the depth test. A BatchedMesh subset would have to be
+ * re-baked from independent CPU math, which z-fights the opaque batch and
+ * makes the overlay vanish (polygon-offset tuning never made it robust). So
+ * for the batched path we recolor the *actual* rendered instances — the
+ * idiomatic BatchedMesh approach (three's own examples do this). It can't be
+ * hidden by depth, parenting, or transparency-pass ordering, because it
+ * changes the pixels that are already being drawn.
+ *
+ * Two independent layers coexist: `selection` (sticky, click) and
+ * `preselection` (transient, hover). Preselection paints over selection;
+ * removing either restores the layer beneath, ending at the instance's
+ * original colour (kept in `mesh.instanceColors`, alpha included — so glass
+ * stays glass). State lives on the BatchedMesh in non-enumerable-ish
+ * `__sel*` / `__pre*` slots; isolate still uses the subset path
+ * (`batchedSubset`) and is unaffected.
+ *
+ * @see batchedSubset — the isolation-subset sibling.
+ * @see design/new/viewer-replacement.md §3b.iv
+ */
+
+
+/** Default highlight RGB if no material colour is available. */
+const DEFAULT_HIGHLIGHT = {r: 0, g: 0.8, b: 1}
+
+const _rgba = new Vector4()
+
+
+/**
+ * Run `fn` for every `BatchedMesh` in a batched model (the mesh itself, or
+ * each batch child of a two-batch Group).
+ *
+ * @param {object} model BatchedMesh or Group root
+ * @param {Function} fn called with each BatchedMesh
+ */
+function eachBatch(model, fn) {
+  if (!model) {
+    return
+  }
+  if (model.isBatchedMesh) {
+    fn(model)
+    return
+  }
+  if (typeof model.traverse === 'function') {
+    model.traverse((obj) => {
+      if (obj.isBatchedMesh) {
+        fn(obj)
+      }
+    })
+  }
+}
+
+
+/**
+ * Repaint one instance to its current layered colour: preselection wins
+ * over selection wins over the instance's original colour. Alpha always
+ * comes from the original (keeps a highlighted glass pane translucent).
+ *
+ * @param {object} mesh BatchedMesh with `instanceColors`
+ * @param {number} batchId
+ */
+function paint(mesh, batchId) {
+  const orig = mesh.instanceColors?.[batchId]
+  const a = orig?.w ?? 1
+  let rgb
+  if (mesh.__preSet?.has(batchId)) {
+    rgb = mesh.__preColor ?? DEFAULT_HIGHLIGHT
+  } else if (mesh.__selSet?.has(batchId)) {
+    rgb = mesh.__selColor ?? DEFAULT_HIGHLIGHT
+  } else {
+    rgb = orig ? {r: orig.x, g: orig.y, b: orig.z} : DEFAULT_HIGHLIGHT
+  }
+  mesh.setColorAt(batchId, _rgba.set(rgb.r, rgb.g, rgb.b, a))
+}
+
+
+/**
+ * Replace a highlight layer with the instances whose parent product is in
+ * `expressIds`, repainting everything whose membership changed.
+ *
+ * @param {object} model BatchedMesh or Group
+ * @param {Array<number>|Set<number>} expressIds parent IFC product ids
+ * @param {object|null} color `{r,g,b}` (0..1) highlight, or null to clear
+ * @param {'sel'|'pre'} layer which layer to set
+ */
+function setLayer(model, expressIds, color, layer) {
+  const ids = expressIds instanceof Set ? expressIds : new Set(expressIds ?? [])
+  const setKey = layer === 'pre' ? '__preSet' : '__selSet'
+  const colorKey = layer === 'pre' ? '__preColor' : '__selColor'
+  eachBatch(model, (mesh) => {
+    if (!mesh.instanceParents || typeof mesh.setColorAt !== 'function') {
+      return
+    }
+    mesh[colorKey] = color ?? undefined
+    const next = new Set()
+    if (color && ids.size > 0) {
+      for (let b = 0; b < mesh.instanceParents.length; b++) {
+        if (ids.has(mesh.instanceParents[b])) {
+          next.add(b)
+        }
+      }
+    }
+    const prev = mesh[setKey] ?? new Set()
+    mesh[setKey] = next
+    // Repaint every instance whose membership in this layer changed; paint()
+    // resolves the layered colour from the still-current sets.
+    for (const b of prev) {
+      if (!next.has(b)) {
+        paint(mesh, b)
+      }
+    }
+    for (const b of next) {
+      paint(mesh, b)
+    }
+  })
+}
+
+
+/**
+ * Set the sticky selection highlight.
+ *
+ * @param {object} model BatchedMesh or Group
+ * @param {Array<number>|Set<number>} expressIds parent IFC product ids
+ * @param {object} [color] `{r,g,b}` 0..1; defaults to cyan
+ */
+export function applyBatchedSelection(model, expressIds, color = DEFAULT_HIGHLIGHT) {
+  setLayer(model, expressIds, color, 'sel')
+}
+
+
+/**
+ * Clear the sticky selection highlight.
+ *
+ * @param {object} model BatchedMesh or Group
+ */
+export function clearBatchedSelection(model) {
+  setLayer(model, [], null, 'sel')
+}
+
+
+/**
+ * Set the transient preselection (hover) highlight. Coexists with — and
+ * paints over — the selection layer.
+ *
+ * @param {object} model BatchedMesh or Group
+ * @param {Array<number>|Set<number>} expressIds parent IFC product ids
+ * @param {object} [color] `{r,g,b}` 0..1; defaults to cyan
+ */
+export function applyBatchedPreselection(model, expressIds, color = DEFAULT_HIGHLIGHT) {
+  setLayer(model, expressIds, color, 'pre')
+}
+
+
+/**
+ * Clear the transient preselection highlight.
+ *
+ * @param {object} model BatchedMesh or Group
+ */
+export function clearBatchedPreselection(model) {
+  setLayer(model, [], null, 'pre')
+}
+
+
+/**
+ * True when the model is, or contains, a decorated BatchedMesh (carries the
+ * `instanceParents` table). Lets call-sites pick the recolor path without a
+ * capability lookup.
+ *
+ * @param {object} model
+ * @return {boolean}
+ */
+export function isBatchedModel(model) {
+  let found = false
+  eachBatch(model, (mesh) => {
+    if (mesh.instanceParents) {
+      found = true
+    }
+  })
+  return found
+}

--- a/src/viewer/ifc/batchedHighlight.test.js
+++ b/src/viewer/ifc/batchedHighlight.test.js
@@ -1,0 +1,143 @@
+/* eslint-disable no-magic-numbers */
+import {Color, Group} from 'three'
+import {
+  applyBatchedPreselection,
+  applyBatchedSelection,
+  clearBatchedPreselection,
+  clearBatchedSelection,
+  isBatchedModel,
+} from './batchedHighlight'
+import {flatMeshToBatchedModel} from './flatMeshToBatchedModel'
+
+
+const IDENTITY_MAT = [
+  1, 0, 0, 0,
+  0, 1, 0, 0,
+  0, 0, 1, 0,
+  0, 0, 0, 1,
+]
+
+const GREY = {x: 0.8, y: 0.8, z: 0.8, w: 1}
+const SELECT = {r: 0, g: 0.8, b: 1}
+const PRESELECT = {r: 1, g: 0, b: 0}
+
+
+/** @return {Float32Array} single-triangle interleaved vert buffer (p+n). */
+function unitTriangleVerts() {
+  return new Float32Array([
+    0, 0, 0, 0, 0, 1,
+    1, 0, 0, 0, 0, 1,
+    0, 1, 0, 0, 0, 1,
+  ])
+}
+
+
+/** @return {object} api with one unit-triangle shape at id 999. */
+function unitTriApi() {
+  const byId = {999: {vertexData: unitTriangleVerts(), indexData: new Uint32Array([0, 1, 2])}}
+  return {
+    GetGeometry(_m, id) {
+      const g = byId[id]
+      return g ? {
+        GetVertexData: () => id,
+        GetIndexData: () => id,
+        GetVertexDataSize: () => g.vertexData.length,
+        GetIndexDataSize: () => g.indexData.length,
+      } : null
+    },
+    GetVertexArray: (ptr) => byId[ptr].vertexData,
+    GetIndexArray: (ptr) => byId[ptr].indexData,
+  }
+}
+
+
+/**
+ * One decorated BatchedMesh: products 100 and 200, each one opaque instance.
+ *
+ * @return {object} a THREE.BatchedMesh with the highlight tables wired
+ */
+function decoratedBatch() {
+  const flatMeshes = [
+    {expressID: 100, geometries: [{geometryExpressID: 999, flatTransformation: IDENTITY_MAT, color: GREY}]},
+    {expressID: 200, geometries: [{geometryExpressID: 999, flatTransformation: IDENTITY_MAT, color: GREY}]},
+  ]
+  const {batches} = flatMeshToBatchedModel(flatMeshes, unitTriApi(), 0)
+  const batch = batches[0]
+  batch.mesh.instanceParents = batch.instanceParents
+  batch.mesh.instanceColors = batch.instanceColors
+  return batch.mesh
+}
+
+
+/**
+ * @param {object} mesh BatchedMesh
+ * @param {number} batchId
+ * @return {Color} the batch instance colour at batchId
+ */
+function colorAt(mesh, batchId) {
+  return mesh.getColorAt(batchId, new Color())
+}
+
+
+/**
+ * @param {object} mesh BatchedMesh
+ * @param {number} expressId parent IFC product id
+ * @return {number} the batchId whose parent product is expressId
+ */
+function batchIdFor(mesh, expressId) {
+  return mesh.instanceParents.indexOf(expressId)
+}
+
+
+describe('viewer/ifc/batchedHighlight', () => {
+  it('recolors only the selected product, leaving others original', () => {
+    const mesh = decoratedBatch()
+    applyBatchedSelection(mesh, [100], SELECT)
+    const sel = colorAt(mesh, batchIdFor(mesh, 100))
+    expect(sel.r).toBeCloseTo(0)
+    expect(sel.b).toBeCloseTo(1)
+    const other = colorAt(mesh, batchIdFor(mesh, 200))
+    expect(other.r).toBeCloseTo(0.8)
+  })
+
+  it('restores the original colour on clear', () => {
+    const mesh = decoratedBatch()
+    applyBatchedSelection(mesh, [100], SELECT)
+    clearBatchedSelection(mesh)
+    const restored = colorAt(mesh, batchIdFor(mesh, 100))
+    expect(restored.r).toBeCloseTo(0.8)
+    expect(restored.g).toBeCloseTo(0.8)
+    expect(restored.b).toBeCloseTo(0.8)
+  })
+
+  it('moves the selection when reselected (old one restored)', () => {
+    const mesh = decoratedBatch()
+    applyBatchedSelection(mesh, [100], SELECT)
+    applyBatchedSelection(mesh, [200], SELECT)
+    expect(colorAt(mesh, batchIdFor(mesh, 100)).r).toBeCloseTo(0.8) // restored
+    expect(colorAt(mesh, batchIdFor(mesh, 200)).b).toBeCloseTo(1) // now selected
+  })
+
+  it('preselection paints over selection and restores the selection beneath', () => {
+    const mesh = decoratedBatch()
+    applyBatchedSelection(mesh, [100], SELECT)
+    applyBatchedPreselection(mesh, [100], PRESELECT)
+    // Hovering the selected product shows the preselection colour.
+    expect(colorAt(mesh, batchIdFor(mesh, 100)).r).toBeCloseTo(1)
+    clearBatchedPreselection(mesh)
+    // Cursor leaves → the selection colour underneath returns (not original).
+    const after = colorAt(mesh, batchIdFor(mesh, 100))
+    expect(after.r).toBeCloseTo(0)
+    expect(after.b).toBeCloseTo(1)
+  })
+
+  it('isBatchedModel detects a BatchedMesh and a Group of them', () => {
+    const mesh = decoratedBatch()
+    expect(isBatchedModel(mesh)).toBe(true)
+    const group = new Group()
+    group.add(mesh)
+    expect(isBatchedModel(group)).toBe(true)
+    expect(isBatchedModel(new Group())).toBe(false)
+    expect(isBatchedModel(null)).toBe(false)
+  })
+})

--- a/src/viewer/ifc/batchedModel.js
+++ b/src/viewer/ifc/batchedModel.js
@@ -1,0 +1,56 @@
+/**
+ * batchedModel — shared walkers for the Conway-direct `THREE.BatchedMesh`
+ * render path. A batched model is either a lone `BatchedMesh` or a Group
+ * of them (the opaque + transparent split), so every consumer that wants
+ * to touch each batch needs the same "mesh-or-Group" traversal. This is
+ * that traversal, factored out of `batchedHighlight` / `batchedSubset` /
+ * `glbExport` so they can't drift.
+ *
+ * @see batchedHighlight — setColorAt selection / preselection.
+ * @see batchedSubset — isolation-subset builder.
+ * @see design/new/viewer-replacement.md §3b.iv
+ */
+
+
+/**
+ * Run `fn` for every `BatchedMesh` in a batched model (the mesh itself, or
+ * each batch child of a two-batch Group).
+ *
+ * @param {object} model BatchedMesh or Group root
+ * @param {Function} fn called with each BatchedMesh
+ */
+export function eachBatch(model, fn) {
+  if (!model) {
+    return
+  }
+  if (model.isBatchedMesh) {
+    fn(model)
+    return
+  }
+  if (typeof model.traverse === 'function') {
+    model.traverse((obj) => {
+      if (obj.isBatchedMesh) {
+        fn(obj)
+      }
+    })
+  }
+}
+
+
+/**
+ * True when the model is, or contains, a decorated BatchedMesh (carries the
+ * `instanceParents` table). Lets call-sites pick the recolor path without a
+ * capability lookup.
+ *
+ * @param {object} model
+ * @return {boolean}
+ */
+export function isBatchedModel(model) {
+  let found = false
+  eachBatch(model, (mesh) => {
+    if (mesh.instanceParents) {
+      found = true
+    }
+  })
+  return found
+}

--- a/src/viewer/ifc/batchedSubset.js
+++ b/src/viewer/ifc/batchedSubset.js
@@ -26,7 +26,7 @@ import {
  *
  * The reconstructed geometry also carries a synthetic per-vertex
  * `expressID` attribute (every vertex of instance *i* tagged with its
- * parent product id). That makes *isolation* subsets pickable through
+ * parent product id). That makes isolation subsets pickable through
  * `CadView`'s existing per-vertex-`expressID` click branch even while the
  * source BatchedMesh is detached from the scene — parity with how the
  * merged path's isolation subsets stay pickable via their shared
@@ -34,10 +34,13 @@ import {
  *
  * `attachBatchedSubsets` exposes the exact `createSubset` / `removeSubset`
  * surface `attachElementSubsets` / `attachInstanceMapSubsets` do, so
- * `ShareViewer.setSelection` (else branch), `highlightIfcItem`
- * (preselection branch) and `IfcIsolator` drive the batched path with no
- * branching of their own. See design/new/viewer-replacement.md §3b.iv.
+ * `IfcIsolator` drives the batched path with no branching of its own. NOTE:
+ * **selection / preselection do NOT use this** — a coplanar overlay subset
+ * z-fights the opaque batch and won't render reliably; those highlight by
+ * recoloring instances in place (`batchedHighlight`). This module is the
+ * isolation subset builder. See design/new/viewer-replacement.md §3b.iv.
  *
+ * @see batchedHighlight — the setColorAt selection / preselection sibling.
  * @see elementSubsets — the per-vertex / instance-map siblings.
  */
 
@@ -45,7 +48,12 @@ import {
 /** Floats per position / normal vector. */
 const VEC3 = 3
 
-/** Customs IDs whose subsets are hover/selection overlays (raycast-mute). */
+/**
+ * Custom IDs whose subsets are hover/selection overlays (raycast-mute).
+ * Defensive only — production selection/preselection now recolor in place
+ * (`batchedHighlight`) and never reach `createSubset`; isolation IDs aren't
+ * here, so isolation subsets stay pickable.
+ */
 const OVERLAY_CUSTOM_IDS = new Set(['selection', 'preselection'])
 
 
@@ -145,28 +153,7 @@ export function buildBatchedSubsetMesh(mesh, idSet, opts = {}) {
   geometry.setAttribute('expressID', new BufferAttribute(expressIDs, 1))
   geometry.setIndex(new BufferAttribute(indices, 1))
 
-  let material = opts.material ?? mesh.material
-  if (opts.raycastInvisible && material && typeof material.clone === 'function') {
-    // Overlay (selection / preselection) sits coplanar with the opaque
-    // batch, but — unlike the merged-path subsets, which share the source's
-    // exact vertex buffer and so get pixel-identical depth — this subset is
-    // re-baked from independent CPU math. Without a depth bias the two
-    // surfaces z-fight and the cyan overlay mostly vanishes. Clone the
-    // (shared, fork-owned) overlay material and pull it toward the camera so
-    // it reliably wins the coplanar depth test; `depthTest` stays on so the
-    // highlight is still occluded by geometry genuinely in front.
-    material = material.clone()
-    material.polygonOffset = true
-    material.polygonOffsetFactor = -1
-    material.polygonOffsetUnits = -1
-    material.needsUpdate = true
-  }
-
-  const subset = new Mesh(geometry, material)
-  if (material !== (opts.material ?? mesh.material)) {
-    // We own this clone — flag it so removeSubset disposes it.
-    subset.userData.disposableMaterial = true
-  }
+  const subset = new Mesh(geometry, opts.material ?? mesh.material)
   // Mirror the source's full local transform (the coordination matrix is
   // stamped onto the BatchedMesh with matrixAutoUpdate off). Copy the
   // matrix and decompose so both representations stay consistent whether
@@ -251,10 +238,6 @@ export function attachBatchedSubsets(model, fallbackParent, defaults = {}) {
       // Batched subset geometry is freshly baked (not shared with the
       // source batch's packed buffers) — always safe to dispose.
       m.geometry?.dispose?.()
-      // Overlay subsets carry a cloned, depth-biased material we own.
-      if (m.userData.disposableMaterial) {
-        m.material?.dispose?.()
-      }
     }
     subsetsByCustomID.delete(customID)
   }

--- a/src/viewer/ifc/batchedSubset.js
+++ b/src/viewer/ifc/batchedSubset.js
@@ -6,6 +6,7 @@ import {
   Mesh,
   Vector3,
 } from 'three'
+import {eachBatch} from './batchedModel'
 
 
 /**
@@ -48,14 +49,6 @@ import {
 /** Floats per position / normal vector. */
 const VEC3 = 3
 
-/**
- * Custom IDs whose subsets are hover/selection overlays (raycast-mute).
- * Defensive only — production selection/preselection now recolor in place
- * (`batchedHighlight`) and never reach `createSubset`; isolation IDs aren't
- * here, so isolation subsets stay pickable.
- */
-const OVERLAY_CUSTOM_IDS = new Set(['selection', 'preselection'])
-
 
 /**
  * Reconstruct a single subset Mesh from one BatchedMesh, baking every
@@ -70,7 +63,6 @@ const OVERLAY_CUSTOM_IDS = new Set(['selection', 'preselection'])
  * @param {Set<number>} idSet parent IFC product expressIDs to keep
  * @param {object} [opts]
  * @param {object} [opts.material] subset material (defaults to the batch's)
- * @param {boolean} [opts.raycastInvisible] mute the subset to the raycaster
  * @return {Mesh|null}
  */
 export function buildBatchedSubsetMesh(mesh, idSet, opts = {}) {
@@ -162,12 +154,6 @@ export function buildBatchedSubsetMesh(mesh, idSet, opts = {}) {
   subset.matrixAutoUpdate = mesh.matrixAutoUpdate
   subset.matrix.copy(mesh.matrix)
   subset.matrix.decompose(subset.position, subset.quaternion, subset.scale)
-  if (opts.raycastInvisible) {
-    // Selection/preselection overlays are coplanar with the source and
-    // would steal clicks; the OutlineEffect renders them via its own
-    // mask pass regardless of raycast. Same guard elementSubsets uses.
-    subset.raycast = () => {/* raycast-invisible overlay */}
-  }
   subset.name = `${mesh.name || 'batch'}__subset`
   subset.userData.sourceMesh = mesh
   return subset
@@ -184,19 +170,13 @@ export function buildBatchedSubsetMesh(mesh, idSet, opts = {}) {
  * @return {Mesh[]}
  */
 export function buildBatchedModelSubsets(modelRoot, ids, opts = {}) {
-  if (!modelRoot || typeof modelRoot.traverse !== 'function') {
-    return []
-  }
   const idSet = ids instanceof Set ? ids : new Set(ids)
   if (idSet.size === 0) {
     return []
   }
   const subsets = []
-  modelRoot.traverse((obj) => {
-    if (!obj.isBatchedMesh) {
-      return
-    }
-    const subset = buildBatchedSubsetMesh(obj, idSet, opts)
+  eachBatch(modelRoot, (mesh) => {
+    const subset = buildBatchedSubsetMesh(mesh, idSet, opts)
     if (subset) {
       subsets.push(subset)
     }
@@ -211,9 +191,10 @@ export function buildBatchedModelSubsets(modelRoot, ids, opts = {}) {
  * `attachInstanceMapSubsets`. Same Map-of-named-slots contract so the
  * shared selection / preselection / isolation call-sites are unchanged.
  *
- * Overlay slots (`selection`, `preselection`) get raycast-muted subsets;
- * isolation slots get pickable ones (parity with the merged path, where
- * isolated geometry stays clickable via its `expressID` attribute).
+ * Subsets stay pickable (parity with the merged path, where isolated
+ * geometry stays clickable via its `expressID` attribute) — only isolation
+ * reaches this builder now; selection / preselection recolor in place
+ * (`batchedHighlight`).
  *
  * @param {object} model BatchedMesh or Group root to decorate
  * @param {object|null} fallbackParent parent for subsets when the source
@@ -253,8 +234,7 @@ export function attachBatchedSubsets(model, fallbackParent, defaults = {}) {
     if (removePrevious) {
       removeSubset(customID)
     }
-    const raycastInvisible = OVERLAY_CUSTOM_IDS.has(customID)
-    const meshes = buildBatchedModelSubsets(model, ids ?? [], {material, raycastInvisible})
+    const meshes = buildBatchedModelSubsets(model, ids ?? [], {material})
     if (meshes.length === 0) {
       return []
     }

--- a/src/viewer/ifc/batchedSubset.js
+++ b/src/viewer/ifc/batchedSubset.js
@@ -145,7 +145,28 @@ export function buildBatchedSubsetMesh(mesh, idSet, opts = {}) {
   geometry.setAttribute('expressID', new BufferAttribute(expressIDs, 1))
   geometry.setIndex(new BufferAttribute(indices, 1))
 
-  const subset = new Mesh(geometry, opts.material ?? mesh.material)
+  let material = opts.material ?? mesh.material
+  if (opts.raycastInvisible && material && typeof material.clone === 'function') {
+    // Overlay (selection / preselection) sits coplanar with the opaque
+    // batch, but — unlike the merged-path subsets, which share the source's
+    // exact vertex buffer and so get pixel-identical depth — this subset is
+    // re-baked from independent CPU math. Without a depth bias the two
+    // surfaces z-fight and the cyan overlay mostly vanishes. Clone the
+    // (shared, fork-owned) overlay material and pull it toward the camera so
+    // it reliably wins the coplanar depth test; `depthTest` stays on so the
+    // highlight is still occluded by geometry genuinely in front.
+    material = material.clone()
+    material.polygonOffset = true
+    material.polygonOffsetFactor = -1
+    material.polygonOffsetUnits = -1
+    material.needsUpdate = true
+  }
+
+  const subset = new Mesh(geometry, material)
+  if (material !== (opts.material ?? mesh.material)) {
+    // We own this clone — flag it so removeSubset disposes it.
+    subset.userData.disposableMaterial = true
+  }
   // Mirror the source's full local transform (the coordination matrix is
   // stamped onto the BatchedMesh with matrixAutoUpdate off). Copy the
   // matrix and decompose so both representations stay consistent whether
@@ -230,6 +251,10 @@ export function attachBatchedSubsets(model, fallbackParent, defaults = {}) {
       // Batched subset geometry is freshly baked (not shared with the
       // source batch's packed buffers) — always safe to dispose.
       m.geometry?.dispose?.()
+      // Overlay subsets carry a cloned, depth-biased material we own.
+      if (m.userData.disposableMaterial) {
+        m.material?.dispose?.()
+      }
     }
     subsetsByCustomID.delete(customID)
   }

--- a/src/viewer/ifc/batchedSubset.js
+++ b/src/viewer/ifc/batchedSubset.js
@@ -1,0 +1,275 @@
+import {
+  BufferAttribute,
+  BufferGeometry,
+  Matrix3,
+  Matrix4,
+  Mesh,
+  Vector3,
+} from 'three'
+
+
+/**
+ * batchedSubset — build raycast/outline "subset" meshes from a
+ * `THREE.BatchedMesh` rendered by the Conway-direct instancing path
+ * (`buildBatchedConwayModel`).
+ *
+ * The merged path stores one big per-vertex slab with an `expressID`
+ * attribute, so `elementSubsets.js` filters triangles by that attribute.
+ * The batched path stores each unique shape *once* in local space plus a
+ * per-instance matrix; the source `expressID` lives in the per-batch
+ * `instanceParents` table (`batchId → parent IFC product expressID`), not
+ * on any vertex. So this module reconstructs a subset by *baking* each
+ * selected instance's local geometry through its instance matrix
+ * (`getMatrixAt`) into a fresh world-aligned `BufferGeometry` — the same
+ * end product (a plain `Mesh` the OutlineEffect / picker understands) by a
+ * different route.
+ *
+ * The reconstructed geometry also carries a synthetic per-vertex
+ * `expressID` attribute (every vertex of instance *i* tagged with its
+ * parent product id). That makes *isolation* subsets pickable through
+ * `CadView`'s existing per-vertex-`expressID` click branch even while the
+ * source BatchedMesh is detached from the scene — parity with how the
+ * merged path's isolation subsets stay pickable via their shared
+ * `expressID` attribute.
+ *
+ * `attachBatchedSubsets` exposes the exact `createSubset` / `removeSubset`
+ * surface `attachElementSubsets` / `attachInstanceMapSubsets` do, so
+ * `ShareViewer.setSelection` (else branch), `highlightIfcItem`
+ * (preselection branch) and `IfcIsolator` drive the batched path with no
+ * branching of their own. See design/new/viewer-replacement.md §3b.iv.
+ *
+ * @see elementSubsets — the per-vertex / instance-map siblings.
+ */
+
+
+/** Floats per position / normal vector. */
+const VEC3 = 3
+
+/** Customs IDs whose subsets are hover/selection overlays (raycast-mute). */
+const OVERLAY_CUSTOM_IDS = new Set(['selection', 'preselection'])
+
+
+/**
+ * Reconstruct a single subset Mesh from one BatchedMesh, baking every
+ * instance whose `instanceParents[batchId]` is in `idSet` into one
+ * world-aligned (model-local) geometry.
+ *
+ * Returns `null` when the mesh isn't a decorated BatchedMesh or no
+ * instance matches — callers treat null as "nothing to highlight here".
+ *
+ * @param {object} mesh a THREE.BatchedMesh carrying `instanceParents` +
+ *   `instanceGeometry`
+ * @param {Set<number>} idSet parent IFC product expressIDs to keep
+ * @param {object} [opts]
+ * @param {object} [opts.material] subset material (defaults to the batch's)
+ * @param {boolean} [opts.raycastInvisible] mute the subset to the raycaster
+ * @return {Mesh|null}
+ */
+export function buildBatchedSubsetMesh(mesh, idSet, opts = {}) {
+  if (!mesh || !mesh.isBatchedMesh || !mesh.instanceParents || !mesh.instanceGeometry) {
+    return null
+  }
+  const parents = mesh.instanceParents
+  const geometries = mesh.instanceGeometry
+  // First pass: which batchIds match, and how big the merged buffers get.
+  const selected = []
+  let vertexTotal = 0
+  let indexTotal = 0
+  for (let batchId = 0; batchId < parents.length; batchId++) {
+    if (!idSet.has(parents[batchId])) {
+      continue
+    }
+    const geom = geometries[batchId]
+    const pos = geom?.attributes?.position
+    const idx = geom?.index
+    if (!pos || !idx) {
+      continue
+    }
+    selected.push(batchId)
+    vertexTotal += pos.count
+    indexTotal += idx.count
+  }
+  if (vertexTotal === 0 || indexTotal === 0) {
+    return null
+  }
+
+  const positions = new Float32Array(vertexTotal * VEC3)
+  const normals = new Float32Array(vertexTotal * VEC3)
+  // Synthetic per-vertex parent id so the subset is pickable through the
+  // per-vertex `expressID` branch (used while isolated; see module doc).
+  const expressIDs = new Uint32Array(vertexTotal)
+  const indices = new Uint32Array(indexTotal)
+  const matrix = new Matrix4()
+  const normalMatrix = new Matrix3()
+  const p = new Vector3()
+  const n = new Vector3()
+  let vOff = 0 // running vertex offset (in vertices, not floats)
+  let iOff = 0
+
+  for (const batchId of selected) {
+    const geom = geometries[batchId]
+    const pos = geom.attributes.position
+    const nrm = geom.attributes.normal
+    const idx = geom.index
+    mesh.getMatrixAt(batchId, matrix)
+    normalMatrix.getNormalMatrix(matrix)
+    const parentId = parents[batchId]
+    const base = vOff
+    for (let v = 0; v < pos.count; v++) {
+      // Bake the instance matrix into positions; the upper-3x3 normal
+      // matrix into normals (keeps lighting on the overlay correct).
+      p.fromBufferAttribute(pos, v).applyMatrix4(matrix)
+      const dst = (vOff + v) * VEC3
+      positions[dst] = p.x
+      positions[dst + 1] = p.y
+      positions[dst + 2] = p.z
+      if (nrm) {
+        n.fromBufferAttribute(nrm, v).applyMatrix3(normalMatrix).normalize()
+        normals[dst] = n.x
+        normals[dst + 1] = n.y
+        normals[dst + 2] = n.z
+      }
+      expressIDs[vOff + v] = parentId
+    }
+    const srcIdx = idx.array
+    for (let i = 0; i < srcIdx.length; i++) {
+      indices[iOff + i] = srcIdx[i] + base
+    }
+    vOff += pos.count
+    iOff += idx.count
+  }
+
+  const geometry = new BufferGeometry()
+  geometry.setAttribute('position', new BufferAttribute(positions, VEC3))
+  geometry.setAttribute('normal', new BufferAttribute(normals, VEC3))
+  geometry.setAttribute('expressID', new BufferAttribute(expressIDs, 1))
+  geometry.setIndex(new BufferAttribute(indices, 1))
+
+  const subset = new Mesh(geometry, opts.material ?? mesh.material)
+  // Mirror the source's full local transform (the coordination matrix is
+  // stamped onto the BatchedMesh with matrixAutoUpdate off). Copy the
+  // matrix and decompose so both representations stay consistent whether
+  // the consumer reads `.matrix` or PRS — and `scene.attach` (used by the
+  // isolator) keeps the world transform on reparent.
+  subset.matrixAutoUpdate = mesh.matrixAutoUpdate
+  subset.matrix.copy(mesh.matrix)
+  subset.matrix.decompose(subset.position, subset.quaternion, subset.scale)
+  if (opts.raycastInvisible) {
+    // Selection/preselection overlays are coplanar with the source and
+    // would steal clicks; the OutlineEffect renders them via its own
+    // mask pass regardless of raycast. Same guard elementSubsets uses.
+    subset.raycast = () => {/* raycast-invisible overlay */}
+  }
+  subset.name = `${mesh.name || 'batch'}__subset`
+  subset.userData.sourceMesh = mesh
+  return subset
+}
+
+
+/**
+ * Walk a batched model root and build one subset Mesh per BatchedMesh
+ * that contributes a matching instance.
+ *
+ * @param {object} modelRoot BatchedMesh, or Group of BatchedMeshes
+ * @param {Array<number>|Set<number>} ids parent IFC expressIDs
+ * @param {object} [opts] see buildBatchedSubsetMesh
+ * @return {Mesh[]}
+ */
+export function buildBatchedModelSubsets(modelRoot, ids, opts = {}) {
+  if (!modelRoot || typeof modelRoot.traverse !== 'function') {
+    return []
+  }
+  const idSet = ids instanceof Set ? ids : new Set(ids)
+  if (idSet.size === 0) {
+    return []
+  }
+  const subsets = []
+  modelRoot.traverse((obj) => {
+    if (!obj.isBatchedMesh) {
+      return
+    }
+    const subset = buildBatchedSubsetMesh(obj, idSet, opts)
+    if (subset) {
+      subsets.push(subset)
+    }
+  })
+  return subsets
+}
+
+
+/**
+ * Attach `createSubset` / `removeSubset` / `disposeSubsets` to a batched
+ * model — the BatchedMesh sibling of `attachElementSubsets` /
+ * `attachInstanceMapSubsets`. Same Map-of-named-slots contract so the
+ * shared selection / preselection / isolation call-sites are unchanged.
+ *
+ * Overlay slots (`selection`, `preselection`) get raycast-muted subsets;
+ * isolation slots get pickable ones (parity with the merged path, where
+ * isolated geometry stays clickable via its `expressID` attribute).
+ *
+ * @param {object} model BatchedMesh or Group root to decorate
+ * @param {object|null} fallbackParent parent for subsets when the source
+ *   has none (headless / test usage)
+ * @param {object} [defaults] default `createSubset` opts (e.g. `material`)
+ * @return {object} model (mutated)
+ */
+export function attachBatchedSubsets(model, fallbackParent, defaults = {}) {
+  if (!model) {
+    return model
+  }
+  const subsetsByCustomID = new Map()
+
+
+  const removeSubset = (customID) => {
+    const prev = subsetsByCustomID.get(customID)
+    if (!prev) {
+      return
+    }
+    for (const m of prev) {
+      m.removeFromParent()
+      // Batched subset geometry is freshly baked (not shared with the
+      // source batch's packed buffers) — always safe to dispose.
+      m.geometry?.dispose?.()
+    }
+    subsetsByCustomID.delete(customID)
+  }
+
+
+  const createSubset = (opts) => {
+    const {
+      ids,
+      customID = 'default',
+      removePrevious = true,
+      material = defaults.material,
+    } = opts || {}
+    if (removePrevious) {
+      removeSubset(customID)
+    }
+    const raycastInvisible = OVERLAY_CUSTOM_IDS.has(customID)
+    const meshes = buildBatchedModelSubsets(model, ids ?? [], {material, raycastInvisible})
+    if (meshes.length === 0) {
+      return []
+    }
+    for (const m of meshes) {
+      const parent = m.userData.sourceMesh?.parent ?? fallbackParent
+      if (parent) {
+        parent.add(m)
+      }
+    }
+    subsetsByCustomID.set(customID, meshes)
+    return meshes
+  }
+
+
+  const disposeSubsets = () => {
+    for (const customID of [...subsetsByCustomID.keys()]) {
+      removeSubset(customID)
+    }
+  }
+
+
+  model.createSubset = createSubset
+  model.removeSubset = removeSubset
+  model.disposeSubsets = disposeSubsets
+  return model
+}

--- a/src/viewer/ifc/batchedSubset.test.js
+++ b/src/viewer/ifc/batchedSubset.test.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-magic-numbers */
-import {Group, Mesh} from 'three'
+import {Group, Mesh, MeshBasicMaterial} from 'three'
 import {
   attachBatchedSubsets,
   buildBatchedModelSubsets,
@@ -120,6 +120,29 @@ describe('viewer/ifc/batchedSubset', () => {
     expect(sel[0].raycast).not.toBe(Mesh.prototype.raycast)
     const iso = mesh.createSubset({ids: [100], customID: 'Bldrs::Share::Isolator'})
     expect(iso[0].raycast).toBe(Mesh.prototype.raycast)
+  })
+
+  it('depth-biases a cloned overlay material so it wins the coplanar test', () => {
+    const mesh = decoratedBatch()
+    const overlay = new MeshBasicMaterial()
+    const subset = buildBatchedSubsetMesh(mesh, new Set([100]), {
+      material: overlay, raycastInvisible: true,
+    })
+    // Cloned (not the shared fork material) and pulled toward the camera.
+    expect(subset.material).not.toBe(overlay)
+    expect(subset.material.polygonOffset).toBe(true)
+    expect(subset.material.polygonOffsetFactor).toBeLessThan(0)
+    expect(subset.userData.disposableMaterial).toBe(true)
+  })
+
+  it('leaves isolation-subset material untouched (no clone, no offset)', () => {
+    const mesh = decoratedBatch()
+    const isoMat = new MeshBasicMaterial()
+    const subset = buildBatchedSubsetMesh(mesh, new Set([100]), {
+      material: isoMat, raycastInvisible: false,
+    })
+    expect(subset.material).toBe(isoMat)
+    expect(subset.userData.disposableMaterial).toBeUndefined()
   })
 
   it('removeSubset clears a named slot', () => {

--- a/src/viewer/ifc/batchedSubset.test.js
+++ b/src/viewer/ifc/batchedSubset.test.js
@@ -1,0 +1,145 @@
+/* eslint-disable no-magic-numbers */
+import {Group, Mesh} from 'three'
+import {
+  attachBatchedSubsets,
+  buildBatchedModelSubsets,
+  buildBatchedSubsetMesh,
+} from './batchedSubset'
+import {flatMeshToBatchedModel} from './flatMeshToBatchedModel'
+
+
+/** Identity 4x4 in three.js column-major flat form. */
+const IDENTITY_MAT = [
+  1, 0, 0, 0,
+  0, 1, 0, 0,
+  0, 0, 1, 0,
+  0, 0, 0, 1,
+]
+
+/** Translate +10 in X (column-major). */
+const TRANSLATE_X10 = [
+  1, 0, 0, 0,
+  0, 1, 0, 0,
+  0, 0, 1, 0,
+  10, 0, 0, 1,
+]
+
+const OPAQUE = {x: 0.8, y: 0.8, z: 0.8, w: 1}
+
+
+/** @return {Float32Array} single-triangle interleaved vert buffer (p+n). */
+function unitTriangleVerts() {
+  return new Float32Array([
+    0, 0, 0, 0, 0, 1,
+    1, 0, 0, 0, 0, 1,
+    0, 1, 0, 0, 0, 1,
+  ])
+}
+
+
+/** @return {object} mock Conway IfcAPI with one unit-triangle shape at id 999. */
+function unitTriApi() {
+  const byId = {999: {vertexData: unitTriangleVerts(), indexData: new Uint32Array([0, 1, 2])}}
+  return {
+    GetGeometry(_modelID, geomExpressID) {
+      const g = byId[geomExpressID]
+      if (!g) {
+        return null
+      }
+      return {
+        GetVertexData: () => geomExpressID,
+        GetIndexData: () => geomExpressID,
+        GetVertexDataSize: () => g.vertexData.length,
+        GetIndexDataSize: () => g.indexData.length,
+      }
+    },
+    GetVertexArray: (ptr) => byId[ptr].vertexData,
+    GetIndexArray: (ptr) => byId[ptr].indexData,
+  }
+}
+
+
+/**
+ * Build a single decorated BatchedMesh from two placements of the unit
+ * triangle (expressIDs 100 @ origin, 200 @ +X10), wiring the per-batch
+ * tables the way `buildBatchedConwayModel` does.
+ *
+ * @return {object} a decorated THREE.BatchedMesh
+ */
+function decoratedBatch() {
+  const flatMeshes = [
+    {expressID: 100, geometries: [{geometryExpressID: 999, flatTransformation: IDENTITY_MAT, color: OPAQUE}]},
+    {expressID: 200, geometries: [{geometryExpressID: 999, flatTransformation: TRANSLATE_X10, color: OPAQUE}]},
+  ]
+  const {batches} = flatMeshToBatchedModel(flatMeshes, unitTriApi(), 0)
+  const batch = batches[0]
+  batch.mesh.instanceParents = batch.instanceParents
+  batch.mesh.instanceOccurrenceIds = batch.instanceOccurrenceIds
+  batch.mesh.instanceGeometry = batch.instanceGeometry
+  return batch.mesh
+}
+
+
+describe('viewer/ifc/batchedSubset', () => {
+  it('bakes the matching instance into a world-aligned subset mesh', () => {
+    const mesh = decoratedBatch()
+    const subset = buildBatchedSubsetMesh(mesh, new Set([200]), {})
+    expect(subset).toBeInstanceOf(Mesh)
+    const pos = subset.geometry.attributes.position
+    expect(pos.count).toBe(3) // one triangle
+    // The +X10 instance matrix is baked into vertex 1 (was at x=1 → 11).
+    expect(pos.getX(1)).toBeCloseTo(11)
+    // Per-vertex expressID is the parent product id, on every vertex.
+    const ids = subset.geometry.attributes.expressID
+    expect(ids.getX(0)).toBe(200)
+    expect(ids.getX(2)).toBe(200)
+    expect(subset.userData.sourceMesh).toBe(mesh)
+  })
+
+  it('merges multiple matching instances and rebases indices', () => {
+    const mesh = decoratedBatch()
+    const subset = buildBatchedSubsetMesh(mesh, new Set([100, 200]), {})
+    expect(subset.geometry.attributes.position.count).toBe(6) // two triangles
+    const idx = subset.geometry.index.array
+    expect(idx.length).toBe(6)
+    // Second instance's indices are rebased past the first instance's verts.
+    expect(Math.max(...idx)).toBe(5)
+  })
+
+  it('returns null when no instance matches', () => {
+    const mesh = decoratedBatch()
+    expect(buildBatchedSubsetMesh(mesh, new Set([999]), {})).toBeNull()
+  })
+
+  it('mutes the raycast on overlay subsets but not isolation subsets', () => {
+    const mesh = decoratedBatch()
+    attachBatchedSubsets(mesh, mesh.parent ?? null, {})
+    const sel = mesh.createSubset({ids: [100], customID: 'selection'})
+    expect(typeof sel[0].raycast).toBe('function')
+    // Overlay subset is raycast-muted (its own no-op, not Mesh.prototype).
+    expect(sel[0].raycast).not.toBe(Mesh.prototype.raycast)
+    const iso = mesh.createSubset({ids: [100], customID: 'Bldrs::Share::Isolator'})
+    expect(iso[0].raycast).toBe(Mesh.prototype.raycast)
+  })
+
+  it('removeSubset clears a named slot', () => {
+    const mesh = decoratedBatch()
+    const root = new Group()
+    root.add(mesh)
+    attachBatchedSubsets(mesh, root, {})
+    const made = mesh.createSubset({ids: [100], customID: 'selection'})
+    expect(made.length).toBe(1)
+    expect(made[0].parent).toBe(mesh.parent)
+    mesh.removeSubset('selection')
+    expect(made[0].parent).toBeNull()
+  })
+
+  it('traverses a Group of batches', () => {
+    const mesh = decoratedBatch()
+    const group = new Group()
+    group.add(mesh)
+    const subsets = buildBatchedModelSubsets(group, [100], {})
+    expect(subsets.length).toBe(1)
+    expect(subsets[0].userData.sourceMesh).toBe(mesh)
+  })
+})

--- a/src/viewer/ifc/batchedSubset.test.js
+++ b/src/viewer/ifc/batchedSubset.test.js
@@ -122,27 +122,11 @@ describe('viewer/ifc/batchedSubset', () => {
     expect(iso[0].raycast).toBe(Mesh.prototype.raycast)
   })
 
-  it('depth-biases a cloned overlay material so it wins the coplanar test', () => {
-    const mesh = decoratedBatch()
-    const overlay = new MeshBasicMaterial()
-    const subset = buildBatchedSubsetMesh(mesh, new Set([100]), {
-      material: overlay, raycastInvisible: true,
-    })
-    // Cloned (not the shared fork material) and pulled toward the camera.
-    expect(subset.material).not.toBe(overlay)
-    expect(subset.material.polygonOffset).toBe(true)
-    expect(subset.material.polygonOffsetFactor).toBeLessThan(0)
-    expect(subset.userData.disposableMaterial).toBe(true)
-  })
-
-  it('leaves isolation-subset material untouched (no clone, no offset)', () => {
+  it('uses the supplied isolation material as-is (no clone)', () => {
     const mesh = decoratedBatch()
     const isoMat = new MeshBasicMaterial()
-    const subset = buildBatchedSubsetMesh(mesh, new Set([100]), {
-      material: isoMat, raycastInvisible: false,
-    })
+    const subset = buildBatchedSubsetMesh(mesh, new Set([100]), {material: isoMat})
     expect(subset.material).toBe(isoMat)
-    expect(subset.userData.disposableMaterial).toBeUndefined()
   })
 
   it('removeSubset clears a named slot', () => {

--- a/src/viewer/ifc/batchedSubset.test.js
+++ b/src/viewer/ifc/batchedSubset.test.js
@@ -111,13 +111,11 @@ describe('viewer/ifc/batchedSubset', () => {
     expect(buildBatchedSubsetMesh(mesh, new Set([999]), {})).toBeNull()
   })
 
-  it('mutes the raycast on overlay subsets but not isolation subsets', () => {
+  it('keeps every subset pickable (selection/preselection recolor, never subset)', () => {
     const mesh = decoratedBatch()
     attachBatchedSubsets(mesh, mesh.parent ?? null, {})
-    const sel = mesh.createSubset({ids: [100], customID: 'selection'})
-    expect(typeof sel[0].raycast).toBe('function')
-    // Overlay subset is raycast-muted (its own no-op, not Mesh.prototype).
-    expect(sel[0].raycast).not.toBe(Mesh.prototype.raycast)
+    // Only isolation reaches this builder now; whatever customID a caller
+    // passes, the subset stays clickable via its baked `expressID` attribute.
     const iso = mesh.createSubset({ids: [100], customID: 'Bldrs::Share::Isolator'})
     expect(iso[0].raycast).toBe(Mesh.prototype.raycast)
   })

--- a/src/viewer/ifc/buildBatchedConwayModel.js
+++ b/src/viewer/ifc/buildBatchedConwayModel.js
@@ -1,4 +1,4 @@
-import {Group, Matrix4, Vector3} from 'three'
+import {Group} from 'three'
 import {attachBatchedSubsets} from './batchedSubset'
 import {flatMeshToBatchedModel} from './flatMeshToBatchedModel'
 import {
@@ -75,32 +75,6 @@ export function buildBatchedConwayModel(capturedFlatMeshes, ifcAPI, modelID, opt
     // is unaffected. Guarded: the method is absent under the Jest `three`
     // mock and present only in the production prototype patch.
     batch.mesh.computeBoundsTree?.()
-  }
-
-  // TEMP diagnostic (batchedMesh flag only — this whole builder runs only
-  // under the flag): the fit heuristic zooms to Box3().setFromObject(model);
-  // Schependomlaan renders as a far dot in batched mode but frames fine on
-  // the merged path, so surface each batch's bounds + the worst instance
-  // translation to find the outlier. Remove once the cause is fixed.
-  const _p = new Vector3()
-  const _mat4Scratch = new Matrix4()
-  for (const batch of batches) {
-    const bb = batch.mesh.boundingBox
-    const size = bb ? bb.getSize(new Vector3()).toArray() : null
-    let maxTrans = 0
-    const m = batch.mesh
-    for (let b = 0; b < batch.instanceParents.length; b++) {
-      m.getMatrixAt(b, _mat4Scratch)
-      _p.setFromMatrixPosition(_mat4Scratch)
-      const mag = Math.max(Math.abs(_p.x), Math.abs(_p.y), Math.abs(_p.z))
-      if (mag > maxTrans) {
-        maxTrans = mag
-      }
-    }
-    // eslint-disable-next-line no-console
-    console.info(
-      `[batchedMesh] bounds: transparent=${batch.transparent} instances=${batch.instanceParents.length} ` +
-      `boxSize=${JSON.stringify(size)} empty=${bb?.isEmpty?.()} maxInstanceTranslation=${maxTrans.toFixed(1)}`)
   }
 
   // Single batch → the BatchedMesh is the model; two → a Group of them.

--- a/src/viewer/ifc/buildBatchedConwayModel.js
+++ b/src/viewer/ifc/buildBatchedConwayModel.js
@@ -23,16 +23,18 @@ import {
  *   - native `batchId` picking (CadView resolves it via the per-batch tables),
  *   - per-geometry three-mesh-bvh bounds trees (`computeBoundsTree`) so the
  *     accelerated raycast stays sub-linear and still emits `batchId`,
- *   - a `createSubset` / `removeSubset` surface (`attachBatchedSubsets`) that
- *     re-bakes selected instances into world-aligned subset Meshes, so 3D
- *     selection-outline, hover-preselection and isolate all light up through
- *     the same call-sites the merged paths use (design/new/viewer-replacement.md
- *     §3b.iv).
+ *   - in-place selection / hover highlight by recoloring the picked product's
+ *     instances (`setColorAt`, via `batchedHighlight`) — a coplanar overlay
+ *     subset z-fights the opaque batch and won't render reliably, so the
+ *     batched path recolors the actual pixels instead,
+ *   - a `createSubset` / `removeSubset` surface (`attachBatchedSubsets`) used
+ *     by `IfcIsolator` to re-bake hide/isolate subsets from the instances
+ *     (design/new/viewer-replacement.md §3b.iv).
  *
  * Capabilities: `expressIdPicking` + `batchedPicking` (NOT `instancePicking`
- * — per-occurrence outline narrowing is still a follow-up; a click highlights
- * every occurrence of the picked product). `setInstanceSelection` guards on
- * `instancePicking` and so no-ops safely; the parent-level highlight from
+ * — per-occurrence narrowing is still a follow-up; a click highlights every
+ * occurrence of the picked product). `setInstanceSelection` guards on
+ * `instancePicking` and so no-ops safely; the parent-level recolor from
  * `setSelection` stands.
  *
  * @param {Array} capturedFlatMeshes FlatMeshes captured during the parse
@@ -61,6 +63,7 @@ export function buildBatchedConwayModel(capturedFlatMeshes, ifcAPI, modelID, opt
     batch.mesh.instanceParents = batch.instanceParents
     batch.mesh.instanceOccurrenceIds = batch.instanceOccurrenceIds
     batch.mesh.instanceGeometry = batch.instanceGeometry
+    batch.mesh.instanceColors = batch.instanceColors
     batch.mesh.computeBoundingBox?.()
     batch.mesh.computeBoundingSphere?.()
     // Per-geometry BVH for the batch. `ShareIfc` patches

--- a/src/viewer/ifc/buildBatchedConwayModel.js
+++ b/src/viewer/ifc/buildBatchedConwayModel.js
@@ -1,3 +1,4 @@
+import {Group} from 'three'
 import {flatMeshToBatchedModel} from './flatMeshToBatchedModel'
 import {
   attachConwayDirectModelMethods,
@@ -7,56 +8,77 @@ import {
 
 /**
  * buildBatchedConwayModel — assemble a Conway FlatMesh stream into a
- * renderable `THREE.BatchedMesh` model, decorated with the non-geometry
- * surface call-sites expect (the `ifcManager` shim + property/spatial
- * closures), so the NavTree + Properties panel light up exactly as on the
- * merged path. The geometry-specific decoration the merged path uses
- * (three-mesh-bvh `IfcInstanceMap`, per-vertex subset construction) does
- * NOT apply to a `BatchedMesh` and is deliberately skipped — picking is
- * native (`batchId`), and 3D selection-outline / isolate is a follow-up
- * (see design/new/viewer-replacement.md §3b.iv).
+ * renderable batched model, decorated with the non-geometry surface
+ * call-sites expect (the `ifcManager` shim + property/spatial closures), so
+ * the NavTree + Properties panel light up exactly as on the merged path.
  *
- * Capabilities are set to `batchedPicking` only (NOT `expressIdPicking` /
- * `instancePicking`): `CadView` resolves a pick through the `batchId`
- * tables here, while `ShareViewer.setSelection` / `setInstanceSelection`
- * guard on those other capabilities and so no-op safely (the selection
- * state — store, NavTree, Properties — still updates; only the
- * OutlineEffect subset is deferred). Nothing in the selection path throws
- * on a model without an `instanceMap`.
+ * The render object is one or two `THREE.BatchedMesh` batches (opaque +
+ * transparent — see `flatMeshToBatchedModel`): a single batch is returned
+ * directly; two are wrapped in a `Group` (the same hierarchical-model shape
+ * the GLB cache-hit path already produces and the viewer already handles).
+ *
+ * Geometry-specific decoration the merged path uses (three-mesh-bvh
+ * `IfcInstanceMap`, per-vertex subset construction) does NOT apply to a
+ * `BatchedMesh` and is skipped; picking is native (`batchId`), and 3D
+ * selection-outline / isolate is a follow-up (design/new/viewer-replacement.md
+ * §3b.iv).
+ *
+ * Capabilities are `batchedPicking` only (NOT `expressIdPicking` /
+ * `instancePicking`): `CadView` resolves a pick through the per-batch
+ * `batchId` tables, while `ShareViewer.setSelection` / `setInstanceSelection`
+ * guard on those other capabilities and so no-op safely (selection *state* —
+ * store, NavTree, Properties — still flows; only the OutlineEffect subset is
+ * deferred). Nothing in the selection path throws on a model without an
+ * `instanceMap`.
  *
  * @param {Array} capturedFlatMeshes FlatMeshes captured during the parse
  * @param {object} ifcAPI Conway-compatible IfcAPI
  * @param {number} modelID
- * @return {object} `{model, stats}` — `model` is the decorated BatchedMesh.
+ * @return {object} `{model, stats}` — `model` is a BatchedMesh or a Group of them.
  */
 export function buildBatchedConwayModel(capturedFlatMeshes, ifcAPI, modelID) {
-  const {mesh, instanceParents, instanceOccurrenceIds, stats} =
-    flatMeshToBatchedModel(capturedFlatMeshes, ifcAPI, modelID)
+  const {batches, stats} = flatMeshToBatchedModel(capturedFlatMeshes, ifcAPI, modelID)
 
-  mesh.modelID = modelID
+  if (batches.length === 0) {
+    // Degenerate (no renderable geometry). Throw so ShareIfcLoader falls
+    // back to the merged path rather than adding an empty model.
+    throw new Error('buildBatchedConwayModel: no renderable geometry')
+  }
 
-  // Pick-resolution tables consumed by CadView's batchId branch.
-  mesh.instanceParents = instanceParents
-  mesh.instanceOccurrenceIds = instanceOccurrenceIds
+  // Each batch carries its own pick tables; CadView reads them off the
+  // raycast-hit child (`intersection.object`).
+  for (const batch of batches) {
+    batch.mesh.instanceParents = batch.instanceParents
+    batch.mesh.instanceOccurrenceIds = batch.instanceOccurrenceIds
+    batch.mesh.computeBoundingBox?.()
+    batch.mesh.computeBoundingSphere?.()
+  }
+
+  // Single batch → the BatchedMesh is the model; two → a Group of them.
+  const model = batches.length === 1 ? batches[0].mesh : new Group()
+  if (model.isGroup) {
+    for (const batch of batches) {
+      model.add(batch.mesh)
+    }
+  }
+
+  model.modelID = modelID
 
   // `ifcManager` shim — several call-sites discriminate "is this an IFC
   // model?" by `if (!m.ifcManager)`; without it the model-loaded effects
   // (NavTree, search index) are skipped. Same shape the merged path attaches.
-  mesh.ifcManager = makeConwayDirectIfcManager(ifcAPI, modelID)
+  model.ifcManager = makeConwayDirectIfcManager(ifcAPI, modelID)
 
-  mesh.computeBoundingBox?.()
-  mesh.computeBoundingSphere?.()
-
-  mesh.capabilities = mesh.capabilities ?? {}
+  model.capabilities = model.capabilities ?? {}
   // batchedPicking only — see the class doc above for why expressIdPicking /
   // instancePicking are intentionally left off.
-  mesh.capabilities.batchedPicking = true
-  mesh.capabilities.ifcSubsets = false
+  model.capabilities.batchedPicking = true
+  model.capabilities.ifcSubsets = false
 
   // Property / spatial closures (getItemProperties, getPropertySets,
   // getSpatialStructure, getIfcType) — identical to the merged path, so the
   // STEP/IFC metadata surface is unchanged.
-  attachConwayDirectModelMethods(mesh, ifcAPI, modelID)
+  attachConwayDirectModelMethods(model, ifcAPI, modelID)
 
-  return {model: mesh, stats}
+  return {model, stats}
 }

--- a/src/viewer/ifc/buildBatchedConwayModel.js
+++ b/src/viewer/ifc/buildBatchedConwayModel.js
@@ -93,13 +93,16 @@ export function buildBatchedConwayModel(capturedFlatMeshes, ifcAPI, modelID, opt
   model.ifcManager = makeConwayDirectIfcManager(ifcAPI, modelID)
 
   model.capabilities = model.capabilities ?? {}
-  // `expressIdPicking` (parent-level subsets via the `createSubset` surface
-  // attached below) + `batchedPicking` (CadView resolves a click through the
-  // per-batch `batchId` tables). NOT `instancePicking` (per-occurrence
-  // narrowing) or `ifcSubsets` (web-ifc-three parser state) — those route
-  // through machinery the batched model doesn't have. With `expressIdPicking`
-  // on, `setSelection` / `highlightIfcItem` fall to the generic
-  // `model.createSubset` branch, which `attachBatchedSubsets` services.
+  // Provisional capabilities for the window before `Loader.js` decorates the
+  // model: `expressIdPicking` + `batchedPicking` (recolor selection via
+  // `batchedHighlight`, isolate via `attachBatchedSubsets`), NOT
+  // `instancePicking` / `ifcSubsets`. NOTE these are *overwritten* — `Loader.js`
+  // calls `decorateShareModel` (replacing `capabilities` with the format
+  // default, which has `ifcSubsets: true`) then `inferModelCapabilities`, which
+  // re-detects the BatchedMesh and re-establishes exactly this set. The
+  // authoritative source is `inferModelCapabilities` (ShareModel.js); this
+  // block only covers the pre-decoration window and keeps the model self-
+  // describing in isolation (tests, direct use).
   model.capabilities.expressIdPicking = true
   model.capabilities.batchedPicking = true
   model.capabilities.ifcSubsets = false

--- a/src/viewer/ifc/buildBatchedConwayModel.js
+++ b/src/viewer/ifc/buildBatchedConwayModel.js
@@ -1,4 +1,4 @@
-import {Group} from 'three'
+import {Group, Matrix4, Vector3} from 'three'
 import {attachBatchedSubsets} from './batchedSubset'
 import {flatMeshToBatchedModel} from './flatMeshToBatchedModel'
 import {
@@ -75,6 +75,32 @@ export function buildBatchedConwayModel(capturedFlatMeshes, ifcAPI, modelID, opt
     // is unaffected. Guarded: the method is absent under the Jest `three`
     // mock and present only in the production prototype patch.
     batch.mesh.computeBoundsTree?.()
+  }
+
+  // TEMP diagnostic (batchedMesh flag only — this whole builder runs only
+  // under the flag): the fit heuristic zooms to Box3().setFromObject(model);
+  // Schependomlaan renders as a far dot in batched mode but frames fine on
+  // the merged path, so surface each batch's bounds + the worst instance
+  // translation to find the outlier. Remove once the cause is fixed.
+  const _p = new Vector3()
+  const _mat4Scratch = new Matrix4()
+  for (const batch of batches) {
+    const bb = batch.mesh.boundingBox
+    const size = bb ? bb.getSize(new Vector3()).toArray() : null
+    let maxTrans = 0
+    const m = batch.mesh
+    for (let b = 0; b < batch.instanceParents.length; b++) {
+      m.getMatrixAt(b, _mat4Scratch)
+      _p.setFromMatrixPosition(_mat4Scratch)
+      const mag = Math.max(Math.abs(_p.x), Math.abs(_p.y), Math.abs(_p.z))
+      if (mag > maxTrans) {
+        maxTrans = mag
+      }
+    }
+    // eslint-disable-next-line no-console
+    console.info(
+      `[batchedMesh] bounds: transparent=${batch.transparent} instances=${batch.instanceParents.length} ` +
+      `boxSize=${JSON.stringify(size)} empty=${bb?.isEmpty?.()} maxInstanceTranslation=${maxTrans.toFixed(1)}`)
   }
 
   // Single batch → the BatchedMesh is the model; two → a Group of them.

--- a/src/viewer/ifc/buildBatchedConwayModel.js
+++ b/src/viewer/ifc/buildBatchedConwayModel.js
@@ -1,4 +1,5 @@
 import {Group} from 'three'
+import {attachBatchedSubsets} from './batchedSubset'
 import {flatMeshToBatchedModel} from './flatMeshToBatchedModel'
 import {
   attachConwayDirectModelMethods,
@@ -17,19 +18,22 @@ import {
  * directly; two are wrapped in a `Group` (the same hierarchical-model shape
  * the GLB cache-hit path already produces and the viewer already handles).
  *
- * Geometry-specific decoration the merged path uses (three-mesh-bvh
- * `IfcInstanceMap`, per-vertex subset construction) does NOT apply to a
- * `BatchedMesh` and is skipped; picking is native (`batchId`), and 3D
- * selection-outline / isolate is a follow-up (design/new/viewer-replacement.md
- * §3b.iv).
+ * The merged path's `IfcInstanceMap` / per-vertex subset construction
+ * doesn't apply to a `BatchedMesh`. Instead this model gets:
+ *   - native `batchId` picking (CadView resolves it via the per-batch tables),
+ *   - per-geometry three-mesh-bvh bounds trees (`computeBoundsTree`) so the
+ *     accelerated raycast stays sub-linear and still emits `batchId`,
+ *   - a `createSubset` / `removeSubset` surface (`attachBatchedSubsets`) that
+ *     re-bakes selected instances into world-aligned subset Meshes, so 3D
+ *     selection-outline, hover-preselection and isolate all light up through
+ *     the same call-sites the merged paths use (design/new/viewer-replacement.md
+ *     §3b.iv).
  *
- * Capabilities are `batchedPicking` only (NOT `expressIdPicking` /
- * `instancePicking`): `CadView` resolves a pick through the per-batch
- * `batchId` tables, while `ShareViewer.setSelection` / `setInstanceSelection`
- * guard on those other capabilities and so no-op safely (selection *state* —
- * store, NavTree, Properties — still flows; only the OutlineEffect subset is
- * deferred). Nothing in the selection path throws on a model without an
- * `instanceMap`.
+ * Capabilities: `expressIdPicking` + `batchedPicking` (NOT `instancePicking`
+ * — per-occurrence outline narrowing is still a follow-up; a click highlights
+ * every occurrence of the picked product). `setInstanceSelection` guards on
+ * `instancePicking` and so no-ops safely; the parent-level highlight from
+ * `setSelection` stands.
  *
  * @param {Array} capturedFlatMeshes FlatMeshes captured during the parse
  * @param {object} ifcAPI Conway-compatible IfcAPI
@@ -46,12 +50,23 @@ export function buildBatchedConwayModel(capturedFlatMeshes, ifcAPI, modelID) {
   }
 
   // Each batch carries its own pick tables; CadView reads them off the
-  // raycast-hit child (`intersection.object`).
+  // raycast-hit child (`intersection.object`). `instanceGeometry` feeds
+  // `batchedSubset` (selection / preselection / isolation re-baking).
   for (const batch of batches) {
     batch.mesh.instanceParents = batch.instanceParents
     batch.mesh.instanceOccurrenceIds = batch.instanceOccurrenceIds
+    batch.mesh.instanceGeometry = batch.instanceGeometry
     batch.mesh.computeBoundingBox?.()
     batch.mesh.computeBoundingSphere?.()
+    // Per-geometry BVH for the batch. `ShareIfc` patches
+    // `BatchedMesh.prototype.computeBoundsTree = computeBatchedBoundsTree`
+    // (+ `raycast = acceleratedRaycast`), so picking on a many-instance
+    // batch resolves through the bounds trees instead of brute force —
+    // and `acceleratedBatchedMeshRaycast` still sets `intersection.batchId`
+    // (validated against three-mesh-bvh r0.9), so the CadView pick branch
+    // is unaffected. Guarded: the method is absent under the Jest `three`
+    // mock and present only in the production prototype patch.
+    batch.mesh.computeBoundsTree?.()
   }
 
   // Single batch → the BatchedMesh is the model; two → a Group of them.
@@ -70,10 +85,24 @@ export function buildBatchedConwayModel(capturedFlatMeshes, ifcAPI, modelID) {
   model.ifcManager = makeConwayDirectIfcManager(ifcAPI, modelID)
 
   model.capabilities = model.capabilities ?? {}
-  // batchedPicking only — see the class doc above for why expressIdPicking /
-  // instancePicking are intentionally left off.
+  // `expressIdPicking` (parent-level subsets via the `createSubset` surface
+  // attached below) + `batchedPicking` (CadView resolves a click through the
+  // per-batch `batchId` tables). NOT `instancePicking` (per-occurrence
+  // narrowing) or `ifcSubsets` (web-ifc-three parser state) — those route
+  // through machinery the batched model doesn't have. With `expressIdPicking`
+  // on, `setSelection` / `highlightIfcItem` fall to the generic
+  // `model.createSubset` branch, which `attachBatchedSubsets` services.
+  model.capabilities.expressIdPicking = true
   model.capabilities.batchedPicking = true
   model.capabilities.ifcSubsets = false
+
+  // Selection / preselection / isolation subsets, re-baked from the batch
+  // instances (see batchedSubset.js). Same `createSubset` / `removeSubset`
+  // contract the merged paths expose, so ShareViewer + IfcIsolator drive the
+  // batched model unchanged. `fallbackParent = null`: in production the
+  // source batch is parented into the scene, so subsets inherit its parent;
+  // headless tests pass their own root.
+  attachBatchedSubsets(model, null, {})
 
   // Property / spatial closures (getItemProperties, getPropertySets,
   // getSpatialStructure, getIfcType) — identical to the merged path, so the

--- a/src/viewer/ifc/buildBatchedConwayModel.js
+++ b/src/viewer/ifc/buildBatchedConwayModel.js
@@ -38,9 +38,14 @@ import {
  * @param {Array} capturedFlatMeshes FlatMeshes captured during the parse
  * @param {object} ifcAPI Conway-compatible IfcAPI
  * @param {number} modelID
+ * @param {object} [opts]
+ * @param {object} [opts.scene] the THREE scene; passed as the subset
+ *   `fallbackParent` so selection / preselection overlays still attach (and
+ *   render their fill) when a source batch has no parent at subset-build
+ *   time. Mirrors the merged paths (`attachInstanceMapSubsets(model, scene)`).
  * @return {object} `{model, stats}` — `model` is a BatchedMesh or a Group of them.
  */
-export function buildBatchedConwayModel(capturedFlatMeshes, ifcAPI, modelID) {
+export function buildBatchedConwayModel(capturedFlatMeshes, ifcAPI, modelID, opts = {}) {
   const {batches, stats} = flatMeshToBatchedModel(capturedFlatMeshes, ifcAPI, modelID)
 
   if (batches.length === 0) {
@@ -101,8 +106,8 @@ export function buildBatchedConwayModel(capturedFlatMeshes, ifcAPI, modelID) {
   // contract the merged paths expose, so ShareViewer + IfcIsolator drive the
   // batched model unchanged. `fallbackParent = null`: in production the
   // source batch is parented into the scene, so subsets inherit its parent;
-  // headless tests pass their own root.
-  attachBatchedSubsets(model, null, {})
+  // `opts.scene` backstops the case where a source batch has no parent yet.
+  attachBatchedSubsets(model, opts.scene ?? null, {})
 
   // Property / spatial closures (getItemProperties, getPropertySets,
   // getSpatialStructure, getIfcType) — identical to the merged path, so the

--- a/src/viewer/ifc/buildBatchedConwayModel.js
+++ b/src/viewer/ifc/buildBatchedConwayModel.js
@@ -1,0 +1,62 @@
+import {flatMeshToBatchedModel} from './flatMeshToBatchedModel'
+import {
+  attachConwayDirectModelMethods,
+  makeConwayDirectIfcManager,
+} from './conwayDirectIfcLoader'
+
+
+/**
+ * buildBatchedConwayModel — assemble a Conway FlatMesh stream into a
+ * renderable `THREE.BatchedMesh` model, decorated with the non-geometry
+ * surface call-sites expect (the `ifcManager` shim + property/spatial
+ * closures), so the NavTree + Properties panel light up exactly as on the
+ * merged path. The geometry-specific decoration the merged path uses
+ * (three-mesh-bvh `IfcInstanceMap`, per-vertex subset construction) does
+ * NOT apply to a `BatchedMesh` and is deliberately skipped — picking is
+ * native (`batchId`), and 3D selection-outline / isolate is a follow-up
+ * (see design/new/viewer-replacement.md §3b.iv).
+ *
+ * Capabilities are set to `batchedPicking` only (NOT `expressIdPicking` /
+ * `instancePicking`): `CadView` resolves a pick through the `batchId`
+ * tables here, while `ShareViewer.setSelection` / `setInstanceSelection`
+ * guard on those other capabilities and so no-op safely (the selection
+ * state — store, NavTree, Properties — still updates; only the
+ * OutlineEffect subset is deferred). Nothing in the selection path throws
+ * on a model without an `instanceMap`.
+ *
+ * @param {Array} capturedFlatMeshes FlatMeshes captured during the parse
+ * @param {object} ifcAPI Conway-compatible IfcAPI
+ * @param {number} modelID
+ * @return {object} `{model, stats}` — `model` is the decorated BatchedMesh.
+ */
+export function buildBatchedConwayModel(capturedFlatMeshes, ifcAPI, modelID) {
+  const {mesh, instanceParents, instanceOccurrenceIds, stats} =
+    flatMeshToBatchedModel(capturedFlatMeshes, ifcAPI, modelID)
+
+  mesh.modelID = modelID
+
+  // Pick-resolution tables consumed by CadView's batchId branch.
+  mesh.instanceParents = instanceParents
+  mesh.instanceOccurrenceIds = instanceOccurrenceIds
+
+  // `ifcManager` shim — several call-sites discriminate "is this an IFC
+  // model?" by `if (!m.ifcManager)`; without it the model-loaded effects
+  // (NavTree, search index) are skipped. Same shape the merged path attaches.
+  mesh.ifcManager = makeConwayDirectIfcManager(ifcAPI, modelID)
+
+  mesh.computeBoundingBox?.()
+  mesh.computeBoundingSphere?.()
+
+  mesh.capabilities = mesh.capabilities ?? {}
+  // batchedPicking only — see the class doc above for why expressIdPicking /
+  // instancePicking are intentionally left off.
+  mesh.capabilities.batchedPicking = true
+  mesh.capabilities.ifcSubsets = false
+
+  // Property / spatial closures (getItemProperties, getPropertySets,
+  // getSpatialStructure, getIfcType) — identical to the merged path, so the
+  // STEP/IFC metadata surface is unchanged.
+  attachConwayDirectModelMethods(mesh, ifcAPI, modelID)
+
+  return {model: mesh, stats}
+}

--- a/src/viewer/ifc/conwayDirectIfcLoader.js
+++ b/src/viewer/ifc/conwayDirectIfcLoader.js
@@ -237,7 +237,7 @@ export function decorateConwayDirectIfcModel(ifcModel, ifcAPI, modelID, opts = {
  * @param {number} modelID
  * @return {object} the shim
  */
-function makeConwayDirectIfcManager(ifcAPI, modelID) {
+export function makeConwayDirectIfcManager(ifcAPI, modelID) {
   return {
     ifcAPI,
     getSpatialStructure: (_modelIDArg, withProperties = false) =>
@@ -260,7 +260,7 @@ function makeConwayDirectIfcManager(ifcAPI, modelID) {
  * @param {object} ifcAPI
  * @param {number} modelID
  */
-function attachConwayDirectModelMethods(ifcModel, ifcAPI, modelID) {
+export function attachConwayDirectModelMethods(ifcModel, ifcAPI, modelID) {
   // Two-arg + single-arg calling conventions exist across consumers:
   //   - `(modelID, withProps)` — CadView.jsx, ShareViewer.getByFloor,
   //     IfcIsolator (mirrors `ifcManager.getSpatialStructure` shape)

--- a/src/viewer/ifc/conwayVector.js
+++ b/src/viewer/ifc/conwayVector.js
@@ -1,0 +1,23 @@
+/**
+ * conwayVector — tiny iteration helper shared by the Conway FlatMesh
+ * consumers (`flatMeshToBatchedModel`, `flatMeshToInstancedModel`).
+ *
+ * Conway's compat surface hands back Emscripten `Vector` objects
+ * (`size()` / `get(i)`), but the same builders also run over plain JS
+ * arrays of FlatMesh-shaped objects in tests. This normalises the two so
+ * the callers don't each carry a byte-identical copy of the loop.
+ */
+
+
+/**
+ * Iterate a Conway `Vector` (size()/get(i)) or a plain Array uniformly.
+ *
+ * @param {object|Array} vec
+ * @param {Function} fn called with each element
+ */
+export function forEachVectorItem(vec, fn) {
+  const size = typeof vec?.size === 'function' ? vec.size() : (vec?.length ?? 0)
+  for (let i = 0; i < size; i++) {
+    fn(typeof vec.get === 'function' ? vec.get(i) : vec[i])
+  }
+}

--- a/src/viewer/ifc/flatMeshToBatchedModel.js
+++ b/src/viewer/ifc/flatMeshToBatchedModel.js
@@ -7,6 +7,7 @@ import {
   MeshLambertMaterial,
   Vector4,
 } from 'three'
+import {forEachVectorItem} from './conwayVector'
 
 
 /**
@@ -91,20 +92,6 @@ const OPAQUE_ALPHA = 1
  *   triangleCount, parentCount, materialCount, transparentInstanceCount,
  *   skippedFlatMeshes, skippedPlacedGeometries}`.
  */
-
-
-/**
- * Iterate a Conway `Vector` (size()/get(i)) or a plain Array uniformly.
- *
- * @param {object|Array} vec
- * @param {Function} fn called with each element
- */
-function forEachVectorItem(vec, fn) {
-  const size = typeof vec?.size === 'function' ? vec.size() : (vec?.length ?? 0)
-  for (let i = 0; i < size; i++) {
-    fn(typeof vec.get === 'function' ? vec.get(i) : vec[i])
-  }
-}
 
 
 /**

--- a/src/viewer/ifc/flatMeshToBatchedModel.js
+++ b/src/viewer/ifc/flatMeshToBatchedModel.js
@@ -2,15 +2,16 @@ import {
   BatchedMesh,
   BufferAttribute,
   BufferGeometry,
-  Color,
   DoubleSide,
   Matrix4,
   MeshLambertMaterial,
+  Vector4,
 } from 'three'
 
 
 /**
- * flatMeshToBatchedModel — Conway FlatMesh stream → a `THREE.BatchedMesh`.
+ * flatMeshToBatchedModel — Conway FlatMesh stream → `THREE.BatchedMesh`
+ * batches.
  *
  * The GPU-instanced counterpart to `flatMeshToBufferGeometry` (the merge
  * path). Conway's compat surface already emits the web-ifc instancing
@@ -21,24 +22,25 @@ import {
  * `geometryExpressID` is fetched once and added to a `BatchedMesh` as one
  * geometry; every placement becomes an *instance* with its own matrix +
  * colour. So N placements of a shape cost 1 vertex copy + N matrices
- * instead of N vertex copies — the ~60% reduction the §3b.iv measurements
- * showed on instance-heavy models.
+ * instead of N vertex copies — the ~60% reduction §3b.iv measured.
  *
  * Why `BatchedMesh` and not `InstancedMesh`-per-shape: the §3b.iv numbers
  * showed naive per-shape instancing explodes the draw count (Snowdon
  * 1 → ~10k). `BatchedMesh` draws *all* its geometries + instances in one
- * multi-draw call, so the draw count stays ~1 while the memory win is
- * taken. Singletons cost nothing extra — they are just instance-count-1
- * geometries in the same batch.
+ * multi-draw call.
  *
- * Picking: `BatchedMesh` raycasts return `intersection.batchId` (the
- * per-instance id from `addInstance`), so this returns the
- * `batchId → parentExpressId` and `batchId → occurrenceId` tables a pick
- * resolves through — no triangle→instance lookup needed. The occurrence id
- * is the same synthetic per-placement id the merge path mints, so
- * selection parity is preserved.
+ * **Transparency:** opaque and transparent instances need different
+ * material states (a transparent material disables `depthWrite` and goes
+ * through the blended pass), so they cannot share one `BatchedMesh`.
+ * Placements are split by alpha into an opaque batch and a transparent
+ * batch, each with per-instance RGBA colour (`setColorAt(Vector4)` writes
+ * alpha into the batch's RGBA colours texture). A shape used both ways has
+ * its geometry in both batches. The caller wraps >1 batch in a Group.
  *
- * Returns the `BatchedMesh` plus those tables and the assembly stats.
+ * Picking: `BatchedMesh` raycasts return `intersection.batchId`, so each
+ * batch carries `batchId → parentExpressId` / `batchId → occurrenceId`
+ * tables. The occurrence id is a single emission-order id space across
+ * both batches, so selection is consistent regardless of the split.
  *
  * @see flatMeshToInstancedModel — the grouping/measurement-only sibling.
  */
@@ -53,19 +55,33 @@ const VERT_STRIDE = 6
 /** Floats per position / normal vector. */
 const VEC3 = 3
 
+/** Indices per triangle. */
+const INDICES_PER_TRIANGLE = 3
+
+/** An instance is transparent (own blended batch) when alpha is below this. */
+const OPAQUE_ALPHA = 1
+
+
+/**
+ * @typedef {object} BatchHandle
+ * @property {BatchedMesh} mesh the batch (one geometry per unique shape it
+ *   uses, one instance per placement).
+ * @property {MeshLambertMaterial} material the batch material.
+ * @property {boolean} transparent whether this is the blended batch.
+ * @property {Uint32Array} instanceParents `batchId → parent IFC product
+ *   expressID`.
+ * @property {Uint32Array} instanceOccurrenceIds `batchId → synthetic 0-based
+ *   occurrence id` (global emission order across both batches).
+ */
+
 
 /**
  * @typedef {object} BatchedModel
- * @property {BatchedMesh} mesh the assembled batch (one geometry per unique
- *   `geometryExpressID`, one instance per placement, per-instance matrix +
- *   colour).
- * @property {MeshLambertMaterial} material the (single) batch material.
- * @property {Uint32Array} instanceParents `batchId → parent IFC product
- *   expressID` (the `FlatMesh.expressID`); the pick resolution table.
- * @property {Uint32Array} instanceOccurrenceIds `batchId → synthetic 0-based
- *   occurrence id` (emission order, the same id space the merge path mints).
- * @property {object} stats `{uniqueGeometryCount, instanceCount,
- *   vertexCount, skippedFlatMeshes, skippedPlacedGeometries}`.
+ * @property {Array<BatchHandle>} batches 1-2 batches (opaque, transparent),
+ *   non-empty only.
+ * @property {object} stats `{uniqueGeometryCount, instanceCount, vertexCount,
+ *   triangleCount, parentCount, materialCount, transparentInstanceCount,
+ *   skippedFlatMeshes, skippedPlacedGeometries}`.
  */
 
 
@@ -116,7 +132,8 @@ function localGeometry(rawVerts, rawIndices, vertCount) {
 
 /**
  * Collect, per unique `geometryExpressID`, its local geometry (fetched once)
- * and the list of placements referencing it.
+ * and the list of placements referencing it, tagging each placement with a
+ * global emission-order occurrence id.
  *
  * @param {object|Array} flatMeshes FlatMesh source
  * @param {object} api Conway-compatible IfcAPI
@@ -125,10 +142,12 @@ function localGeometry(rawVerts, rawIndices, vertCount) {
  */
 function collectGroups(flatMeshes, api, modelID) {
   const groups = new Map()
+  const bad = new Set() // geomExpressIDs that resolved to no usable geometry
   const totals = {
-    placements: 0, vertexCount: 0, indexCount: 0,
+    placements: 0, transparentPlacements: 0, vertexCount: 0, indexCount: 0,
     skippedFlatMeshes: 0, skippedPlacedGeometries: 0,
   }
+  let occurrenceId = 0 // global, emission order — shared across both batches
   forEachVectorItem(flatMeshes, (flatMesh) => {
     const parentExpressId = flatMesh?.expressID
     const placedVec = flatMesh?.geometries
@@ -140,9 +159,17 @@ function collectGroups(flatMeshes, api, modelID) {
       const geomExpressID = placed?.geometryExpressID
       let group = groups.get(geomExpressID)
       if (group === undefined) {
+        // Known-bad shape: count this placement as skipped (matching the
+        // merged path's per-placement semantics) but don't re-cross the
+        // Conway boundary for a geometry we already rejected.
+        if (bad.has(geomExpressID)) {
+          totals.skippedPlacedGeometries++
+          return
+        }
         // eslint-disable-next-line new-cap
         const geom = api.GetGeometry(modelID, geomExpressID)
         if (!geom) {
+          bad.add(geomExpressID)
           totals.skippedPlacedGeometries++
           return
         }
@@ -150,7 +177,11 @@ function collectGroups(flatMeshes, api, modelID) {
         const indexSize = geom.GetIndexDataSize()
         // eslint-disable-next-line new-cap
         const vertSize = geom.GetVertexDataSize()
-        if (indexSize === 0 || vertSize === 0) {
+        // vertSize must be a whole number of `[p,n]` vertices — otherwise the
+        // truncated vertCount would leave indices pointing past the copied
+        // vertices (a corrupt triangle in the shared batch buffer).
+        if (indexSize === 0 || vertSize === 0 || vertSize % VERT_STRIDE !== 0) {
+          bad.add(geomExpressID)
           totals.skippedPlacedGeometries++
           return
         }
@@ -159,17 +190,23 @@ function collectGroups(flatMeshes, api, modelID) {
         const rawVerts = api.GetVertexArray(geom.GetVertexData(), vertCount * VERT_STRIDE)
         // eslint-disable-next-line new-cap
         const rawIndices = api.GetIndexArray(geom.GetIndexData(), indexSize)
-        group = {geometry: localGeometry(rawVerts, rawIndices, vertCount), placements: []}
+        group = {
+          geometry: localGeometry(rawVerts, rawIndices, vertCount),
+          vertCount,
+          indexCount: indexSize,
+          placements: [],
+        }
         groups.set(geomExpressID, group)
         totals.vertexCount += vertCount
         totals.indexCount += indexSize
       }
-      group.placements.push({
-        matrix: placed.flatTransformation,
-        color: placed.color ?? DEFAULT_COLOR,
-        parentExpressId,
-      })
+      const color = placed.color ?? DEFAULT_COLOR
+      group.placements.push({matrix: placed.flatTransformation, color, parentExpressId, occurrenceId})
+      occurrenceId++
       totals.placements++
+      if (color.w < OPAQUE_ALPHA) {
+        totals.transparentPlacements++
+      }
     })
   })
   return {groups, totals}
@@ -177,7 +214,64 @@ function collectGroups(flatMeshes, api, modelID) {
 
 
 /**
- * Build a `THREE.BatchedMesh` from a captured Conway FlatMesh stream.
+ * Build one `BatchedMesh` from the placements of every group that match the
+ * given transparency, or null when none do.
+ *
+ * @param {Map} groups geometryExpressID → group
+ * @param {boolean} transparent select transparent (alpha<1) placements
+ * @return {BatchHandle|null}
+ */
+function buildBatch(groups, transparent) {
+  // Size the batch up front: a geometry slot for each shape with a matching
+  // placement, an instance slot per matching placement.
+  let vertexCount = 0
+  let indexCount = 0
+  let instanceCount = 0
+  const used = []
+  for (const group of groups.values()) {
+    const placements = group.placements.filter((p) => (p.color.w < OPAQUE_ALPHA) === transparent)
+    if (placements.length === 0) {
+      continue
+    }
+    used.push({group, placements})
+    vertexCount += group.vertCount
+    indexCount += group.indexCount
+    instanceCount += placements.length
+  }
+  if (instanceCount === 0) {
+    return null
+  }
+
+  const material = new MeshLambertMaterial({side: DoubleSide})
+  if (transparent) {
+    material.transparent = true
+    // Don't occlude geometry behind the glass; per-instance alpha blends.
+    material.depthWrite = false
+  }
+  const mesh = new BatchedMesh(instanceCount, vertexCount, indexCount, material)
+  const instanceParents = new Uint32Array(instanceCount)
+  const instanceOccurrenceIds = new Uint32Array(instanceCount)
+  const matrix = new Matrix4()
+  const rgba = new Vector4()
+
+  for (const {group, placements} of used) {
+    const geometryId = mesh.addGeometry(group.geometry)
+    for (const placement of placements) {
+      const batchId = mesh.addInstance(geometryId)
+      mesh.setMatrixAt(batchId, matrix.fromArray(placement.matrix))
+      // Vector4 carries alpha into the batch's RGBA colours texture.
+      mesh.setColorAt(batchId, rgba.set(
+        placement.color.x, placement.color.y, placement.color.z, placement.color.w))
+      instanceParents[batchId] = placement.parentExpressId
+      instanceOccurrenceIds[batchId] = placement.occurrenceId
+    }
+  }
+  return {mesh, material, transparent, instanceParents, instanceOccurrenceIds}
+}
+
+
+/**
+ * Build `THREE.BatchedMesh` batches from a captured Conway FlatMesh stream.
  *
  * @param {object|Array} flatMeshes FlatMesh source
  * @param {object} api Conway-compatible IfcAPI. Needs `GetGeometry`,
@@ -188,39 +282,17 @@ function collectGroups(flatMeshes, api, modelID) {
 export function flatMeshToBatchedModel(flatMeshes, api, modelID) {
   const {groups, totals} = collectGroups(flatMeshes, api, modelID)
 
-  const material = new MeshLambertMaterial({side: DoubleSide})
-  // Capacities must bound the whole batch up front: one geometry slot per
-  // unique shape worth of verts/indices, one instance slot per placement.
-  const mesh = new BatchedMesh(
-    Math.max(totals.placements, 1),
-    Math.max(totals.vertexCount, 1),
-    Math.max(totals.indexCount, 1),
-    material)
+  const batches = [buildBatch(groups, false), buildBatch(groups, true)].filter(Boolean)
 
-  const instanceParents = new Uint32Array(totals.placements)
-  const instanceOccurrenceIds = new Uint32Array(totals.placements)
-  const matrix = new Matrix4()
-  const color = new Color()
-  let occurrenceId = 0 // synthetic, emission order — matches the merge path
-
-  for (const group of groups.values()) {
-    const geometryId = mesh.addGeometry(group.geometry)
-    for (const placement of group.placements) {
-      const batchId = mesh.addInstance(geometryId)
-      mesh.setMatrixAt(batchId, matrix.fromArray(placement.matrix))
-      mesh.setColorAt(batchId, color.setRGB(
-        placement.color.x, placement.color.y, placement.color.z))
-      instanceParents[batchId] = placement.parentExpressId
-      instanceOccurrenceIds[batchId] = occurrenceId++
+  const parents = new Set()
+  for (const batch of batches) {
+    for (const p of batch.instanceParents) {
+      parents.add(p)
     }
   }
 
-  const INDICES_PER_TRIANGLE = 3
   return {
-    mesh,
-    material,
-    instanceParents,
-    instanceOccurrenceIds,
+    batches,
     stats: {
       uniqueGeometryCount: groups.size,
       instanceCount: totals.placements,
@@ -229,8 +301,9 @@ export function flatMeshToBatchedModel(flatMeshes, api, modelID) {
       // `[conwayDirect] parsed` log line works unchanged. triangleCount /
       // vertexCount are the *unique* (deduped) totals — the memory win.
       triangleCount: (totals.indexCount / INDICES_PER_TRIANGLE) | 0,
-      parentCount: new Set(instanceParents).size,
-      materialCount: 1,
+      parentCount: parents.size,
+      materialCount: batches.length,
+      transparentInstanceCount: totals.transparentPlacements,
       skippedFlatMeshes: totals.skippedFlatMeshes,
       skippedPlacedGeometries: totals.skippedPlacedGeometries,
     },

--- a/src/viewer/ifc/flatMeshToBatchedModel.js
+++ b/src/viewer/ifc/flatMeshToBatchedModel.js
@@ -76,6 +76,10 @@ const OPAQUE_ALPHA = 1
  *   local-space shape geometry` this instance was added from. Retained so
  *   `batchedSubset` can re-bake a selection/isolation subset (the packed
  *   batch buffers aren't conveniently re-readable per instance).
+ * @property {Array<object>} instanceColors `batchId → original `{x,y,z,w}`
+ *   RGBA`. Retained so `batchedHighlight` can recolor a selected instance
+ *   via `setColorAt` and restore the exact original afterwards (alpha
+ *   included — `getColorAt` would drop it).
  */
 
 
@@ -256,6 +260,7 @@ function buildBatch(groups, transparent) {
   const instanceParents = new Uint32Array(instanceCount)
   const instanceOccurrenceIds = new Uint32Array(instanceCount)
   const instanceGeometry = new Array(instanceCount)
+  const instanceColors = new Array(instanceCount)
   const matrix = new Matrix4()
   const rgba = new Vector4()
 
@@ -270,9 +275,13 @@ function buildBatch(groups, transparent) {
       instanceParents[batchId] = placement.parentExpressId
       instanceOccurrenceIds[batchId] = placement.occurrenceId
       instanceGeometry[batchId] = group.geometry
+      instanceColors[batchId] = placement.color
     }
   }
-  return {mesh, material, transparent, instanceParents, instanceOccurrenceIds, instanceGeometry}
+  return {
+    mesh, material, transparent,
+    instanceParents, instanceOccurrenceIds, instanceGeometry, instanceColors,
+  }
 }
 
 

--- a/src/viewer/ifc/flatMeshToBatchedModel.js
+++ b/src/viewer/ifc/flatMeshToBatchedModel.js
@@ -1,0 +1,238 @@
+import {
+  BatchedMesh,
+  BufferAttribute,
+  BufferGeometry,
+  Color,
+  DoubleSide,
+  Matrix4,
+  MeshLambertMaterial,
+} from 'three'
+
+
+/**
+ * flatMeshToBatchedModel — Conway FlatMesh stream → a `THREE.BatchedMesh`.
+ *
+ * The GPU-instanced counterpart to `flatMeshToBufferGeometry` (the merge
+ * path). Conway's compat surface already emits the web-ifc instancing
+ * model: each `PlacedGeometry` references a shared, source-unit *local*-
+ * space geometry by `geometryExpressID` plus its own `flatTransformation`
+ * placement matrix. The merge path discards that sharing — it bakes each
+ * matrix into a private vertex slab. This builder keeps it: each unique
+ * `geometryExpressID` is fetched once and added to a `BatchedMesh` as one
+ * geometry; every placement becomes an *instance* with its own matrix +
+ * colour. So N placements of a shape cost 1 vertex copy + N matrices
+ * instead of N vertex copies — the ~60% reduction the §3b.iv measurements
+ * showed on instance-heavy models.
+ *
+ * Why `BatchedMesh` and not `InstancedMesh`-per-shape: the §3b.iv numbers
+ * showed naive per-shape instancing explodes the draw count (Snowdon
+ * 1 → ~10k). `BatchedMesh` draws *all* its geometries + instances in one
+ * multi-draw call, so the draw count stays ~1 while the memory win is
+ * taken. Singletons cost nothing extra — they are just instance-count-1
+ * geometries in the same batch.
+ *
+ * Picking: `BatchedMesh` raycasts return `intersection.batchId` (the
+ * per-instance id from `addInstance`), so this returns the
+ * `batchId → parentExpressId` and `batchId → occurrenceId` tables a pick
+ * resolves through — no triangle→instance lookup needed. The occurrence id
+ * is the same synthetic per-placement id the merge path mints, so
+ * selection parity is preserved.
+ *
+ * Returns the `BatchedMesh` plus those tables and the assembly stats.
+ *
+ * @see flatMeshToInstancedModel — the grouping/measurement-only sibling.
+ */
+
+
+/** Fallback colour used when a PlacedGeometry has no `.color` field. */
+const DEFAULT_COLOR = {x: 0.8, y: 0.8, z: 0.8, w: 1}
+
+/** Interleaved vertex stride from Conway: `[px, py, pz, nx, ny, nz]`. */
+const VERT_STRIDE = 6
+
+/** Floats per position / normal vector. */
+const VEC3 = 3
+
+
+/**
+ * @typedef {object} BatchedModel
+ * @property {BatchedMesh} mesh the assembled batch (one geometry per unique
+ *   `geometryExpressID`, one instance per placement, per-instance matrix +
+ *   colour).
+ * @property {MeshLambertMaterial} material the (single) batch material.
+ * @property {Uint32Array} instanceParents `batchId → parent IFC product
+ *   expressID` (the `FlatMesh.expressID`); the pick resolution table.
+ * @property {Uint32Array} instanceOccurrenceIds `batchId → synthetic 0-based
+ *   occurrence id` (emission order, the same id space the merge path mints).
+ * @property {object} stats `{uniqueGeometryCount, instanceCount,
+ *   vertexCount, skippedFlatMeshes, skippedPlacedGeometries}`.
+ */
+
+
+/**
+ * Iterate a Conway `Vector` (size()/get(i)) or a plain Array uniformly.
+ *
+ * @param {object|Array} vec
+ * @param {Function} fn called with each element
+ */
+function forEachVectorItem(vec, fn) {
+  const size = typeof vec?.size === 'function' ? vec.size() : (vec?.length ?? 0)
+  for (let i = 0; i < size; i++) {
+    fn(typeof vec.get === 'function' ? vec.get(i) : vec[i])
+  }
+}
+
+
+/**
+ * De-interleave a Conway `[p,n]` vertex buffer into a local-space
+ * `BufferGeometry` (position + normal + index). No transform is applied —
+ * placement is per-instance on the BatchedMesh.
+ *
+ * @param {Float32Array} rawVerts interleaved p+n, `vertCount * 6` floats
+ * @param {Uint32Array} rawIndices u32 indices
+ * @param {number} vertCount vertices
+ * @return {BufferGeometry}
+ */
+function localGeometry(rawVerts, rawIndices, vertCount) {
+  const positions = new Float32Array(vertCount * VEC3)
+  const normals = new Float32Array(vertCount * VEC3)
+  for (let v = 0; v < vertCount; v++) {
+    const src = v * VERT_STRIDE
+    const dst = v * VEC3
+    positions[dst] = rawVerts[src]
+    positions[dst + 1] = rawVerts[src + 1]
+    positions[dst + 2] = rawVerts[src + 2]
+    normals[dst] = rawVerts[src + 3]
+    normals[dst + 1] = rawVerts[src + 4]
+    normals[dst + 2] = rawVerts[src + 5]
+  }
+  const geometry = new BufferGeometry()
+  geometry.setAttribute('position', new BufferAttribute(positions, VEC3))
+  geometry.setAttribute('normal', new BufferAttribute(normals, VEC3))
+  geometry.setIndex(new BufferAttribute(Uint32Array.from(rawIndices), 1))
+  return geometry
+}
+
+
+/**
+ * Collect, per unique `geometryExpressID`, its local geometry (fetched once)
+ * and the list of placements referencing it.
+ *
+ * @param {object|Array} flatMeshes FlatMesh source
+ * @param {object} api Conway-compatible IfcAPI
+ * @param {number} modelID
+ * @return {{groups: Map, totals: object}}
+ */
+function collectGroups(flatMeshes, api, modelID) {
+  const groups = new Map()
+  const totals = {
+    placements: 0, vertexCount: 0, indexCount: 0,
+    skippedFlatMeshes: 0, skippedPlacedGeometries: 0,
+  }
+  forEachVectorItem(flatMeshes, (flatMesh) => {
+    const parentExpressId = flatMesh?.expressID
+    const placedVec = flatMesh?.geometries
+    if (parentExpressId === undefined || !placedVec) {
+      totals.skippedFlatMeshes++
+      return
+    }
+    forEachVectorItem(placedVec, (placed) => {
+      const geomExpressID = placed?.geometryExpressID
+      let group = groups.get(geomExpressID)
+      if (group === undefined) {
+        // eslint-disable-next-line new-cap
+        const geom = api.GetGeometry(modelID, geomExpressID)
+        if (!geom) {
+          totals.skippedPlacedGeometries++
+          return
+        }
+        // eslint-disable-next-line new-cap
+        const indexSize = geom.GetIndexDataSize()
+        // eslint-disable-next-line new-cap
+        const vertSize = geom.GetVertexDataSize()
+        if (indexSize === 0 || vertSize === 0) {
+          totals.skippedPlacedGeometries++
+          return
+        }
+        const vertCount = (vertSize / VERT_STRIDE) | 0
+        // eslint-disable-next-line new-cap
+        const rawVerts = api.GetVertexArray(geom.GetVertexData(), vertCount * VERT_STRIDE)
+        // eslint-disable-next-line new-cap
+        const rawIndices = api.GetIndexArray(geom.GetIndexData(), indexSize)
+        group = {geometry: localGeometry(rawVerts, rawIndices, vertCount), placements: []}
+        groups.set(geomExpressID, group)
+        totals.vertexCount += vertCount
+        totals.indexCount += indexSize
+      }
+      group.placements.push({
+        matrix: placed.flatTransformation,
+        color: placed.color ?? DEFAULT_COLOR,
+        parentExpressId,
+      })
+      totals.placements++
+    })
+  })
+  return {groups, totals}
+}
+
+
+/**
+ * Build a `THREE.BatchedMesh` from a captured Conway FlatMesh stream.
+ *
+ * @param {object|Array} flatMeshes FlatMesh source
+ * @param {object} api Conway-compatible IfcAPI. Needs `GetGeometry`,
+ *   `GetVertexArray`, `GetIndexArray`.
+ * @param {number} modelID
+ * @return {BatchedModel}
+ */
+export function flatMeshToBatchedModel(flatMeshes, api, modelID) {
+  const {groups, totals} = collectGroups(flatMeshes, api, modelID)
+
+  const material = new MeshLambertMaterial({side: DoubleSide})
+  // Capacities must bound the whole batch up front: one geometry slot per
+  // unique shape worth of verts/indices, one instance slot per placement.
+  const mesh = new BatchedMesh(
+    Math.max(totals.placements, 1),
+    Math.max(totals.vertexCount, 1),
+    Math.max(totals.indexCount, 1),
+    material)
+
+  const instanceParents = new Uint32Array(totals.placements)
+  const instanceOccurrenceIds = new Uint32Array(totals.placements)
+  const matrix = new Matrix4()
+  const color = new Color()
+  let occurrenceId = 0 // synthetic, emission order — matches the merge path
+
+  for (const group of groups.values()) {
+    const geometryId = mesh.addGeometry(group.geometry)
+    for (const placement of group.placements) {
+      const batchId = mesh.addInstance(geometryId)
+      mesh.setMatrixAt(batchId, matrix.fromArray(placement.matrix))
+      mesh.setColorAt(batchId, color.setRGB(
+        placement.color.x, placement.color.y, placement.color.z))
+      instanceParents[batchId] = placement.parentExpressId
+      instanceOccurrenceIds[batchId] = occurrenceId++
+    }
+  }
+
+  const INDICES_PER_TRIANGLE = 3
+  return {
+    mesh,
+    material,
+    instanceParents,
+    instanceOccurrenceIds,
+    stats: {
+      uniqueGeometryCount: groups.size,
+      instanceCount: totals.placements,
+      vertexCount: totals.vertexCount,
+      // Keys below mirror buildConwayIfcModel's stats so the shared
+      // `[conwayDirect] parsed` log line works unchanged. triangleCount /
+      // vertexCount are the *unique* (deduped) totals — the memory win.
+      triangleCount: (totals.indexCount / INDICES_PER_TRIANGLE) | 0,
+      parentCount: new Set(instanceParents).size,
+      materialCount: 1,
+      skippedFlatMeshes: totals.skippedFlatMeshes,
+      skippedPlacedGeometries: totals.skippedPlacedGeometries,
+    },
+  }
+}

--- a/src/viewer/ifc/flatMeshToBatchedModel.js
+++ b/src/viewer/ifc/flatMeshToBatchedModel.js
@@ -72,6 +72,10 @@ const OPAQUE_ALPHA = 1
  *   expressID`.
  * @property {Uint32Array} instanceOccurrenceIds `batchId → synthetic 0-based
  *   occurrence id` (global emission order across both batches).
+ * @property {Array<BufferGeometry>} instanceGeometry `batchId → the shared
+ *   local-space shape geometry` this instance was added from. Retained so
+ *   `batchedSubset` can re-bake a selection/isolation subset (the packed
+ *   batch buffers aren't conveniently re-readable per instance).
  */
 
 
@@ -251,6 +255,7 @@ function buildBatch(groups, transparent) {
   const mesh = new BatchedMesh(instanceCount, vertexCount, indexCount, material)
   const instanceParents = new Uint32Array(instanceCount)
   const instanceOccurrenceIds = new Uint32Array(instanceCount)
+  const instanceGeometry = new Array(instanceCount)
   const matrix = new Matrix4()
   const rgba = new Vector4()
 
@@ -264,9 +269,10 @@ function buildBatch(groups, transparent) {
         placement.color.x, placement.color.y, placement.color.z, placement.color.w))
       instanceParents[batchId] = placement.parentExpressId
       instanceOccurrenceIds[batchId] = placement.occurrenceId
+      instanceGeometry[batchId] = group.geometry
     }
   }
-  return {mesh, material, transparent, instanceParents, instanceOccurrenceIds}
+  return {mesh, material, transparent, instanceParents, instanceOccurrenceIds, instanceGeometry}
 }
 
 

--- a/src/viewer/ifc/flatMeshToBatchedModel.js
+++ b/src/viewer/ifc/flatMeshToBatchedModel.js
@@ -165,6 +165,13 @@ function collectGroups(flatMeshes, api, modelID) {
     }
     forEachVectorItem(placedVec, (placed) => {
       const geomExpressID = placed?.geometryExpressID
+      // Skip a placement with no geometry id — mirrors the parent guard
+      // above. Without it, an undefined id would key one shared "undefined"
+      // group and cross the Conway boundary with a bogus id.
+      if (geomExpressID === undefined) {
+        totals.skippedPlacedGeometries++
+        return
+      }
       let group = groups.get(geomExpressID)
       if (group === undefined) {
         // Known-bad shape: count this placement as skipped (matching the

--- a/src/viewer/ifc/flatMeshToBatchedModel.test.js
+++ b/src/viewer/ifc/flatMeshToBatchedModel.test.js
@@ -1,0 +1,133 @@
+/* eslint-disable no-magic-numbers */
+import {BatchedMesh} from 'three'
+import {flatMeshToBatchedModel} from './flatMeshToBatchedModel'
+
+
+/** Identity 4x4 in three.js column-major flat form. */
+const IDENTITY_MAT = [
+  1, 0, 0, 0,
+  0, 1, 0, 0,
+  0, 0, 1, 0,
+  0, 0, 0, 1,
+]
+
+
+/** @return {Float32Array} single-triangle interleaved vert buffer (p+n). */
+function unitTriangleVerts() {
+  return new Float32Array([
+    0, 0, 0, 0, 0, 1,
+    1, 0, 0, 0, 0, 1,
+    0, 1, 0, 0, 0, 1,
+  ])
+}
+
+
+/**
+ * @param {object} byGeomExpressId map of geomExpressID → {vertexData, indexData}
+ * @return {object} mock Conway IfcAPI
+ */
+function makeApi(byGeomExpressId) {
+  const api = {
+    _verts: new Map(),
+    _indices: new Map(),
+    GetGeometry(_modelID, geomExpressID) {
+      const g = byGeomExpressId[geomExpressID]
+      if (!g) {
+        return null
+      }
+      // Encode the geomExpressID into the data-pointer so GetVertexArray /
+      // GetIndexArray return the right buffer per geometry.
+      return {
+        GetVertexData: () => geomExpressID,
+        GetIndexData: () => geomExpressID,
+        GetVertexDataSize: () => g.vertexData.length,
+        GetIndexDataSize: () => g.indexData.length,
+      }
+    },
+    GetVertexArray(ptr) {
+      return byGeomExpressId[ptr].vertexData
+    },
+    GetIndexArray(ptr) {
+      return byGeomExpressId[ptr].indexData
+    },
+  }
+  return api
+}
+
+
+describe('viewer/ifc/flatMeshToBatchedModel', () => {
+  it('builds a BatchedMesh with one geometry per shape and one instance per placement', () => {
+    // One shared shape, three placements — the instancing case.
+    const api = makeApi({999: {vertexData: unitTriangleVerts(), indexData: new Uint32Array([0, 1, 2])}})
+    const flatMeshes = [{
+      expressID: 100,
+      geometries: {
+        size: () => 3,
+        get: () => ({geometryExpressID: 999, flatTransformation: IDENTITY_MAT}),
+      },
+    }]
+    const {mesh, instanceParents, instanceOccurrenceIds, stats} =
+      flatMeshToBatchedModel(flatMeshes, api, 0)
+    expect(mesh).toBeInstanceOf(BatchedMesh)
+    expect(stats.uniqueGeometryCount).toBe(1) // one shared shape
+    expect(stats.instanceCount).toBe(3) // three placements
+    expect(stats.vertexCount).toBe(3) // shape stored once (not 9)
+    // Every placement resolves back to its parent product, with a distinct
+    // synthetic occurrence id in emission order.
+    expect(Array.from(instanceParents)).toEqual([100, 100, 100])
+    expect(Array.from(instanceOccurrenceIds)).toEqual([0, 1, 2])
+  })
+
+  it('adds a distinct geometry per unique geometryExpressID (compound case)', () => {
+    const api = makeApi({
+      1: {vertexData: unitTriangleVerts(), indexData: new Uint32Array([0, 1, 2])},
+      2: {vertexData: unitTriangleVerts(), indexData: new Uint32Array([0, 1, 2])},
+    })
+    const flatMeshes = [{
+      expressID: 100,
+      geometries: {
+        size: () => 2,
+        get: (i) => ({geometryExpressID: i === 0 ? 1 : 2, flatTransformation: IDENTITY_MAT}),
+      },
+    }]
+    const {stats} = flatMeshToBatchedModel(flatMeshes, api, 0)
+    expect(stats.uniqueGeometryCount).toBe(2)
+    expect(stats.instanceCount).toBe(2)
+    expect(stats.vertexCount).toBe(6) // two distinct shapes, 3 verts each
+  })
+
+  it('maps each instance to the right parent across multiple products', () => {
+    const api = makeApi({999: {vertexData: unitTriangleVerts(), indexData: new Uint32Array([0, 1, 2])}})
+    const flatMeshes = [
+      {expressID: 100, geometries: [{geometryExpressID: 999, flatTransformation: IDENTITY_MAT}]},
+      {expressID: 200, geometries: [{geometryExpressID: 999, flatTransformation: IDENTITY_MAT}]},
+    ]
+    const {instanceParents, stats} = flatMeshToBatchedModel(flatMeshes, api, 0)
+    expect(stats.uniqueGeometryCount).toBe(1) // shared shape across two products
+    expect(stats.instanceCount).toBe(2)
+    expect(Array.from(instanceParents)).toEqual([100, 200])
+  })
+
+  it('skips FlatMeshes without an expressID and missing/empty geometry', () => {
+    const api = makeApi({
+      999: {vertexData: unitTriangleVerts(), indexData: new Uint32Array([0, 1, 2])},
+      0: {vertexData: new Float32Array([]), indexData: new Uint32Array([])},
+    })
+    const flatMeshes = [
+      {expressID: undefined, geometries: [{geometryExpressID: 999, flatTransformation: IDENTITY_MAT}]},
+      {
+        expressID: 100,
+        geometries: [
+          {geometryExpressID: 999, flatTransformation: IDENTITY_MAT},
+          {geometryExpressID: 777, flatTransformation: IDENTITY_MAT}, // missing
+          {geometryExpressID: 0, flatTransformation: IDENTITY_MAT}, // empty
+        ],
+      },
+    ]
+    const {stats} = flatMeshToBatchedModel(flatMeshes, api, 0)
+    expect(stats.uniqueGeometryCount).toBe(1)
+    expect(stats.instanceCount).toBe(1)
+    expect(stats.skippedFlatMeshes).toBe(1)
+    expect(stats.skippedPlacedGeometries).toBe(2)
+  })
+})

--- a/src/viewer/ifc/flatMeshToBatchedModel.test.js
+++ b/src/viewer/ifc/flatMeshToBatchedModel.test.js
@@ -11,6 +11,9 @@ const IDENTITY_MAT = [
   0, 0, 0, 1,
 ]
 
+const OPAQUE = {x: 0.8, y: 0.8, z: 0.8, w: 1}
+const GLASS = {x: 0.6, y: 0.8, z: 1, w: 0.4}
+
 
 /** @return {Float32Array} single-triangle interleaved vert buffer (p+n). */
 function unitTriangleVerts() {
@@ -27,16 +30,12 @@ function unitTriangleVerts() {
  * @return {object} mock Conway IfcAPI
  */
 function makeApi(byGeomExpressId) {
-  const api = {
-    _verts: new Map(),
-    _indices: new Map(),
+  return {
     GetGeometry(_modelID, geomExpressID) {
       const g = byGeomExpressId[geomExpressID]
       if (!g) {
         return null
       }
-      // Encode the geomExpressID into the data-pointer so GetVertexArray /
-      // GetIndexArray return the right buffer per geometry.
       return {
         GetVertexData: () => geomExpressID,
         GetIndexData: () => geomExpressID,
@@ -51,83 +50,101 @@ function makeApi(byGeomExpressId) {
       return byGeomExpressId[ptr].indexData
     },
   }
-  return api
+}
+
+
+/** @return {object} api with one unit-triangle shape at id 999. */
+function unitTriApi() {
+  return makeApi({999: {vertexData: unitTriangleVerts(), indexData: new Uint32Array([0, 1, 2])}})
 }
 
 
 describe('viewer/ifc/flatMeshToBatchedModel', () => {
-  it('builds a BatchedMesh with one geometry per shape and one instance per placement', () => {
-    // One shared shape, three placements — the instancing case.
-    const api = makeApi({999: {vertexData: unitTriangleVerts(), indexData: new Uint32Array([0, 1, 2])}})
+  it('builds one opaque batch: one geometry per shape, one instance per placement', () => {
     const flatMeshes = [{
       expressID: 100,
       geometries: {
         size: () => 3,
-        get: () => ({geometryExpressID: 999, flatTransformation: IDENTITY_MAT}),
+        get: () => ({geometryExpressID: 999, flatTransformation: IDENTITY_MAT, color: OPAQUE}),
       },
     }]
-    const {mesh, instanceParents, instanceOccurrenceIds, stats} =
-      flatMeshToBatchedModel(flatMeshes, api, 0)
-    expect(mesh).toBeInstanceOf(BatchedMesh)
+    const {batches, stats} = flatMeshToBatchedModel(flatMeshes, unitTriApi(), 0)
+    expect(batches.length).toBe(1)
+    expect(batches[0].transparent).toBe(false)
+    expect(batches[0].mesh).toBeInstanceOf(BatchedMesh)
     expect(stats.uniqueGeometryCount).toBe(1) // one shared shape
     expect(stats.instanceCount).toBe(3) // three placements
-    expect(stats.vertexCount).toBe(3) // shape stored once (not 9)
-    // Every placement resolves back to its parent product, with a distinct
-    // synthetic occurrence id in emission order.
-    expect(Array.from(instanceParents)).toEqual([100, 100, 100])
-    expect(Array.from(instanceOccurrenceIds)).toEqual([0, 1, 2])
+    expect(stats.vertexCount).toBe(3) // stored once (not 9)
+    expect(stats.transparentInstanceCount).toBe(0)
+    expect(Array.from(batches[0].instanceParents)).toEqual([100, 100, 100])
+    expect(Array.from(batches[0].instanceOccurrenceIds)).toEqual([0, 1, 2])
   })
 
-  it('adds a distinct geometry per unique geometryExpressID (compound case)', () => {
-    const api = makeApi({
-      1: {vertexData: unitTriangleVerts(), indexData: new Uint32Array([0, 1, 2])},
-      2: {vertexData: unitTriangleVerts(), indexData: new Uint32Array([0, 1, 2])},
-    })
+  it('splits opaque and transparent placements into separate batches', () => {
+    // Same shape, one opaque + one glass placement → two batches.
     const flatMeshes = [{
       expressID: 100,
-      geometries: {
-        size: () => 2,
-        get: (i) => ({geometryExpressID: i === 0 ? 1 : 2, flatTransformation: IDENTITY_MAT}),
-      },
+      geometries: [
+        {geometryExpressID: 999, flatTransformation: IDENTITY_MAT, color: OPAQUE},
+        {geometryExpressID: 999, flatTransformation: IDENTITY_MAT, color: GLASS},
+      ],
     }]
-    const {stats} = flatMeshToBatchedModel(flatMeshes, api, 0)
-    expect(stats.uniqueGeometryCount).toBe(2)
-    expect(stats.instanceCount).toBe(2)
-    expect(stats.vertexCount).toBe(6) // two distinct shapes, 3 verts each
+    const {batches, stats} = flatMeshToBatchedModel(flatMeshes, unitTriApi(), 0)
+    expect(batches.length).toBe(2)
+    const opaque = batches.find((b) => !b.transparent)
+    const transparent = batches.find((b) => b.transparent)
+    expect(opaque.material.transparent).toBe(false)
+    expect(transparent.material.transparent).toBe(true)
+    expect(transparent.material.depthWrite).toBe(false)
+    expect(stats.transparentInstanceCount).toBe(1)
+    expect(stats.materialCount).toBe(2)
+    // The occurrence id space is global across both batches (emission order).
+    expect(Array.from(opaque.instanceOccurrenceIds)).toEqual([0])
+    expect(Array.from(transparent.instanceOccurrenceIds)).toEqual([1])
   })
 
-  it('maps each instance to the right parent across multiple products', () => {
+  it('emits only an opaque batch when nothing is transparent', () => {
+    const flatMeshes = [
+      {expressID: 100, geometries: [{geometryExpressID: 999, flatTransformation: IDENTITY_MAT, color: OPAQUE}]},
+      {expressID: 200, geometries: [{geometryExpressID: 999, flatTransformation: IDENTITY_MAT, color: OPAQUE}]},
+    ]
+    const {batches, stats} = flatMeshToBatchedModel(flatMeshes, unitTriApi(), 0)
+    expect(batches.length).toBe(1)
+    expect(stats.uniqueGeometryCount).toBe(1) // shared across two products
+    expect(stats.instanceCount).toBe(2)
+    expect(Array.from(batches[0].instanceParents)).toEqual([100, 200])
+  })
+
+  it('skips a bad geometry once (no redundant re-fetch) and counts each skipped placement', () => {
+    let getGeometryCalls = 0
     const api = makeApi({999: {vertexData: unitTriangleVerts(), indexData: new Uint32Array([0, 1, 2])}})
-    const flatMeshes = [
-      {expressID: 100, geometries: [{geometryExpressID: 999, flatTransformation: IDENTITY_MAT}]},
-      {expressID: 200, geometries: [{geometryExpressID: 999, flatTransformation: IDENTITY_MAT}]},
-    ]
-    const {instanceParents, stats} = flatMeshToBatchedModel(flatMeshes, api, 0)
-    expect(stats.uniqueGeometryCount).toBe(1) // shared shape across two products
-    expect(stats.instanceCount).toBe(2)
-    expect(Array.from(instanceParents)).toEqual([100, 200])
+    const wrapped = {...api, GetGeometry(m, id) {
+      getGeometryCalls++
+      // eslint-disable-next-line new-cap
+      return api.GetGeometry(m, id)
+    }}
+    const flatMeshes = [{
+      expressID: 100,
+      geometries: [
+        {geometryExpressID: 999, flatTransformation: IDENTITY_MAT, color: OPAQUE},
+        {geometryExpressID: 777, flatTransformation: IDENTITY_MAT, color: OPAQUE}, // bad, ref'd twice
+        {geometryExpressID: 777, flatTransformation: IDENTITY_MAT, color: OPAQUE},
+      ],
+    }]
+    const {stats} = flatMeshToBatchedModel(flatMeshes, wrapped, 0)
+    expect(stats.skippedPlacedGeometries).toBe(2) // each bad placement counted
+    // GetGeometry called once for 999 + once for 777 (not twice) = 2.
+    expect(getGeometryCalls).toBe(2)
   })
 
-  it('skips FlatMeshes without an expressID and missing/empty geometry', () => {
-    const api = makeApi({
-      999: {vertexData: unitTriangleVerts(), indexData: new Uint32Array([0, 1, 2])},
-      0: {vertexData: new Float32Array([]), indexData: new Uint32Array([])},
-    })
+  it('skips FlatMeshes without an expressID', () => {
     const flatMeshes = [
-      {expressID: undefined, geometries: [{geometryExpressID: 999, flatTransformation: IDENTITY_MAT}]},
-      {
-        expressID: 100,
-        geometries: [
-          {geometryExpressID: 999, flatTransformation: IDENTITY_MAT},
-          {geometryExpressID: 777, flatTransformation: IDENTITY_MAT}, // missing
-          {geometryExpressID: 0, flatTransformation: IDENTITY_MAT}, // empty
-        ],
-      },
+      {expressID: undefined, geometries: [{geometryExpressID: 999, flatTransformation: IDENTITY_MAT, color: OPAQUE}]},
+      {expressID: 100, geometries: [{geometryExpressID: 999, flatTransformation: IDENTITY_MAT, color: OPAQUE}]},
     ]
-    const {stats} = flatMeshToBatchedModel(flatMeshes, api, 0)
-    expect(stats.uniqueGeometryCount).toBe(1)
-    expect(stats.instanceCount).toBe(1)
+    const {batches, stats} = flatMeshToBatchedModel(flatMeshes, unitTriApi(), 0)
     expect(stats.skippedFlatMeshes).toBe(1)
-    expect(stats.skippedPlacedGeometries).toBe(2)
+    expect(stats.instanceCount).toBe(1)
+    expect(batches.length).toBe(1)
   })
 })

--- a/src/viewer/ifc/flatMeshToInstancedModel.js
+++ b/src/viewer/ifc/flatMeshToInstancedModel.js
@@ -25,6 +25,8 @@
  * @see flatMeshToBufferGeometry — the merge (baked) path this mirrors.
  */
 
+import {forEachVectorItem} from './conwayVector'
+
 
 /** Fallback colour used when a PlacedGeometry has no `.color` field. */
 const DEFAULT_COLOR = {x: 0.8, y: 0.8, z: 0.8, w: 1}
@@ -100,21 +102,6 @@ const BYTES_PER_INSTANCE = ((4 * 4) + 4) * 4
  * @property {object} stats see `computeStats` — draw-call and
  *   vertex-memory comparison of the merged vs. instanced shapes.
  */
-
-
-/**
- * Iterate the FlatMesh source uniformly whether it is a Conway
- * `Vector` (size()/get(i)) or a plain Array of FlatMesh-shaped objects.
- *
- * @param {object|Array} vec
- * @param {Function} fn called with each element
- */
-function forEachVectorItem(vec, fn) {
-  const size = typeof vec?.size === 'function' ? vec.size() : (vec?.length ?? 0)
-  for (let i = 0; i < size; i++) {
-    fn(typeof vec.get === 'function' ? vec.get(i) : vec[i])
-  }
-}
 
 
 /**

--- a/src/viewer/three/IfcIsolator.js
+++ b/src/viewer/three/IfcIsolator.js
@@ -85,6 +85,29 @@ export default class IfcIsolator {
   async setModel(ifcModel) {
     this.ifcModel = ifcModel
     const ids = new Set()
+    // BatchedMesh render path (`?feature=batchedMesh`): element IDs aren't a
+    // per-vertex attribute — they live in each batch's `instanceParents`
+    // table. Union those so hide / isolate (which gate on `visualElementsIds`
+    // and drive the `createSubset` surface attachBatchedSubsets installed)
+    // see the model's elements. Checked first because a BatchedMesh also has
+    // a `.geometry` (its packed buffer) that would mislead the branch below.
+    let foundBatched = false
+    if (typeof ifcModel.traverse === 'function') {
+      ifcModel.traverse((obj) => {
+        if (obj.isBatchedMesh && obj.instanceParents) {
+          foundBatched = true
+          for (const id of obj.instanceParents) {
+            ids.add(id)
+          }
+        }
+      })
+    }
+    if (foundBatched) {
+      this.visualElementsIds = [...ids]
+      const rootElement = await this.ifcModel.ifcManager.getSpatialStructure(0, false)
+      this.collectSpatialElementsId(rootElement)
+      return
+    }
     if (ifcModel.geometry && ifcModel.geometry.attributes) {
       const attr = ifcModel.geometry.attributes.expressID
       if (attr) {

--- a/src/viewer/three/IfcIsolator.test.js
+++ b/src/viewer/three/IfcIsolator.test.js
@@ -316,6 +316,22 @@ describe('viewer/three/IfcIsolator', () => {
       })
     })
 
+    it('unions expressIDs from a BatchedMesh model via instanceParents', () => {
+      const iso = makeIsolator()
+      // A BatchedMesh has a `.geometry` (its packed buffer) but no
+      // per-vertex expressID — the IDs live in `instanceParents`. The
+      // batched branch must win over the geometry-attribute branch.
+      const geom = new BufferGeometry()
+      geom.setAttribute('position', new BufferAttribute(new Float32Array(9), 3))
+      const model = new Mesh(geom, new MeshBasicMaterial())
+      model.isBatchedMesh = true
+      model.instanceParents = new Uint32Array([100, 100, 200, 300])
+      model.ifcManager = makeFakeManager()
+      return iso.setModel(model).then(() => {
+        expect(iso.visualElementsIds.sort((a, b) => a - b)).toEqual([100, 200, 300])
+      })
+    })
+
     it('skips Group children without an expressID attribute', () => {
       const iso = makeIsolator()
       const root = new Group()

--- a/src/viewer/three/context/camera/controls/orbit-control.js
+++ b/src/viewer/three/context/camera/controls/orbit-control.js
@@ -41,7 +41,31 @@ export class OrbitControl extends IfcComponent {
     // TODO(#1561): frame the loader's named primary-model object, not the
     // last scene child. Lights/helpers/isolation subsets appended after the
     // model can otherwise become the framing target.
-    const box = new Box3().setFromObject(scene.children[scene.children.length - 1])
+    const framed = scene.children[scene.children.length - 1]
+    const box = new Box3().setFromObject(framed)
+    // TEMP diagnostic (batched over-zoom): identify exactly what the fit
+    // frames and whether its world transform carries the coordination matrix.
+    try {
+      const e = framed?.matrixWorld?.elements
+      console.info(
+        `[fitDiag v2] framed type=${framed?.type} name="${framed?.name}" uuid=${framed?.uuid?.slice(0, 8)} ` +
+        `isGroup=${!!framed?.isGroup} children=${framed?.children?.length} ` +
+        `matrixWorldTranslation=[${e ? [e[12].toFixed(1), e[13].toFixed(1), e[14].toFixed(1)] : '?'}] ` +
+        `boxMin=[${box.min.toArray().map((n) => n.toFixed(1))}] boxMax=[${box.max.toArray().map((n) => n.toFixed(1))}]`)
+      let biggest = null
+      let biggestR = 0
+      scene.children.forEach((c) => {
+        const cb = new Box3().setFromObject(c)
+        const r = cb.isEmpty() ? 0 : cb.getSize(new Vector3()).length()
+        if (r > biggestR) {
+          biggestR = r
+          biggest = c
+        }
+      })
+      console.info(`[fitDiag v2] biggestChild type=${biggest?.type} diag=${biggestR.toFixed(1)} sceneChildCount=${scene.children.length}`)
+    } catch (e) {
+      console.warn('[fitDiag v2] framed-object diag failed', e)
+    }
 
     // True enclosing sphere of the model (half the box diagonal). The old
     // `max(x,y,z) * 0.5` used half the longest *edge*, which under-sizes the

--- a/src/viewer/three/context/camera/controls/orbit-control.js
+++ b/src/viewer/three/context/camera/controls/orbit-control.js
@@ -41,73 +41,7 @@ export class OrbitControl extends IfcComponent {
     // TODO(#1561): frame the loader's named primary-model object, not the
     // last scene child. Lights/helpers/isolation subsets appended after the
     // model can otherwise become the framing target.
-    const framed = scene.children[scene.children.length - 1]
-    const box = new Box3().setFromObject(framed)
-    // TEMP diagnostic (batched over-zoom): identify exactly what the fit
-    // frames and whether its world transform carries the coordination matrix.
-    try {
-      const e = framed?.matrixWorld?.elements
-      console.info(
-        `[fitDiag v2] framed type=${framed?.type} name="${framed?.name}" uuid=${framed?.uuid?.slice(0, 8)} ` +
-        `isGroup=${!!framed?.isGroup} children=${framed?.children?.length} ` +
-        `matrixWorldTranslation=[${e ? [e[12].toFixed(1), e[13].toFixed(1), e[14].toFixed(1)] : '?'}] ` +
-        `boxMin=[${box.min.toArray().map((n) => n.toFixed(1))}] boxMax=[${box.max.toArray().map((n) => n.toFixed(1))}]`)
-      let biggest = null
-      let biggestR = 0
-      scene.children.forEach((c) => {
-        const cb = new Box3().setFromObject(c)
-        const r = cb.isEmpty() ? 0 : cb.getSize(new Vector3()).length()
-        if (r > biggestR) {
-          biggestR = r
-          biggest = c
-        }
-      })
-      console.info(`[fitDiag v2] biggestChild type=${biggest?.type} diag=${biggestR.toFixed(1)} sceneChildCount=${scene.children.length}`)
-      // Dump every descendant of the framed object whose WORLD box is large,
-      // with its cached boundingBox, geometry boundingBox, and matrixWorld
-      // scale/translation — pinpoints whether a child's bounds or transform
-      // blew up between the two fits.
-      const fmt = (b) => b ? `[${b.min.toArray().map((n) => n.toFixed(0))}]→[${b.max.toArray().map((n) => n.toFixed(0))}]` : 'null'
-      ;(framed?.children ?? []).forEach((c, i) => {
-        const cb = new Box3().setFromObject(c)
-        console.info(
-          `[fitDiag v2]   child[${i}] type=${c.type} isBatched=${!!c.isBatchedMesh} visible=${c.visible} ` +
-          `name="${c.name}" uuid=${c.uuid?.slice(0, 8)} grandkids=${c.children?.length} ` +
-          `worldBox=${fmt(cb)}`)
-      })
-      framed?.traverse?.((o) => {
-        const wb = new Box3().setFromObject(o)
-        if (wb.isEmpty() || wb.getSize(new Vector3()).length() < 100) {
-          return
-        }
-        const me = o.matrixWorld.elements
-        let maxTrans = -1
-        let instCount = -1
-        if (o.isBatchedMesh && typeof o.getMatrixAt === 'function') {
-          const p = new Vector3()
-          const mat = o.matrixWorld.clone()
-          instCount = o.instanceParents?.length ?? -1
-          maxTrans = 0
-          for (let b = 0; b < instCount; b++) {
-            o.getMatrixAt(b, mat)
-            p.setFromMatrixPosition(mat)
-            const mag = Math.max(Math.abs(p.x), Math.abs(p.y), Math.abs(p.z))
-            if (mag > maxTrans) {
-              maxTrans = mag
-            }
-          }
-        }
-        console.info(
-          `[fitDiag v2]   node type=${o.type} isBatched=${!!o.isBatchedMesh} visible=${o.visible} ` +
-          `name="${o.name}" uuid=${o.uuid?.slice(0, 8)} parentType=${o.parent?.type} parentUuid=${o.parent?.uuid?.slice(0, 8)} ` +
-          `objBox=${fmt(o.boundingBox)} geomBox=${fmt(o.geometry?.boundingBox)} ` +
-          `mwScale=[${me[0].toFixed(2)},${me[5].toFixed(2)},${me[10].toFixed(2)}] ` +
-          `mwTrans=[${me[12].toFixed(0)},${me[13].toFixed(0)},${me[14].toFixed(0)}] ` +
-          `instCount=${instCount} maxInstTrans=${maxTrans.toFixed(1)} worldBox=${fmt(wb)}`)
-      })
-    } catch (e) {
-      console.warn('[fitDiag v2] framed-object diag failed', e)
-    }
+    const box = new Box3().setFromObject(scene.children[scene.children.length - 1])
 
     // True enclosing sphere of the model (half the box diagonal). The old
     // `max(x,y,z) * 0.5` used half the longest *edge*, which under-sizes the
@@ -147,26 +81,6 @@ export class OrbitControl extends IfcComponent {
     camera.near = Math.max(controls.minDistance * 0.5, 0.1)
     camera.far = (controls.maxDistance + sphere.radius) * 1.5
     camera.updateProjectionMatrix()
-
-    // TEMP diagnostic (batched over-zoom on Schependomlaan): the fit box is
-    // correct (~24m) yet the model shows as a far dot in batched mode. Logged
-    // SYNCHRONOUSLY (before the await, which may never resolve if the
-    // transition is interrupted) so it always fires — the `v2` tag confirms
-    // the freshly-deployed bundle is running. A deferred read reports where
-    // the camera actually settled, distinguishing "camera parked wrong" from
-    // "geometry rendered small". Remove once resolved.
-    const cam = this.ifcCamera.perspectiveCamera
-    console.info(
-      `[fitDiag v2] sphereR=${sphere.radius.toFixed(1)} fitDistance=${fitDistance.toFixed(1)} ` +
-      `preFitCamDist=${cam.position.distanceTo(sphere.center).toFixed(1)} ` +
-      `near=${camera.near.toFixed(2)} far=${camera.far.toFixed(1)} ` +
-      `sphereCenter=[${sphere.center.x.toFixed(1)},${sphere.center.y.toFixed(1)},${sphere.center.z.toFixed(1)}]`)
-    const c = sphere.center.clone()
-    setTimeout(() => {
-      console.info(
-        `[fitDiag v2] settled camPos=[${cam.position.x.toFixed(1)},${cam.position.y.toFixed(1)},` +
-        `${cam.position.z.toFixed(1)}] settledCamDistToCenter=${cam.position.distanceTo(c).toFixed(1)}`)
-    }, 1500)
 
     await controls.fitToSphere(sphere, true)
   }

--- a/src/viewer/three/context/camera/controls/orbit-control.js
+++ b/src/viewer/three/context/camera/controls/orbit-control.js
@@ -83,6 +83,19 @@ export class OrbitControl extends IfcComponent {
     camera.updateProjectionMatrix()
 
     await controls.fitToSphere(sphere, true)
+
+    // TEMP diagnostic (batched over-zoom on Schependomlaan): the fit box is
+    // correct (~24m) yet the model shows as a far dot in batched mode. Log
+    // the sphere/fit distance and where the camera actually ended up so we
+    // can tell "camera parked wrong" from "geometry rendered small". Logs on
+    // every model load so batched vs merged can be compared. Remove once
+    // resolved.
+    const camPos = this.ifcCamera.perspectiveCamera.position
+    console.info(
+      `[fitDiag] sphereR=${sphere.radius.toFixed(1)} fitDistance=${fitDistance.toFixed(1)} ` +
+      `camPos=[${camPos.x.toFixed(1)},${camPos.y.toFixed(1)},${camPos.z.toFixed(1)}] ` +
+      `camDistToCenter=${camPos.distanceTo(sphere.center).toFixed(1)} ` +
+      `sphereCenter=[${sphere.center.x.toFixed(1)},${sphere.center.y.toFixed(1)},${sphere.center.z.toFixed(1)}]`)
   }
   activateOrbitControls() {
     const controls = this.ifcCamera.cameraControls

--- a/src/viewer/three/context/camera/controls/orbit-control.js
+++ b/src/viewer/three/context/camera/controls/orbit-control.js
@@ -63,6 +63,40 @@ export class OrbitControl extends IfcComponent {
         }
       })
       console.info(`[fitDiag v2] biggestChild type=${biggest?.type} diag=${biggestR.toFixed(1)} sceneChildCount=${scene.children.length}`)
+      // Dump every descendant of the framed object whose WORLD box is large,
+      // with its cached boundingBox, geometry boundingBox, and matrixWorld
+      // scale/translation — pinpoints whether a child's bounds or transform
+      // blew up between the two fits.
+      const fmt = (b) => b ? `[${b.min.toArray().map((n) => n.toFixed(0))}]→[${b.max.toArray().map((n) => n.toFixed(0))}]` : 'null'
+      framed?.traverse?.((o) => {
+        const wb = new Box3().setFromObject(o)
+        if (wb.isEmpty() || wb.getSize(new Vector3()).length() < 100) {
+          return
+        }
+        const me = o.matrixWorld.elements
+        let maxTrans = -1
+        let instCount = -1
+        if (o.isBatchedMesh && typeof o.getMatrixAt === 'function') {
+          const p = new Vector3()
+          const mat = o.matrixWorld.clone()
+          instCount = o.instanceParents?.length ?? -1
+          maxTrans = 0
+          for (let b = 0; b < instCount; b++) {
+            o.getMatrixAt(b, mat)
+            p.setFromMatrixPosition(mat)
+            const mag = Math.max(Math.abs(p.x), Math.abs(p.y), Math.abs(p.z))
+            if (mag > maxTrans) {
+              maxTrans = mag
+            }
+          }
+        }
+        console.info(
+          `[fitDiag v2]   node type=${o.type} isBatched=${!!o.isBatchedMesh} ` +
+          `objBox=${fmt(o.boundingBox)} geomBox=${fmt(o.geometry?.boundingBox)} ` +
+          `mwScale=[${me[0].toFixed(2)},${me[5].toFixed(2)},${me[10].toFixed(2)}] ` +
+          `mwTrans=[${me[12].toFixed(0)},${me[13].toFixed(0)},${me[14].toFixed(0)}] ` +
+          `instCount=${instCount} maxInstTrans=${maxTrans.toFixed(1)} worldBox=${fmt(wb)}`)
+      })
     } catch (e) {
       console.warn('[fitDiag v2] framed-object diag failed', e)
     }

--- a/src/viewer/three/context/camera/controls/orbit-control.js
+++ b/src/viewer/three/context/camera/controls/orbit-control.js
@@ -82,20 +82,27 @@ export class OrbitControl extends IfcComponent {
     camera.far = (controls.maxDistance + sphere.radius) * 1.5
     camera.updateProjectionMatrix()
 
-    await controls.fitToSphere(sphere, true)
-
     // TEMP diagnostic (batched over-zoom on Schependomlaan): the fit box is
-    // correct (~24m) yet the model shows as a far dot in batched mode. Log
-    // the sphere/fit distance and where the camera actually ended up so we
-    // can tell "camera parked wrong" from "geometry rendered small". Logs on
-    // every model load so batched vs merged can be compared. Remove once
-    // resolved.
-    const camPos = this.ifcCamera.perspectiveCamera.position
+    // correct (~24m) yet the model shows as a far dot in batched mode. Logged
+    // SYNCHRONOUSLY (before the await, which may never resolve if the
+    // transition is interrupted) so it always fires — the `v2` tag confirms
+    // the freshly-deployed bundle is running. A deferred read reports where
+    // the camera actually settled, distinguishing "camera parked wrong" from
+    // "geometry rendered small". Remove once resolved.
+    const cam = this.ifcCamera.perspectiveCamera
     console.info(
-      `[fitDiag] sphereR=${sphere.radius.toFixed(1)} fitDistance=${fitDistance.toFixed(1)} ` +
-      `camPos=[${camPos.x.toFixed(1)},${camPos.y.toFixed(1)},${camPos.z.toFixed(1)}] ` +
-      `camDistToCenter=${camPos.distanceTo(sphere.center).toFixed(1)} ` +
+      `[fitDiag v2] sphereR=${sphere.radius.toFixed(1)} fitDistance=${fitDistance.toFixed(1)} ` +
+      `preFitCamDist=${cam.position.distanceTo(sphere.center).toFixed(1)} ` +
+      `near=${camera.near.toFixed(2)} far=${camera.far.toFixed(1)} ` +
       `sphereCenter=[${sphere.center.x.toFixed(1)},${sphere.center.y.toFixed(1)},${sphere.center.z.toFixed(1)}]`)
+    const c = sphere.center.clone()
+    setTimeout(() => {
+      console.info(
+        `[fitDiag v2] settled camPos=[${cam.position.x.toFixed(1)},${cam.position.y.toFixed(1)},` +
+        `${cam.position.z.toFixed(1)}] settledCamDistToCenter=${cam.position.distanceTo(c).toFixed(1)}`)
+    }, 1500)
+
+    await controls.fitToSphere(sphere, true)
   }
   activateOrbitControls() {
     const controls = this.ifcCamera.cameraControls

--- a/src/viewer/three/context/camera/controls/orbit-control.js
+++ b/src/viewer/three/context/camera/controls/orbit-control.js
@@ -68,6 +68,13 @@ export class OrbitControl extends IfcComponent {
       // scale/translation — pinpoints whether a child's bounds or transform
       // blew up between the two fits.
       const fmt = (b) => b ? `[${b.min.toArray().map((n) => n.toFixed(0))}]→[${b.max.toArray().map((n) => n.toFixed(0))}]` : 'null'
+      ;(framed?.children ?? []).forEach((c, i) => {
+        const cb = new Box3().setFromObject(c)
+        console.info(
+          `[fitDiag v2]   child[${i}] type=${c.type} isBatched=${!!c.isBatchedMesh} visible=${c.visible} ` +
+          `name="${c.name}" uuid=${c.uuid?.slice(0, 8)} grandkids=${c.children?.length} ` +
+          `worldBox=${fmt(cb)}`)
+      })
       framed?.traverse?.((o) => {
         const wb = new Box3().setFromObject(o)
         if (wb.isEmpty() || wb.getSize(new Vector3()).length() < 100) {
@@ -91,7 +98,8 @@ export class OrbitControl extends IfcComponent {
           }
         }
         console.info(
-          `[fitDiag v2]   node type=${o.type} isBatched=${!!o.isBatchedMesh} ` +
+          `[fitDiag v2]   node type=${o.type} isBatched=${!!o.isBatchedMesh} visible=${o.visible} ` +
+          `name="${o.name}" uuid=${o.uuid?.slice(0, 8)} parentType=${o.parent?.type} parentUuid=${o.parent?.uuid?.slice(0, 8)} ` +
           `objBox=${fmt(o.boundingBox)} geomBox=${fmt(o.geometry?.boundingBox)} ` +
           `mwScale=[${me[0].toFixed(2)},${me[5].toFixed(2)},${me[10].toFixed(2)}] ` +
           `mwTrans=[${me[12].toFixed(0)},${me[13].toFixed(0)},${me[14].toFixed(0)}] ` +

--- a/src/viewer/three/context/context.js
+++ b/src/viewer/three/context/context.js
@@ -92,15 +92,34 @@ export class IfcContext {
     this.items.components.length = 0
     this.items.ifcModels.forEach((model) => {
       model.removeFromParent()
-      if (model.geometry.boundsTree) {
-        model.geometry.disposeBoundsTree()
-      }
-      model.geometry.dispose()
-      if (Array.isArray(model.material)) {
-        model.material.forEach((mat) => mat.dispose())
-      } else {
-        model.material.dispose()
-      }
+      // Free any attached subset controller (batched isolation subsets + their
+      // baked geometries; no-op on models without one).
+      model.disposeSubsets?.()
+      // Dispose by traversal so every model shape frees its GPU resources: a
+      // plain Mesh (merged / wit-three), a BatchedMesh (Conway-direct
+      // `?feature=batchedMesh`), or a Group of either (batched opaque+
+      // transparent, or a GLB cache-hit). The old single-Mesh assumption threw
+      // on a Group (no `.geometry` / `.material`), aborting disposal mid-loop
+      // and leaking the remaining models.
+      model.traverse((obj) => {
+        if (obj.isBatchedMesh) {
+          // Per-geometry BVH (patched onto the prototype in ShareIfc) + the
+          // batch's internal matrix/color textures + packed geometry.
+          obj.disposeBoundsTree?.()
+          obj.dispose?.()
+        } else if (obj.isMesh) {
+          if (obj.geometry?.boundsTree) {
+            obj.geometry.disposeBoundsTree()
+          }
+          obj.geometry?.dispose?.()
+        }
+        const material = obj.material
+        if (Array.isArray(material)) {
+          material.forEach((mat) => mat?.dispose?.())
+        } else {
+          material?.dispose?.()
+        }
+      })
     })
     this.items.ifcModels.length = 0
     this.items.pickableIfcModels.length = 0


### PR DESCRIPTION
The render swap from PR1's grouper. Renders the Conway-direct geometry as a `THREE.BatchedMesh` — one geometry per shared `geometryExpressID` + per-instance transforms — instead of the merged `BufferGeometry`. Behind `?feature=batchedMesh` with a defensive fallback to the merged path on any construction error.

## Why BatchedMesh (the data decided it)
PR1's measurements (§3b.iv) showed the memory win is real on instance-heavy models (Revit Snowdon ~60% / ~63 MB; STEP `Arty.step` 26% / 25 MB) — **but** naive InstancedMesh-per-shape would explode the draw count (Snowdon 1 → ~10k). `BatchedMesh` multi-draws the whole batch (many shapes + per-instance transforms) in ~1 call, so it takes the memory win without the draw-call blowup. Singletons cost nothing extra.

## What's here

### Render
- **`flatMeshToBatchedModel.js`** — pure builder: fetch each unique shape once into a local-space `BufferGeometry` (`addGeometry`), one instance per placement (`addInstance` + `setMatrixAt` + `setColorAt`). Returns `batchId → parentExpressId` / `batchId → occurrenceId` tables for native picking + the retained per-batch `instanceGeometry`. **Unit-tested against the real `three.BatchedMesh`.**
- **Transparency** — opaque and blended instances can't share one material state, so placements are split by alpha into an **opaque batch** and a **transparent batch** (`depthWrite:false`, per-instance RGBA via `setColorAt(Vector4)`); >1 batch wraps in a `Group`. The occurrence-id space is global across both batches, so selection is split-agnostic. (Fixes the "glass no longer transparent" smoke-test finding.)
- **`buildBatchedConwayModel.js`** — glue: builds the mesh + attaches the `ifcManager` shim + property/spatial closures, so **NavTree + Properties light up identically**.

### Interaction (follow-ups, now landed)
- **Selection / hover-preselection / isolate** all drive the same call-sites the merged paths use. `batchedSubset.js` re-bakes the selected instances (`getMatrixAt` + retained `instanceGeometry`) into world-aligned subset Meshes carrying a synthetic per-vertex `expressID`, exposed through the standard `createSubset` / `removeSubset` contract. Capabilities are now `expressIdPicking` + `batchedPicking`, so `setSelection` / `highlightIfcItem` fall to the generic `model.createSubset` branch and `IfcIsolator` works unchanged (`visualElementsIds` unioned from `instanceParents`).
- **`three-mesh-bvh` accelerated raycast on `BatchedMesh`** — `ShareIfc` patches `BatchedMesh.prototype.{computeBoundsTree,raycast}` and each batch builds its per-geometry bounds trees. Validated that `acceleratedBatchedMeshRaycast` still emits `intersection.batchId`, so the pick path is sub-linear and unaffected.
- **Grouper stats** are forced to info-level when the flag is on, so the eval shows the dedup numbers next to what rendered.
- **`CadView` pick** — `intersection.batchId → parentExpressId`, funnelled through `selectItemsInScene`.

### GLB cache
A `BatchedMesh` model is **not GLB-cacheable yet** (no per-primitive geometry for `GLTFExporter`, no per-vertex `_EXPRESSID` for `BLDRS_face_ids`), so `exportAndCacheGlb` skips it and the model re-parses on the next load. A batched-aware GLB schema is future work.

## Safety
Ships **off by default**; default users are byte-identical. Render + pick can't be exercised headlessly, so this is a deploy-preview validation gate. Fallback to the merged path on any construction error means the flag can't break a load.

## How to validate in the preview
Open a model with `?feature=batchedMesh` and confirm: geometry renders correctly (placement, colour, **glass transparency**, no origin-collapse); the `[conwayDirect] parsed` + grouper-stats logs show the deduped counts; clicking a part outlines it and updates Properties + NavTree + permalink; hover preselects; H-isolate / hide work. Try Snowdon (Revit) and a STEP assembly.

## Remaining follow-ups (§3b.iv)
- **Per-occurrence outline narrowing** — selection currently highlights every occurrence of the picked product; narrowing to one placement needs `instancePicking` (pairs with the `expressID → occurrence path` generalization, #1569 — `batchId` is that per-occurrence handle).
- **Flip to always-on** — deferred pending smoke-test of the flagged path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y6URFWeMJexmXPGfp8N8S4)_