### PR TITLE
feat(loader): GLB-cache the BatchedMesh render path via merged-mesh bake

### DIFF
--- a/design/new/viewer-replacement.md
+++ b/design/new/viewer-replacement.md
@@ -761,10 +761,22 @@ Three settled conclusions:
     `BatchedMesh.prototype.{computeBoundsTree,raycast}` and each batch builds
     its per-geometry bounds trees; `acceleratedBatchedMeshRaycast` still
     emits `intersection.batchId`, so the pick path is unaffected.
-  - *GLB cache.* A `BatchedMesh` model is **not** GLB-cacheable yet (no
-    per-primitive geometry for `GLTFExporter`, no per-vertex `_EXPRESSID` for
-    `BLDRS_face_ids`), so `exportAndCacheGlb` skips it and the model
-    re-parses on the next load; a batched-aware GLB schema is future work.
+  - *GLB cache.* `GLTFExporter` can't serialise a `BatchedMesh`'s packed
+    buffer, and a batch carries no per-vertex `_EXPRESSID` for the
+    `BLDRS_face_ids` picking capture. So before serialising, `exportAndCacheGlb`
+    bakes the batched model into the *same* merged-mesh shape the merged
+    Conway-direct path emits (`batchedModelToMergedMesh`): one indexed
+    geometry with per-vertex `expressID`/`instanceID`, colour-binned into
+    `geometry.groups[]` + `MeshLambertMaterial[]`, instance matrices baked
+    into the vertices and the coordination transform kept on the node. The
+    resulting GLB is **byte-compatible with a merged Conway-direct cache
+    artifact**, so the reader hydrates it through the existing cache-hit path
+    as an `instancePicking` model — no reader-side changes, no schema bump.
+    Consequence: a reload from cache is the merged mesh, not a live
+    `BatchedMesh` — the same cache-hit/cache-miss shape divergence §3b.iii
+    already notes for the Conway-direct path. A batched-native GLB schema
+    (EXT_mesh_gpu_instancing, preserving the instanced representation across
+    the round-trip) remains future work.
   - *Fit-to-frame.* `Loader.js#readModel` hoists a Group root's first child
     geometry onto `model.geometry` ("generalize to multi-mesh" TODO). A
     `BatchedMesh`'s `.geometry` is its packed buffer — every shape in

--- a/src/loader/glbExport.js
+++ b/src/loader/glbExport.js
@@ -41,6 +41,7 @@ import {
   captureBldrsSpatialTree,
 } from './bldrsSpatialTree'
 import {eachBatch} from '../viewer/ifc/batchedModel'
+import {batchedModelToMergedMesh, disposeMergedMesh} from '../viewer/ifc/batchedToMergedMesh'
 import {glbCacheKey} from './glbCacheKey'
 import {
   activeGlbCompressionMode,
@@ -146,8 +147,9 @@ function silenceGltfExporterMaterialWarnings() {
 
 /**
  * True when the model root is, or contains, a `THREE.BatchedMesh`. Such
- * models are produced by the Conway-direct instancing path and are not
- * yet GLB-cacheable (see `exportAndCacheGlb`).
+ * models come from the Conway-direct instancing path (`?feature=batchedMesh`)
+ * and are baked back to a merged mesh before serialising (see
+ * `exportAndCacheGlb`), since `GLTFExporter` can't serialise a packed batch.
  *
  * @param {object} model Three.js root (Mesh / Group / Scene / BatchedMesh)
  * @return {boolean}
@@ -188,15 +190,19 @@ function modelHasBatchedMesh(model) {
 export async function exportAndCacheGlb({model, kindLabel, cacheKeyArgs, ifcManager = null}) {
   const startMs = Date.now()
   try {
-    // BatchedMesh render path (`?feature=batchedMesh`): a `THREE.BatchedMesh`
-    // has no standard per-primitive geometry/attributes for `GLTFExporter`
-    // to serialize, and it carries no per-vertex `_EXPRESSID` for the
-    // `BLDRS_face_ids` capture — a cached artifact would be empty or
-    // unpickable on read-back. Skip the cache write entirely; the model
-    // re-parses (fast, flag-gated) on the next load. A batched-aware GLB
-    // schema is future work (design/new/viewer-replacement.md §3b.iv).
-    if (modelHasBatchedMesh(model)) {
-      glbInfo('writer: skipped (BatchedMesh model is not GLB-cacheable yet)')
+    // BatchedMesh render path (`?feature=batchedMesh`): `GLTFExporter` can't
+    // serialise a `THREE.BatchedMesh`'s packed buffer, and a batch carries
+    // no per-vertex `_EXPRESSID` for the `BLDRS_face_ids` picking capture.
+    // Bake it into the same merged-mesh shape the Conway-direct merged path
+    // produces (per-vertex expressID/instanceID + colour-binned materials);
+    // the resulting GLB is byte-compatible with a merged cache artifact and
+    // reads back through the existing cache-hit path unchanged
+    // (design/new/viewer-replacement.md §3b.iv). The bake is transient —
+    // disposed right after serialisation below.
+    const isBatched = modelHasBatchedMesh(model)
+    const exportModel = isBatched ? batchedModelToMergedMesh(model) : model
+    if (isBatched && !exportModel) {
+      glbInfo('writer: skipped (batched model produced no exportable geometry)')
       return false
     }
     const filePath = cacheKeyArgs.sourcePath
@@ -205,7 +211,15 @@ export async function exportAndCacheGlb({model, kindLabel, cacheKeyArgs, ifcMana
       `writer: ${kindLabel} source, key=${cacheKeyArgs.ns1}/${cacheKeyArgs.ns2}/${cacheKeyArgs.ns3}/` +
       `${filePath} sha=${cacheKeyArgs.sourceHash} requestedCompression=${requestedMode || 'none'}`)
     glbVerbose('writer: cacheKeyArgs =', cacheKeyArgs)
-    const rawBytes = await exportThreeModelAsGlb(model)
+    if (isBatched) {
+      glbVerbose('writer: baked BatchedMesh model to a merged mesh for export')
+    }
+    const rawBytes = await exportThreeModelAsGlb(exportModel)
+    // The baked mesh is a transient, off-scene copy; free its buffers now
+    // that the bytes are captured (the source batched model is untouched).
+    if (exportModel !== model) {
+      disposeMergedMesh(exportModel)
+    }
     if (!rawBytes || rawBytes.byteLength === 0) {
       glbInfo('writer: skipped (GLTFExporter produced no bytes)')
       return false

--- a/src/loader/glbExport.test.js
+++ b/src/loader/glbExport.test.js
@@ -51,6 +51,49 @@ import {BLDRS_GLB_SCHEMA_VERSION} from './glbCacheKey'
 import {BLDRS_TITLE_EXTRAS_KEY, exportAndCacheGlb, exportThreeModelAsGlb} from './glbExport'
 import {parseGlb, serializeGlb} from './injectGlbExtensions'
 import {gitHubCacheKey} from './sourceCacheKey'
+import {flatMeshToBatchedModel} from '../viewer/ifc/flatMeshToBatchedModel'
+
+
+/**
+ * Build a decorated single-batch `THREE.BatchedMesh` (two placements of one
+ * unit triangle) the way `buildBatchedConwayModel` does — enough for the
+ * writer's batched→merged bake path. Uses the real `flatMeshToBatchedModel`
+ * over a tiny mock Conway IfcAPI.
+ *
+ * @return {object} decorated BatchedMesh
+ */
+function buildDecoratedBatchedMesh() {
+  const verts = new Float32Array([
+    0, 0, 0, 0, 0, 1,
+    1, 0, 0, 0, 0, 1,
+    0, 1, 0, 0, 0, 1,
+  ])
+  const idxData = new Uint32Array([0, 1, 2])
+  const GEOM_ID = 999
+  const api = {
+    GetGeometry: (_m, id) => (id === GEOM_ID ? {
+      GetVertexData: () => 0,
+      GetIndexData: () => 0,
+      GetVertexDataSize: () => verts.length,
+      GetIndexDataSize: () => idxData.length,
+    } : null),
+    GetVertexArray: () => verts,
+    GetIndexArray: () => idxData,
+  }
+  const ident = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]
+  const shift = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 10, 0, 0, 1]
+  const grey = {x: 0.8, y: 0.8, z: 0.8, w: 1}
+  const {batches} = flatMeshToBatchedModel([
+    {expressID: 100, geometries: [{geometryExpressID: GEOM_ID, flatTransformation: ident, color: grey}]},
+    {expressID: 200, geometries: [{geometryExpressID: GEOM_ID, flatTransformation: shift, color: grey}]},
+  ], api, 0)
+  const batch = batches[0]
+  batch.mesh.instanceParents = batch.instanceParents
+  batch.mesh.instanceOccurrenceIds = batch.instanceOccurrenceIds
+  batch.mesh.instanceGeometry = batch.instanceGeometry
+  batch.mesh.instanceColors = batch.instanceColors
+  return batch.mesh
+}
 
 
 /**
@@ -152,14 +195,14 @@ describe('loader/glbExport', () => {
       expect(branch).toBe('main')
     })
 
-    it('skips a BatchedMesh model (not GLB-cacheable yet) without exporting', async () => {
+    it('skips an undecorated BatchedMesh (no source tables → nothing to bake)', async () => {
       const ok = await exportAndCacheGlb({model: {isBatchedMesh: true}, ...ctx})
       expect(ok).toBe(false)
       expect(mockExporterParse).not.toHaveBeenCalled()
       expect(mockWriteGlbBytesToOPFS).not.toHaveBeenCalled()
     })
 
-    it('skips a Group that contains a BatchedMesh', async () => {
+    it('skips a Group whose only BatchedMesh child has no convertible instances', async () => {
       const model = {
         traverse: (fn) => {
           fn({isBatchedMesh: false})
@@ -169,6 +212,27 @@ describe('loader/glbExport', () => {
       const ok = await exportAndCacheGlb({model, ...ctx})
       expect(ok).toBe(false)
       expect(mockWriteGlbBytesToOPFS).not.toHaveBeenCalled()
+    })
+
+    it('bakes a decorated batched model to a merged mesh and exports it', async () => {
+      // A real decorated BatchedMesh (two placements of one shape). The writer
+      // must bake it to a plain merged Mesh — carrying per-vertex expressID —
+      // and hand THAT to GLTFExporter, not the un-serialisable batch.
+      const batchedMesh = buildDecoratedBatchedMesh()
+      let exported = null
+      mockExporterParse.mockImplementation((input, onDone) => {
+        exported = input
+        onDone(makeValidEmptyGlb().buffer)
+      })
+
+      const ok = await exportAndCacheGlb({model: batchedMesh, ...ctx})
+      expect(ok).toBe(true)
+      // Serialised the baked merged mesh, not the BatchedMesh.
+      expect(exported).not.toBe(batchedMesh)
+      expect(exported.isBatchedMesh).toBeFalsy()
+      expect(exported.geometry.getAttribute('expressID')).toBeDefined()
+      expect(exported.geometry.getAttribute('instanceID')).toBeDefined()
+      expect(mockWriteGlbBytesToOPFS).toHaveBeenCalledTimes(1)
     })
 
     it('returns false (no throw) when the exporter produces no bytes', async () => {

--- a/src/viewer/ifc/batchedToMergedMesh.js
+++ b/src/viewer/ifc/batchedToMergedMesh.js
@@ -1,0 +1,265 @@
+import {
+  BufferAttribute,
+  BufferGeometry,
+  Color,
+  DoubleSide,
+  Matrix3,
+  Matrix4,
+  Mesh,
+  MeshLambertMaterial,
+  Vector3,
+} from 'three'
+import {eachBatch} from './batchedModel'
+
+
+/**
+ * batchedToMergedMesh — flatten a Conway-direct `THREE.BatchedMesh` model
+ * (`?feature=batchedMesh`) into a single merged `THREE.Mesh` for GLB
+ * export / caching.
+ *
+ * A `BatchedMesh` stores each unique shape once in local space plus a
+ * per-instance matrix / colour, and keeps the source IFC ids in per-batch
+ * side tables (`instanceParents` / `instanceOccurrenceIds`) rather than on
+ * any vertex. `GLTFExporter` can't serialise that packed representation,
+ * and a serialised batch would carry no per-vertex `_EXPRESSID` for the
+ * `BLDRS_face_ids` picking capture — so the batched path used to skip the
+ * cache entirely.
+ *
+ * This bakes it back into exactly the shape the merged Conway-direct path
+ * (`flatMeshToBufferGeometry`) produces: one indexed `BufferGeometry` with
+ * per-vertex `position` / `normal` / `expressID` / `instanceID`, colour-
+ * binned into `geometry.groups[]` + an array of `MeshLambertMaterial`.
+ * `GLTFExporter` renames `expressID` → `_EXPRESSID` and `instanceID` →
+ * `_INSTANCEID` verbatim, so the resulting GLB is byte-compatible with a
+ * merged Conway-direct cache artifact — the reader hydrates it as an
+ * `instancePicking` model through the existing cache-hit path with **no
+ * reader-side changes and no schema bump**. (The consequence: a reload
+ * from cache is the merged mesh, not a live BatchedMesh — the same
+ * cache-hit/cache-miss shape divergence §3b.iii already notes for the
+ * Conway-direct path.)
+ *
+ * Instance matrices are baked into the vertices in model-local space; the
+ * coordination matrix (stamped on the batched *root* node with
+ * `matrixAutoUpdate` off, see `ShareIfcLoader`) is copied onto the merged
+ * mesh's node so on-screen placement is reproduced exactly — matching how
+ * the merged path keeps the coordination transform on the node and the
+ * `flatTransformation` baked into vertices.
+ *
+ * @see flatMeshToBufferGeometry — the merged-path template this mirrors.
+ * @see design/new/viewer-replacement.md §3b.iv
+ */
+
+
+/** Fallback colour when an instance carries no colour entry. */
+const DEFAULT_COLOR = {x: 0.8, y: 0.8, z: 0.8, w: 1}
+
+/** Floats per position / normal vector. */
+const VEC3 = 3
+
+/** Alpha at/above which a colour is opaque (gets a non-transparent material). */
+const OPAQUE_ALPHA = 1
+
+
+/**
+ * Stringify an RGBA colour for use as a colour-bin Map key. Mirrors
+ * `flatMeshToBufferGeometry.colorKey` — float concat, no quantisation
+ * (equal IFC colours produce bit-equal floats).
+ *
+ * @param {{x: number, y: number, z: number, w: number}} color
+ * @return {string}
+ */
+function colorKey(color) {
+  return `${color.x}|${color.y}|${color.z}|${color.w}`
+}
+
+
+/**
+ * Collect one entry per rendered instance across every batch of a batched
+ * model, snapshotting the placement matrix and the source local geometry.
+ *
+ * @param {object} model BatchedMesh or Group of BatchedMeshes
+ * @return {Array<object>} `{parentExpressId, instanceId, geom, matrix, color,
+ *   vertCount, indexCount}` per instance
+ */
+function collectInstanceEntries(model) {
+  const entries = []
+  const scratch = new Matrix4()
+  eachBatch(model, (mesh) => {
+    // Only a decorated batch (carrying the side tables) is convertible; a
+    // bare BatchedMesh has no source ids to bake in. Skip it — the caller
+    // treats an empty entry list as "nothing to export".
+    if (!mesh.instanceParents || !mesh.instanceGeometry ||
+        typeof mesh.getMatrixAt !== 'function') {
+      return
+    }
+    const parents = mesh.instanceParents
+    const occurrences = mesh.instanceOccurrenceIds
+    const geometries = mesh.instanceGeometry
+    const colors = mesh.instanceColors
+    for (let batchId = 0; batchId < parents.length; batchId++) {
+      const geom = geometries[batchId]
+      const pos = geom?.attributes?.position
+      const idx = geom?.index
+      if (!pos || !idx) {
+        continue
+      }
+      mesh.getMatrixAt(batchId, scratch)
+      entries.push({
+        parentExpressId: parents[batchId],
+        // `instanceOccurrenceIds` is globally unique across both batches
+        // (minted in FlatMesh emission order) — the id per-instance picking
+        // needs. Fall back to batchId only if the table is absent.
+        instanceId: occurrences ? occurrences[batchId] : batchId,
+        geom,
+        matrix: scratch.clone(),
+        color: colors?.[batchId] ?? DEFAULT_COLOR,
+        vertCount: pos.count,
+        indexCount: idx.count,
+      })
+    }
+  })
+  return entries
+}
+
+
+/**
+ * Bake a Conway-direct batched model into a single merged `THREE.Mesh`
+ * suitable for `GLTFExporter`, in the same layout `flatMeshToBufferGeometry`
+ * emits (see module doc).
+ *
+ * @param {object} model BatchedMesh or Group of BatchedMeshes
+ * @return {Mesh|null} merged mesh (array material + colour groups), or null
+ *   when the model has no convertible instances
+ */
+export function batchedModelToMergedMesh(model) {
+  const entries = collectInstanceEntries(model)
+  if (entries.length === 0) {
+    return null
+  }
+
+  // Bin by colour in first-seen order (→ material index), so each colour's
+  // triangles stay contiguous for the `geometry.groups[]` / `materials[]`
+  // pairing three.js's multi-material renderer uses.
+  const bins = new Map()
+  for (const entry of entries) {
+    const key = colorKey(entry.color)
+    let bin = bins.get(key)
+    if (!bin) {
+      bin = {color: entry.color, entries: []}
+      bins.set(key, bin)
+    }
+    bin.entries.push(entry)
+  }
+  let totalVerts = 0
+  let totalIndices = 0
+  for (const bin of bins.values()) {
+    for (const entry of bin.entries) {
+      entry.vertOffset = totalVerts
+      totalVerts += entry.vertCount
+      totalIndices += entry.indexCount
+    }
+  }
+
+  const positions = new Float32Array(totalVerts * VEC3)
+  const normals = new Float32Array(totalVerts * VEC3)
+  const expressIDs = new Uint32Array(totalVerts)
+  const instanceIDs = new Uint32Array(totalVerts)
+  const indices = new Uint32Array(totalIndices)
+  const materials = []
+  const groups = []
+  const p = new Vector3()
+  const n = new Vector3()
+  const normalMatrix = new Matrix3()
+  let vCursor = 0
+  let iCursor = 0
+  let materialIndex = 0
+
+  for (const bin of bins.values()) {
+    const groupStart = iCursor
+    // Match flatMeshToBufferGeometry's material: MeshLambertMaterial(color,
+    // DoubleSide) + transparent/opacity when alpha < 1.
+    const col = new Color(bin.color.x, bin.color.y, bin.color.z)
+    const material = new MeshLambertMaterial({color: col, side: DoubleSide})
+    if (bin.color.w !== OPAQUE_ALPHA) {
+      material.transparent = true
+      material.opacity = bin.color.w
+    }
+    materials.push(material)
+    for (const entry of bin.entries) {
+      const posAttr = entry.geom.attributes.position
+      const nrmAttr = entry.geom.attributes.normal
+      const srcIdx = entry.geom.index.array
+      normalMatrix.getNormalMatrix(entry.matrix)
+      for (let v = 0; v < entry.vertCount; v++) {
+        p.fromBufferAttribute(posAttr, v).applyMatrix4(entry.matrix)
+        const dst = (vCursor + v) * VEC3
+        positions[dst] = p.x
+        positions[dst + 1] = p.y
+        positions[dst + 2] = p.z
+        if (nrmAttr) {
+          n.fromBufferAttribute(nrmAttr, v).applyMatrix3(normalMatrix).normalize()
+          normals[dst] = n.x
+          normals[dst + 1] = n.y
+          normals[dst + 2] = n.z
+        }
+        expressIDs[vCursor + v] = entry.parentExpressId
+        instanceIDs[vCursor + v] = entry.instanceId
+      }
+      for (let k = 0; k < entry.indexCount; k++) {
+        indices[iCursor + k] = srcIdx[k] + entry.vertOffset
+      }
+      vCursor += entry.vertCount
+      iCursor += entry.indexCount
+    }
+    const groupCount = iCursor - groupStart
+    if (groupCount > 0) {
+      groups.push({start: groupStart, count: groupCount, materialIndex})
+    }
+    materialIndex++
+  }
+
+  const geometry = new BufferGeometry()
+  geometry.setAttribute('position', new BufferAttribute(positions, VEC3))
+  geometry.setAttribute('normal', new BufferAttribute(normals, VEC3))
+  geometry.setAttribute('expressID', new BufferAttribute(expressIDs, 1))
+  geometry.setAttribute('instanceID', new BufferAttribute(instanceIDs, 1))
+  geometry.setIndex(new BufferAttribute(indices, 1))
+  for (const g of groups) {
+    geometry.addGroup(g.start, g.count, g.materialIndex)
+  }
+
+  const merged = new Mesh(geometry, materials)
+  // Carry the coordination transform from the batched root node (stamped
+  // with matrixAutoUpdate off) so the exported GLB reproduces on-screen
+  // placement; instance matrices are already baked into the vertices.
+  if (model.matrix && typeof model.matrix.copy === 'function') {
+    merged.matrixAutoUpdate = model.matrixAutoUpdate ?? false
+    merged.matrix.copy(model.matrix)
+    merged.matrix.decompose(merged.position, merged.quaternion, merged.scale)
+  }
+  if (typeof model.name === 'string') {
+    merged.name = model.name
+  }
+  return merged
+}
+
+
+/**
+ * Dispose a merged mesh built by `batchedModelToMergedMesh` — frees its
+ * freshly-baked geometry + per-bin materials. The source batched model is
+ * untouched (the merged mesh owns independent buffers).
+ *
+ * @param {Mesh} mesh
+ */
+export function disposeMergedMesh(mesh) {
+  if (!mesh) {
+    return
+  }
+  mesh.geometry?.dispose?.()
+  const material = mesh.material
+  if (Array.isArray(material)) {
+    material.forEach((m) => m?.dispose?.())
+  } else {
+    material?.dispose?.()
+  }
+}

--- a/src/viewer/ifc/batchedToMergedMesh.test.js
+++ b/src/viewer/ifc/batchedToMergedMesh.test.js
@@ -1,0 +1,175 @@
+/* eslint-disable no-magic-numbers */
+import {Group, Matrix4, Mesh} from 'three'
+import {batchedModelToMergedMesh, disposeMergedMesh} from './batchedToMergedMesh'
+import {flatMeshToBatchedModel} from './flatMeshToBatchedModel'
+
+
+/** Identity 4x4 in three.js column-major flat form. */
+const IDENTITY_MAT = [
+  1, 0, 0, 0,
+  0, 1, 0, 0,
+  0, 0, 1, 0,
+  0, 0, 0, 1,
+]
+
+/** Translate +10 in X (column-major). */
+const TRANSLATE_X10 = [
+  1, 0, 0, 0,
+  0, 1, 0, 0,
+  0, 0, 1, 0,
+  10, 0, 0, 1,
+]
+
+const GREY = {x: 0.8, y: 0.8, z: 0.8, w: 1}
+const RED = {x: 1, y: 0, z: 0, w: 1}
+const GLASS = {x: 0.5, y: 0.5, z: 1, w: 0.4}
+
+
+/** @return {Float32Array} single-triangle interleaved vert buffer (p+n). */
+function unitTriangleVerts() {
+  return new Float32Array([
+    0, 0, 0, 0, 0, 1,
+    1, 0, 0, 0, 0, 1,
+    0, 1, 0, 0, 0, 1,
+  ])
+}
+
+
+/** @return {object} mock Conway IfcAPI with one unit-triangle shape at id 999. */
+function unitTriApi() {
+  const byId = {999: {vertexData: unitTriangleVerts(), indexData: new Uint32Array([0, 1, 2])}}
+  return {
+    GetGeometry(_modelID, geomExpressID) {
+      const g = byId[geomExpressID]
+      if (!g) {
+        return null
+      }
+      return {
+        GetVertexData: () => geomExpressID,
+        GetIndexData: () => geomExpressID,
+        GetVertexDataSize: () => g.vertexData.length,
+        GetIndexDataSize: () => g.indexData.length,
+      }
+    },
+    GetVertexArray: (ptr) => byId[ptr].vertexData,
+    GetIndexArray: (ptr) => byId[ptr].indexData,
+  }
+}
+
+
+/**
+ * Build a batched model from the given flatMeshes, wiring the per-batch side
+ * tables onto each mesh the way `buildBatchedConwayModel` does, and wrapping
+ * >1 batch in a Group.
+ *
+ * @param {Array} flatMeshes
+ * @return {object} BatchedMesh or Group of them
+ */
+function batchedModel(flatMeshes) {
+  const {batches} = flatMeshToBatchedModel(flatMeshes, unitTriApi(), 0)
+  for (const batch of batches) {
+    batch.mesh.instanceParents = batch.instanceParents
+    batch.mesh.instanceOccurrenceIds = batch.instanceOccurrenceIds
+    batch.mesh.instanceGeometry = batch.instanceGeometry
+    batch.mesh.instanceColors = batch.instanceColors
+  }
+  if (batches.length === 1) {
+    return batches[0].mesh
+  }
+  const group = new Group()
+  for (const batch of batches) {
+    group.add(batch.mesh)
+  }
+  return group
+}
+
+
+describe('viewer/ifc/batchedToMergedMesh', () => {
+  it('bakes every instance into one merged mesh with per-vertex ids', () => {
+    const model = batchedModel([
+      {expressID: 100, geometries: [{geometryExpressID: 999, flatTransformation: IDENTITY_MAT, color: GREY}]},
+      {expressID: 200, geometries: [{geometryExpressID: 999, flatTransformation: TRANSLATE_X10, color: GREY}]},
+    ])
+    const merged = batchedModelToMergedMesh(model)
+    expect(merged).toBeInstanceOf(Mesh)
+    const pos = merged.geometry.attributes.position
+    expect(pos.count).toBe(6) // two unit triangles
+    // Second instance's +X10 matrix is baked into its vertices.
+    const xs = Array.from({length: 6}, (_, v) => pos.getX(v))
+    expect(Math.max(...xs)).toBeCloseTo(11)
+    // Indices are rebased across the two instances.
+    expect(Math.max(...merged.geometry.index.array)).toBe(5)
+    // Per-vertex expressID resolves the parent product; instanceID is unique.
+    const express = merged.geometry.attributes.expressID
+    const instance = merged.geometry.attributes.instanceID
+    const expressSet = new Set(Array.from({length: 6}, (_, v) => express.getX(v)))
+    expect(expressSet).toEqual(new Set([100, 200]))
+    const instanceSet = new Set(Array.from({length: 6}, (_, v) => instance.getX(v)))
+    expect(instanceSet.size).toBe(2) // two distinct occurrence ids
+  })
+
+  it('bins by colour into one material + group per distinct colour', () => {
+    const model = batchedModel([
+      {expressID: 100, geometries: [{geometryExpressID: 999, flatTransformation: IDENTITY_MAT, color: GREY}]},
+      {expressID: 200, geometries: [{geometryExpressID: 999, flatTransformation: IDENTITY_MAT, color: RED}]},
+    ])
+    const merged = batchedModelToMergedMesh(model)
+    expect(Array.isArray(merged.material)).toBe(true)
+    expect(merged.material).toHaveLength(2)
+    expect(merged.geometry.groups).toHaveLength(2)
+    // Each group covers one triangle (3 indices).
+    for (const g of merged.geometry.groups) {
+      expect(g.count).toBe(3)
+    }
+  })
+
+  it('flags a transparent colour bin transparent with its alpha', () => {
+    const model = batchedModel([
+      {expressID: 100, geometries: [{geometryExpressID: 999, flatTransformation: IDENTITY_MAT, color: GREY}]},
+      {expressID: 300, geometries: [{geometryExpressID: 999, flatTransformation: IDENTITY_MAT, color: GLASS}]},
+    ])
+    const merged = batchedModelToMergedMesh(model)
+    // A GREY (opaque) + GLASS (alpha 0.4) model splits into two render batches;
+    // both instances survive the merge, and the glass material stays translucent.
+    const transparentMats = merged.material.filter((m) => m.transparent)
+    expect(transparentMats).toHaveLength(1)
+    expect(transparentMats[0].opacity).toBeCloseTo(0.4)
+    expect(merged.geometry.attributes.position.count).toBe(6) // both triangles baked
+  })
+
+  it('carries the coordination matrix from the batched root onto the merged node', () => {
+    const model = batchedModel([
+      {expressID: 100, geometries: [{geometryExpressID: 999, flatTransformation: IDENTITY_MAT, color: GREY}]},
+    ])
+    // Stamp a coordination transform on the root the way ShareIfcLoader does.
+    model.matrixAutoUpdate = false
+    model.matrix.copy(new Matrix4().makeTranslation(5, 6, 7))
+    const merged = batchedModelToMergedMesh(model)
+    expect(merged.matrixAutoUpdate).toBe(false)
+    expect(merged.matrix.elements[12]).toBeCloseTo(5)
+    expect(merged.matrix.elements[13]).toBeCloseTo(6)
+    expect(merged.matrix.elements[14]).toBeCloseTo(7)
+    // Decomposed PRS stays consistent with the matrix.
+    expect(merged.position.x).toBeCloseTo(5)
+  })
+
+  it('returns null for a model with no convertible instances', () => {
+    expect(batchedModelToMergedMesh(new Group())).toBeNull()
+    expect(batchedModelToMergedMesh(null)).toBeNull()
+  })
+
+  it('disposeMergedMesh frees geometry and every material', () => {
+    const model = batchedModel([
+      {expressID: 100, geometries: [{geometryExpressID: 999, flatTransformation: IDENTITY_MAT, color: GREY}]},
+      {expressID: 200, geometries: [{geometryExpressID: 999, flatTransformation: IDENTITY_MAT, color: RED}]},
+    ])
+    const merged = batchedModelToMergedMesh(model)
+    const geomSpy = jest.spyOn(merged.geometry, 'dispose')
+    const matSpies = merged.material.map((m) => jest.spyOn(m, 'dispose'))
+    disposeMergedMesh(merged)
+    expect(geomSpy).toHaveBeenCalled()
+    for (const spy of matSpies) {
+      expect(spy).toHaveBeenCalled()
+    }
+  })
+})


### PR DESCRIPTION
## What

Makes the `?feature=batchedMesh` render path (merged in #1571) participate in the OPFS GLB cache. Previously `exportAndCacheGlb` **skipped** batched models entirely, so every load re-parsed the IFC from source.

## Why it was skipped

Two hard blockers:
1. `GLTFExporter` can't serialise a `THREE.BatchedMesh`'s packed buffer (no standard per-primitive geometry).
2. A batch carries no per-vertex `_EXPRESSID` — the id lives in the per-batch `instanceParents` table — so `BLDRS_face_ids` picking capture had nothing to read.

## Approach — bake to the merged shape, reuse the whole reader

Rather than invent a batched-native GLB schema, bake the batched model into **the exact merged-mesh shape the merged Conway-direct path (`flatMeshToBufferGeometry`) already emits**, then run the existing export pipeline on it.

- **`src/viewer/ifc/batchedToMergedMesh.js`** (new) — `batchedModelToMergedMesh` walks every instance of every batch (via the shared `eachBatch`), bakes each instance matrix into local-space vertices, and emits one indexed `BufferGeometry` with per-vertex `position` / `normal` / `expressID` / `instanceID`, colour-binned into `geometry.groups[]` + an array of `MeshLambertMaterial` (transparent bins keep their alpha). The coordination transform on the batched root node is copied onto the merged node; instance matrices bake into the vertices — matching how the merged path keeps node-transform vs baked-vertices split. `disposeMergedMesh` frees the transient bake.
- **`src/loader/glbExport.js`** — the batched skip becomes a bake; serialise the merged mesh and dispose it right after the bytes are captured. `model` (title, `modelID`, `ifcManager` captures) is untouched — only the exported bytes come from the bake.

## The key property: byte-compatible artifact, zero reader changes

Because the baked GLB carries `_EXPRESSID` / `_INSTANCEID` per vertex, it is **byte-compatible with a merged Conway-direct cache artifact**. The reader hydrates it as an `instancePicking` model through the existing cache-hit path — **no reader-side changes, no schema bump**.

**Trade-off:** a reload from cache is the merged mesh, not a live `BatchedMesh` — the same cache-hit/cache-miss shape divergence §3b.iii already documents for the Conway-direct path. All user-facing features (picking, isolate/hide, NavTree, Properties, transparency, permalinks) work on the cache-hit model via the merged/`instancePicking` machinery. The only thing not preserved across the round-trip is the in-memory instancing (draw-call/VRAM) win — a first-load-only property. A batched-native GLB schema (`EXT_mesh_gpu_instancing`) that preserves the instanced representation remains future work.

## Tests

- New baker unit suite: bake / colour-bin / transparency / coordination-matrix carry / dispose / null-guard.
- New `glbExport` case proving a decorated batched model bakes and exports (serialises a plain merged `Mesh` carrying `expressID`/`instanceID`, not the batch). The two stale "not cacheable yet" skip tests were reframed to the still-valid undecorated-batch case.
- Full pre-commit gate green (1770 tests). Design note §3b.iv updated.

## Smoke test

Load a model with `?feature=batchedMesh` (cache miss → BatchedMesh render, writes the baked GLB), then reload (cache hit → merged model). Confirm picking / isolate / NavTree / Properties / transparency all behave on the reloaded model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y6URFWeMJexmXPGfp8N8S4

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y6URFWeMJexmXPGfp8N8S4)_