### PR TITLE
Upgrade @bldrs-ai/conway to 1.347.1107

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@babel/plugin-syntax-import-assertions": "7.18.6",
     "@babel/preset-env": "7.18.10",
     "@babel/preset-react": "7.18.6",
-    "@bldrs-ai/conway": "1.347.1107",
+    "@bldrs-ai/conway": "1.349.1111",
     "@bldrs-ai/ifclib": "5.3.3",
     "@emotion/react": "11.10.0",
     "@emotion/styled": "11.10.0",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@babel/plugin-syntax-import-assertions": "7.18.6",
     "@babel/preset-env": "7.18.10",
     "@babel/preset-react": "7.18.6",
-    "@bldrs-ai/conway": "1.334.1066",
+    "@bldrs-ai/conway": "1.347.1107",
     "@bldrs-ai/ifclib": "5.3.3",
     "@emotion/react": "11.10.0",
     "@emotion/styled": "11.10.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2473,10 +2473,10 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@bldrs-ai/conway@1.334.1066":
-  version "1.334.1066"
-  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.334.1066.tgz#b2b5d3719f41c92f04a556aea10649817e33f648"
-  integrity sha512-ohP1MVBAzKrgH64LZHtUZr7ssAavgqz1PSsy/h1/eBTDCm28exFWmxopTthzoivYSd+awwbOiVOy8yUliOAJGw==
+"@bldrs-ai/conway@1.347.1107":
+  version "1.347.1107"
+  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.347.1107.tgz#f3989b17539e5470acada69c1aa7ba8844600dc9"
+  integrity sha512-xW/Xrw/QoAaFEovG6ZwJ2tWyRyHEpYhIIfvyc+F583meG6oJRV5NdDx7ojGrq9QpuTCq72Rr710Wa/SuvWATRQ==
   dependencies:
     gl-matrix "3.4.3"
     seedrandom "3.0.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2473,10 +2473,10 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@bldrs-ai/conway@1.347.1107":
-  version "1.347.1107"
-  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.347.1107.tgz#f3989b17539e5470acada69c1aa7ba8844600dc9"
-  integrity sha512-xW/Xrw/QoAaFEovG6ZwJ2tWyRyHEpYhIIfvyc+F583meG6oJRV5NdDx7ojGrq9QpuTCq72Rr710Wa/SuvWATRQ==
+"@bldrs-ai/conway@1.349.1111":
+  version "1.349.1111"
+  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.349.1111.tgz#c5c772b81b70d96328001d0e44b4bd2ee5ae1670"
+  integrity sha512-kIiYqK/AzMq09m1iwZRJB/KWv6xLVHGMmERpHiqpn94ttxvoE8+NxFvWJzvmOs5ilS2hzx9VG9AltkgbYeFbtw==
   dependencies:
     gl-matrix "3.4.3"
     seedrandom "3.0.5"


### PR DESCRIPTION
## Summary
Updates the Conway dependency to a newer version (1.347.1107, from 1.334.1066).

## Changes
- Bumped `@bldrs-ai/conway` package version in `package.json`
- Lockfile updated with transitive dependency resolution

## Notes
This is a dependency upgrade. Review the Conway changelog to understand what improvements or fixes are included in this version bump.

https://claude.ai/code/session_01LfHL21ghUKsAq4xBCNFLdi