### PR TITLE
STEP occurrence-keyed selection: IfcInstanceMap foundation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,7 @@ This file is the router for AI assistants working in this repo. Keep it small. T
 | Marketing / blog site (Next.js SSG, sibling build to the viewer SPA), MDX content collections, SEO pipeline | [marketing/README.md](marketing/README.md) |
 | AdSense / ads strategy, route policy, test-hermeticity rules | [design/new/ads.md](design/new/ads.md) |
 | Conway-direct IFC pipeline, IfcInstanceMap, per-instance picking, `?feature=conwayDirectIfc` | [design/new/viewer-replacement.md](design/new/viewer-replacement.md) §3b |
+| STEP occurrence-keyed selection (NavTree↔scene per-occurrence), `PlacedGeometry.occurrencePath`, why one nut highlights all | [design/new/step-occurrence-selection.md](design/new/step-occurrence-selection.md) |
 | Removing the `conway-web-ifc-adapter` shim, the `web-ifc` engine seam (`webIfcShimAlias`/`USE_WEBIFC_SHIM`), Conway version-lag, runtime engine swap | [design/new/adapter-removal.md](design/new/adapter-removal.md) |
 | Epic/Story/Track catalogue, Pro-MVP phase plan, post-MVP loveables | [design/roadmap.md](design/roadmap.md) |
 

--- a/design/new/step-occurrence-selection.md
+++ b/design/new/step-occurrence-selection.md
@@ -35,25 +35,31 @@ already assigns one synthetic instance per `PlacedGeometry`.
 
 ### Done (this PR)
 
-- `IfcInstanceMap` now captures **`instanceIdToOccurrencePath`** from each
-  `PlacedGeometry.occurrencePath`, with `getOccurrencePathByInstance(id)`.
-  Additive and safe: `null` for IFC / a Conway without the field, so every
-  existing path is unchanged until the data appears. Unit-tested in
-  `IfcInstanceMap.test.js`.
+- **Data foundation.** `IfcInstanceMap` captures `instanceIdToOccurrencePath`
+  from each `PlacedGeometry.occurrencePath`, with `getOccurrencePathByInstance`
+  (instance → path) and `getInstanceIdsByOccurrencePath` (path → instances).
+  `bldrsSpatialTree.serializeNode` preserves `occurrencePath` so cache-hit trees
+  keep it. Store carries `selectedOccurrencePath`. All unit-tested; additive and
+  `null`/absent for IFC.
+- **Scene pick → NavTree (per-occurrence).** `canvasDoubleClickHandler` resolves
+  the picked instance's occurrence path and carries it into the selection funnel;
+  the NavTree scroll + `isSelected` match on the occurrence path, so a scene pick
+  highlights the *one* node — not every reuse. (Scene highlight was already
+  per-instance via `setInstanceSelection`.)
+- **NavTree click → NavTree (per-occurrence).** A node click passes its
+  `occurrencePath`, so clicking one occurrence of a reused part highlights only
+  that node in the tree, not all six.
 
-### Remaining (follow-up, needs the Conway bump + in-browser validation)
+### Remaining (follow-up)
 
-1. **Pick → occurrence.** In `CadView.canvasDoubleClickHandler`, resolve the
-   picked instance to its occurrence path (not just `parentExpressId`) and carry
-   it into selection.
-2. **NavTree node identity.** Key selection/highlight/scroll on the occurrence
-   path (nodes already expose `occurrencePath`) instead of the colliding
-   `expressID`, so one nut highlights one nut.
-3. **Highlight.** `IfcInstanceMap.createSubsetMeshByParent` collects *all* a
-   part-type's instances; add an occurrence-scoped subset so only the picked
-   occurrence lights up.
-4. **Permalink.** Extend the `#n:;p:` / element-path URL to encode the
-   occurrence path, and resolve it on load.
+1. **NavTree click → occurrence-scoped scene highlight.** A node click still
+   highlights *all* the part-type's instances in the 3D scene (only the tree
+   narrows). Resolve the node's `occurrencePath` → the per-mesh instance ids
+   (`getInstanceIdsByOccurrencePath` across the scene meshes) and pass them as
+   `instanceIds` so `setInstanceSelection` lights up only that occurrence. Needs
+   care with the per-mesh instance-id spaces, and in-browser validation.
+2. **Permalink.** Extend the `#n:;p:` / element-path URL to encode the occurrence
+   path and resolve it on load.
 
 Each step degrades gracefully to today's type-level behavior when no occurrence
 path is present.

--- a/design/new/step-occurrence-selection.md
+++ b/design/new/step-occurrence-selection.md
@@ -84,15 +84,23 @@ order; BVH permutes only the index buffer, not the numbering).
   just nicer: the node's NAUO id can't reach the PDS-keyed mesh, so without the
   path resolution a STEP node click highlights *nothing* in the scene.
 
+- **Cache-hit parity.** The occurrence tables also survive the GLB cache. The
+  writer persists the global `instanceId → occurrencePath` table on
+  `BLDRS_face_ids` (`glbExport` reads it off `model.instanceMap`); the reader
+  decodes it to `userData.bldrsFaceIds.occurrencePaths`, and `Loader.js`
+  reattaches it to each restored per-mesh map via
+  `IfcInstanceMap.attachOccurrencePaths` (only for the instance ids that mesh
+  actually holds, since the GLB splits into per-material primitives). Schema
+  bumped `0.8.0 → 0.9.0` so stale occurrence-less caches read as a miss and get
+  rewritten. **This is why an already-cached STEP model (e.g. one loaded on the
+  same preview origin before this change) has to be re-fetched once: OPFS holds
+  the old 0.8.0 artifact with no occurrence data until the schema bump forces a
+  re-parse.**
+
 ### Remaining (follow-up)
 
 1. **Permalink.** Extend the `#n:;p:` / element-path URL to encode the occurrence
    path and resolve it on load.
-2. **Cache-hit parity.** The occurrence tables ride the cache-miss
-   `buildConwayIfcModel` path; the cache-hit GLB restore
-   (`instanceMapFromTriangleIds` / `instanceMapFromGeometry` in `Loader.js`) does
-   not yet reconstruct them, so a reloaded (GLB-cached) STEP model falls back to
-   type-level selection until the path is persisted per-instance in the artifact.
 
 Each step degrades gracefully to today's type-level behavior when no occurrence
 path is present (IFC, single-occurrence parts).

--- a/design/new/step-occurrence-selection.md
+++ b/design/new/step-occurrence-selection.md
@@ -101,6 +101,21 @@ order; BVH permutes only the index buffer, not the numbering).
 
 1. **Permalink.** Extend the `#n:;p:` / element-path URL to encode the occurrence
    path and resolve it on load.
+2. **Root-level parts.** A placement directly under the product root has an empty
+   occurrence path (no NAUO), which `getOccurrencePathByInstance` normalizes to
+   `null` — an empty path can't disambiguate anything. So a scene pick of a
+   *root-level* part can't reconcile to its NavTree node (the pick reports the
+   PDS id, which never equals the node's id), and it silently degrades to
+   type-level. Harmless when the file has one root assembly (the common case);
+   only bites files with several distinct parts placed directly at the root. A
+   real fix needs a PDS→product-definition→node reverse map, out of scope here.
+3. **`?feature=batchedMesh`.** The BatchedMesh render path builds no
+   `IfcInstanceMap`, so per-occurrence (and all per-instance) selection no-ops
+   under that flag — a documented gap in `buildBatchedConwayModel`, not a
+   regression (NAUO≠PDS meant a STEP node click highlighted nothing there
+   before this work either).
 
 Each step degrades gracefully to today's type-level behavior when no occurrence
-path is present (IFC, single-occurrence parts).
+path is present (IFC, single-occurrence parts). NavTree **shift-click** on an
+occurrence node also degrades to type-level accumulate (multi-select wins the
+modifier slot; per-occurrence highlight is single-selection only).

--- a/design/new/step-occurrence-selection.md
+++ b/design/new/step-occurrence-selection.md
@@ -27,39 +27,72 @@ Share consumes this once it bumps to the Conway release that ships #353.
 
 ## Share side
 
-Selection flow today (all keyed on the scalar `expressID`):
-`NavTree click → node.expressID → viewer.setSelection([expressID])`, and
-`scene pick → triangle → IfcInstanceMap instance → parentExpressId → NavTree`.
-The mesh instance map (`src/viewer/ifc/IfcInstanceMap.js`) is the seam: it
-already assigns one synthetic instance per `PlacedGeometry`.
+### The id-space mismatch (why scalar `expressID` can't join the two sides)
+
+The two surfaces speak **different express-id spaces** for STEP:
+
+- **NavTree node** `expressID` = the occurrence's **NAUO** express id
+  (`AP214ProductStructureExtraction.buildNode`: `occurrenceExpressID ?? productDefId`).
+- **Geometry** `FlatMesh.expressID` / `IfcInstanceMap.parentExpressId` = the
+  geometry's owning element, the **`product_definition_shape`** (PDS), shared by
+  every occurrence of the part type (`ap214_scene_builder.geometryOccurrences`).
+
+So a NAUO id never equals a PDS id, and the *old* scalar-keyed flow
+(`node.expressID === selectedElements[0]`) matched **nothing** in either
+direction — the "no interaction between NavTree and scene" symptom. The one key
+**both** sides carry is the **occurrence path** (Conway's occurrence test proves
+the 18 geometry paths equal the 18 tree-leaf paths), so all cross-boundary
+selection now joins on it, not on the scalar id.
+
+### The runtime data path (where occurrence data had to be threaded)
+
+The cache-miss STEP load is `buildConwayIfcModel` → `decorateConwayDirectIfcModel`.
+`buildConwayIfcModel`'s map (via `instanceMapFromOrderedPlacedRanges`) *did* carry
+the occurrence tables — but `decorateConwayDirectIfcModel` **rebuilds** the map
+from geometry attributes (`instanceMapFromGeometry`) after the BVH permutes the
+index buffer, and per-vertex attributes can't encode a variable-length path. Two
+gaps closed: (a) `flatMeshToBufferGeometry` now stamps `occurrencePath` onto each
+range; (b) `decorateConwayDirectIfcModel` carries the occurrence tables
+(`instanceIdToOccurrencePath` / `occurrencePathToInstanceIds`) forward onto the
+rebuilt map — safe because the synthetic instance ids line up 1:1 (same emission
+order; BVH permutes only the index buffer, not the numbering).
 
 ### Done (this PR)
 
-- **Data foundation.** `IfcInstanceMap` captures `instanceIdToOccurrencePath`
-  from each `PlacedGeometry.occurrencePath`, with `getOccurrencePathByInstance`
-  (instance → path) and `getInstanceIdsByOccurrencePath` (path → instances).
-  `bldrsSpatialTree.serializeNode` preserves `occurrencePath` so cache-hit trees
-  keep it. Store carries `selectedOccurrencePath`. All unit-tested; additive and
-  `null`/absent for IFC.
+- **Data foundation.** `IfcInstanceMap` captures `instanceIdToOccurrencePath` +
+  `occurrencePathToInstanceIds` from each `PlacedGeometry.occurrencePath`, with
+  `getOccurrencePathByInstance` (instance → path) and
+  `getInstanceIdsByOccurrencePath` (path → instances).
+  `flatMeshToBufferGeometry` + `decorateConwayDirectIfcModel` thread the path to
+  the *runtime* map (see above). `bldrsSpatialTree.serializeNode` preserves
+  `occurrencePath` for cache-hit trees; `NavTreePanel.mapSpatialNode` keeps it on
+  the rendered node objects. Store carries `selectedOccurrencePath`. Unit-tested;
+  additive and `null`/absent for IFC.
 - **Scene pick → NavTree (per-occurrence).** `canvasDoubleClickHandler` resolves
-  the picked instance's occurrence path and carries it into the selection funnel;
-  the NavTree scroll + `isSelected` match on the occurrence path, so a scene pick
-  highlights the *one* node — not every reuse. (Scene highlight was already
-  per-instance via `setInstanceSelection`.)
+  the picked instance's occurrence path and carries it into the selection funnel.
+  The NavTree scroll + `isSelected` **match on the occurrence path** (not the
+  colliding PDS id the pick reports as `selectedElements[0]`), and the tree
+  auto-expands from the leaf NAUO id, so a scene pick reveals and highlights the
+  *one* node. Scene highlight is per-instance via `setInstanceSelection`.
 - **NavTree click → NavTree (per-occurrence).** A node click passes its
-  `occurrencePath`, so clicking one occurrence of a reused part highlights only
-  that node in the tree, not all six.
+  `occurrencePath`; the tree highlights only that occurrence, not all six.
+- **NavTree click → occurrence-scoped scene highlight.**
+  `ShareViewer.getInstanceIdsForOccurrencePath` resolves a node's path to the
+  exact instance ids (prefix-inclusive, so an assembly node lights up its whole
+  sub-tree) across the scene meshes; the click funnels them as `instanceIds` so
+  `setInstanceSelection` highlights only that occurrence. This is required, not
+  just nicer: the node's NAUO id can't reach the PDS-keyed mesh, so without the
+  path resolution a STEP node click highlights *nothing* in the scene.
 
 ### Remaining (follow-up)
 
-1. **NavTree click → occurrence-scoped scene highlight.** A node click still
-   highlights *all* the part-type's instances in the 3D scene (only the tree
-   narrows). Resolve the node's `occurrencePath` → the per-mesh instance ids
-   (`getInstanceIdsByOccurrencePath` across the scene meshes) and pass them as
-   `instanceIds` so `setInstanceSelection` lights up only that occurrence. Needs
-   care with the per-mesh instance-id spaces, and in-browser validation.
-2. **Permalink.** Extend the `#n:;p:` / element-path URL to encode the occurrence
+1. **Permalink.** Extend the `#n:;p:` / element-path URL to encode the occurrence
    path and resolve it on load.
+2. **Cache-hit parity.** The occurrence tables ride the cache-miss
+   `buildConwayIfcModel` path; the cache-hit GLB restore
+   (`instanceMapFromTriangleIds` / `instanceMapFromGeometry` in `Loader.js`) does
+   not yet reconstruct them, so a reloaded (GLB-cached) STEP model falls back to
+   type-level selection until the path is persisted per-instance in the artifact.
 
 Each step degrades gracefully to today's type-level behavior when no occurrence
-path is present.
+path is present (IFC, single-occurrence parts).

--- a/design/new/step-occurrence-selection.md
+++ b/design/new/step-occurrence-selection.md
@@ -1,0 +1,59 @@
+# STEP occurrence-keyed selection
+
+## Problem
+
+STEP reuses one part (`product_definition`) across many occurrences. Conway's
+geometry historically owned each mesh by the part *type*
+(`product_definition_shape`), shared by every occurrence, and Share keys
+selection on that scalar `expressID`. So selecting one nut in the NavTree
+highlights *all* nuts, and a scene pick can't tell which occurrence was hit.
+The unique key is the **occurrence path** — the ordered NAUO express ids
+root→leaf — which the product-structure tree already carries on every node as
+`occurrencePath`, but which was absent from the geometry.
+
+See Conway `design/new/step-metadata-nist.md` §"Occurrence identity".
+
+## Conway side (PR #353 — landed upstream)
+
+- Each geometry instance is stamped with its occurrence path, threaded through
+  the AP214 assembly walk.
+- The web-ifc compat surface exposes it: **`PlacedGeometry.occurrencePath`**
+  (`ReadonlyArray<number>`; `undefined` for IFC, empty for a root-level STEP
+  placement). `FlatMesh`es still group by the shared part-type expressID; the
+  per-occurrence identity rides on each `PlacedGeometry`, which lines up 1:1
+  with Share's per-instance `IfcInstanceMap`.
+
+Share consumes this once it bumps to the Conway release that ships #353.
+
+## Share side
+
+Selection flow today (all keyed on the scalar `expressID`):
+`NavTree click → node.expressID → viewer.setSelection([expressID])`, and
+`scene pick → triangle → IfcInstanceMap instance → parentExpressId → NavTree`.
+The mesh instance map (`src/viewer/ifc/IfcInstanceMap.js`) is the seam: it
+already assigns one synthetic instance per `PlacedGeometry`.
+
+### Done (this PR)
+
+- `IfcInstanceMap` now captures **`instanceIdToOccurrencePath`** from each
+  `PlacedGeometry.occurrencePath`, with `getOccurrencePathByInstance(id)`.
+  Additive and safe: `null` for IFC / a Conway without the field, so every
+  existing path is unchanged until the data appears. Unit-tested in
+  `IfcInstanceMap.test.js`.
+
+### Remaining (follow-up, needs the Conway bump + in-browser validation)
+
+1. **Pick → occurrence.** In `CadView.canvasDoubleClickHandler`, resolve the
+   picked instance to its occurrence path (not just `parentExpressId`) and carry
+   it into selection.
+2. **NavTree node identity.** Key selection/highlight/scroll on the occurrence
+   path (nodes already expose `occurrencePath`) instead of the colliding
+   `expressID`, so one nut highlights one nut.
+3. **Highlight.** `IfcInstanceMap.createSubsetMeshByParent` collects *all* a
+   part-type's instances; add an occurrence-scoped subset so only the picked
+   occurrence lights up.
+4. **Permalink.** Extend the `#n:;p:` / element-path URL to encode the
+   occurrence path, and resolve it on load.
+
+Each step degrades gracefully to today's type-level behavior when no occurrence
+path is present.

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@babel/plugin-syntax-import-assertions": "7.18.6",
     "@babel/preset-env": "7.18.10",
     "@babel/preset-react": "7.18.6",
-    "@bldrs-ai/conway": "1.349.1111",
+    "@bldrs-ai/conway": "1.353.1118",
     "@bldrs-ai/ifclib": "5.3.3",
     "@emotion/react": "11.10.0",
     "@emotion/styled": "11.10.0",

--- a/src/Components/Bot/BotChat.jsx
+++ b/src/Components/Bot/BotChat.jsx
@@ -85,7 +85,20 @@ export default function BotChat() {
     }
     setInput('')
 
-    const setSelectedElements = useStore.getState().setSelectedElements
+    // Wrap the store setter so a bot-driven selection also clears the
+    // per-occurrence / per-instance keys. `selectItemsInScene` (the normal
+    // selection funnel) resets those on every call; the bot bypasses it and
+    // sets `selectedElements` directly, so without this a stale
+    // `selectedOccurrencePath` from a prior STEP pick would keep the NavTree
+    // highlighting the old occurrence instead of the bot's new selection.
+    // Wrapping here also covers the eval'd `client_code`, which receives this
+    // same setter.
+    const rawSetSelectedElements = useStore.getState().setSelectedElements
+    const setSelectedElements = (ids) => {
+      useStore.getState().setSelectedInstanceIds([])
+      useStore.getState().setSelectedOccurrencePath(null)
+      rawSetSelectedElements(ids)
+    }
     const selectedElements = useStore.getState().selectedElements
 
     const userMsg = {id: uuid(), position: 'right', title: 'You:', text: content, date: new Date()}

--- a/src/Components/NavTree/NavTreePanel.jsx
+++ b/src/Components/NavTree/NavTreePanel.jsx
@@ -7,6 +7,7 @@ import {ToggleButton, ToggleButtonGroup, Tooltip} from '@mui/material'
 import {styled} from '@mui/material/styles'
 import useStore from '../../store/useStore'
 import {assertDefined} from '../../utils/assert'
+import {occurrencePathKey} from '../../utils/occurrencePaths'
 import Panel from '../SideDrawer/Panel'
 import NavTreeNode from './NavTreeNode'
 import {removeHashParams} from './hashState'
@@ -36,6 +37,14 @@ export default function NavTreePanel({
   const setExpandedTypes = useStore((state) => state.setExpandedTypes)
   const viewer = useStore((state) => state.viewer)
   const itemDefaultHeight = 24
+
+  // Canonical key of the selected occurrence path, computed once per render and
+  // threaded to every row — the per-row `isSelected` check and the scroll
+  // effect both compare against it, so joining it here avoids re-joining the
+  // (invariant) selected path for each of the many visible rows.
+  const selectedOccurrencePathKey =
+    selectedOccurrencePath && selectedOccurrencePath.length > 0 ?
+      occurrencePathKey(selectedOccurrencePath) : null
 
   const [navigationMode, setNavigationMode] = useState('spatial-tree')
   const isNavTree = navigationMode === 'spatial-tree'
@@ -95,11 +104,10 @@ export default function NavTreePanel({
     // (product_definition_shape), which never equals a tree node's id (its NAUO
     // express id) — the shared occurrence path is the only reliable join, so
     // prefer it. Falls back to expressID for IFC and when no occurrence is set.
-    if (selectedOccurrencePath && selectedOccurrencePath.length > 0) {
-      const target = selectedOccurrencePath.join('/')
+    if (selectedOccurrencePathKey !== null) {
       index = visibleNodes.findIndex(
         ({node}) => Array.isArray(node.occurrencePath) &&
-          node.occurrencePath.join('/') === target,
+          occurrencePathKey(node.occurrencePath) === selectedOccurrencePathKey,
       )
     }
     if (index < 0) {
@@ -113,7 +121,7 @@ export default function NavTreePanel({
     if (index >= 0 && listRef.current) {
       listRef.current.scrollToItem(index, 'center')
     }
-  }, [selectedElements, selectedOccurrencePath, visibleNodes])
+  }, [selectedElements, selectedOccurrencePathKey, visibleNodes])
 
   // Function to get item size
   const getItemSize = useCallback(
@@ -170,7 +178,7 @@ export default function NavTreePanel({
               expandedNodeIds,
               setExpandedNodeIds,
               selectedNodeIds: selectedElements,
-              selectedOccurrencePath,
+              selectedOccurrencePathKey,
               selectWithShiftClickEvents,
               model,
               viewer,
@@ -279,7 +287,7 @@ const RenderRow = ({index, style, data}) => {
     expandedNodeIds,
     setExpandedNodeIds,
     selectedNodeIds,
-    selectedOccurrencePath,
+    selectedOccurrencePathKey,
     selectWithShiftClickEvents,
     model,
     viewer,
@@ -299,10 +307,9 @@ const RenderRow = ({index, style, data}) => {
     // product_definition_shape id, which never equals this node's NAUO express
     // id), and it uniquely identifies one occurrence so a reused part lights up
     // only the clicked/picked node, not every reuse. Falls back to expressID for
-    // IFC and when no occurrence is selected (selectedOccurrencePath is null).
-    if (selectedOccurrencePath && selectedOccurrencePath.length > 0 &&
-        Array.isArray(node.occurrencePath)) {
-      isSelected = node.occurrencePath.join('/') === selectedOccurrencePath.join('/')
+    // IFC and when no occurrence is selected (selectedOccurrencePathKey is null).
+    if (selectedOccurrencePathKey !== null && Array.isArray(node.occurrencePath)) {
+      isSelected = occurrencePathKey(node.occurrencePath) === selectedOccurrencePathKey
     } else {
       isSelected = selectedNodeIds.includes(node.expressID.toString())
     }
@@ -352,7 +359,10 @@ const RenderRow = ({index, style, data}) => {
       // Pass the STEP occurrence path so clicking one occurrence of a reused
       // part highlights only that node, not every node sharing the expressID.
       // Undefined for IFC — selection stays keyed on the expressID alone.
-      selectWithShiftClickEvents(event.shiftKey, node.expressID.toString(), node.occurrencePath)
+      // `hasChildren` lets the scene-highlight resolver pick its lookup: a leaf
+      // takes the O(1) exact path, an assembly needs the descendant scan.
+      selectWithShiftClickEvents(
+        event.shiftKey, node.expressID.toString(), node.occurrencePath, hasChildren)
     }
   }
 

--- a/src/Components/NavTree/NavTreePanel.jsx
+++ b/src/Components/NavTree/NavTreePanel.jsx
@@ -90,26 +90,28 @@ export default function NavTreePanel({
 
   // Scroll to selected element
   useEffect(() => {
-    const nodeId = selectedElements[0]
-    if (nodeId) {
-      // STEP: a reused part shares one expressID across occurrences, so prefer
-      // the node on the selected occurrence path; fall back to first-by-expressID
-      // for IFC / when no occurrence is selected.
-      const matchesOccurrence = (node) =>
-        !selectedOccurrencePath || !Array.isArray(node.occurrencePath) ||
-        node.occurrencePath.join('/') === selectedOccurrencePath.join('/')
-      let index = visibleNodes.findIndex(
-        ({node}) => node.expressID && node.expressID.toString() === nodeId &&
-          matchesOccurrence(node),
+    let index = -1
+    // STEP: a scene pick reports the geometry's owner id
+    // (product_definition_shape), which never equals a tree node's id (its NAUO
+    // express id) — the shared occurrence path is the only reliable join, so
+    // prefer it. Falls back to expressID for IFC and when no occurrence is set.
+    if (selectedOccurrencePath && selectedOccurrencePath.length > 0) {
+      const target = selectedOccurrencePath.join('/')
+      index = visibleNodes.findIndex(
+        ({node}) => Array.isArray(node.occurrencePath) &&
+          node.occurrencePath.join('/') === target,
       )
-      if (index < 0) {
+    }
+    if (index < 0) {
+      const nodeId = selectedElements[0]
+      if (nodeId) {
         index = visibleNodes.findIndex(
           ({node}) => node.expressID && node.expressID.toString() === nodeId,
         )
       }
-      if (index >= 0 && listRef.current) {
-        listRef.current.scrollToItem(index, 'center')
-      }
+    }
+    if (index >= 0 && listRef.current) {
+      listRef.current.scrollToItem(index, 'center')
     }
   }, [selectedElements, selectedOccurrencePath, visibleNodes])
 
@@ -230,13 +232,21 @@ function getVisibleNodes(treeData, expandedNodeIds, isNavTree, model) {
     const childArray = Array.isArray(node.children) ?
       node.children.filter((c) => c && c.expressID !== undefined) :
       []
-    return {
+    const mapped = {
       nodeId: node.expressID.toString(),
       label: reifyName({properties: model}, node),
       expressID: node.expressID,
       hasChildren: childArray.length > 0,
       children: childArray.map(mapSpatialNode),
     }
+    // Preserve the STEP occurrence path (NAUO express ids) so RenderRow's
+    // `isSelected` and the scroll effect can distinguish a reused part's
+    // occurrences — the scalar `expressID` collides across them, so without
+    // this a single-node click / pick highlights every reuse. Absent for IFC.
+    if (Array.isArray(node.occurrencePath)) {
+      mapped.occurrencePath = node.occurrencePath
+    }
+    return mapped
   }
 
   if (isNavTree) {
@@ -284,14 +294,17 @@ const RenderRow = ({index, style, data}) => {
   let isSelected = false
 
   if (!hasChildren) {
-    // For element nodes
-    isSelected = selectedNodeIds.includes(node.expressID.toString())
-    // STEP per-occurrence: when a specific occurrence is selected, only the node
-    // on that exact occurrence path stays highlighted — otherwise every reuse of
-    // the shared part type (same expressID) would light up. No-op for IFC and
-    // when no occurrence is selected (selectedOccurrencePath is null).
-    if (isSelected && selectedOccurrencePath && Array.isArray(node.occurrencePath)) {
+    // STEP: match on the occurrence path when one is selected — it's the only
+    // key shared with the geometry side (a scene pick reports the part-type's
+    // product_definition_shape id, which never equals this node's NAUO express
+    // id), and it uniquely identifies one occurrence so a reused part lights up
+    // only the clicked/picked node, not every reuse. Falls back to expressID for
+    // IFC and when no occurrence is selected (selectedOccurrencePath is null).
+    if (selectedOccurrencePath && selectedOccurrencePath.length > 0 &&
+        Array.isArray(node.occurrencePath)) {
       isSelected = node.occurrencePath.join('/') === selectedOccurrencePath.join('/')
+    } else {
+      isSelected = selectedNodeIds.includes(node.expressID.toString())
     }
   }
 

--- a/src/Components/NavTree/NavTreePanel.jsx
+++ b/src/Components/NavTree/NavTreePanel.jsx
@@ -31,6 +31,7 @@ export default function NavTreePanel({
   const setIsNavTreeVisible = useStore((state) => state.setIsNavTreeVisible)
   const rootElement = useStore((state) => state.rootElement)
   const selectedElements = useStore((state) => state.selectedElements)
+  const selectedOccurrencePath = useStore((state) => state.selectedOccurrencePath)
   const setExpandedElements = useStore((state) => state.setExpandedElements)
   const setExpandedTypes = useStore((state) => state.setExpandedTypes)
   const viewer = useStore((state) => state.viewer)
@@ -91,14 +92,26 @@ export default function NavTreePanel({
   useEffect(() => {
     const nodeId = selectedElements[0]
     if (nodeId) {
-      const index = visibleNodes.findIndex(
-        ({node}) => node.expressID && node.expressID.toString() === nodeId,
+      // STEP: a reused part shares one expressID across occurrences, so prefer
+      // the node on the selected occurrence path; fall back to first-by-expressID
+      // for IFC / when no occurrence is selected.
+      const matchesOccurrence = (node) =>
+        !selectedOccurrencePath || !Array.isArray(node.occurrencePath) ||
+        node.occurrencePath.join('/') === selectedOccurrencePath.join('/')
+      let index = visibleNodes.findIndex(
+        ({node}) => node.expressID && node.expressID.toString() === nodeId &&
+          matchesOccurrence(node),
       )
+      if (index < 0) {
+        index = visibleNodes.findIndex(
+          ({node}) => node.expressID && node.expressID.toString() === nodeId,
+        )
+      }
       if (index >= 0 && listRef.current) {
         listRef.current.scrollToItem(index, 'center')
       }
     }
-  }, [selectedElements, visibleNodes])
+  }, [selectedElements, selectedOccurrencePath, visibleNodes])
 
   // Function to get item size
   const getItemSize = useCallback(
@@ -155,6 +168,7 @@ export default function NavTreePanel({
               expandedNodeIds,
               setExpandedNodeIds,
               selectedNodeIds: selectedElements,
+              selectedOccurrencePath,
               selectWithShiftClickEvents,
               model,
               viewer,
@@ -255,6 +269,7 @@ const RenderRow = ({index, style, data}) => {
     expandedNodeIds,
     setExpandedNodeIds,
     selectedNodeIds,
+    selectedOccurrencePath,
     selectWithShiftClickEvents,
     model,
     viewer,
@@ -271,6 +286,13 @@ const RenderRow = ({index, style, data}) => {
   if (!hasChildren) {
     // For element nodes
     isSelected = selectedNodeIds.includes(node.expressID.toString())
+    // STEP per-occurrence: when a specific occurrence is selected, only the node
+    // on that exact occurrence path stays highlighted — otherwise every reuse of
+    // the shared part type (same expressID) would light up. No-op for IFC and
+    // when no occurrence is selected (selectedOccurrencePath is null).
+    if (isSelected && selectedOccurrencePath && Array.isArray(node.occurrencePath)) {
+      isSelected = node.occurrencePath.join('/') === selectedOccurrencePath.join('/')
+    }
   }
 
   const rowRef = useRef(null)
@@ -314,7 +336,10 @@ const RenderRow = ({index, style, data}) => {
       const elementIds = node.children.map((child) => child.expressID.toString())
       selectWithShiftClickEvents(event.shiftKey, elementIds)
     } else if (node.expressID) {
-      selectWithShiftClickEvents(event.shiftKey, node.expressID.toString())
+      // Pass the STEP occurrence path so clicking one occurrence of a reused
+      // part highlights only that node, not every node sharing the expressID.
+      // Undefined for IFC — selection stays keyed on the expressID alone.
+      selectWithShiftClickEvents(event.shiftKey, node.expressID.toString(), node.occurrencePath)
     }
   }
 

--- a/src/Containers/CadView.jsx
+++ b/src/Containers/CadView.jsx
@@ -57,6 +57,7 @@ export default function CadView({
   const searchIndex = useStore((state) => state.searchIndex)
   const selectedElements = useStore((state) => state.selectedElements)
   const selectedInstanceIds = useStore((state) => state.selectedInstanceIds)
+  const selectedOccurrencePath = useStore((state) => state.selectedOccurrencePath)
   const setSelectedInstanceIds = useStore((state) => state.setSelectedInstanceIds)
   const setSelectedOccurrencePath = useStore((state) => state.setSelectedOccurrencePath)
   const setCutPlaneDirections = useStore((state) => state.setCutPlaneDirections)
@@ -903,8 +904,18 @@ export default function CadView({
           props = await viewer.getProperties(0, Number(lastId))
         }
         setSelectedElement(props)
-        // Update the expanded elements in NavTreePanel
-        const pathIds = getParentPathIdsForElement(elementsById, parseInt(lastId))
+        // Update the expanded elements in NavTreePanel. For a STEP occurrence
+        // the parent-link walk must key off the occurrence's own tree node —
+        // its leaf NAUO express id (the last occurrence-path entry) — not
+        // `lastId`, which on a scene pick is the geometry's
+        // product_definition_shape id and isn't a tree node at all. Walking
+        // from the leaf NAUO expands every ancestor up to the root so the
+        // picked node is actually visible (and scrollable) in the tree.
+        const expandFromId =
+          (selectedOccurrencePath && selectedOccurrencePath.length > 0) ?
+            selectedOccurrencePath[selectedOccurrencePath.length - 1] :
+            parseInt(lastId)
+        const pathIds = getParentPathIdsForElement(elementsById, expandFromId)
         if (pathIds) {
           setExpandedElements(pathIds.map((n) => `${n}`))
         }
@@ -919,7 +930,7 @@ export default function CadView({
         setSelectedElement(null)
       }
     })()
-  }, [selectedElements, selectedInstanceIds])
+  }, [selectedElements, selectedInstanceIds, selectedOccurrencePath])
   /* eslint-enable */
 
 
@@ -958,16 +969,21 @@ export default function CadView({
             // it goes straight to the funnel with no permalink.
             if (Array.isArray(expressIdOrIds)) {
               selectItemsInScene(expressIdOrIds, false)
+            } else if (occurrencePath && occurrencePath.length > 0) {
+              // STEP occurrence node. The tree node's id is its NAUO express id,
+              // but the geometry is keyed by the shared product_definition_shape,
+              // so parent-level selection (elementSelection → setSelection) can't
+              // reach the mesh — the occurrence path is the only shared key.
+              // Resolve it to the exact instance ids and drive the per-instance
+              // highlight directly, mirroring the scene-pick funnel. The node's
+              // expressID stays the "selection" so properties / nav / the tree's
+              // per-occurrence highlight (selectedOccurrencePath) all key off it.
+              const instanceIds =
+                typeof viewer.getInstanceIdsForOccurrencePath === 'function' ?
+                  viewer.getInstanceIdsForOccurrencePath(0, occurrencePath) : []
+              selectItemsInScene([expressIdOrIds], true, instanceIds, occurrencePath)
             } else {
-              // STEP: when the clicked node carries an occurrence path, inject
-              // it into the funnel (wrapping selectItemsInScene keeps
-              // elementSelection's signature untouched) so the NavTree
-              // highlights only that occurrence. Absent for IFC — unchanged.
-              const select = (occurrencePath && occurrencePath.length > 0) ?
-                (ids, updateNav, instanceIds = []) =>
-                  selectItemsInScene(ids, updateNav, instanceIds, occurrencePath) :
-                selectItemsInScene
-              elementSelection(viewer, elementsById, select, isShiftKeyDown, expressIdOrIds)
+              elementSelection(viewer, elementsById, selectItemsInScene, isShiftKeyDown, expressIdOrIds)
             }
           }}
           deselectItems={deselectItems}

--- a/src/Containers/CadView.jsx
+++ b/src/Containers/CadView.jsx
@@ -987,32 +987,40 @@ export default function CadView({
         <RootLandscape
           pathPrefix={pathPrefix}
           branch={modelPath.branch}
-          selectWithShiftClickEvents={(isShiftKeyDown, expressIdOrIds, occurrencePath = null) => {
-            // The element-types tree passes an array (every element of a
-            // type) to select the group at once; the spatial tree and
-            // the scene pass a single expressID. elementSelection is
-            // single-id (shift toggle + descendants); the group case
-            // replaces the selection wholesale, like a search result, so
-            // it goes straight to the funnel with no permalink.
-            if (Array.isArray(expressIdOrIds)) {
-              selectItemsInScene(expressIdOrIds, false)
-            } else if (occurrencePath && occurrencePath.length > 0) {
-              // STEP occurrence node. The tree node's id is its NAUO express id,
-              // but the geometry is keyed by the shared product_definition_shape,
-              // so parent-level selection (elementSelection → setSelection) can't
-              // reach the mesh — the occurrence path is the only shared key.
-              // Resolve it to the exact instance ids and drive the per-instance
-              // highlight directly, mirroring the scene-pick funnel. The node's
-              // expressID stays the "selection" so properties / nav / the tree's
-              // per-occurrence highlight (selectedOccurrencePath) all key off it.
-              const instanceIds =
-                typeof viewer.getInstanceIdsForOccurrencePath === 'function' ?
-                  viewer.getInstanceIdsForOccurrencePath(0, occurrencePath) : []
-              selectItemsInScene([expressIdOrIds], true, instanceIds, occurrencePath)
-            } else {
-              elementSelection(viewer, elementsById, selectItemsInScene, isShiftKeyDown, expressIdOrIds)
-            }
-          }}
+          selectWithShiftClickEvents={
+            (isShiftKeyDown, expressIdOrIds, occurrencePath = null, hasChildren = false) => {
+              // The element-types tree passes an array (every element of a
+              // type) to select the group at once; the spatial tree and
+              // the scene pass a single expressID. elementSelection is
+              // single-id (shift toggle + descendants); the group case
+              // replaces the selection wholesale, like a search result, so
+              // it goes straight to the funnel with no permalink.
+              if (Array.isArray(expressIdOrIds)) {
+                selectItemsInScene(expressIdOrIds, false)
+              } else if (occurrencePath && occurrencePath.length > 0 && !isShiftKeyDown) {
+                // STEP occurrence node (non-shift). The tree node's id is its NAUO
+                // express id, but the geometry is keyed by the shared
+                // product_definition_shape, so parent-level selection
+                // (elementSelection → setSelection) can't reach the mesh — the
+                // occurrence path is the only shared key. Resolve it to the exact
+                // instance ids and drive the per-instance highlight directly,
+                // mirroring the scene-pick funnel. The node's expressID stays the
+                // "selection" so properties / nav / the tree's per-occurrence
+                // highlight (selectedOccurrencePath) all key off it.
+                //
+                // Shift-click falls through to elementSelection instead, which
+                // toggles/accumulates against the current selection (multi-select);
+                // the per-occurrence scene highlight is single-selection only, so
+                // shift keeps its legacy type-level accumulate behavior.
+                const instanceIds =
+                  typeof viewer.getInstanceIdsForOccurrencePath === 'function' ?
+                    viewer.getInstanceIdsForOccurrencePath(
+                      0, occurrencePath, {includeDescendants: hasChildren}) : []
+                selectItemsInScene([expressIdOrIds], true, instanceIds, occurrencePath)
+              } else {
+                elementSelection(viewer, elementsById, selectItemsInScene, isShiftKeyDown, expressIdOrIds)
+              }
+            }}
           deselectItems={deselectItems}
         />
       )}

--- a/src/Containers/CadView.jsx
+++ b/src/Containers/CadView.jsx
@@ -58,6 +58,7 @@ export default function CadView({
   const selectedElements = useStore((state) => state.selectedElements)
   const selectedInstanceIds = useStore((state) => state.selectedInstanceIds)
   const setSelectedInstanceIds = useStore((state) => state.setSelectedInstanceIds)
+  const setSelectedOccurrencePath = useStore((state) => state.setSelectedOccurrencePath)
   const setCutPlaneDirections = useStore((state) => state.setCutPlaneDirections)
   const setElementTypesMap = useStore((state) => state.setElementTypesMap)
   const setIsNavTreeVisible = useStore((state) => state.setIsNavTreeVisible)
@@ -543,7 +544,12 @@ export default function CadView({
         // Shift = the whole IFC element (every instance) → no
         // per-instance restriction; no-shift = just this PlacedGeometry.
         const instanceIds = event.shiftKey ? [] : [instanceId]
-        selectItemsInScene([parentExpressId], true, instanceIds)
+        // STEP: the picked instance's occurrence path so the NavTree highlights
+        // the one occurrence, not every reuse of the part type. Null on shift
+        // (whole element) and for IFC / single-occurrence parts.
+        const occurrencePath = event.shiftKey ? null :
+          (mesh.instanceMap.getOccurrencePathByInstance?.(instanceId) ?? null)
+        selectItemsInScene([parentExpressId], true, instanceIds, occurrencePath)
         return
       }
       // Non-instance branch: elementSelection funnels through
@@ -672,8 +678,12 @@ export default function CadView({
    *   source (NavTree, search, permalink) doesn't inherit the instance
    *   subset left behind by an earlier scene pick. Only the Conway
    *   scene-pick path passes a non-empty value.
+   * @param {Array<number>} occurrencePath STEP occurrence path (NAUO express
+   *   ids) of the selected occurrence, or null. Disambiguates which NavTree
+   *   node highlights when a reused part's occurrences share one expressID;
+   *   null (the default) clears it for IFC and non-occurrence sources.
    */
-  function selectItemsInScene(resultIDs, updateNavigation = true, instanceIds = []) {
+  function selectItemsInScene(resultIDs, updateNavigation = true, instanceIds = [], occurrencePath = null) {
     // NOTE: we might want to compare with previous selection to avoid unnecessary updates
     if (!viewer) {
       return
@@ -683,6 +693,10 @@ export default function CadView({
       const resIds = resultIDs.map((id) => `${id}`)
       setSelectedElements(resIds)
       setSelectedInstanceIds(instanceIds)
+      // STEP per-occurrence key: a reused part's occurrences share one
+      // expressID, so this disambiguates which NavTree node to highlight.
+      // Every non-occurrence caller passes null, clearing any stale path.
+      setSelectedOccurrencePath(occurrencePath)
       // Sets the url to the first selected element path.
       if (resultIDs.length > 0 && updateNavigation) {
         const firstId = resultIDs.slice(0, 1)
@@ -935,7 +949,7 @@ export default function CadView({
         <RootLandscape
           pathPrefix={pathPrefix}
           branch={modelPath.branch}
-          selectWithShiftClickEvents={(isShiftKeyDown, expressIdOrIds) => {
+          selectWithShiftClickEvents={(isShiftKeyDown, expressIdOrIds, occurrencePath = null) => {
             // The element-types tree passes an array (every element of a
             // type) to select the group at once; the spatial tree and
             // the scene pass a single expressID. elementSelection is
@@ -945,7 +959,15 @@ export default function CadView({
             if (Array.isArray(expressIdOrIds)) {
               selectItemsInScene(expressIdOrIds, false)
             } else {
-              elementSelection(viewer, elementsById, selectItemsInScene, isShiftKeyDown, expressIdOrIds)
+              // STEP: when the clicked node carries an occurrence path, inject
+              // it into the funnel (wrapping selectItemsInScene keeps
+              // elementSelection's signature untouched) so the NavTree
+              // highlights only that occurrence. Absent for IFC — unchanged.
+              const select = (occurrencePath && occurrencePath.length > 0) ?
+                (ids, updateNav, instanceIds = []) =>
+                  selectItemsInScene(ids, updateNav, instanceIds, occurrencePath) :
+                selectItemsInScene
+              elementSelection(viewer, elementsById, select, isShiftKeyDown, expressIdOrIds)
             }
           }}
           deselectItems={deselectItems}

--- a/src/loader/Loader.js
+++ b/src/loader/Loader.js
@@ -26,7 +26,7 @@ import {updateRecentFileLastModified} from '../connections/persistence'
 import {testUuid} from '../utils/strings'
 import {decorateShareModel, inferModelCapabilities} from '../viewer/ShareModel'
 import {attachElementSubsets, attachInstanceMapSubsets, summariseElementIdAttribute} from '../viewer/three/elementSubsets'
-import {instanceMapFromGeometry, instanceMapFromTriangleIds} from '../viewer/ifc/IfcInstanceMap'
+import {attachOccurrencePaths, instanceMapFromGeometry, instanceMapFromTriangleIds} from '../viewer/ifc/IfcInstanceMap'
 import {dereferenceAndProxyDownloadContents} from './urls'
 import BLDLoader from './BLDLoader'
 import {BldrsElementPropertiesReader} from './bldrsElementProperties'
@@ -525,6 +525,11 @@ export async function load(
   if (model.capabilities.instancePicking ||
       model.userData?.bldrsFaceIds) {
     const faceIdsPerPrimitive = model.userData?.bldrsFaceIds?.perPrimitive ?? null
+    // Global STEP occurrence-path table (index = synthetic instance id),
+    // persisted by the writer so a cache-hit STEP model can rebuild the
+    // per-occurrence tables the cache-miss instance map carried. Null for
+    // IFC / pre-occurrence artifacts. Read before the userData is freed below.
+    const occurrencePaths = model.userData?.bldrsFaceIds?.occurrencePaths ?? null
     // Per-vertex IDs are only trustworthy on uncompressed artifacts.
     // DRACO quantises integer attributes and Meshopt welds shared
     // vertices — both silently corrupt _EXPRESSID / _INSTANCEID. We
@@ -591,6 +596,13 @@ export async function load(
         }
       }
       if (map) {
+        // Restore STEP per-occurrence tables from the persisted global
+        // table (no-op for IFC / when absent), so scene↔NavTree selection
+        // keys on the occurrence path — not the part-type id shared across
+        // every reuse — on cache-hit exactly as it does on cache-miss.
+        if (occurrencePaths) {
+          attachOccurrencePaths(map, occurrencePaths)
+        }
         obj.instanceMap = map
         attached++
         totalInstances += map.instanceCount

--- a/src/loader/bldrsFaceIds.js
+++ b/src/loader/bldrsFaceIds.js
@@ -137,7 +137,14 @@ export class BldrsFaceIdsReader {
     })
 
     if (gltf.scene) {
-      gltf.scene.userData.bldrsFaceIds = {perPrimitive: resolved}
+      // Global STEP occurrence-path table (index = synthetic instance id),
+      // persisted alongside the per-triangle ids so a cache-hit STEP model
+      // can restore per-occurrence selection. Sanitised to arrays / null;
+      // absent (undefined) for IFC and pre-occurrence artifacts.
+      const occurrencePaths = Array.isArray(parsed.occurrencePaths) ?
+        parsed.occurrencePaths.map((p) => (Array.isArray(p) ? p : null)) :
+        null
+      gltf.scene.userData.bldrsFaceIds = {perPrimitive: resolved, occurrencePaths}
       const total = resolved.reduce(
         (n, e) => n + (e?.expressIds?.length ?? 0), 0)
       glbInfo(
@@ -270,7 +277,14 @@ function readAccessorAsUint32(json, bin, accIdx) {
  * payloads are Base64-encoded so they fit the existing JSON+gzip
  * inject pipeline without API changes.
  *
- * @param {object} captured `{perPrimitive: [{expressIds, instanceIds}|null, ...]}`
+ * When `captured.occurrencePaths` is present (STEP on a Conway that emits
+ * per-instance occurrence paths), it rides along as a top-level
+ * `occurrencePaths` array (index = synthetic instance id) so the reader can
+ * restore per-occurrence selection on cache-hit — the per-triangle arrays
+ * only carry the scalar instance id, not the variable-length path.
+ *
+ * @param {object} captured `{perPrimitive: [{expressIds, instanceIds}|null, ...],
+ *   occurrencePaths?: Array<Array<number>|null>}`
  * @return {object|null} extension data ready for `injectGlbExtensions`
  */
 export function buildFaceIdsExtensionData(captured) {
@@ -298,7 +312,15 @@ export function buildFaceIdsExtensionData(captured) {
     }
     return out
   })
-  return {perPrimitive}
+  const data = {perPrimitive}
+  // Occurrence paths are small (one entry per placed instance) and already
+  // JSON-native (nested int arrays), so carry them verbatim — the whole
+  // payload is gzipped downstream. Only emit when the source provides them.
+  if (Array.isArray(captured.occurrencePaths)) {
+    data.occurrencePaths = captured.occurrencePaths.map(
+      (p) => (Array.isArray(p) ? p : null))
+  }
+  return data
 }
 
 

--- a/src/loader/bldrsFaceIds.test.js
+++ b/src/loader/bldrsFaceIds.test.js
@@ -257,6 +257,42 @@ describe('loader/bldrsFaceIds', () => {
       expect(entry.firstExpressId).toBe(entry.expressIds[0])
     })
 
+    it('round-trips the global STEP occurrence-path table (index = instance id)', async () => {
+      const indices = new Uint32Array([0, 1, 2, 3, 4, 5])
+      const expressIdsPerVertex = new Uint32Array([700000, 700000, 700000, 700000, 700000, 700000])
+      const instanceIdsPerVertex = new Uint32Array([0, 0, 0, 1, 1, 1])
+      const glb = makeGlbWithIds({indices, expressIdsPerVertex, instanceIdsPerVertex})
+      const {json, bin} = parseGlb(glb)
+      const captured = capturePerTriangleIds(json, bin)
+      // Two occurrences of one reused part (same expressID), distinct paths.
+      captured.occurrencePaths = [[10, 20], [11, 20]]
+      const extensionData = buildFaceIdsExtensionData(captured)
+      const {bytes: withExt} = injectGlbExtensions(glb, [
+        {name: BLDRS_FACE_IDS_EXTENSION_NAME, data: extensionData, compress: true},
+      ])
+
+      const reader = new BldrsFaceIdsReader(parserFromGlb(withExt))
+      const gltf = {scene: {userData: {}}}
+      await reader.afterRoot(gltf)
+      expect(gltf.scene.userData.bldrsFaceIds.occurrencePaths).toEqual([[10, 20], [11, 20]])
+    })
+
+    it('leaves occurrencePaths null when the source carries none (IFC)', async () => {
+      const indices = new Uint32Array([0, 1, 2])
+      const expressIdsPerVertex = new Uint32Array([42, 42, 42])
+      const glb = makeGlbWithIds({indices, expressIdsPerVertex})
+      const {json, bin} = parseGlb(glb)
+      const extensionData = buildFaceIdsExtensionData(capturePerTriangleIds(json, bin))
+      expect(extensionData.occurrencePaths).toBeUndefined()
+      const {bytes: withExt} = injectGlbExtensions(glb, [
+        {name: BLDRS_FACE_IDS_EXTENSION_NAME, data: extensionData, compress: true},
+      ])
+      const reader = new BldrsFaceIdsReader(parserFromGlb(withExt))
+      const gltf = {scene: {userData: {}}}
+      await reader.afterRoot(gltf)
+      expect(gltf.scene.userData.bldrsFaceIds.occurrencePaths).toBeNull()
+    })
+
     it('is a no-op when the GLB has no BLDRS_face_ids extension', async () => {
       const indices = new Uint32Array([0, 1, 2])
       const expressIdsPerVertex = new Uint32Array([1, 1, 1])

--- a/src/loader/bldrsSpatialTree.js
+++ b/src/loader/bldrsSpatialTree.js
@@ -90,6 +90,12 @@ function serializeNode(node, depth = 0) {
   if (node.LongName !== undefined) {
     out.LongName = node.LongName
   }
+  // Preserve the STEP occurrence path (NAUO express ids) so a cache-hit tree
+  // can still key selection per-occurrence — without it, a reloaded (GLB-cached)
+  // STEP model would fall back to the colliding scalar expressID. Absent for IFC.
+  if (Array.isArray(node.occurrencePath)) {
+    out.occurrencePath = node.occurrencePath
+  }
   if (Array.isArray(node.children) && node.children.length > 0) {
     out.children = []
     for (const child of node.children) {

--- a/src/loader/glbCacheKey.js
+++ b/src/loader/glbCacheKey.js
@@ -15,6 +15,13 @@
 /**
  * Current Bldrs GLB artifact schema version. Bumped on any backwards-
  * incompatible change to the BLDRS_* extension contract or cache-key shape.
+ * 0.9.0 — extended `BLDRS_face_ids` with a global STEP occurrence-path
+ *         table (`occurrencePaths`, index = synthetic instance id) so a
+ *         cache-hit STEP model restores per-occurrence NavTree↔scene
+ *         selection instead of collapsing to the part-type id shared by
+ *         every reuse. Older 0.8.0 artifacts read as miss; next miss
+ *         rewrites with the table attached. IFC artifacts are unaffected
+ *         (no occurrence data). See design/new/step-occurrence-selection.md.
  * 0.8.0 — added `BLDRS_face_ids` glTF extension carrying per-triangle
  *         `expressID` / `instanceID` arrays as a Base64-encoded JSON
  *         payload, separate from the per-vertex attribute stream.
@@ -55,7 +62,7 @@
  * 0.2.0 — generalised cache key from GitHub-only (owner/repo/branch) to a
  *         per-source-kind 3-level namespace (ns1/ns2/ns3).
  */
-export const BLDRS_GLB_SCHEMA_VERSION = '0.8.0'
+export const BLDRS_GLB_SCHEMA_VERSION = '0.9.0'
 
 
 /**

--- a/src/loader/glbExport.js
+++ b/src/loader/glbExport.js
@@ -244,6 +244,18 @@ export async function exportAndCacheGlb({model, kindLabel, cacheKeyArgs, ifcMana
         '[glb] writer: parseGlb for face_ids capture threw; ' +
         'skipping face_ids (DRACO will skip too):', e)
     }
+    // STEP per-occurrence identity. The per-triangle arrays above only
+    // carry the scalar instance id; the occurrence path (a variable-length
+    // NAUO chain) lives on the live instance map. Persist the global
+    // `instanceId → path` table alongside face_ids so a cache-hit STEP
+    // model can restore per-occurrence NavTree↔scene selection instead of
+    // collapsing to the shared part-type id. Absent for IFC.
+    if (faceIds) {
+      const occurrencePaths = model?.instanceMap?.instanceIdToOccurrencePath
+      if (Array.isArray(occurrencePaths)) {
+        faceIds.occurrencePaths = occurrencePaths
+      }
+    }
     await yieldToBrowser()
     const capturePromise = (async () => {
       const spatialTree = await captureBldrsSpatialTree(ifcManager, modelId)

--- a/src/store/NavTreeSlice.js
+++ b/src/store/NavTreeSlice.js
@@ -48,5 +48,12 @@ export default function createNavTreeSlice(set, get) {
     // selects the whole IFC element.
     selectedInstanceIds: [],
     setSelectedInstanceIds: (ids) => set(() => ({selectedInstanceIds: ids})),
+
+    // STEP occurrence path (NAUO express ids) of the selected occurrence, or
+    // null. A reused part's occurrences share one `selectedElements` expressID,
+    // so this is what lets the NavTree highlight the one clicked/picked node
+    // instead of every reuse. Null for IFC and single-occurrence parts.
+    selectedOccurrencePath: null,
+    setSelectedOccurrencePath: (path) => set(() => ({selectedOccurrencePath: path})),
   }
 }

--- a/src/utils/occurrencePaths.js
+++ b/src/utils/occurrencePaths.js
@@ -1,0 +1,44 @@
+/**
+ * STEP occurrence-path helpers.
+ *
+ * An occurrence path is the ordered list of NAUO express ids (root→leaf) that
+ * uniquely places one instance of a reused STEP part — the key that lets
+ * NavTree↔scene selection tell a reused part's occurrences apart when the
+ * scalar expressID collides. See design/new/step-occurrence-selection.md.
+ *
+ * Every occurrence-path comparison and map key in the app must go through here
+ * so the separator convention is single-sourced (see `occurrencePathKey`).
+ */
+
+
+/**
+ * Canonical string key for an occurrence path.
+ *
+ * The `/` separator is load-bearing: it prevents a numeric-prefix collision
+ * where `[1]` would otherwise match `[12]` under bare concatenation or a
+ * `startsWith` descendant test (there's a dedicated ShareViewer test for this).
+ * Keep every occurrence-path map key / equality test routed through this
+ * function so that invariant can never drift between call sites.
+ *
+ * @param {Array<number>} path NAUO express ids, root→leaf
+ * @return {string}
+ */
+export function occurrencePathKey(path) {
+  return path.join('/')
+}
+
+
+/**
+ * True when two occurrence paths denote the same occurrence. Ordered
+ * comparison (paths are root→leaf sequences, not sets).
+ *
+ * @param {Array<number>|null|undefined} a
+ * @param {Array<number>|null|undefined} b
+ * @return {boolean}
+ */
+export function occurrencePathsEqual(a, b) {
+  if (!Array.isArray(a) || !Array.isArray(b)) {
+    return false
+  }
+  return occurrencePathKey(a) === occurrencePathKey(b)
+}

--- a/src/utils/occurrencePaths.test.js
+++ b/src/utils/occurrencePaths.test.js
@@ -1,0 +1,25 @@
+/* eslint-disable no-magic-numbers */
+import {occurrencePathKey, occurrencePathsEqual} from './occurrencePaths'
+
+
+describe('utils/occurrencePaths', () => {
+  describe('occurrencePathKey', () => {
+    it('joins on a separator that blocks numeric-prefix collisions', () => {
+      // The whole point of the '/' separator: [1] must not key the same as [12].
+      expect(occurrencePathKey([1])).toBe('1')
+      expect(occurrencePathKey([12])).toBe('12')
+      expect(occurrencePathKey([1, 20])).toBe('1/20')
+      expect(occurrencePathKey([1])).not.toBe(occurrencePathKey([12]))
+    })
+  })
+
+  describe('occurrencePathsEqual', () => {
+    it('is an ordered comparison, false for non-arrays', () => {
+      expect(occurrencePathsEqual([10, 20], [10, 20])).toBe(true)
+      expect(occurrencePathsEqual([10, 20], [20, 10])).toBe(false)
+      expect(occurrencePathsEqual([10, 20], [10])).toBe(false)
+      expect(occurrencePathsEqual(null, [10])).toBe(false)
+      expect(occurrencePathsEqual([10], undefined)).toBe(false)
+    })
+  })
+})

--- a/src/viewer/ShareViewer.js
+++ b/src/viewer/ShareViewer.js
@@ -567,6 +567,52 @@ export class ShareViewer {
 
 
   /**
+   * Resolve a STEP occurrence path (NAUO express ids) to the synthetic
+   * `IfcInstanceMap` instance ids placed at — or under — it, across
+   * every child Mesh of the model. This is the NavTree→scene join a
+   * plain expressID can't make: a tree node's id is its NAUO express
+   * id, but the geometry is owned by the (part-type-shared)
+   * `product_definition_shape`, so the two never coincide on a scalar
+   * id. The occurrence path is the only key both sides carry, so a
+   * NavTree click resolves through it to the exact instances to
+   * highlight (then `setInstanceSelection` draws them).
+   *
+   * Prefix-inclusive: clicking an assembly node lights up every leaf
+   * occurrence beneath it (the node's path is a prefix of theirs),
+   * while a leaf part resolves to just its own instance(s). Returns an
+   * empty array for IFC / non-occurrence models (no map) so callers
+   * fall back to parent-level selection.
+   *
+   * @param {number} modelID
+   * @param {Array<number>} occurrencePath NAUO express ids, root→leaf
+   * @return {number[]} synthetic instance ids (empty when none)
+   */
+  getInstanceIdsForOccurrencePath(modelID, occurrencePath) {
+    const model = this._modelById(modelID)
+    if (!model || !Array.isArray(occurrencePath) || occurrencePath.length === 0) {
+      return []
+    }
+    const target = occurrencePath.join('/')
+    const descendantPrefix = `${target}/`
+    const ids = []
+    model.traverse((obj) => {
+      const byPath = obj.isMesh ? obj.instanceMap?.occurrencePathToInstanceIds : null
+      if (!byPath) {
+        return
+      }
+      for (const [key, list] of byPath) {
+        if (key === target || key.startsWith(descendantPrefix)) {
+          for (let i = 0; i < list.length; i++) {
+            ids.push(list[i])
+          }
+        }
+      }
+    })
+    return ids
+  }
+
+
+  /**
    * Traverse a Conway-direct model, build a subset Mesh from every
    * child Mesh's `instanceMap` via `buildSubset(mesh)`, parent each
    * subset under the corresponding source mesh's parent (so the

--- a/src/viewer/ShareViewer.js
+++ b/src/viewer/ShareViewer.js
@@ -17,6 +17,7 @@ import ShareIfc from './ifc/ShareIfc'
 import {IfcContext} from './three/context'
 import ThreeContext from './three/ThreeContext'
 import debug from '../utils/debug'
+import {occurrencePathKey} from '../utils/occurrencePaths'
 import {modelHasCapability} from './ShareModel'
 import {
   applyBatchedPreselection,
@@ -602,19 +603,35 @@ export class ShareViewer {
    *
    * @param {number} modelID
    * @param {Array<number>} occurrencePath NAUO express ids, root→leaf
+   * @param {object} [opts]
+   * @param {boolean} [opts.includeDescendants] When false (a leaf node, which
+   *   can have no descendants), take the O(1) exact-key lookup instead of
+   *   scanning every occurrence key on every mesh — the common NavTree click.
+   *   Defaults to true (the assembly case, which needs the prefix scan).
    * @return {number[]} synthetic instance ids (empty when none)
    */
-  getInstanceIdsForOccurrencePath(modelID, occurrencePath) {
+  getInstanceIdsForOccurrencePath(modelID, occurrencePath, {includeDescendants = true} = {}) {
     const model = this._modelById(modelID)
     if (!model || !Array.isArray(occurrencePath) || occurrencePath.length === 0) {
       return []
     }
-    const target = occurrencePath.join('/')
+    const target = occurrencePathKey(occurrencePath)
     const descendantPrefix = `${target}/`
     const ids = []
     model.traverse((obj) => {
       const byPath = obj.isMesh ? obj.instanceMap?.occurrencePathToInstanceIds : null
       if (!byPath) {
+        return
+      }
+      if (!includeDescendants) {
+        // Leaf: at most one key can match (a leaf has no descendant paths), so
+        // an O(1) Map lookup replaces the per-key scan on this mesh.
+        const exact = byPath.get(target)
+        if (exact) {
+          for (let i = 0; i < exact.length; i++) {
+            ids.push(exact[i])
+          }
+        }
         return
       }
       for (const [key, list] of byPath) {

--- a/src/viewer/ShareViewer.test.js
+++ b/src/viewer/ShareViewer.test.js
@@ -32,7 +32,7 @@ jest.mock('three', () => jest.requireActual('three'))
 import '../../__mocks__/shareViewerTestHarness'
 import {BufferAttribute, BufferGeometry, Group, Mesh, Scene} from 'three'
 import {ShareViewer} from './ShareViewer'
-import {instanceMapFromGeometry} from './ifc/IfcInstanceMap'
+import {instanceMapFromGeometry, instanceMapFromOrderedPlacedRanges} from './ifc/IfcInstanceMap'
 import Selector from './three/Selector'
 import ThreeContext from './three/ThreeContext'
 
@@ -422,5 +422,102 @@ describe('viewer/ShareViewer Conway-direct selection helpers', () => {
       // Only one removeFromHighlighting call.
       expect(viewer.highlighter.removeFromHighlighting).toHaveBeenCalledTimes(1)
     })
+  })
+})
+
+
+/**
+ * Build a Mesh whose `instanceMap` carries STEP occurrence paths — one range
+ * per (parent, occurrencePath). Uses the ordered-ranges populator so the map
+ * gets `occurrencePathToInstanceIds` (the reverse index the resolver reads).
+ *
+ * @param {Array<{parentExpressId: number, triangleCount: number,
+ *   occurrencePath: number[]}>} ranges
+ * @return {Mesh}
+ */
+function makeOccurrenceMesh(ranges) {
+  const totalTris = ranges.reduce((n, r) => n + r.triangleCount, 0)
+  const geom = new BufferGeometry()
+  geom.setAttribute(
+    'position', new BufferAttribute(new Float32Array(totalTris * 9), 3))
+  geom.setIndex(new BufferAttribute(new Uint32Array(totalTris * 3), 1))
+  const mesh = new Mesh(geom)
+  mesh.instanceMap = instanceMapFromOrderedPlacedRanges(ranges, {geometry: geom})
+  return mesh
+}
+
+
+/**
+ * @param {object} model top-level Object3D to expose as ifcModels[0]
+ * @return {object} ShareViewer-prototype-bound stand-in with _modelById wired
+ */
+function makeResolverViewer(model) {
+  const viewer = Object.create(ShareViewer.prototype)
+  viewer.IFC = {context: {items: {ifcModels: [model]}}}
+  return viewer
+}
+
+
+describe('viewer/ShareViewer getInstanceIdsForOccurrencePath', () => {
+  it('resolves a leaf occurrence path to exactly its own instance(s)', () => {
+    // One reused part-type (parent 100) placed at two occurrences; the paths
+    // differ only in their root NAUO. A leaf lookup must return just its one
+    // instance, not the sibling reuse.
+    const mesh = makeOccurrenceMesh([
+      {parentExpressId: 100, triangleCount: 1, occurrencePath: [10, 20]},
+      {parentExpressId: 100, triangleCount: 1, occurrencePath: [11, 20]},
+    ])
+    const viewer = makeResolverViewer(mesh)
+
+    const first = ShareViewer.prototype.getInstanceIdsForOccurrencePath.call(viewer, 0, [10, 20])
+    const second = ShareViewer.prototype.getInstanceIdsForOccurrencePath.call(viewer, 0, [11, 20])
+    expect(first).toEqual([0])
+    expect(second).toEqual([1])
+  })
+
+  it('is prefix-inclusive: an assembly path lights up every leaf beneath it', () => {
+    // Two leaves under assembly-occurrence [10]; a lookup on [10] returns both,
+    // a lookup on the exact leaf returns just one.
+    const mesh = makeOccurrenceMesh([
+      {parentExpressId: 100, triangleCount: 1, occurrencePath: [10, 20]},
+      {parentExpressId: 101, triangleCount: 1, occurrencePath: [10, 21]},
+      {parentExpressId: 102, triangleCount: 1, occurrencePath: [99]},
+    ])
+    const viewer = makeResolverViewer(mesh)
+
+    expect(ShareViewer.prototype.getInstanceIdsForOccurrencePath.call(viewer, 0, [10]).sort())
+      .toEqual([0, 1])
+    expect(ShareViewer.prototype.getInstanceIdsForOccurrencePath.call(viewer, 0, [10, 20]))
+      .toEqual([0])
+  })
+
+  it('does not treat a numeric-prefix collision as a descendant ([1] must not match [12])', () => {
+    // Guards the `startsWith` join: keying on the raw string would let [1] match
+    // "12/..."; the '/' separator in the key prevents that.
+    const mesh = makeOccurrenceMesh([
+      {parentExpressId: 100, triangleCount: 1, occurrencePath: [1, 5]},
+      {parentExpressId: 101, triangleCount: 1, occurrencePath: [12, 5]},
+    ])
+    const viewer = makeResolverViewer(mesh)
+    expect(ShareViewer.prototype.getInstanceIdsForOccurrencePath.call(viewer, 0, [1]))
+      .toEqual([0])
+  })
+
+  it('returns [] for an empty path, missing model, or a map without occurrence data', () => {
+    const mesh = makeOccurrenceMesh([
+      {parentExpressId: 100, triangleCount: 1, occurrencePath: [10, 20]},
+    ])
+    const viewer = makeResolverViewer(mesh)
+    expect(ShareViewer.prototype.getInstanceIdsForOccurrencePath.call(viewer, 0, [])).toEqual([])
+
+    const noModel = makeResolverViewer(null)
+    expect(ShareViewer.prototype.getInstanceIdsForOccurrencePath.call(noModel, 0, [10, 20]))
+      .toEqual([])
+
+    // IFC-style mesh: instanceMap from per-vertex attrs has no occurrence tables.
+    const ifcMesh = makeTaggedMesh(1, 100)
+    const ifcViewer = makeResolverViewer(ifcMesh)
+    expect(ShareViewer.prototype.getInstanceIdsForOccurrencePath.call(ifcViewer, 0, [10, 20]))
+      .toEqual([])
   })
 })

--- a/src/viewer/ShareViewer.test.js
+++ b/src/viewer/ShareViewer.test.js
@@ -475,6 +475,21 @@ describe('viewer/ShareViewer getInstanceIdsForOccurrencePath', () => {
     expect(second).toEqual([1])
   })
 
+  it('with includeDescendants:false takes the exact leaf lookup (no descendants)', () => {
+    // A leaf click must resolve to only its own instance even though a deeper
+    // path exists that has it as a prefix — the exact-key branch must not scan.
+    const mesh = makeOccurrenceMesh([
+      {parentExpressId: 100, triangleCount: 1, occurrencePath: [10]},
+      {parentExpressId: 101, triangleCount: 1, occurrencePath: [10, 20]},
+    ])
+    const viewer = makeResolverViewer(mesh)
+    expect(ShareViewer.prototype.getInstanceIdsForOccurrencePath.call(
+      viewer, 0, [10], {includeDescendants: false})).toEqual([0])
+    // Same path with descendants included also pulls the child at [10,20].
+    expect(ShareViewer.prototype.getInstanceIdsForOccurrencePath.call(
+      viewer, 0, [10], {includeDescendants: true}).sort()).toEqual([0, 1])
+  })
+
   it('is prefix-inclusive: an assembly path lights up every leaf beneath it', () => {
     // Two leaves under assembly-occurrence [10]; a lookup on [10] returns both,
     // a lookup on the exact leaf returns just one.

--- a/src/viewer/ifc/IfcInstanceMap.js
+++ b/src/viewer/ifc/IfcInstanceMap.js
@@ -3,6 +3,7 @@ import {
   BufferGeometry,
   Mesh,
 } from 'three'
+import {occurrencePathKey} from '../../utils/occurrencePaths'
 
 
 /**
@@ -104,6 +105,10 @@ export class IfcInstanceMap {
    *   STEP models on a Conway that emits `PlacedGeometry.occurrencePath`; the
    *   parent expressID collides across a reused part's occurrences, so this is
    *   what distinguishes them. Absent (null) for IFC and older engines.
+   * @param {Map<string, Array<number>>} [fields.occurrencePathToInstanceIds]
+   *   Reverse index of the above — occurrence-path key (`occurrencePathKey`) →
+   *   the synthetic instance ids placed there. The NavTree→scene direction.
+   *   Absent (null) for IFC and older engines.
    */
   constructor({
     triangleIndexToInstanceId,
@@ -214,7 +219,7 @@ export class IfcInstanceMap {
     if (!byPath || !Array.isArray(occurrencePath) || occurrencePath.length === 0) {
       return null
     }
-    const list = byPath.get(occurrencePath.join('/'))
+    const list = byPath.get(occurrencePathKey(occurrencePath))
     return list ? Uint32Array.from(list) : null
   }
 
@@ -424,7 +429,7 @@ export function attachOccurrencePaths(instanceMap, occurrencePathsByInstanceId) 
     }
     perInstance[inst] = path
     any = true
-    const key = path.join('/')
+    const key = occurrencePathKey(path)
     const list = byPath.get(key)
     if (list) {
       list.push(inst)
@@ -487,7 +492,7 @@ export function instanceMapFromOrderedPlacedRanges(ranges, opts = {}) {
       const path = valid[inst].occurrencePath ?? null
       instanceIdToOccurrencePath[inst] = path
       if (path && path.length > 0) {
-        const key = path.join('/')
+        const key = occurrencePathKey(path)
         const list = occurrencePathToInstanceIds.get(key)
         if (list) {
           list.push(inst)

--- a/src/viewer/ifc/IfcInstanceMap.js
+++ b/src/viewer/ifc/IfcInstanceMap.js
@@ -99,6 +99,11 @@ export class IfcInstanceMap {
    * @param {Uint32Array} fields.instanceIdToParentExpressId
    * @param {Map<number, Uint32Array>} fields.parentExpressIdToInstanceIds
    * @param {BufferGeometry} fields.sourceGeometry
+   * @param {Array<Array<number>>} [fields.instanceIdToOccurrencePath]
+   *   Per-instance STEP occurrence path (NAUO express ids). Present only for
+   *   STEP models on a Conway that emits `PlacedGeometry.occurrencePath`; the
+   *   parent expressID collides across a reused part's occurrences, so this is
+   *   what distinguishes them. Absent (null) for IFC and older engines.
    */
   constructor({
     triangleIndexToInstanceId,
@@ -106,12 +111,14 @@ export class IfcInstanceMap {
     instanceIdToParentExpressId,
     parentExpressIdToInstanceIds,
     sourceGeometry,
+    instanceIdToOccurrencePath = null,
   }) {
     this.triangleIndexToInstanceId = triangleIndexToInstanceId
     this.instanceIdToTriangleIndices = instanceIdToTriangleIndices
     this.instanceIdToParentExpressId = instanceIdToParentExpressId
     this.parentExpressIdToInstanceIds = parentExpressIdToInstanceIds
     this.sourceGeometry = sourceGeometry
+    this.instanceIdToOccurrencePath = instanceIdToOccurrencePath
   }
 
 
@@ -164,6 +171,25 @@ export class IfcInstanceMap {
       return null
     }
     return this.instanceIdToParentExpressId[instanceId]
+  }
+
+
+  /**
+   * STEP occurrence path (NAUO express ids, root→leaf) for the given synthetic
+   * instance ID — the identity that disambiguates a reused part's occurrences.
+   * Returns `null` when the model carries no occurrence paths (IFC, older
+   * engines) or the instance ID is out of range, so callers fall back to the
+   * scalar parent expressID.
+   *
+   * @param {number} instanceId
+   * @return {Array<number>|null}
+   */
+  getOccurrencePathByInstance(instanceId) {
+    const paths = this.instanceIdToOccurrencePath
+    if (!paths || instanceId < 0 || instanceId >= paths.length) {
+      return null
+    }
+    return paths[instanceId] ?? null
   }
 
 
@@ -360,12 +386,19 @@ export function instanceMapFromOrderedPlacedRanges(ranges, opts = {}) {
   const instanceCount = valid.length
   const triangleIndexToInstanceId = new Uint32Array(totalTriangles)
   const instanceIdToParentExpressId = new Uint32Array(instanceCount)
+  // Only carry occurrence paths when the source actually provides them (STEP on
+  // a Conway that emits them); IFC leaves this null so nothing downstream pays.
+  const hasOccurrencePaths = valid.some((r) => r.occurrencePath !== undefined)
+  const instanceIdToOccurrencePath = hasOccurrencePaths ? new Array(instanceCount) : null
   const triangleListsByInstance = new Map()
   const instanceListsByParent = new Map()
   let tri = 0
   for (let inst = 0; inst < valid.length; inst++) {
     const {parentExpressId, triangleCount} = valid[inst]
     instanceIdToParentExpressId[inst] = parentExpressId
+    if (instanceIdToOccurrencePath) {
+      instanceIdToOccurrencePath[inst] = valid[inst].occurrencePath ?? null
+    }
     let parentList = instanceListsByParent.get(parentExpressId)
     if (!parentList) {
       parentList = []
@@ -390,6 +423,7 @@ export function instanceMapFromOrderedPlacedRanges(ranges, opts = {}) {
     instanceIdToParentExpressId,
     parentExpressIdToInstanceIds,
     sourceGeometry: opts.geometry ?? null,
+    instanceIdToOccurrencePath,
   })
 }
 
@@ -628,7 +662,9 @@ export function instanceMapFromFlatMeshes(flatMeshes, api, modelID, opts = {}) {
       if (triangleCount <= 0) {
         continue
       }
-      ranges.push({parentExpressId, triangleCount})
+      // Conway (STEP) tags each PlacedGeometry with its occurrence path so a
+      // reused part's occurrences stay distinguishable; undefined for IFC.
+      ranges.push({parentExpressId, triangleCount, occurrencePath: placed.occurrencePath})
     }
   }
   return instanceMapFromOrderedPlacedRanges(ranges, opts)

--- a/src/viewer/ifc/IfcInstanceMap.js
+++ b/src/viewer/ifc/IfcInstanceMap.js
@@ -384,6 +384,63 @@ function buildSubsetMesh(sourceGeometry, ids, lookupTriangles, opts) {
 
 
 /**
+ * Attach STEP occurrence-path tables to an already-built `IfcInstanceMap`
+ * from a global `instanceId → occurrencePath` table (the cache-hit GLB
+ * restore path). The cache-miss populators derive these tables from the
+ * per-PlacedGeometry stream, but a GLB cache round-trip loses the paths —
+ * the per-triangle / per-vertex ID arrays only carry the scalar
+ * `expressID` + `instanceID`, not the variable-length path. So the writer
+ * persists the global table (see `BLDRS_face_ids`), and this reattaches it.
+ *
+ * Only instance ids actually present in this map (a cache-hit GLB is split
+ * into per-material primitives, so each mesh owns a subset of the global
+ * ids) get an entry, so the reverse `occurrencePathToInstanceIds` never
+ * claims instances this mesh can't render. No-op when the map already has
+ * occurrence tables, the global table is absent, or nothing matches
+ * (IFC) — leaving the map's `null` tables so callers fall back to scalar
+ * keying.
+ *
+ * @param {IfcInstanceMap} instanceMap map to enrich in place
+ * @param {Array<Array<number>|null>} occurrencePathsByInstanceId global
+ *   table indexed by synthetic instance id (from the cache-miss build)
+ */
+export function attachOccurrencePaths(instanceMap, occurrencePathsByInstanceId) {
+  if (!instanceMap || instanceMap.instanceIdToOccurrencePath ||
+      !Array.isArray(occurrencePathsByInstanceId)) {
+    return
+  }
+  const count = instanceMap.instanceIdToParentExpressId?.length ?? 0
+  if (count === 0) {
+    return
+  }
+  const perInstance = new Array(count).fill(null)
+  const byPath = new Map()
+  let any = false
+  // Walk only the instance ids this mesh actually holds triangles for.
+  for (const inst of instanceMap.instanceIdToTriangleIndices.keys()) {
+    const path = occurrencePathsByInstanceId[inst] ?? null
+    if (!Array.isArray(path) || path.length === 0) {
+      continue
+    }
+    perInstance[inst] = path
+    any = true
+    const key = path.join('/')
+    const list = byPath.get(key)
+    if (list) {
+      list.push(inst)
+    } else {
+      byPath.set(key, [inst])
+    }
+  }
+  if (!any) {
+    return
+  }
+  instanceMap.instanceIdToOccurrencePath = perInstance
+  instanceMap.occurrencePathToInstanceIds = byPath
+}
+
+
+/**
  * Build an IfcInstanceMap from a per-PlacedGeometry triangle range
  * stream. Each entry contributes `triangleCount` triangles to the
  * merged buffer; the populator assigns a fresh synthetic instance

--- a/src/viewer/ifc/IfcInstanceMap.js
+++ b/src/viewer/ifc/IfcInstanceMap.js
@@ -99,7 +99,7 @@ export class IfcInstanceMap {
    * @param {Uint32Array} fields.instanceIdToParentExpressId
    * @param {Map<number, Uint32Array>} fields.parentExpressIdToInstanceIds
    * @param {BufferGeometry} fields.sourceGeometry
-   * @param {Array<Array<number>>} [fields.instanceIdToOccurrencePath]
+   * @param {Array<Array<number>|null>} [fields.instanceIdToOccurrencePath]
    *   Per-instance STEP occurrence path (NAUO express ids). Present only for
    *   STEP models on a Conway that emits `PlacedGeometry.occurrencePath`; the
    *   parent expressID collides across a reused part's occurrences, so this is
@@ -189,7 +189,12 @@ export class IfcInstanceMap {
     if (!paths || instanceId < 0 || instanceId >= paths.length) {
       return null
     }
-    return paths[instanceId] ?? null
+    const path = paths[instanceId]
+    // A root-level / single-occurrence placement has an empty path — no
+    // disambiguating occurrence — so normalize it to null alongside the
+    // no-data case, letting truthiness-testing callers fall back to the
+    // scalar parent expressID instead of keying on a meaningless empty path.
+    return path && path.length > 0 ? path : null
   }
 
 

--- a/src/viewer/ifc/IfcInstanceMap.js
+++ b/src/viewer/ifc/IfcInstanceMap.js
@@ -112,6 +112,7 @@ export class IfcInstanceMap {
     parentExpressIdToInstanceIds,
     sourceGeometry,
     instanceIdToOccurrencePath = null,
+    occurrencePathToInstanceIds = null,
   }) {
     this.triangleIndexToInstanceId = triangleIndexToInstanceId
     this.instanceIdToTriangleIndices = instanceIdToTriangleIndices
@@ -119,6 +120,7 @@ export class IfcInstanceMap {
     this.parentExpressIdToInstanceIds = parentExpressIdToInstanceIds
     this.sourceGeometry = sourceGeometry
     this.instanceIdToOccurrencePath = instanceIdToOccurrencePath
+    this.occurrencePathToInstanceIds = occurrencePathToInstanceIds
   }
 
 
@@ -195,6 +197,25 @@ export class IfcInstanceMap {
     // no-data case, letting truthiness-testing callers fall back to the
     // scalar parent expressID instead of keying on a meaningless empty path.
     return path && path.length > 0 ? path : null
+  }
+
+
+  /**
+   * Synthetic instance IDs placed at a given STEP occurrence path — the
+   * NavTree→scene direction (a clicked node highlights only its own
+   * occurrence, not every reuse of the part type). Returns `null` when the
+   * model carries no occurrence paths or the path matches nothing.
+   *
+   * @param {Array<number>} occurrencePath NAUO express ids, root→leaf
+   * @return {Uint32Array|null}
+   */
+  getInstanceIdsByOccurrencePath(occurrencePath) {
+    const byPath = this.occurrencePathToInstanceIds
+    if (!byPath || !Array.isArray(occurrencePath) || occurrencePath.length === 0) {
+      return null
+    }
+    const list = byPath.get(occurrencePath.join('/'))
+    return list ? Uint32Array.from(list) : null
   }
 
 
@@ -395,6 +416,10 @@ export function instanceMapFromOrderedPlacedRanges(ranges, opts = {}) {
   // a Conway that emits them); IFC leaves this null so nothing downstream pays.
   const hasOccurrencePaths = valid.some((r) => r.occurrencePath !== undefined)
   const instanceIdToOccurrencePath = hasOccurrencePaths ? new Array(instanceCount) : null
+  // Reverse index for NavTree→scene: a tree node's occurrence path → the
+  // instance(s) placed there. Keyed by the path joined on '/'. Only non-empty
+  // paths are indexed (an empty root path can't disambiguate occurrences).
+  const occurrencePathToInstanceIds = hasOccurrencePaths ? new Map() : null
   const triangleListsByInstance = new Map()
   const instanceListsByParent = new Map()
   let tri = 0
@@ -402,7 +427,17 @@ export function instanceMapFromOrderedPlacedRanges(ranges, opts = {}) {
     const {parentExpressId, triangleCount} = valid[inst]
     instanceIdToParentExpressId[inst] = parentExpressId
     if (instanceIdToOccurrencePath) {
-      instanceIdToOccurrencePath[inst] = valid[inst].occurrencePath ?? null
+      const path = valid[inst].occurrencePath ?? null
+      instanceIdToOccurrencePath[inst] = path
+      if (path && path.length > 0) {
+        const key = path.join('/')
+        const list = occurrencePathToInstanceIds.get(key)
+        if (list) {
+          list.push(inst)
+        } else {
+          occurrencePathToInstanceIds.set(key, [inst])
+        }
+      }
     }
     let parentList = instanceListsByParent.get(parentExpressId)
     if (!parentList) {
@@ -429,6 +464,7 @@ export function instanceMapFromOrderedPlacedRanges(ranges, opts = {}) {
     parentExpressIdToInstanceIds,
     sourceGeometry: opts.geometry ?? null,
     instanceIdToOccurrencePath,
+    occurrencePathToInstanceIds,
   })
 }
 

--- a/src/viewer/ifc/IfcInstanceMap.test.js
+++ b/src/viewer/ifc/IfcInstanceMap.test.js
@@ -8,9 +8,11 @@ import {
 import {
   IfcInstanceMap,
   NO_INSTANCE_ID,
+  attachOccurrencePaths,
   instanceMapFromFlatMeshes,
   instanceMapFromGeometry,
   instanceMapFromOrderedPlacedRanges,
+  instanceMapFromTriangleIds,
 } from './IfcInstanceMap'
 
 
@@ -577,6 +579,51 @@ describe('viewer/ifc/IfcInstanceMap', () => {
       const wholeWall = map.createSubsetMeshByParent([100])
       expect(oneInstance.geometry.getIndex().array.length).toBe(3)
       expect(wholeWall.geometry.getIndex().array.length).toBe(126)
+    })
+  })
+
+
+  describe('attachOccurrencePaths (cache-hit restore)', () => {
+    it('restores occurrence tables from a global instanceId→path table', () => {
+      // Two reused occurrences (instance 0 and 1) sharing parent 100.
+      const map = instanceMapFromTriangleIds(
+        new Uint32Array([100, 100]), new Uint32Array([0, 1]))
+      expect(map.instanceIdToOccurrencePath).toBeNull()
+
+      attachOccurrencePaths(map, [[10, 20], [11, 20]])
+      expect(map.getOccurrencePathByInstance(0)).toEqual([10, 20])
+      expect(map.getOccurrencePathByInstance(1)).toEqual([11, 20])
+      expect(Array.from(map.getInstanceIdsByOccurrencePath([10, 20]))).toEqual([0])
+      expect(Array.from(map.getInstanceIdsByOccurrencePath([11, 20]))).toEqual([1])
+    })
+
+    it('only indexes instance ids the mesh actually holds (per-primitive subset)', () => {
+      // A cache-hit primitive covering only global instance id 5 — the global
+      // table has entries for 0..5 but only 5 is present in this mesh, so the
+      // reverse index must not claim ids 0..4 this mesh can't render.
+      const map = instanceMapFromTriangleIds(
+        new Uint32Array([100]), new Uint32Array([5]))
+      const global = [[1], [2], [3], [4], [5], [10, 20]]
+      attachOccurrencePaths(map, global)
+      expect(Array.from(map.getInstanceIdsByOccurrencePath([10, 20]))).toEqual([5])
+      expect(map.getInstanceIdsByOccurrencePath([1])).toBeNull()
+      expect(map.getOccurrencePathByInstance(5)).toEqual([10, 20])
+    })
+
+    it('is a no-op for IFC (no matching paths) and when tables already exist', () => {
+      const ifcMap = instanceMapFromTriangleIds(
+        new Uint32Array([100]), new Uint32Array([0]))
+      attachOccurrencePaths(ifcMap, [null])
+      expect(ifcMap.instanceIdToOccurrencePath).toBeNull()
+
+      // Already-populated map (cache-miss) is left untouched.
+      const occMap = instanceMapFromOrderedPlacedRanges([
+        {parentExpressId: 100, triangleCount: 1, occurrencePath: [7, 8]},
+      ])
+      const before = occMap.instanceIdToOccurrencePath
+      attachOccurrencePaths(occMap, [[99]])
+      expect(occMap.instanceIdToOccurrencePath).toBe(before)
+      expect(occMap.getOccurrencePathByInstance(0)).toEqual([7, 8])
     })
   })
 })

--- a/src/viewer/ifc/IfcInstanceMap.test.js
+++ b/src/viewer/ifc/IfcInstanceMap.test.js
@@ -82,6 +82,17 @@ describe('viewer/ifc/IfcInstanceMap', () => {
       expect(map.getOccurrencePathByInstance(1)).toEqual([3810, 1927, 1916])
     })
 
+    it('normalizes a root-level (empty) occurrence path to null', () => {
+      // A root-level STEP placement carries an empty path; callers testing
+      // truthiness must fall back to the parent expressID, so [] reads as null.
+      const map = instanceMapFromOrderedPlacedRanges([
+        {parentExpressId: 6210, triangleCount: 1, occurrencePath: []},
+        {parentExpressId: 1915, triangleCount: 1, occurrencePath: [3810, 1921, 1916]},
+      ])
+      expect(map.getOccurrencePathByInstance(0)).toBeNull()
+      expect(map.getOccurrencePathByInstance(1)).toEqual([3810, 1921, 1916])
+    })
+
     it('leaves occurrence paths null for IFC ranges (no occurrencePath)', () => {
       const map = instanceMapFromOrderedPlacedRanges([
         {parentExpressId: 100, triangleCount: 1},

--- a/src/viewer/ifc/IfcInstanceMap.test.js
+++ b/src/viewer/ifc/IfcInstanceMap.test.js
@@ -69,6 +69,27 @@ describe('viewer/ifc/IfcInstanceMap', () => {
       expect(Array.from(map.instanceIdToParentExpressId)).toEqual([10, 40])
     })
 
+    it('captures a distinct occurrence path per instance for STEP ranges', () => {
+      // One reused part (parentExpressId 1915) at two occurrences: the parent
+      // id collides, the occurrence path disambiguates.
+      const map = instanceMapFromOrderedPlacedRanges([
+        {parentExpressId: 1915, triangleCount: 2, occurrencePath: [3810, 1921, 1916]},
+        {parentExpressId: 1915, triangleCount: 2, occurrencePath: [3810, 1927, 1916]},
+      ])
+      expect(map.getParentExpressIdByInstance(0)).toBe(1915)
+      expect(map.getParentExpressIdByInstance(1)).toBe(1915)
+      expect(map.getOccurrencePathByInstance(0)).toEqual([3810, 1921, 1916])
+      expect(map.getOccurrencePathByInstance(1)).toEqual([3810, 1927, 1916])
+    })
+
+    it('leaves occurrence paths null for IFC ranges (no occurrencePath)', () => {
+      const map = instanceMapFromOrderedPlacedRanges([
+        {parentExpressId: 100, triangleCount: 1},
+      ])
+      expect(map.instanceIdToOccurrencePath).toBeNull()
+      expect(map.getOccurrencePathByInstance(0)).toBeNull()
+    })
+
     it('handles an empty stream', () => {
       const map = instanceMapFromOrderedPlacedRanges([])
       expect(map.triangleCount).toBe(0)

--- a/src/viewer/ifc/IfcInstanceMap.test.js
+++ b/src/viewer/ifc/IfcInstanceMap.test.js
@@ -82,6 +82,20 @@ describe('viewer/ifc/IfcInstanceMap', () => {
       expect(map.getOccurrencePathByInstance(1)).toEqual([3810, 1927, 1916])
     })
 
+    it('reverse-maps an occurrence path to its instance(s)', () => {
+      const map = instanceMapFromOrderedPlacedRanges([
+        {parentExpressId: 1915, triangleCount: 1, occurrencePath: [3810, 1921, 1916]},
+        {parentExpressId: 1915, triangleCount: 1, occurrencePath: [3810, 1927, 1916]},
+        {parentExpressId: 6210, triangleCount: 1, occurrencePath: []},
+      ])
+      // Each reused-nut occurrence resolves to exactly its own instance.
+      expect(Array.from(map.getInstanceIdsByOccurrencePath([3810, 1921, 1916]))).toEqual([0])
+      expect(Array.from(map.getInstanceIdsByOccurrencePath([3810, 1927, 1916]))).toEqual([1])
+      // Empty / unknown paths resolve to null (caller falls back to expressID).
+      expect(map.getInstanceIdsByOccurrencePath([])).toBeNull()
+      expect(map.getInstanceIdsByOccurrencePath([9, 9, 9])).toBeNull()
+    })
+
     it('normalizes a root-level (empty) occurrence path to null', () => {
       // A root-level STEP placement carries an empty path; callers testing
       // truthiness must fall back to the parent expressID, so [] reads as null.

--- a/src/viewer/ifc/buildConwayIfcModel.test.js
+++ b/src/viewer/ifc/buildConwayIfcModel.test.js
@@ -84,6 +84,32 @@ describe('viewer/ifc/buildConwayIfcModel', () => {
     expect(stats.parentCount).toBe(1)
   })
 
+  it('threads each PlacedGeometry.occurrencePath into the instance map (STEP)', () => {
+    // One reused part-type (parent 100) at two occurrences. The assembled map
+    // must let a caller resolve occurrence-path → instance and back, so a
+    // reused STEP part stays per-occurrence selectable end-to-end.
+    const api = makeApi({
+      999: {
+        vertexData: unitTriangleVerts(),
+        indexData: new Uint32Array([0, 1, 2]),
+      },
+    })
+    const flatMeshes = [{
+      expressID: 100,
+      geometries: {
+        size: () => 2,
+        get: (i) => i === 0 ?
+          {geometryExpressID: 999, flatTransformation: IDENTITY_MAT, occurrencePath: [10, 20]} :
+          {geometryExpressID: 999, flatTransformation: IDENTITY_MAT, occurrencePath: [11, 20]},
+      },
+    }]
+    const {instanceMap} = buildConwayIfcModel(flatMeshes, api, 0)
+    expect(Array.from(instanceMap.getInstanceIdsByOccurrencePath([10, 20]))).toEqual([0])
+    expect(Array.from(instanceMap.getInstanceIdsByOccurrencePath([11, 20]))).toEqual([1])
+    expect(instanceMap.getOccurrencePathByInstance(0)).toEqual([10, 20])
+    expect(instanceMap.getOccurrencePathByInstance(1)).toEqual([11, 20])
+  })
+
   it('preserves per-instance separation through to subset construction', () => {
     // Three instances of one shared shape — the IfcMappedItem
     // motivating case. Per-instance subset returns one triangle's

--- a/src/viewer/ifc/conwayDirectIfcLoader.js
+++ b/src/viewer/ifc/conwayDirectIfcLoader.js
@@ -196,7 +196,26 @@ export function decorateConwayDirectIfcModel(ifcModel, ifcAPI, modelID, opts = {
       ifcModel.geometry.getIndex() &&
       ifcModel.geometry.getAttribute?.('expressID') &&
       ifcModel.geometry.getAttribute?.('instanceID')) {
+    // The pre-reorder map from `buildConwayIfcModel` carries the STEP
+    // per-occurrence tables (`instanceIdToOccurrencePath` /
+    // `occurrencePathToInstanceIds`), but the BVH permute forces a
+    // rebuild from geometry attributes — and `instanceMapFromGeometry`
+    // reads only `expressID` + `instanceID` per vertex, so it can't
+    // recover the occurrence path (a variable-length array, not a
+    // per-vertex scalar). Carry those tables forward by hand. The
+    // synthetic instance ids line up 1:1: `flatMeshToBufferGeometry`
+    // stamps per-vertex `instanceID` in the same emission order
+    // `instanceMapFromOrderedPlacedRanges` numbered the build map, and
+    // the reorder permutes only the index buffer, not that numbering.
+    // Without this, scene→NavTree picks and per-occurrence tree
+    // narrowing fall back to the colliding part-type expressID (every
+    // reuse of a nut highlights together).
+    const buildMap = ifcModel.instanceMap
     ifcModel.instanceMap = instanceMapFromGeometry(ifcModel.geometry)
+    if (buildMap?.instanceIdToOccurrencePath) {
+      ifcModel.instanceMap.instanceIdToOccurrencePath = buildMap.instanceIdToOccurrencePath
+      ifcModel.instanceMap.occurrencePathToInstanceIds = buildMap.occurrencePathToInstanceIds
+    }
   }
 
   ifcModel.capabilities = ifcModel.capabilities ?? {}

--- a/src/viewer/ifc/conwayDirectIfcLoader.js
+++ b/src/viewer/ifc/conwayDirectIfcLoader.js
@@ -213,8 +213,21 @@ export function decorateConwayDirectIfcModel(ifcModel, ifcAPI, modelID, opts = {
     const buildMap = ifcModel.instanceMap
     ifcModel.instanceMap = instanceMapFromGeometry(ifcModel.geometry)
     if (buildMap?.instanceIdToOccurrencePath) {
-      ifcModel.instanceMap.instanceIdToOccurrencePath = buildMap.instanceIdToOccurrencePath
-      ifcModel.instanceMap.occurrencePathToInstanceIds = buildMap.occurrencePathToInstanceIds
+      // Guard the 1:1 assumption instead of trusting it silently. If the two
+      // populators ever number instances differently (e.g. one drops a
+      // degenerate PlacedGeometry the other keeps), copying the tables over
+      // would bind occurrence paths to the wrong instances — a silent
+      // wrong-nut-highlights bug. On mismatch, skip the transfer and degrade
+      // to type-level selection rather than mis-highlight.
+      if (buildMap.instanceCount === ifcModel.instanceMap.instanceCount) {
+        ifcModel.instanceMap.instanceIdToOccurrencePath = buildMap.instanceIdToOccurrencePath
+        ifcModel.instanceMap.occurrencePathToInstanceIds = buildMap.occurrencePathToInstanceIds
+      } else {
+        console.warn(
+          '[conwayDirect] occurrence-path transfer skipped: instance-count mismatch ' +
+          `(build ${buildMap.instanceCount}, geometry ${ifcModel.instanceMap.instanceCount}); ` +
+          'STEP selection degrades to type-level for this model')
+      }
     }
   }
 

--- a/src/viewer/ifc/flatMeshToBufferGeometry.js
+++ b/src/viewer/ifc/flatMeshToBufferGeometry.js
@@ -59,11 +59,14 @@ import {
  *   expressID per-vertex, instanceID per-vertex; uint32 index). Carries
  *   `groups[]` binding each color-bin's contiguous triangle range to
  *   a `materials[]` index.
- * @property {Array<{parentExpressId: number, triangleCount: number}>} ranges
+ * @property {Array<{parentExpressId: number, triangleCount: number,
+ *   occurrencePath: (Array<number>|undefined)}>} ranges
  *   per-PlacedGeometry ranges in EMISSION order (color-binned), ready
  *   for `instanceMapFromOrderedPlacedRanges`. NOT the FlatMesh-walk
  *   order — color binning permutes the emission so each color's
- *   triangles stay contiguous in the merged buffer.
+ *   triangles stay contiguous in the merged buffer. `occurrencePath`
+ *   is the STEP NAUO express-id path off `PlacedGeometry.occurrencePath`
+ *   (undefined for IFC).
  * @property {Array<MeshLambertMaterial>} materials one per distinct
  *   PlacedGeometry color (RGBA). Caller assigns this to
  *   `mesh.material` (array form) — three.js's renderer pairs each
@@ -283,7 +286,11 @@ export function flatMeshToBufferGeometry(flatMeshes, api, modelID) {
       }
       vCursor += vertCount
       iCursor += indexCount
-      ranges.push({parentExpressId, triangleCount})
+      // Carry the STEP occurrence path (NAUO express ids) off the
+      // PlacedGeometry so `instanceMapFromOrderedPlacedRanges` can key a
+      // reused part's occurrences apart. `undefined` for IFC, so the
+      // downstream map leaves its occurrence tables null.
+      ranges.push({parentExpressId, triangleCount, occurrencePath: placed.occurrencePath})
       p++
     }
     // Close the group spanning this colour bin's contiguous index range.

--- a/src/viewer/ifc/flatMeshToBufferGeometry.test.js
+++ b/src/viewer/ifc/flatMeshToBufferGeometry.test.js
@@ -133,6 +133,32 @@ describe('viewer/ifc/flatMeshToBufferGeometry', () => {
     expect(Array.from(geometry.getIndex().array)).toEqual([0, 1, 2])
   })
 
+  it('carries each PlacedGeometry.occurrencePath onto its range (STEP)', () => {
+    // Two occurrences of one reused part-type: same parentExpressId, distinct
+    // occurrence paths. The ranges must preserve each path so the downstream
+    // IfcInstanceMap can tell the occurrences apart.
+    const api = wireGeomFetch(makeApi({
+      999: {
+        vertexData: unitTriangleVerts(),
+        indexData: new Uint32Array([0, 1, 2]),
+      },
+    }))
+    const flatMeshes = [{
+      expressID: 100,
+      geometries: {
+        size: () => 2,
+        get: (i) => i === 0 ?
+          {geometryExpressID: 999, flatTransformation: IDENTITY_MAT, occurrencePath: [10, 20]} :
+          {geometryExpressID: 999, flatTransformation: translation(5, 0, 0), occurrencePath: [10, 30]},
+      },
+    }]
+    const {ranges} = flatMeshToBufferGeometry(flatMeshes, api, 0)
+    expect(ranges).toEqual([
+      {parentExpressId: 100, triangleCount: 1, occurrencePath: [10, 20]},
+      {parentExpressId: 100, triangleCount: 1, occurrencePath: [10, 30]},
+    ])
+  })
+
   it('applies the per-instance flatTransformation to vertex positions', () => {
     // Two instances of the same shape, one translated +5 in X.
     const api = wireGeomFetch(makeApi({

--- a/yarn.lock
+++ b/yarn.lock
@@ -2473,10 +2473,10 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@bldrs-ai/conway@1.349.1111":
-  version "1.349.1111"
-  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.349.1111.tgz#c5c772b81b70d96328001d0e44b4bd2ee5ae1670"
-  integrity sha512-kIiYqK/AzMq09m1iwZRJB/KWv6xLVHGMmERpHiqpn94ttxvoE8+NxFvWJzvmOs5ilS2hzx9VG9AltkgbYeFbtw==
+"@bldrs-ai/conway@1.353.1118":
+  version "1.353.1118"
+  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.353.1118.tgz#ce3e8da5703b70723f2480d67f63b7902dd24df8"
+  integrity sha512-+DjPla0OCbf/f1SwBBbJ95M8stxD7wRP4ewXFurgkF7Fs7aDHN/qxwXvyh8oJjxQOBHmPzs+zjALF2EgMZxrCQ==
   dependencies:
     gl-matrix "3.4.3"
     seedrandom "3.0.5"


### PR DESCRIPTION
## Why

STEP reuses one part (`product_definition`) across many occurrences. Share keys selection on the scalar `expressID`, which is shared across a reused part's occurrences — so **selecting one nut in the NavTree highlights all nuts**, and a scene pick can't tell which occurrence was hit. The unique key is the **occurrence path** (NAUO express ids root→leaf), which the product-structure tree already carries but the geometry did not.

Conway now tags each `PlacedGeometry` with `occurrencePath` (PR **bldrs-ai/conway#353**). This PR starts the Share side.

## This PR (foundation — safe to land independently)

`IfcInstanceMap` already assigns one synthetic instance per `PlacedGeometry`. This threads the per-instance occurrence identity into it:

- new `instanceIdToOccurrencePath` + `getOccurrencePathByInstance(instanceId)`;
- `instanceMapFromFlatMeshes` carries `placed.occurrencePath` into the ranges; `instanceMapFromOrderedPlacedRanges` builds the per-instance array **only when the source provides paths**;
- **additive and safe** — `null` for IFC and any Conway without the field, so every existing selection path is byte-for-byte unchanged until the data appears.

Unit-tested in `IfcInstanceMap.test.js` (distinct path per instance for a reused part; null fallback for IFC). Full jest + eslint + typecheck gate green.

## Draft, because the rest depends on:

1. **Bumping `@bldrs-ai/conway`** to the release that ships #353 (so `PlacedGeometry.occurrencePath` is actually present), and
2. **In-browser validation** on the deploy preview (the sandbox that authored this can't reach `*.netlify.app`).

Remaining wiring — pick→occurrence, NavTree node identity, occurrence-scoped highlight, and the `#n:;p:` permalink — is specified in [`design/new/step-occurrence-selection.md`](design/new/step-occurrence-selection.md). Each step degrades gracefully to today's type-level behavior when no occurrence path is present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LfHL21ghUKsAq4xBCNFLdi)_