### PR TITLE
docs(step): make occurrence-keyed selection reachable from the roadmap + refresh status

### DIFF
--- a/design/new/step-occurrence-selection.md
+++ b/design/new/step-occurrence-selection.md
@@ -57,7 +57,7 @@ range; (b) `decorateConwayDirectIfcModel` carries the occurrence tables
 rebuilt map — safe because the synthetic instance ids line up 1:1 (same emission
 order; BVH permutes only the index buffer, not the numbering).
 
-### Done (this PR)
+### Done (landed — PRs #1573 + #1575)
 
 - **Data foundation.** `IfcInstanceMap` captures `instanceIdToOccurrencePath` +
   `occurrencePathToInstanceIds` from each `PlacedGeometry.occurrencePath`, with
@@ -125,7 +125,7 @@ order; BVH permutes only the index buffer, not the numbering).
    (the store is keyed by node id); child-leaf eyes still read "shown." Toggling
    the assembly eye is the way to reveal them again. Making descendant eyes
    follow would need per-node hidden-state derived from the occurrence prefix.
-2. **Root-level parts.** A placement directly under the product root has an empty
+5. **Root-level parts.** A placement directly under the product root has an empty
    occurrence path (no NAUO), which `getOccurrencePathByInstance` normalizes to
    `null` — an empty path can't disambiguate anything. So a scene pick of a
    *root-level* part can't reconcile to its NavTree node (the pick reports the
@@ -133,7 +133,7 @@ order; BVH permutes only the index buffer, not the numbering).
    type-level. Harmless when the file has one root assembly (the common case);
    only bites files with several distinct parts placed directly at the root. A
    real fix needs a PDS→product-definition→node reverse map, out of scope here.
-3. **`?feature=batchedMesh`.** The BatchedMesh render path builds no
+6. **`?feature=batchedMesh`.** The BatchedMesh render path builds no
    `IfcInstanceMap`, so per-occurrence (and all per-instance) selection no-ops
    under that flag — a documented gap in `buildBatchedConwayModel`, not a
    regression (NAUO≠PDS meant a STEP node click highlighted nothing there

--- a/design/new/viewer-replacement.md
+++ b/design/new/viewer-replacement.md
@@ -673,16 +673,21 @@ plan asks of Share and the per-instance id GPU instancing needs are the
 **same** identifier. Doing them together is cheaper than either alone, and
 STEP assemblies are both the forcing function and the biggest beneficiary.
 
-**Landed (PR #1573, merged Conway-direct path).** The `expressID → ordered
-occurrence path` generalization is real: `PlacedGeometry.occurrencePath`
-(the root→leaf NAUO ids) now keys per-occurrence selection both ways —
-scene pick → per-occurrence NavTree highlight, NavTree click → occurrence-
-scoped scene highlight — via `setInstanceSelection` on `instancePicking`
-models. Full design in `design/new/step-occurrence-selection.md`. This
-shipped on the **merged** Conway-direct path only; the **batched** path
-carries `batchedPicking` (product-level) not `instancePicking`, so it still
-highlights every occurrence of the picked product — see the batched
-selection follow-up below.
+**Landed (PRs #1573 + #1575, merged Conway-direct path).** The `expressID →
+ordered occurrence path` generalization is real: `PlacedGeometry.occurrencePath`
+(the root→leaf NAUO ids) now keys per-occurrence behavior both ways —
+scene pick → per-occurrence NavTree highlight (+ auto-expand to the node),
+NavTree click → occurrence-scoped scene highlight — via `setInstanceSelection`
+on `instancePicking` models. #1575 extended it past selection: per-occurrence
+**hide** (the NavTree eye / `H` hide one occurrence, not every reuse) and
+**GLB-cache persistence** (the `instanceId → occurrencePath` table rides
+`BLDRS_face_ids`, schema `0.9.0`, so a cache-hit STEP model keeps per-occurrence
+behavior). Full design + remaining follow-ups (permalink, per-occurrence
+isolate) in `design/new/step-occurrence-selection.md`. This shipped on the
+**merged** Conway-direct path only; the **batched** path carries
+`batchedPicking` (product-level) not `instancePicking`, so it still highlights
+every occurrence of the picked product — see the batched selection follow-up
+below.
 
 **Measured (PR1, 2026-06).** The grouper ran over real models.
 **vtx reduction** = the share of merged vertex memory the geometry

--- a/design/roadmap.md
+++ b/design/roadmap.md
@@ -194,6 +194,16 @@ slice, and isolation controls expected of a BIM viewer.
   (now owns `selectedInstanceIds` + the URL path). Reactivated the `SynchronizedView` E2E
   (was `describe.skip`). Stories: <a href="https://github.com/bldrs-ai/Share/issues/1046" target="_blank" rel="noopener noreferrer">#1046</a> (sync) +
   <a href="https://github.com/bldrs-ai/Share/issues/1180" target="_blank" rel="noopener noreferrer">#1180</a> (permalinks).
+- STEP occurrence-keyed selection + hide ✔ (NEW). For STEP / AP214 assemblies, one
+  part type is reused across many occurrences (e.g. every as1 bolt shares one
+  `product_definition_shape`), so the scalar-`expressID` selection key collapsed them
+  all. NavTree↔scene selection and the hide/eye now key on the per-occurrence path
+  (root→leaf NAUO ids from Conway's `PlacedGeometry.occurrencePath`), so a reused part
+  selects, reveals-in-tree, and hides as a *single* occurrence — and it survives the GLB
+  cache. Conway-side extraction is the `step-metadata` track (see Track T1 + conway's
+  `step-metadata-nist.md`); Share-side design +
+  remaining follow-ups (permalink encoding, per-occurrence isolate) in
+  `design/new/step-occurrence-selection.md`. PRs #1573 + #1575, E2E over `as1-oc-214.stp`.
 
 **Epic `view-110`: Cut planes** ✔
 *PDF View.3 — Cut sub-item ✔.*
@@ -537,7 +547,9 @@ same list-item order: What, Status, Unblocks, Pro-MVP impact, Doc.
 ### Track T1: Viewer Replacement
 
 - **What:** Replace `web-ifc-viewer` + `web-ifc-three`. Cuts the three.js 0.135 anchor;
-  ships Conway-direct IFC parse, per-instance picking, unified Clipper.
+  ships Conway-direct IFC parse, per-instance picking, unified Clipper. Conway-direct
+  also parses **STEP / AP214** assemblies, with per-occurrence NavTree↔scene selection
+  and hide keyed on the occurrence path (`design/new/step-occurrence-selection.md`).
 - **Status:** Phases 0–4 + 5a + 5b landed. `conwayDirectIfc` + `glb` default-on.
   Remaining: Phase 5 cleanup (drop wit-three entirely), perf items (on-demand
   rendering, hover-pick throttle), per-product mesh emission spike, **public-launch


### PR DESCRIPTION
Documentation-only pass to bring the STEP design docs current with the occurrence-keyed selection work that landed in PRs #1573 + #1575, and to make it reachable from the product plan.

## What changed

- **`design/roadmap.md`** — added the STEP occurrence-keyed selection + per-occurrence hide work under Epic `view-100` and Track T1, linking `design/new/step-occurrence-selection.md` and conway's `step-metadata-nist.md`. STEP occurrence work wasn't in the roadmap at all before, so it was unreachable from the top-level plan.
- **`design/new/viewer-replacement.md`** — updated the "Landed" occurrence-identity paragraph to cover #1575's additions: per-occurrence hide, NavTree auto-expand-to-selection, and GLB-cache persistence of occurrence data (schema bump 0.8.0 → 0.9.0).
- **`design/new/step-occurrence-selection.md`** — retitled the done section to "landed (PRs #1573 + #1575)" and fixed the mangled follow-up numbering.

## Notes

- Docs only — no code or runtime surface touched.
- Deliberately did **not** mark STEP permalink, Properties-panel, or comment verification as done — those weren't validated in this thread and remain tracked follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LfHL21ghUKsAq4xBCNFLdi

---
_Generated by [Claude Code](https://claude.ai/code/session_01LfHL21ghUKsAq4xBCNFLdi)_