### PR TITLE
Roadmap v0.3–v0.6: growth reconciliation, AI pivot, strategy synthesis, milestone tiers + MVP bar

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,7 +44,7 @@ This file is the router for AI assistants working in this repo. Keep it small. T
 | STEP occurrence-keyed selection (NavTree↔scene per-occurrence), `PlacedGeometry.occurrencePath`, why one nut highlights all | [design/new/step-occurrence-selection.md](design/new/step-occurrence-selection.md) |
 | The `?feature=look` render look — PBR materials + gradient IBL + tone-mapping, Neutral/Flat toggle, `looks.js`/`lookMaterial.js`, `LightingGui`, why it's all behind one flag (default off) | [design/new/viewer-replacement.md](design/new/viewer-replacement.md) §6e |
 | Removing the `conway-web-ifc-adapter` shim, the `web-ifc` engine seam (`webIfcShimAlias`/`USE_WEBIFC_SHIM`), Conway version-lag, runtime engine swap | [design/new/adapter-removal.md](design/new/adapter-removal.md) |
-| Epic/Story/Track catalogue, Pro-MVP phase plan, growth-funnel Phase G, AI-workspace pivot (§7), post-MVP loveables | [design/roadmap.md](design/roadmap.md) |
+| Epic/Story/Track catalogue, milestone tier rubric (§2.1), MVP bar + phase plan (§6, ex-"Pro-MVP"), growth-funnel Phase G, AI-workspace pivot (§7), post-MVP loveables | [design/roadmap.md](design/roadmap.md) |
 
 Anything not in this table is invisible to the router. When you create a doc that future assistants should consult, add a row above with a one-line "when to read" hint. Don't rely on filesystem discovery.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,7 +44,7 @@ This file is the router for AI assistants working in this repo. Keep it small. T
 | STEP occurrence-keyed selection (NavTree↔scene per-occurrence), `PlacedGeometry.occurrencePath`, why one nut highlights all | [design/new/step-occurrence-selection.md](design/new/step-occurrence-selection.md) |
 | The `?feature=look` render look — PBR materials + gradient IBL + tone-mapping, Neutral/Flat toggle, `looks.js`/`lookMaterial.js`, `LightingGui`, why it's all behind one flag (default off) | [design/new/viewer-replacement.md](design/new/viewer-replacement.md) §6e |
 | Removing the `conway-web-ifc-adapter` shim, the `web-ifc` engine seam (`webIfcShimAlias`/`USE_WEBIFC_SHIM`), Conway version-lag, runtime engine swap | [design/new/adapter-removal.md](design/new/adapter-removal.md) |
-| Epic/Story/Track catalogue, Pro-MVP phase plan, post-MVP loveables | [design/roadmap.md](design/roadmap.md) |
+| Epic/Story/Track catalogue, Pro-MVP phase plan, growth-funnel Phase G, AI-workspace pivot (§7), post-MVP loveables | [design/roadmap.md](design/roadmap.md) |
 
 Anything not in this table is invisible to the router. When you create a doc that future assistants should consult, add a row above with a one-line "when to read" hint. Don't rely on filesystem discovery.
 

--- a/design/roadmap.md
+++ b/design/roadmap.md
@@ -314,15 +314,20 @@ slice, and isolation controls expected of a BIM viewer.
   (root→leaf NAUO ids from Conway's `PlacedGeometry.occurrencePath`), so a reused part
   selects, reveals-in-tree, and hides as a *single* occurrence — and it survives the GLB
   cache. Conway-side extraction is the `step-metadata` track (see Track T1 + conway's
-  `step-metadata-nist.md`); Share-side design +
-  remaining follow-ups (permalink encoding, per-occurrence isolate) in
+  `step-metadata-nist.md`); Share-side design + remaining follow-ups
+  (per-occurrence isolate, reveal-hidden ghosts) in
   `design/new/step-occurrence-selection.md`. PRs #1573 + #1575, E2E over `as1-oc-214.stp`.
+  Since landed: **occurrence-path permalinks round-trip** (the element-path URL
+  encodes `[rootExpressId, ...occurrencePath]` and resolves on load; PR #1581,
+  E2E `navTreePermalink.spec.ts`) and STEP selection on SRR-attached-brep
+  exports (Alibre/ST-Developer, e.g. Arty_Z7 — PR #1580).
 - STEP metadata: NavTree names + Properties 🟡 (NEW). Conway now extracts AP214/AP242
   product structure + properties and emits them through the `web-ifc` compat surface
   in the exact shapes Share consumes (conway #345 arc), so a STEP file lights up the
   NavTree + Properties panel with no Share code change. Share-side follow-through:
   <a href="https://github.com/bldrs-ai/Share/issues/1569" target="_blank" rel="noopener noreferrer">#1569</a> (verify against the NIST corpus after the next Conway release bump;
-  generalize the selection/permalink key to the occurrence path) and
+  the occurrence-path selection/permalink generalization it asks for landed in
+  PR #1581) and
   <a href="https://github.com/bldrs-ai/Share/issues/1570" target="_blank" rel="noopener noreferrer">#1570</a> (pin down the `{value}`-handle + reference-graph contract `ifclib`
   imposes on the engine; defensive `reifyName`; possible re-home to conway).
 - Open bugs feeding Phase A stabilisation: <a href="https://github.com/bldrs-ai/Share/issues/1561" target="_blank" rel="noopener noreferrer">#1561</a> camera fit keys off "last scene
@@ -877,7 +882,8 @@ same list-item order: What, Status, Unblocks, Pro-MVP impact, Doc.
   active (§3b.iv):** grouper analysis (#1568), `BatchedMesh` render path behind
   `?feature=batchedMesh` (#1571), batched→merged GLB-cache bake (#1574).
   **STEP metadata** extraction landed conway-side (conway #345 arc); Share
-  verification + occurrence-path permalink key are open (#1569, #1570).
+  verification is open (#1569, #1570); the occurrence-path selection/permalink
+  key landed (PRs #1573/#1575/#1581).
   Remaining: perf items (on-demand rendering, hover-pick throttle), per-product
   mesh emission spike, `batchedMesh` always-on flip, `EXT_mesh_gpu_instancing`
   cache schema (§3b.v), **public-launch test gate** (4-angle screenshots + GLB
@@ -1090,7 +1096,7 @@ format pages + positioning page indexed.
   heuristic, <a href="https://github.com/bldrs-ai/Share/issues/1545" target="_blank" rel="noopener noreferrer">#1545</a> wrong arg to `getIfcType`, <a href="https://github.com/bldrs-ai/Share/issues/1249" target="_blank" rel="noopener noreferrer">#1249</a> (critical) element-permalink
   hydration on private models.
 - STEP follow-through: Conway release bump + <a href="https://github.com/bldrs-ai/Share/issues/1569" target="_blank" rel="noopener noreferrer">#1569</a> NavTree/Properties verification
-  over the NIST corpus; occurrence-path permalink key.
+  over the NIST corpus (the occurrence-path permalink key landed — PR #1581).
 - T1 **public-launch gate**: 4-angle screenshot harness + GLB bit-level diff against
   golden artifacts. Runs in CI. This is the "we won't regress on the things that
   worked" insurance.

--- a/design/roadmap.md
+++ b/design/roadmap.md
@@ -371,7 +371,8 @@ slice, and isolation controls expected of a BIM viewer.
   product structure + properties and emits them through the `web-ifc` compat surface
   in the exact shapes Share consumes (conway #345 arc), so a STEP file lights up the
   NavTree + Properties panel with no Share code change. Share-side follow-through:
-  <a href="https://github.com/bldrs-ai/Share/issues/1569" target="_blank" rel="noopener noreferrer">#1569</a> (verify against the NIST corpus after the next Conway release bump;
+  <a href="https://github.com/bldrs-ai/Share/issues/1569" target="_blank" rel="noopener noreferrer">#1569</a> (verify against the NIST corpus — unblocked now that the Conway bump
+  landed, PR #1584 → conway 1.356.1126;
   the occurrence-path selection/permalink generalization it asks for landed in
   PR #1581) and
   <a href="https://github.com/bldrs-ai/Share/issues/1570" target="_blank" rel="noopener noreferrer">#1570</a> (pin down the `{value}`-handle + reference-graph contract `ifclib`
@@ -1180,8 +1181,9 @@ format pages + positioning page indexed.
 - Correctness bugs on the rebuilt path: <a href="https://github.com/bldrs-ai/Share/issues/1561" target="_blank" rel="noopener noreferrer">#1561</a> camera-fit "last scene child"
   heuristic, <a href="https://github.com/bldrs-ai/Share/issues/1545" target="_blank" rel="noopener noreferrer">#1545</a> wrong arg to `getIfcType`, <a href="https://github.com/bldrs-ai/Share/issues/1249" target="_blank" rel="noopener noreferrer">#1249</a> (critical) element-permalink
   hydration on private models.
-- STEP follow-through: Conway release bump + <a href="https://github.com/bldrs-ai/Share/issues/1569" target="_blank" rel="noopener noreferrer">#1569</a> NavTree/Properties verification
-  over the NIST corpus (the occurrence-path permalink key landed — PR #1581).
+- STEP follow-through: <a href="https://github.com/bldrs-ai/Share/issues/1569" target="_blank" rel="noopener noreferrer">#1569</a> NavTree/Properties verification over the NIST
+  corpus — unblocked: the Conway release bump landed (PR #1584) and the
+  occurrence-path permalink key landed (PR #1581).
 - T1 **public-launch gate**: 4-angle screenshot harness + GLB bit-level diff against
   golden artifacts. Runs in CI. This is the "we won't regress on the things that
   worked" insurance.

--- a/design/roadmap.md
+++ b/design/roadmap.md
@@ -8,7 +8,7 @@ extract preserved in this commit's history; key Epic list inlined in §4.
 
 This doc normalizes the legacy Epic list against ~2 years of execution since the last
 top-down review, surfaces the work that landed without story tracking, and lays out the
-**Pro/billing-ready MVP** plan plus the loveable backlog beyond it.
+**MVP plan** (billing-ready by definition — §2.1) plus the loveable backlog beyond it.
 
 **v0.3 (2026-07-02) folds in three things:**
 
@@ -27,7 +27,7 @@ top-down review, surfaces the work that landed without story tracking, and lays 
    "post-MVP polish" into an active parallel phase — §4.10 (Grow), Track T9,
    §6 Phase G.
 3. **The AI-workspace pivot** — the product direction after (and partly alongside)
-   the Pro-MVP: a Claude-Code-like conversational workspace over CAD/BIM models,
+   the MVP: a Claude-Code-like conversational workspace over CAD/BIM models,
    multi-user, with user-generated AI-app toolbelts. New Epic group §4.11
    (Assist), Tracks T10–T11, plan in §7. Several long-held loveables
    (`search-310`, `apps-300`, `apps-310`) are absorbed into it.
@@ -70,7 +70,9 @@ the basics; Pro = power features earning feature-level positive feedback;
 Enterprise = an operating business with validated ICPs — and re-passes the
 numbering against that. Big movers: billing and funnel measurement *into* the
 MVP band, the Assist/AI arc *out* to the Pro band. Rubric + full ID lineage in
-§2.1; the exhaustive open-MVP checklist is §6.0.
+§2.1; the exhaustive open-MVP checklist is §6.0. The "Pro-MVP plan" is renamed
+to just the **MVP plan** — under this rubric the MVP *is* the paying launch, so
+the prefix was redundant (and collided with the 300-band "Pro" milestone).
 
 It is the single source of truth for Epic/Story/Track structure. The wiki page
 `Planning:-Requirements` and the `epic`-labeled GitHub issues mirror this doc; when they
@@ -91,7 +93,7 @@ disagree, this doc wins and the others get updated.
 
 The original PDF interleaved capability lists and implementation notes. This doc keeps
 them split: §3 is the master overview (one row per Epic and Track), §4 is the Epic
-catalogue, §5 is the Track catalogue, §6 is the Pro-MVP sequencing across both, §7 is
+catalogue, §5 is the Track catalogue, §6 is the MVP sequencing across both, §7 is
 the AI-workspace pivot plan, §8 is what's loveable but post-MVP.
 
 
@@ -139,7 +141,7 @@ What the milestone reading changes (the v0.6 re-pass):
   channels to 400) — §7's pivot sequencing is unchanged; only the band signal
   moved. Nothing AI is required for the MVP trickle.
 
-Tier is **not** schedule: the Pro-MVP phase column carries sequencing; the ID
+Tier is **not** schedule: the Phase column carries sequencing; the ID
 carries the milestone. §6.0 enumerates the open 100-band work exhaustively.
 
 **ID lineage** — every epic that has ever been renumbered (all other IDs have
@@ -185,27 +187,27 @@ restored to their original meanings.
 | AI-apps toolbelt | assist-130 (v0.3) | assist-200 | `assist-320` |
 | Multi-user channels + AI modes | assist-120 (v0.3) | assist-300 | `assist-400` |
 
-**Pro-MVP column legend** (used in §3 and §5):
+**Phase column legend** (used in §3 and §5):
 
-- **A–E** = phase in the Pro-MVP plan (§6). A = stabilise viewer, B = identity +
+- **A–E** = phase in the MVP plan (§6). A = stabilise viewer, B = identity +
   multi-account, C = sharing v1, D = subscribe + ads, E = launch checklist.
 - **G** = growth-funnel phase (§6 Phase G) — runs **parallel** to A–C and starts
   now; small, high-leverage, mostly independent of the viewer/identity arcs.
-- **AI** = AI-workspace pivot arc (§7) — sequenced after the Pro-MVP launch, with
+- **AI** = AI-workspace pivot arc (§7) — sequenced after the MVP launch, with
   flagged foundations allowed to start earlier (see §7.4).
-- **—** = already shipped; no Pro-MVP work pending.
+- **—** = already shipped; no MVP work pending.
 - **Post** = held in §8 Post-MVP backlog.
 
 
 ## 3. Status overview
 
-The master tables. Each Epic and Track lists status, Pro-MVP phase, and the
+The master tables. Each Epic and Track lists status, phase, and the
 cross-references that connect them. The detailed bodies live in §4 (Epics) and §5
 (Tracks).
 
 ### 3.1 Epics
 
-| Verb | ID | Name | Status | Pro-MVP | Tracks |
+| Verb | ID | Name | Status | Phase | Tracks |
 |---|---|---|---|---|---|
 | Open | `open-100` | Open from local file system | ✔ | — | — |
 | Open | `open-110` | Open from GitHub URL / UI | ✔ | — | — |
@@ -265,7 +267,7 @@ cross-references that connect them. The detailed bodies live in §4 (Epics) and 
 
 ### 3.2 Tracks
 
-| ID | Name | Status | Pro-MVP | Unblocks |
+| ID | Name | Status | Phase | Unblocks |
 |---|---|---|---|---|
 | T1 | Viewer Replacement | 🟡 | A (launch gate) | `view-100`, `view-110`, `view-200`, `view-130`, `view-300`, T2 |
 | T2 | GLB Model Sharing | 🟡 | C (Ph 4 + 5) | `share-110`, `notes-300`, `view-130` |
@@ -284,7 +286,7 @@ cross-references that connect them. The detailed bodies live in §4 (Epics) and 
 
 Each Epic block: heading with stable ID; one-sentence purpose; status; legacy reference
 in italics; closed stories (with GH numbers); open stories; gaps relevant to the
-Pro-MVP; relevant tracks from §5.
+MVP; relevant tracks from §5.
 
 
 ### 4.1 Open
@@ -323,7 +325,7 @@ original list; landed via `googleDrive` flag now default-on).
 - Open: <a href="https://github.com/bldrs-ai/Share/issues/1251" target="_blank" rel="noopener noreferrer">#1251</a> Open 200: import and overlay multiple models.
 - Pre-condition: Conway-direct + GLB cache are stable per-model (✔ via T1/T2), so
   scaling to N models is now a UI + state-management problem, not an engine problem.
-- **Not in Pro-MVP.** Loveable post-MVP.
+- **Not in MVP.** Loveable post-MVP.
 
 **Epic `open-300`: Multiple sources / multi-account Sources tab** 🟡
 *PDF didn't anticipate multi-account; absorbed from T3 Identity Decoupling.*
@@ -414,7 +416,7 @@ multi-worker; etc.*
   narrowing on the batched path; `EXT_mesh_gpu_instancing` batched-native GLB cache
   (§3b.v) so the round-trip stays instanced and the artifact shrinks.
 - Pre-public-launch gate: 4-angle screenshot harness + GLB bit-level diff (called out
-  in `viewer-replacement.md` §3b.iii final paragraph). **Required for Pro-MVP.**
+  in `viewer-replacement.md` §3b.iii final paragraph). **Required for MVP.**
 
 **Epic `view-200`: Persistent visibility / Isolate** 🟡
 *PDF "View element subsets" — partial.*
@@ -487,7 +489,7 @@ visualization on top (post-MVP loveable):
   categories on Notes) so filtering has meaningful axes. Pairs with T6 (notes
   sidecar formats) once notes carry richer anchor + tag data.
 
-**Pro-MVP**: split.
+**Phasing:** split.
 - Placemark polish (<a href="https://github.com/bldrs-ai/Share/issues/929" target="_blank" rel="noopener noreferrer">#929</a>/<a href="https://github.com/bldrs-ai/Share/issues/930" target="_blank" rel="noopener noreferrer">#930</a>/<a href="https://github.com/bldrs-ai/Share/issues/931" target="_blank" rel="noopener noreferrer">#931</a>/<a href="https://github.com/bldrs-ai/Share/issues/932" target="_blank" rel="noopener noreferrer">#932</a>/<a href="https://github.com/bldrs-ai/Share/issues/985" target="_blank" rel="noopener noreferrer">#985</a>/<a href="https://github.com/bldrs-ai/Share/issues/998" target="_blank" rel="noopener noreferrer">#998</a>/<a href="https://github.com/bldrs-ai/Share/issues/892" target="_blank" rel="noopener noreferrer">#892</a>) is candidate for
   **Phase C** alongside Notes work in the share flow — sharing a model with a
   pin-anchored discussion is a strong demo, and the URL-sync bug (<a href="https://github.com/bldrs-ai/Share/issues/930" target="_blank" rel="noopener noreferrer">#930</a>) blocks
@@ -527,20 +529,20 @@ publicly — and the recipient sees what was intended.
 - Open: <a href="https://github.com/bldrs-ai/Share/issues/1421" target="_blank" rel="noopener noreferrer">#1421</a> Share (200) Extended login flow — the dialog that picks between
   anonymous-public-5-day, free-public-long-term, Pro-private, etc. This is the
   surface where the Pro pricing tiers become visible.
-- **Required for Pro-MVP** (it's where the upgrade prompt lives).
+- **Required for MVP** (it's where the upgrade prompt lives).
 
 **Epic `share-130`: Private link sharing + visibility chip** 🟡 (NEW)
 *Not in PDF except as "Private hosting" sub-bullet under Open.1.*
 - Track dependency: T4 Multi-User Sharing PR1 (landed: provider scaffolding + Drive
   adapter); PR2 (Drive Share dialog UI); PR3 (GitHub sharing adapter).
 - Open: feature flag `sharing` is off; turn-on once PR2 lands.
-- **Required for Pro-MVP** (private sharing is a paid feature per <a href="https://github.com/bldrs-ai/Share/issues/1421" target="_blank" rel="noopener noreferrer">#1421</a>).
+- **Required for MVP** (private sharing is a paid feature per <a href="https://github.com/bldrs-ai/Share/issues/1421" target="_blank" rel="noopener noreferrer">#1421</a>).
 
 **Epic `share-200`: Grant/revoke per-principal sharing** 🟡 (NEW)
 *Not in PDF.*
 - Track dependency: T4 PR2/PR3 (Share dialog People panel — invites people/teams).
 - Open: same `sharing` flag as `share-130`.
-- **Pro-MVP**: Pro feature.
+- **MVP impact:** ships in Phase C alongside the Share dialog, but not load-bearing for the trickle (MLP band).
 
 **Epic `share-400`: Folder-scoped boundaries** ⬜ (NEW)
 *Not in PDF.*
@@ -579,7 +581,7 @@ a specific version of the model.
 - Closed: <a href="https://github.com/bldrs-ai/Share/issues/980" target="_blank" rel="noopener noreferrer">#980</a> Save model, <a href="https://github.com/bldrs-ai/Share/issues/1154" target="_blank" rel="noopener noreferrer">#1154</a> Show specific version.
 - Open: <a href="https://github.com/bldrs-ai/Share/issues/850" target="_blank" rel="noopener noreferrer">#850</a> Versions 100 sha path (filtering to single-file commits unresolved); <a href="https://github.com/bldrs-ai/Share/issues/890" target="_blank" rel="noopener noreferrer">#890</a>
   Versions 200 Delete a version (UI + flow not landed).
-- **Pro-MVP**: enough is done for free-tier; Delete + branch UX polish slot post-MVP.
+- **MVP impact:** enough is done for free-tier; Delete + branch UX polish slot post-MVP.
 
 **Epic `versions-300`: Diff between versions** ⬜
 *PDF Collab table — "Showing Diffs?"*
@@ -632,17 +634,17 @@ changes (Google → GitHub or vice versa).
 - Track dependency: T3 PR1 merged (provider scaffolding + Netlify Functions). PR2
   (SourcesTab integration) + PR3 (switchover + flag retire) open.
 - Open: feature flag `githubAsSource` off.
-- **Required for Pro-MVP.**
+- **Required for MVP.**
 
 **Epic `identity-120`: Auth disambiguation across linked identities** 🟡
 - Open: <a href="https://github.com/bldrs-ai/Share/issues/1422" target="_blank" rel="noopener noreferrer">#1422</a> Auth Disambiguation — primary + linked stored in cookie; chooser surface
   for prior identities on next login.
-- **Required for Pro-MVP** (otherwise users with two GH accounts can't tell what
+- **Required for MVP** (otherwise users with two GH accounts can't tell what
   they're billed under).
 
 **Epic `identity-300`: Profile drawer + multi-account picker** ⬜
 - Implicit in T3 PR2 design.
-- **Required for Pro-MVP** — the "Saving as X — GitHub" footer in the Save dialog
+- **Required for MVP** — the "Saving as X — GitHub" footer in the Save dialog
   (`identity-decoupling-decisions.md` §Q4).
 
 
@@ -689,13 +691,13 @@ User finds out about Bldrs, gets oriented, leaves feedback, and finds product he
 - Google Analytics integrated via `gtagEvent` (visible in code; called from `CadView`,
   GLB pipeline, etc.).
 - Open: 👍/👎 exit feedback widget; in-app Google Forms survey link.
-- **Pro-MVP**: at least one feedback affordance is needed for the public launch.
+- **MVP impact:** at least one feedback affordance is needed for the public launch.
 
 **Epic `community-200`: Bug report w/ screenshot + session state** ⬜
 *PDF Community.2 (MVP).*
 - Never started. The closest seed is `?feature=perf` for diagnostics; structured bug
   capture + auto-redaction of model bytes is the missing piece.
-- **Post-MVP** unless Pro-MVP support burden makes it Day-1 critical.
+- **Post-MVP** unless MVP support burden makes it Day-1 critical.
 
 **Epic `community-210`: AEC outreach (Stack Overflow, Twitter)** 🔮
 *PDF Community.3 (🥇 MLP — ❤️ Kate?).*
@@ -732,14 +734,14 @@ not just a revenue trickle.*
   **model size/complexity** (plus private sharing, multi-account, ad-free).
   Threshold placement is a §10 open question — it wants the model-size
   distribution from telemetry before it's picked.
-- **Required for Pro-MVP.**
+- **Required for MVP.**
 
 **Epic `subscribe-110`: Stripe checkout + portal** ⬜ (NEW)
 - Tasks: `create-portal-session` Netlify Function exists already (per identity
   decoupling decisions doc — model pattern for new functions). Add
   `create-checkout-session`; webhook for status changes; persist Pro flag against
   Auth0 `sub`.
-- **Required for Pro-MVP.**
+- **Required for MVP.**
 
 **Epic `subscribe-120`: Quota tracking** ⬜ (NEW)
 - Tasks: server-side counter keyed by Auth0 `sub` (per identity-decoupling-decisions
@@ -752,12 +754,12 @@ not just a revenue trickle.*
 - Experiment instrumentation is part of the epic, not an afterthought: events
   for threshold-hit, upgrade-prompt-shown, converted/churned, so the quota run
   yields decision-grade evidence either way.
-- **Required for Pro-MVP.**
+- **Required for MVP.**
 
 **Epic `subscribe-130`: Ads on free tier** 🟡
 - Track dependency: T7 Ads (<a href="https://github.com/bldrs-ai/Share/issues/1524" target="_blank" rel="noopener noreferrer">#1524</a>). Phase 1 activation in flight (<a href="https://github.com/bldrs-ai/Share/issues/1523" target="_blank" rel="noopener noreferrer">#1523</a>).
 - Open: Phases 2 (manual slots) + 3 (responsive) + 4 (consent gating).
-- **Required for Pro-MVP** — the free tier monetisation path.
+- **Required for MVP** — the free tier monetisation path.
 - Scope note: T7 is **on-site AdSense** (revenue). The Google Ads **acquisition**
   campaigns (Smart→Search rebuild, keywords, geo, bidding) are out of repo scope —
   owned in the private bizdev growth-strategy doc §4. The in-repo dependency runs
@@ -910,7 +912,7 @@ vision, architecture, and sequencing. Design doc to draft: `design/new/ai-worksp
 
 Each track has its own long-form design doc. This section is the one-paragraph
 overview + status + Epic linkage; details live in the linked docs. Each entry uses the
-same list-item order: What, Status, Unblocks, Pro-MVP impact, Doc.
+same list-item order: What, Status, Unblocks, MVP impact, Doc.
 
 
 ### Track T1: Viewer Replacement
@@ -940,7 +942,7 @@ same list-item order: What, Status, Unblocks, Pro-MVP impact, Doc.
   go live: flip the flag default + regenerate the screenshot baselines (one PR).
   See `design/new/viewer-replacement.md` §6e.
 - **Unblocks:** `view-100`, `view-110`, `view-200`, `view-130`, `view-300`, T2.
-- **Pro-MVP impact:** Required — public-launch gate.
+- **MVP impact:** Required — public-launch gate.
 - **Doc:** `design/new/viewer-replacement.md`.
 
 
@@ -951,7 +953,7 @@ same list-item order: What, Status, Unblocks, Pro-MVP impact, Doc.
 - **Status:** Phases 4 (Notes + view-states v0.1 round-trip), 5 (originator share
   flow), 6 (shared cache tier — Drive/Firebase) open.
 - **Unblocks:** `share-110`, `notes-300`, `view-130` perf wins.
-- **Pro-MVP impact:** Phase 5 (originator share flow) — required. Phase 4 — required
+- **MVP impact:** Phase 5 (originator share flow) — required. Phase 4 — required
   (so notes survive cache hits). Phase 6 — post-MVP optimisation.
 - **Doc:** `design/new/glb-model-sharing.md`.
 
@@ -965,7 +967,7 @@ same list-item order: What, Status, Unblocks, Pro-MVP impact, Doc.
   integration, recents migration) + PR3 (switchover + flag retire) open.
 - **Unblocks:** `identity-110`, `identity-120`, `identity-300`, `open-300`,
   `share-200`, `subscribe-120` (quota keying), and T4 PR3 (GH sharing).
-- **Pro-MVP impact:** PR2 + PR3 required.
+- **MVP impact:** PR2 + PR3 required.
 - **Docs:** `design/new/identity-decoupling.md` + `identity-decoupling-decisions.md`.
 
 
@@ -978,7 +980,7 @@ same list-item order: What, Status, Unblocks, Pro-MVP impact, Doc.
   sharing adapter), PR4 (folder boundary routes) open. PR5 (GH token-health parity)
   and PR6 (flag retire) follow.
 - **Unblocks:** `share-130`, `share-200`, `share-400`, `notes-300`, `versions-310`.
-- **Pro-MVP impact:** PR2 + PR3 required (private sharing is a paid feature). PR4
+- **MVP impact:** PR2 + PR3 required (private sharing is a paid feature). PR4
   post-MVP. PR5 nice-to-have.
 - **Docs:** `design/new/multi-user-sharing.md` + `design/new/sharing-pr3-github.md`.
 
@@ -990,7 +992,7 @@ same list-item order: What, Status, Unblocks, Pro-MVP impact, Doc.
 - **Status:** Proposed. Not started.
 - **Unblocks:** `open-200`. Pattern reusable for GH recents once `githubAsSource`
   lands.
-- **Pro-MVP impact:** Polish; not strictly required for paid launch but the support
+- **MVP impact:** Polish; not strictly required for paid launch but the support
   cost of "Failed to parse model" on dead recents is real.
 - **Doc:** `design/new/drive-recents-head-check.md`.
 
@@ -1001,7 +1003,7 @@ same list-item order: What, Status, Unblocks, Pro-MVP impact, Doc.
   between Drive snapshots and git issues/commits.
 - **Status:** Not started.
 - **Unblocks:** `notes-300`, `notes-200` (BCF can be derived), `versions-310`.
-- **Pro-MVP impact:** Post-MVP. Quarter-scale work.
+- **MVP impact:** Post-MVP. Quarter-scale work.
 - **Doc:** `multi-user-sharing.md` §Stretch (Q1–Q4).
 
 
@@ -1010,7 +1012,7 @@ same list-item order: What, Status, Unblocks, Pro-MVP impact, Doc.
 - **What:** AdSense free-tier monetisation without Auto-ads on viewer routes.
 - **Status:** Phase 1 activation in flight (<a href="https://github.com/bldrs-ai/Share/issues/1523" target="_blank" rel="noopener noreferrer">#1523</a>). Phases 2–4 outlined.
 - **Unblocks:** `subscribe-130`.
-- **Pro-MVP impact:** Phase 1 required (activate publisher account). Phases 2–3
+- **MVP impact:** Phase 1 required (activate publisher account). Phases 2–3
   should land before public launch but can lag a beat.
 - **Doc:** `design/new/ads.md` + epic <a href="https://github.com/bldrs-ai/Share/issues/1524" target="_blank" rel="noopener noreferrer">#1524</a>.
 
@@ -1028,7 +1030,7 @@ same list-item order: What, Status, Unblocks, Pro-MVP impact, Doc.
   aligns with the moat (small models free + unlimited; the threshold sits where
   Share is the only thing that works). Phase D runs as an instrumented
   experiment; see §4.9.
-- **Pro-MVP impact:** Required end-to-end.
+- **MVP impact:** Required end-to-end.
 - **Doc:** TBD — to be drafted in `design/new/pro-billing.md`.
 
 
@@ -1046,7 +1048,7 @@ same list-item order: What, Status, Unblocks, Pro-MVP impact, Doc.
 - **Unblocks:** `grow-100`, `grow-200`, `grow-120`, `grow-400`; honest measurement
   of every outreach move in `community-210`; conversion-based bidding for the
   (out-of-repo) acquisition campaigns; the Phase D quota-threshold pick.
-- **Pro-MVP impact:** Phase G — parallel, starts now. Cheap relative to everything
+- **MVP impact:** Phase G — parallel, starts now. Cheap relative to everything
   else in §6 and the only work that grows the top of the funnel.
 - **Docs:** `bldrs-ai/bizdev` `docs/growth-strategy.md` + `docs/ai-strategy.md`
   (**private** — numbers stay there) + `design/new/ads.md` (on-site ads only).
@@ -1063,7 +1065,7 @@ same list-item order: What, Status, Unblocks, Pro-MVP impact, Doc.
   `design/new/ai-workspace.md` first — see §7.4 AI.0 and §10 open questions.
 - **Unblocks:** `assist-310`, `assist-400`, `search-310` (as retrieval), and the
   §7 AI-metering upsell.
-- **Pro-MVP impact:** None (pivot arc). Must not destabilise Phases A–E.
+- **MVP impact:** None (pivot arc). Must not destabilise Phases A–E.
 - **Doc:** TBD — `design/new/ai-workspace.md`.
 
 
@@ -1080,12 +1082,17 @@ same list-item order: What, Status, Unblocks, Pro-MVP impact, Doc.
   broken with its suite disabled — repair is the first slice.
 - **Unblocks:** `assist-320`, `apps-300` (MCP-first public API), `apps-310`
   (checks as toolbelt apps).
-- **Pro-MVP impact:** None (pivot arc), except the #1386 repair which is
+- **MVP impact:** None (pivot arc), except the #1386 repair which is
   independently worthwhile.
 - **Doc:** TBD — `design/new/ai-workspace.md` (sandbox/security section).
 
 
-## 6. Pro-MVP plan
+## 6. MVP plan
+
+*(Called the "Pro-MVP plan" in v0.2–v0.5 and in older issues/PR descriptions —
+same plan. Renamed in v0.6: under the milestone rubric (§2.1) the MVP **is** the
+paying launch, and "Pro" now names the 300-band milestone, so the prefix
+collided.)*
 
 Goal: ship the **paid tier** publicly. Free + Pro coexist; anonymous use stays
 possible; private sharing + multi-account + quota are paid; ads run on free.
@@ -1137,7 +1144,7 @@ into a funnel with no earned channels wastes the launch.
 
 ### Phase G (parallel, starts now): Growth funnel + SEO surfaces
 **Goal:** the funnel is measurable, share links unfurl, and search intent has a
-landing page — before the Pro launch needs any of it.
+landing page — before the MVP launch needs any of it.
 - `grow-120` first slice: GA hygiene guard (`navigator.webdriver` +
   hostname check on GA init) — cleans CI/e2e/preview pollution out of prod data.
 - `grow-120` events: `share_link_created`, `share_link_opened`,
@@ -1160,7 +1167,7 @@ format pages + positioning page indexed.
 
 
 ### Phase A: Stabilise the rebuilt viewer (foundation)
-**Goal:** the Pro launch can't ship if the viewer regresses on real models.
+**Goal:** the MVP launch can't ship if the viewer regresses on real models.
 - T1 remaining slices:
   - `IfcViewsManager` deletion (§3c.iv slice 1).
   - On-demand rendering (dirty-flag) — biggest framerate win available.
@@ -1261,7 +1268,7 @@ stated hypotheses.
   spike traffic against an uninstrumented funnel is wasted; with Phase G landed
   it's the launch amplifier.
 
-**Exit:** Pro launch announcement.
+**Exit:** MVP launch announcement.
 
 
 ## 7. The AI-workspace pivot
@@ -1269,7 +1276,7 @@ stated hypotheses.
 **Status:** direction agreed (2026-07). Design doc to draft at
 `design/new/ai-workspace.md` before implementation starts. This section is the
 roadmap-level summary: the vision, the three architecture surfaces, what existing
-work it absorbs, and how it sequences against the Pro-MVP.
+work it absorbs, and how it sequences against the MVP.
 
 ### 7.1 Vision
 
@@ -1358,7 +1365,7 @@ Two v0.4 constraints on that architecture:
 
 ### 7.4 Sequencing
 
-The pivot **follows the Pro-MVP**: Phases B–D give it identity, sharing, and the
+The pivot **follows the MVP**: Phases B–D give it identity, sharing, and the
 billing/quota rails that AI usage metering hangs off — metered agent usage is the
 natural Pro anchor, a cleaner upsell than private links alone. Foundations that
 can't destabilise the launch may start earlier behind flags.
@@ -1369,7 +1376,7 @@ can't destabilise the launch may start earlier behind flags.
   model, Notes/channels relationship. Fix <a href="https://github.com/bldrs-ai/Share/issues/1386" target="_blank" rel="noopener noreferrer">#1386</a> and re-enable the iframe
   suite — the sandbox foundation must hold weight before anything is built on it.
 - **AI.1 — Workspace shell.** `assist-300` left drawer behind
-  `?feature=workspace`. No AI dependency; can overlap Pro-MVP phases.
+  `?feature=workspace`. No AI dependency; can overlap MVP phases.
 - **AI.2 — Agent v0, single-user.** `assist-310`: viewer MCP tool surface (T11) +
   agent loop (T10) + conversation panel. One user, one conversation per
   project/model. **This is the demo that sells the pivot — and it must be run
@@ -1442,7 +1449,7 @@ reflects current product-pull:
 Once this doc lands, the backfill order:
 
 1. **GitHub issues — Epics first.**
-   For each Epic in §4 with status 🟡 or ⬜ and `Pro-MVP impact: required`, create an
+   For each Epic in §4 with status 🟡 or ⬜ and `MVP impact: required`, create an
    `epic`-labeled GH issue with the body content from the Epic block. Stable ID
    becomes the issue title prefix (e.g. `epic: open-300: SourcesTab with parallel GH +
    Drive accounts`). One pass; expect ~12–15 new Epic issues. The v0.3 groups ride
@@ -1454,12 +1461,12 @@ Once this doc lands, the backfill order:
    <a href="https://github.com/bldrs-ai/Share/issues/890" target="_blank" rel="noopener noreferrer">#890</a>, <a href="https://github.com/bldrs-ai/Share/issues/892" target="_blank" rel="noopener noreferrer">#892</a>), use `mcp__github__sub_issue_write` to attach them under the right
    Epic. Re-title for consistency where useful.
 3. **GitHub issues — backfill missing stories.**
-   For Epics with `Pro-MVP impact: required` but no story coverage, create one story
+   For Epics with `MVP impact: required` but no story coverage, create one story
    per acceptance criterion. Stories enter the queue with the corresponding `epic`
    sub-issue parent.
 4. **Wiki rewrite.**
    Replace `Planning:-Requirements` with a public-facing summary derived from §4 of
-   this doc. Strip the implementation links and `Pro-MVP impact` rows; keep the
+   this doc. Strip the implementation links and `MVP impact` rows; keep the
    Epic-by-Epic structure with status. The wiki page becomes the user-facing roadmap.
 5. **CLAUDE.md router row.**
    Added in this commit so future assistants find this doc.
@@ -1485,7 +1492,7 @@ without sign-off.
   `identity-decoupling-decisions.md` §Open Implementation Details. Needs to be
   resolved before Phase D quota tracking ships (the quota key is meaningless if the
   functions are anonymous).
-- **BCF priority.** Industry-credibility win vs. cost. If we want it for Pro-MVP it
+- **BCF priority.** Industry-credibility win vs. cost. If we want it for MVP it
   becomes Phase C scope; otherwise it slips to post-MVP per §8 item 7.
 - **AI pivot — agent runtime placement.** Client-direct LLM calls (user's key /
   our key in the browser) vs a server-side broker (Netlify Functions or a real
@@ -1522,7 +1529,7 @@ without sign-off.
 ## 11. Doc maintenance
 
 - **When an Epic ships:** update its row in §3.1 and its block in §4 from 🟡 → ✔.
-  Move it out of the Pro-MVP phase list in §6 if it was there.
+  Move it out of the MVP phase list in §6 if it was there.
 - **When a story closes:** add it to the Closed list under its Epic; PR description
   should reference `roadmap.md` if the change moves an Epic state.
 - **When a track lands a slice:** update the Status line of the track in §3.2 and §5.

--- a/design/roadmap.md
+++ b/design/roadmap.md
@@ -68,7 +68,10 @@ unchanged.
 
 The master tables. Each Epic and Track lists status, phase, and the
 cross-references that connect them. The detailed bodies live in §4 (Epics) and §5
-(Tracks).
+(Tracks). **Phase column**: A–E = MVP-plan phases (§6: A stabilise viewer,
+B identity, C sharing, D subscribe+ads, E launch checklist); G = growth funnel
+(§6 Phase G, parallel, starts now); AI = pivot arc (§7, after MVP launch);
+— = shipped, nothing pending; Post = §8 backlog.
 
 ### 3.1 Epics
 
@@ -1406,10 +1409,10 @@ without sign-off.
   400s Enterprise), at the next free ten within that band (e.g. the next
   MVP-band Open epic is `open-130`). Add the matching row to §3.1, keeping rows
   tier-sorted within the group. Don't renumber existing IDs outside a deliberate
-  tier change — the v0.5/v0.6 renorms are recorded in the §2.1 lineage table.
+  tier change — the v0.5/v0.6 renorms are recorded in the Changelog's ID-lineage table.
 - **When an Epic changes tier** (promoted into the MVP band, or demoted out):
   that *is* a renumber — do it deliberately, one epic at a time, and add the row
-  (or a new column entry) to the §2.1 lineage table. If it enters or leaves the
+  (or a new column entry) to the Changelog's ID-lineage table. If it enters or leaves the
   100 band, update the §6.0 MVP checklist in the same commit.
 - **Don't delete done Epics.** They stay in §4 as the historical record of what
   shipped, which is what §8 "Post-MVP backlog" is measured against.
@@ -1479,7 +1482,53 @@ estimable from the Ads funnel; MLP = respectable acceleration by building out
 the basics; Pro = power features earning feature-level positive feedback;
 Enterprise = an operating business with validated ICPs — and re-passes the
 numbering against that. Big movers: billing and funnel measurement *into* the
-MVP band, the Assist/AI arc *out* to the Pro band. Rubric + full ID lineage in
-§2.1; the exhaustive open-MVP checklist is §6.0. The "Pro-MVP plan" is renamed
+MVP band, the Assist/AI arc *out* to the Pro band. Rubric in §2.1; full ID
+lineage below; the exhaustive open-MVP checklist is §6.0. The "Pro-MVP plan" is renamed
 to just the **MVP plan** — under this rubric the MVP *is* the paying launch, so
 the prefix was redundant (and collided with the 300-band "Pro" milestone).
+
+
+## ID lineage
+
+Every epic that has ever been renumbered (all other IDs have been stable since
+v0.2). Resolve any ID you meet in an older branch, issue, or PR description
+through this table; several numbers were **reused across revisions**
+(`share-120`, `share-130`, `share-200`, `open-200`, `view-130`, `view-220`,
+`view-230`, `assist-300`), and `subscribe-100/110/120` were restored to their
+original meanings.
+
+| Epic (current name) | v0.2–v0.4 | v0.5 | v0.6 (current) |
+|---|---|---|---|
+| Recents reliability | open-150 | open-130 | `open-200` |
+| Open multiple IFCs in one session | open-140 | open-200 | `open-210` |
+| Multi-account Sources tab | open-130 | open-300 | `open-300` |
+| Persistent visibility / Isolate | view-130 | view-200 | `view-200` |
+| Selection camera + measurement | view-140 | view-210 | `view-210` |
+| Performance + large-model viewing | view-150 | view-130 | `view-130` |
+| Common view operations | view-170 | view-230 | `view-220` |
+| Placemarks + maps-style filtering | view-180 | view-240 | `view-230` |
+| ETL / Table view | view-160 | view-220 | `view-300` |
+| Extended Share/Login flow | share-150 | share-200 | `share-120` |
+| Private link sharing | share-120 | share-300 | `share-130` |
+| Grant/revoke per-principal | share-130 | share-310 | `share-200` |
+| Folder-scoped boundaries | share-140 | share-400 | `share-400` |
+| BCF round-trip | notes-110 | notes-200 | `notes-200` |
+| Drive-backed notes | notes-120 | notes-210 | `notes-300` |
+| Diff between versions | versions-110 | versions-200 | `versions-300` |
+| Portable versions for Drive | versions-120 | versions-210 | `versions-310` |
+| Cross-repo search | search-110 | search-200 | `search-300` |
+| Knowledge graph | search-120 | search-210 | `search-310` |
+| Profile drawer + multi-account picker | identity-130 | identity-300 | `identity-300` |
+| v1.0 Public API + IDE | apps-130 | apps-200 | `apps-300` |
+| Bldrs Integrate | apps-120 | apps-210 | `apps-310` |
+| Bug report w/ screenshot | community-120 | community-200 | `community-200` |
+| AEC outreach | community-130 | community-210 | `community-210` |
+| Pricing tiers + feature manager | subscribe-100 | subscribe-300 | `subscribe-100` |
+| Stripe checkout + portal | subscribe-110 | subscribe-310 | `subscribe-110` |
+| Quota tracking | subscribe-120 | subscribe-320 | `subscribe-120` |
+| Rich share-link previews (OG) | grow-110 (v0.3) | grow-110 | `grow-200` |
+| Large-model + sovereignty positioning | grow-130 (v0.4) | grow-400 | `grow-400` |
+| Workspace shell (left drawer) | assist-100 (v0.3) | assist-100 | `assist-300` |
+| Conversational agent panel | assist-110 (v0.3) | assist-110 | `assist-310` |
+| AI-apps toolbelt | assist-130 (v0.3) | assist-200 | `assist-320` |
+| Multi-user channels + AI modes | assist-120 (v0.3) | assist-300 | `assist-400` |

--- a/design/roadmap.md
+++ b/design/roadmap.md
@@ -1,6 +1,6 @@
 # Bldrs Share Roadmap
 
-**Status:** Draft v0.5 — tier renumbering (100 MVP / 200 MLP / 300 Pro / 400 Enterprise)
+**Status:** Draft v0.6 — milestone-based tiers (MVP = paying trickle w/ estimable CAC)
 **Date:** 2026-07-03
 **Owner:** Pablo
 **Source baseline:** `Share Requirements` Google Doc (Aug 2021, last updated Nov 2022). PDF
@@ -30,7 +30,7 @@ top-down review, surfaces the work that landed without story tracking, and lays 
    the Pro-MVP: a Claude-Code-like conversational workspace over CAD/BIM models,
    multi-user, with user-generated AI-app toolbelts. New Epic group §4.11
    (Assist), Tracks T10–T11, plan in §7. Several long-held loveables
-   (`search-210`, `apps-200`, `apps-210`) are absorbed into it.
+   (`search-310`, `apps-300`, `apps-310`) are absorbed into it.
 
 **v0.4 (2026-07-03)** reconciles against the AI-strategy synthesis
 (`bldrs-ai/bizdev` `docs/ai-strategy.md` — **private**: MAU/revenue/fundraise
@@ -48,7 +48,7 @@ re-cut this roadmap:
   unlimited (the funnel is demand-gen); the paywall sits at the threshold where
   Share is the only thing that works. Phase D runs as an **instrumented
   experiment** with stated hypotheses, not a revenue switch. Reflected in
-  `subscribe-300`/`subscribe-320` and Phase D.
+  `subscribe-100`/`subscribe-120` and Phase D.
 - **Data sovereignty is a first-class feature.** "Runs in-browser, your model
   never leaves your machine" is an enterprise wedge, not a privacy nicety — and
   it constrains §7 architecture (the agent loop must not silently break the
@@ -61,8 +61,16 @@ re-cut this roadmap:
 **v0.5 (2026-07-03)** renorms Epic numbering so the hundreds digit encodes the
 **tier**, matching the convention the story issues already use ("Open 200",
 "View 200", "Share (200)"): **100s = MVP, 200s = MLP, 300s = Pro, 400s =
-Enterprise**. Rubric + old→new mapping in §2.1. One-time renumber; the
-maintenance rules (§11) forbid doing it again.
+Enterprise**.
+
+**v0.6 (2026-07-03)** redefines the tiers as **business milestones** rather
+than capability levels — MVP = a steady *trickle* of paying customers with CAC
+estimable from the Ads funnel; MLP = respectable acceleration by building out
+the basics; Pro = power features earning feature-level positive feedback;
+Enterprise = an operating business with validated ICPs — and re-passes the
+numbering against that. Big movers: billing and funnel measurement *into* the
+MVP band, the Assist/AI arc *out* to the Pro band. Rubric + full ID lineage in
+§2.1; the exhaustive open-MVP checklist is §6.0.
 
 It is the single source of truth for Epic/Story/Track structure. The wiki page
 `Planning:-Requirements` and the `epic`-labeled GitHub issues mirror this doc; when they
@@ -101,45 +109,81 @@ Per the PDF: 🥉 = MVP, 🥇 = MLP (Minimum Loveable Product), ❤️ = persona
 those markers in §4 next to the original ranking so we don't lose the people-attached
 intent. New work added since the PDF is marked `(NEW)`.
 
-### 2.1 Tier rubric (Epic ID numbering, v0.5)
+### 2.1 Tier rubric (Epic ID numbering, v0.6 — milestone-based)
 
-The hundreds digit of every Epic ID encodes the **product tier** of the
-capability; sub-steps (110, 120, …) order epics within a tier. This matches the
-story-title convention already in the issues ("Open 200", "View 200",
-"Share (200)") and the PDF's 🥉/🥇 split.
+The hundreds digit of every Epic ID encodes the **business milestone the epic
+is needed for** — not a feature-fanciness scale. An epic's tier is the earliest
+milestone below that doesn't happen without it; sub-steps (110, 120, …) order
+epics within a band. This supersedes the short-lived v0.5 capability-tier
+reading; the story-title convention in issues ("Open 200", "View 200") is
+unchanged.
 
-| Range | Tier | Meaning |
+| Range | Milestone | The bar (qualitative; measured via `grow-120` events — numbers live bizdev-side) |
 |---|---|---|
-| 100–199 | **MVP** | As tight as possible — our best guess of the minimum product. Free tier. Roughly the PDF's 🥉. |
-| 200–299 | **MLP** | Minimum Loveable — opportunistic stretch on 100-level implementations. Roughly the PDF's 🥇. |
-| 300–399 | **Pro** | Paid-tier capabilities (private sharing, multi-account, quota uplift, subscription machinery). |
-| 400–499 | **Enterprise** | Org-scale: data-sovereignty posture, folder/team boundaries, security-review readiness. |
+| 100–199 | **MVP** | An initial **trickle of paying customers** — not just the first — arriving steadily, with **CAC estimable** from the Ads funnel (spend ÷ paid conversions) and a steady trickle of signups. |
+| 200–299 | **MLP** | Significant strides on that trickle by **building out the basics** — signup/paid growth accelerating at a respectable rate. |
+| 300–399 | **Pro** | Confidence stage: **power features** shipping and earning **positive feedback at the feature level**. |
+| 400–499 | **Enterprise** | A fully up-and-running business: validated **ideal customer personas**, breadth of positive feedback, org-scale packaging (sovereignty posture, admin, boundaries). |
 
-Tier is **not** schedule: a 300-level epic can be in an early Pro-MVP phase
-(private sharing is Phase C) and a 400-level page can ship in Phase G. The
-Pro-MVP column carries the schedule; the ID carries the tier.
+What the milestone reading changes (the v0.6 re-pass):
 
-**v0.5 renumbering map** (unchanged IDs omitted — everything already 100-level
-MVP kept its number):
+- **Billing is MVP.** No trickle of payers without pricing tiers, checkout, and
+  the size/complexity quota — `subscribe-100/110/120` return to the 100 band
+  (their original numbers, as it happens).
+- **Measurement is MVP.** CAC is not estimable without the `grow-120` funnel
+  events, and the steady signup trickle needs `grow-100` landing targets.
+- **The paid offer is MVP.** The extended share flow (`share-120`) is the
+  paywall surface; private link sharing (`share-130`) is the headline paid
+  feature beside the size quota.
+- **AI is the Pro arc.** The Assist epics move to `assist-3xx` (multi-user
+  channels to 400) — §7's pivot sequencing is unchanged; only the band signal
+  moved. Nothing AI is required for the MVP trickle.
 
-| Old → New | Old → New | Old → New |
-|---|---|---|
-| open-130 → open-300 | view-180 → view-240 | search-120 → search-210 |
-| open-140 → open-200 | share-120 → share-300 | identity-130 → identity-300 |
-| open-150 → open-130 | share-130 → share-310 | apps-120 → apps-210 |
-| view-130 → view-200 | share-140 → share-400 | apps-130 → apps-200 |
-| view-140 → view-210 | share-150 → share-200 | community-120 → community-200 |
-| view-150 → view-130 | notes-110 → notes-200 | community-130 → community-210 |
-| view-160 → view-220 | notes-120 → notes-210 | subscribe-100 → subscribe-300 |
-| view-170 → view-230 | versions-110 → versions-200 | subscribe-110 → subscribe-310 |
-| — | versions-120 → versions-210 | subscribe-120 → subscribe-320 |
-| — | search-110 → search-200 | grow-130 → grow-400 |
-| — | assist-130 → assist-200 | assist-120 → assist-300 |
+Tier is **not** schedule: the Pro-MVP phase column carries sequencing; the ID
+carries the milestone. §6.0 enumerates the open 100-band work exhaustively.
 
-⚠ Two numbers were **reused for a different epic** than before the renorm:
-`open-130` (now Recents reliability; was multi-account Sources) and `view-130`
-(now Performance/large-model; was persistent visibility). When reading pre-v0.5
-branches, issues, or PR descriptions, check this table before trusting an ID.
+**ID lineage** — every epic that has ever been renumbered (all other IDs have
+been stable since v0.2). Resolve any ID you meet in an older branch, issue, or
+PR description through this table; several numbers were reused across
+revisions (`share-120`, `share-130`, `share-200`, `open-200`, `view-130`,
+`view-220`, `view-230`, `assist-300`), and `subscribe-100/110/120` were
+restored to their original meanings.
+
+| Epic (current name) | v0.2–v0.4 | v0.5 | v0.6 (current) |
+|---|---|---|---|
+| Recents reliability | open-150 | open-130 | `open-200` |
+| Open multiple IFCs in one session | open-140 | open-200 | `open-210` |
+| Multi-account Sources tab | open-130 | open-300 | `open-300` |
+| Persistent visibility / Isolate | view-130 | view-200 | `view-200` |
+| Selection camera + measurement | view-140 | view-210 | `view-210` |
+| Performance + large-model viewing | view-150 | view-130 | `view-130` |
+| Common view operations | view-170 | view-230 | `view-220` |
+| Placemarks + maps-style filtering | view-180 | view-240 | `view-230` |
+| ETL / Table view | view-160 | view-220 | `view-300` |
+| Extended Share/Login flow | share-150 | share-200 | `share-120` |
+| Private link sharing | share-120 | share-300 | `share-130` |
+| Grant/revoke per-principal | share-130 | share-310 | `share-200` |
+| Folder-scoped boundaries | share-140 | share-400 | `share-400` |
+| BCF round-trip | notes-110 | notes-200 | `notes-200` |
+| Drive-backed notes | notes-120 | notes-210 | `notes-300` |
+| Diff between versions | versions-110 | versions-200 | `versions-300` |
+| Portable versions for Drive | versions-120 | versions-210 | `versions-310` |
+| Cross-repo search | search-110 | search-200 | `search-300` |
+| Knowledge graph | search-120 | search-210 | `search-310` |
+| Profile drawer + multi-account picker | identity-130 | identity-300 | `identity-300` |
+| v1.0 Public API + IDE | apps-130 | apps-200 | `apps-300` |
+| Bldrs Integrate | apps-120 | apps-210 | `apps-310` |
+| Bug report w/ screenshot | community-120 | community-200 | `community-200` |
+| AEC outreach | community-130 | community-210 | `community-210` |
+| Pricing tiers + feature manager | subscribe-100 | subscribe-300 | `subscribe-100` |
+| Stripe checkout + portal | subscribe-110 | subscribe-310 | `subscribe-110` |
+| Quota tracking | subscribe-120 | subscribe-320 | `subscribe-120` |
+| Rich share-link previews (OG) | grow-110 (v0.3) | grow-110 | `grow-200` |
+| Large-model + sovereignty positioning | grow-130 (v0.4) | grow-400 | `grow-400` |
+| Workspace shell (left drawer) | assist-100 (v0.3) | assist-100 | `assist-300` |
+| Conversational agent panel | assist-110 (v0.3) | assist-110 | `assist-310` |
+| AI-apps toolbelt | assist-130 (v0.3) | assist-200 | `assist-320` |
+| Multi-user channels + AI modes | assist-120 (v0.3) | assist-300 | `assist-400` |
 
 **Pro-MVP column legend** (used in §3 and §5):
 
@@ -166,8 +210,8 @@ cross-references that connect them. The detailed bodies live in §4 (Epics) and 
 | Open | `open-100` | Open from local file system | ✔ | — | — |
 | Open | `open-110` | Open from GitHub URL / UI | ✔ | — | — |
 | Open | `open-120` | Open from Google Drive | ✔ | — | — |
-| Open | `open-130` | Recents reliability | 🟡 | E | T5 |
-| Open | `open-200` | Open multiple IFCs in one session | ⬜ | Post | — |
+| Open | `open-200` | Recents reliability | 🟡 | E | T5 |
+| Open | `open-210` | Open multiple IFCs in one session | ⬜ | Post | — |
 | Open | `open-300` | Multi-account Sources tab | 🟡 | B | T3 |
 | View | `view-100` | 3D + NavTree + Properties | ✔ | — | T1, T2 |
 | View | `view-110` | Cut planes | ✔ | — | T1 |
@@ -175,65 +219,65 @@ cross-references that connect them. The detailed bodies live in §4 (Epics) and 
 | View | `view-130` | Performance + large-model viewing | 🟡 | A | T1, T2 |
 | View | `view-200` | Persistent visibility / Isolate | 🟡 | Post | T1 |
 | View | `view-210` | Selection-based camera + measurement | ⬜ | Post | — |
-| View | `view-220` | ETL / Table view (❤️ Markus) | 🔮 | Post | T1 |
-| View | `view-230` | Common view ops (nav-cube, explode, undo, IDS) | ⬜ | Post | — |
-| View | `view-240` | Placemarks + maps-style issues w/filtering (🥇) | 🟡 | C, Post | T1, T6 |
+| View | `view-220` | Common view ops (nav-cube, explode, undo, IDS) | ⬜ | Post | — |
+| View | `view-230` | Placemarks + maps-style issues w/filtering (🥇) | 🟡 | C, Post | T1, T6 |
+| View | `view-300` | ETL / Table view (❤️ Markus) | 🔮 | Post | T1 |
 | Share | `share-100` | Share link to current view | ✔ | — | — |
 | Share | `share-110` | Save model to user's hosting (originator share) | 🟡 | C | T2 |
-| Share | `share-200` | Extended Share/Login flow (<a href="https://github.com/bldrs-ai/Share/issues/1421" target="_blank" rel="noopener noreferrer">#1421</a>) | 🟡 | C, D | — |
-| Share | `share-300` | Private link sharing + visibility chip | 🟡 | C | T4 |
-| Share | `share-310` | Grant/revoke per-principal sharing | 🟡 | C | T4 |
+| Share | `share-120` | Extended Share/Login flow (<a href="https://github.com/bldrs-ai/Share/issues/1421" target="_blank" rel="noopener noreferrer">#1421</a>) | 🟡 | C, D | — |
+| Share | `share-130` | Private link sharing + visibility chip | 🟡 | C | T4 |
+| Share | `share-200` | Grant/revoke per-principal sharing | 🟡 | C | T4 |
 | Share | `share-400` | Folder-scoped boundaries | ⬜ | Post | T4 |
 | Notes | `notes-100` | Anchored notes (GitHub-backed) | ✔ | — | — |
 | Notes | `notes-200` | BCF round-trip | ⬜ | Post | — |
-| Notes | `notes-210` | Drive-backed notes (NotesProvider) | 🔮 | Post | T4, T6 |
+| Notes | `notes-300` | Drive-backed notes (NotesProvider) | 🔮 | Post | T4, T6 |
 | Versions | `versions-100` | Show specific version + branch/commit nav | 🟡 | — | — |
-| Versions | `versions-200` | Diff between versions | ⬜ | Post | — |
-| Versions | `versions-210` | Portable versions for Drive | 🔮 | Post | T6 |
+| Versions | `versions-300` | Diff between versions | ⬜ | Post | — |
+| Versions | `versions-310` | Portable versions for Drive | 🔮 | Post | T6 |
 | Search | `search-100` | Search current model | 🟡 | — | — |
-| Search | `search-200` | Search across GitHub repos (❤️ Oleg) | 🔮 | Post | — |
-| Search | `search-210` | Knowledge graph (🥇, ❤️ Johannes) | 🔮 | AI | T10 |
+| Search | `search-300` | Search across GitHub repos (❤️ Oleg) | 🔮 | Post | — |
+| Search | `search-310` | Knowledge graph (🥇, ❤️ Johannes) | 🔮 | AI | T10 |
 | Identity | `identity-100` | Auth0 primary login | ✔ | — | — |
 | Identity | `identity-110` | GitHub as Sources peer | 🟡 | B | T3 |
 | Identity | `identity-120` | Auth disambiguation (<a href="https://github.com/bldrs-ai/Share/issues/1422" target="_blank" rel="noopener noreferrer">#1422</a>) | 🟡 | B | — |
 | Identity | `identity-300` | Profile drawer + multi-account picker | ⬜ | B | T3 |
 | Apps | `apps-100` | Browse + select app (AppsDrawer) | ✔ | — | — |
 | Apps | `apps-110` | XYZ demo app (v0.1 API dogfood) | ✔ | — | — |
-| Apps | `apps-200` | v1.0 Public API + IDE (🥇) | 🔮 | AI | T11 |
-| Apps | `apps-210` | Bldrs Integrate (CI + ArchiCAD/Speckle) | 🔮 | AI | T11 |
+| Apps | `apps-300` | v1.0 Public API + IDE (🥇) | 🔮 | AI | T11 |
+| Apps | `apps-310` | Bldrs Integrate (CI + ArchiCAD/Speckle) | 🔮 | AI | T11 |
 | Community | `community-100` | Welcome dialog + onboarding | ✔ | — | — |
 | Community | `community-110` | Analytics + survey + thumbs feedback | 🟡 | E | — |
 | Community | `community-200` | Bug report w/ screenshot + session state | ⬜ | Post | — |
 | Community | `community-210` | AEC outreach (🥇) | 🔮 | Post | — |
+| Subscribe | `subscribe-100` | Pricing tiers + feature manager (NEW) | ⬜ | D | T8 |
+| Subscribe | `subscribe-110` | Stripe checkout + portal (NEW) | ⬜ | D | T8 |
+| Subscribe | `subscribe-120` | Quota tracking (NEW) | ⬜ | D | T8, T3 |
 | Subscribe | `subscribe-130` | Ads on free tier | 🟡 | D | T7 |
-| Subscribe | `subscribe-300` | Pricing tiers + feature manager (NEW) | ⬜ | D | T8 |
-| Subscribe | `subscribe-310` | Stripe checkout + portal (NEW) | ⬜ | D | T8 |
-| Subscribe | `subscribe-320` | Quota tracking (NEW) | ⬜ | D | T8, T3 |
 | Subscribe | `subscribe-400` | Enterprise tier definition (NEW) | ⬜ | Post | T8 |
 | Grow | `grow-100` | SEO format landing pages `/viewer/*` (NEW) | ⬜ | G | T9 |
-| Grow | `grow-110` | Rich share-link previews / OG cards (NEW) | ⬜ | G | T9 |
 | Grow | `grow-120` | Funnel instrumentation + GA hygiene (NEW) | ⬜ | G | T9 |
+| Grow | `grow-200` | Rich share-link previews / OG cards (NEW) | ⬜ | G | T9 |
 | Grow | `grow-400` | Large-model + data-sovereignty positioning (NEW) | ⬜ | G | T9 |
-| Assist | `assist-100` | Workspace shell: left drawer projects + org nav (NEW) | ⬜ | AI | — |
-| Assist | `assist-110` | Conversational agent panel, single-user (NEW) | ⬜ | AI | T10, T11 |
-| Assist | `assist-200` | AI-apps toolbelt: save/version/run + MCP (NEW) | ⬜ | AI | T11 |
-| Assist | `assist-300` | Multi-user channels + AI participation modes (NEW) | ⬜ | AI | T10 |
+| Assist | `assist-300` | Workspace shell: left drawer projects + org nav (NEW) | ⬜ | AI | — |
+| Assist | `assist-310` | Conversational agent panel, single-user (NEW) | ⬜ | AI | T10, T11 |
+| Assist | `assist-320` | AI-apps toolbelt: save/version/run + MCP (NEW) | ⬜ | AI | T11 |
+| Assist | `assist-400` | Multi-user channels + AI participation modes (NEW) | ⬜ | AI | T10 |
 
 ### 3.2 Tracks
 
 | ID | Name | Status | Pro-MVP | Unblocks |
 |---|---|---|---|---|
-| T1 | Viewer Replacement | 🟡 | A (launch gate) | `view-100`, `view-110`, `view-200`, `view-130`, `view-220`, T2 |
-| T2 | GLB Model Sharing | 🟡 | C (Ph 4 + 5) | `share-110`, `notes-210`, `view-130` |
-| T3 | Identity Decoupling | 🟡 | B (PR2 + PR3) | `identity-110`, `identity-120`, `identity-300`, `open-300`, `share-310`, `subscribe-320`, T4 PR3 |
-| T4 | Multi-User Sharing | 🟡 | C (PR2 + PR3) | `share-300`, `share-310`, `share-400`, `notes-210`, `versions-210` |
-| T5 | Drive Recents HEAD-check | ⬜ | E (polish) | `open-130` |
-| T6 | Notes & Versions sidecar formats | ⬜ | Post | `notes-200`, `notes-210`, `versions-210` |
+| T1 | Viewer Replacement | 🟡 | A (launch gate) | `view-100`, `view-110`, `view-200`, `view-130`, `view-300`, T2 |
+| T2 | GLB Model Sharing | 🟡 | C (Ph 4 + 5) | `share-110`, `notes-300`, `view-130` |
+| T3 | Identity Decoupling | 🟡 | B (PR2 + PR3) | `identity-110`, `identity-120`, `identity-300`, `open-300`, `share-200`, `subscribe-120`, T4 PR3 |
+| T4 | Multi-User Sharing | 🟡 | C (PR2 + PR3) | `share-130`, `share-200`, `share-400`, `notes-300`, `versions-310` |
+| T5 | Drive Recents HEAD-check | ⬜ | E (polish) | `open-200` |
+| T6 | Notes & Versions sidecar formats | ⬜ | Post | `notes-200`, `notes-300`, `versions-310` |
 | T7 | Ads | 🟡 | D | `subscribe-130` |
-| T8 | Pro/Billing (NEW) | ⬜ | D | `subscribe-300`, `subscribe-310`, `subscribe-320`, §7 AI metering |
-| T9 | Growth funnel & SEO surfaces (NEW) | ⬜ | G | `grow-100`, `grow-110`, `grow-120` |
-| T10 | Agent runtime & conversation store (NEW) | ⬜ | AI (§7) | `assist-110`, `assist-300`, `search-210` |
-| T11 | App sandbox + MCP bridge (NEW) | ⬜ | AI (§7) | `assist-200`, `apps-200`, `apps-210` |
+| T8 | Pro/Billing (NEW) | ⬜ | D | `subscribe-100`, `subscribe-110`, `subscribe-120`, §7 AI metering |
+| T9 | Growth funnel & SEO surfaces (NEW) | ⬜ | G | `grow-100`, `grow-200`, `grow-120` |
+| T10 | Agent runtime & conversation store (NEW) | ⬜ | AI (§7) | `assist-310`, `assist-400`, `search-310` |
+| T11 | App sandbox + MCP bridge (NEW) | ⬜ | AI (§7) | `assist-320`, `apps-300`, `apps-310` |
 
 
 ## 4. Normalized Epic catalogue
@@ -266,15 +310,15 @@ original list; landed via `googleDrive` flag now default-on).
 - Open: needs Drive Save (mirrors GitHub Save flow) — captured under `share-110`.
 - Track dependency: T3 Identity Decoupling for the multi-account case.
 
-**Epic `open-130`: Recents reliability** 🟡 (NEW)
+**Epic `open-200`: Recents reliability** 🟡 (NEW)
 *Not in PDF — surfaced by support friction.*
 - Track dependency: T5 Drive recents HEAD-check (proposed).
 - Open: <a href="https://github.com/bldrs-ai/Share/issues/1548" target="_blank" rel="noopener noreferrer">#1548</a> local recent fails hard after a cache clear — needs a typed
   "file no longer available" alert (T5's pre-flight pattern applied to the
   OPFS/local case, not just Drive).
-- Story to file: `open-130: Recents show typed unreachable alert + remove-recent`.
+- Story to file: `open-200: Recents show typed unreachable alert + remove-recent`.
 
-**Epic `open-200`: Open multiple IFCs in one session** ⬜
+**Epic `open-210`: Open multiple IFCs in one session** ⬜
 *PDF Open.3 — never started.*
 - Open: <a href="https://github.com/bldrs-ai/Share/issues/1251" target="_blank" rel="noopener noreferrer">#1251</a> Open 200: import and overlay multiple models.
 - Pre-condition: Conway-direct + GLB cache are stable per-model (✔ via T1/T2), so
@@ -384,22 +428,13 @@ multi-worker; etc.*
   measurement between elements.
 - **Post-MVP.** Useful for the loveable target but not blocking.
 
-**Epic `view-220`: ETL / Table view / element subsets** 🔮 (❤️ Markus)
-*PDF View.2 — never started.*
-- The original loveable: select a model subset, choose attributes (psets, geometry,
-  location), export CSV or stream to an API. Mapping tables across projects.
-- Pre-condition: T1 `IfcModelService` query surface — once `idsByType`,
-  `getItemProperties`, `getPropertySets` are all routed through the Conway-direct
-  service (mostly done), the ETL layer is a UI-level Epic on top.
-- **Post-MVP loveable.** Markus is the design partner here.
-
-**Epic `view-230`: Common view operations** ⬜
+**Epic `view-220`: Common view operations** ⬜
 *PDF View.3 — partially done (Cut ✔). Still missing:*
 - Nav-cube, Explode, undo/redo.
 - IDS (was MVD) — quality-check rules for the IFC. Discussed in PDF page 4–5.
 - **Post-MVP.** IDS is a non-trivial spec implementation.
 
-**Epic `view-240`: Placemarks + maps-style view of issues w/filtering** 🟡
+**Epic `view-230`: Placemarks + maps-style view of issues w/filtering** 🟡
 *PDF View.4 (🥇 MLP). Placemarks are the in-scene-pin primitive on which the
 loveable maps-style filtering visualization will sit. The PDF treats them as one
 Epic and we keep that pairing here.*
@@ -407,7 +442,7 @@ Epic and we keep that pairing here.*
 The placemark primitive has two creation modes:
 - **Transient** — created in-app, lives only in the URL hash (`#m:x,y,z`), no
   backing storage. Sharable as a bare permalink. This mode is why Placemarks
-  belongs under `view-240` rather than `notes-*` — the primitive doesn't require
+  belongs under `view-230` rather than `notes-*` — the primitive doesn't require
   Notes (or any storage layer) to exist.
 - **Anchored to a Note** — persisted via the GitHub Issue store; the note's
   share-URL carries the placemark hash so the recipient lands on the pin with
@@ -459,6 +494,15 @@ visualization on top (post-MVP loveable):
   the share-a-note flow today.
 - Maps-style filtering UI itself is **Post-MVP loveable** (§8 item 10).
 
+**Epic `view-300`: ETL / Table view / element subsets** 🔮 (❤️ Markus)
+*PDF View.2 — never started.*
+- The original loveable: select a model subset, choose attributes (psets, geometry,
+  location), export CSV or stream to an API. Mapping tables across projects.
+- Pre-condition: T1 `IfcModelService` query surface — once `idsByType`,
+  `getItemProperties`, `getPropertySets` are all routed through the Conway-direct
+  service (mostly done), the ETL layer is a UI-level Epic on top.
+- **Post-MVP loveable.** Markus is the design partner here.
+
 
 ### 4.3 Share (split out of legacy Collab)
 
@@ -479,23 +523,23 @@ publicly — and the recipient sees what was intended.
 - Track dependency: T2 Phase 5 (originator share flow: drop IFC → GLB written
   locally → upload artifact to Drive/GitHub/Firebase → link).
 
-**Epic `share-200`: Extended Share/Login flow (one-click)** 🟡 (NEW)
+**Epic `share-120`: Extended Share/Login flow (one-click)** 🟡 (NEW)
 - Open: <a href="https://github.com/bldrs-ai/Share/issues/1421" target="_blank" rel="noopener noreferrer">#1421</a> Share (200) Extended login flow — the dialog that picks between
   anonymous-public-5-day, free-public-long-term, Pro-private, etc. This is the
   surface where the Pro pricing tiers become visible.
 - **Required for Pro-MVP** (it's where the upgrade prompt lives).
 
-**Epic `share-300`: Private link sharing + visibility chip** 🟡 (NEW)
+**Epic `share-130`: Private link sharing + visibility chip** 🟡 (NEW)
 *Not in PDF except as "Private hosting" sub-bullet under Open.1.*
 - Track dependency: T4 Multi-User Sharing PR1 (landed: provider scaffolding + Drive
   adapter); PR2 (Drive Share dialog UI); PR3 (GitHub sharing adapter).
 - Open: feature flag `sharing` is off; turn-on once PR2 lands.
 - **Required for Pro-MVP** (private sharing is a paid feature per <a href="https://github.com/bldrs-ai/Share/issues/1421" target="_blank" rel="noopener noreferrer">#1421</a>).
 
-**Epic `share-310`: Grant/revoke per-principal sharing** 🟡 (NEW)
+**Epic `share-200`: Grant/revoke per-principal sharing** 🟡 (NEW)
 *Not in PDF.*
 - Track dependency: T4 PR2/PR3 (Share dialog People panel — invites people/teams).
-- Open: same `sharing` flag as `share-300`.
+- Open: same `sharing` flag as `share-130`.
 - **Pro-MVP**: Pro feature.
 
 **Epic `share-400`: Folder-scoped boundaries** ⬜ (NEW)
@@ -517,7 +561,7 @@ a specific version of the model.
 - Open: <a href="https://github.com/bldrs-ai/Share/issues/892" target="_blank" rel="noopener noreferrer">#892</a> Notes 200 Anchor a note to an element — the Notes-side flow for
   binding a placemark to a note; data path works. The Placemark primitive and
   its open polish issues (<a href="https://github.com/bldrs-ai/Share/issues/928" target="_blank" rel="noopener noreferrer">#928</a>/<a href="https://github.com/bldrs-ai/Share/issues/929" target="_blank" rel="noopener noreferrer">#929</a>/<a href="https://github.com/bldrs-ai/Share/issues/930" target="_blank" rel="noopener noreferrer">#930</a>/<a href="https://github.com/bldrs-ai/Share/issues/931" target="_blank" rel="noopener noreferrer">#931</a>/<a href="https://github.com/bldrs-ai/Share/issues/932" target="_blank" rel="noopener noreferrer">#932</a>/<a href="https://github.com/bldrs-ai/Share/issues/985" target="_blank" rel="noopener noreferrer">#985</a>/<a href="https://github.com/bldrs-ai/Share/issues/998" target="_blank" rel="noopener noreferrer">#998</a>) are tracked under
-  `view-240`.
+  `view-230`.
 
 **Epic `notes-200`: BCF round-trip** ⬜
 *PDF Collab.2 — "GitHub then BCF at some point".*
@@ -525,7 +569,7 @@ a specific version of the model.
   consumable in Solibri / Navisworks / Tekla and vice versa.
 - **Post-MVP.** Strong for AEC industry credibility.
 
-**Epic `notes-210`: Drive-backed notes (provider-neutral NotesProvider)** 🔮 (NEW)
+**Epic `notes-300`: Drive-backed notes (provider-neutral NotesProvider)** 🔮 (NEW)
 *Not in original PDF; introduced in `multi-user-sharing.md` Stretch §Q1-Q4.*
 - Track dependency: T4 Stretch (sidecar formats, NotesProvider abstraction).
 - **Post-MVP**: Q1–Q4 of T4 Stretch arc.
@@ -537,12 +581,12 @@ a specific version of the model.
   Versions 200 Delete a version (UI + flow not landed).
 - **Pro-MVP**: enough is done for free-tier; Delete + branch UX polish slot post-MVP.
 
-**Epic `versions-200`: Diff between versions** ⬜
+**Epic `versions-300`: Diff between versions** ⬜
 *PDF Collab table — "Showing Diffs?"*
 - Never started; needs a structural-diff between two IFC versions.
 - **Post-MVP.** Significant scope.
 
-**Epic `versions-210`: Portable versions for Drive (Versions manifest)** 🔮 (NEW)
+**Epic `versions-310`: Portable versions for Drive (Versions manifest)** 🔮 (NEW)
 - Track dependency: T4 Stretch Q3.
 - **Post-MVP.**
 
@@ -558,18 +602,18 @@ data graph.
 - Open: <a href="https://github.com/bldrs-ai/Share/issues/1254" target="_blank" rel="noopener noreferrer">#1254</a> Search 100 Search model based on element name (highlighting in scene).
 - Story to file: cover NavTree + scene highlighting under the same E2E.
 
-**Epic `search-200`: Search across GitHub repos** 🔮 (❤️ Oleg)
+**Epic `search-300`: Search across GitHub repos** 🔮 (❤️ Oleg)
 *PDF Search.2.*
 - Never started. Cross-repo search for "all walls with `LoadBearing=true` across my
   org's repos".
 - **Post-MVP loveable.** Oleg is the design partner.
 
-**Epic `search-210`: Knowledge graph / ask questions** 🔮 (❤️ Johannes)
+**Epic `search-310`: Knowledge graph / ask questions** 🔮 (❤️ Johannes)
 *PDF Search.3 (🥇 MLP).*
 - Never started. Natural-language QA over building data with citations back to the
   model.
 - **Absorbed by the AI pivot (§7).** Natural-language QA over the model is the
-  first-class job of the conversational panel (`assist-110`); the knowledge-graph
+  first-class job of the conversational panel (`assist-310`); the knowledge-graph
   substrate becomes its retrieval layer (Track T10). Johannes stays the design
   partner.
 
@@ -609,7 +653,7 @@ Third-party (and dogfooded) apps add capabilities to Share via a stable API.
 **Epic `apps-100`: Browse + select app (AppsDrawer)** ✔
 - Closed: <a href="https://github.com/bldrs-ai/Share/issues/1282" target="_blank" rel="noopener noreferrer">#1282</a> Apps 100.
 - Open: nothing immediate as a free-standing Epic — but the AppsDrawer + `WidgetApi/`
-  iframe surface is the **seed of the AI-apps toolbelt** (`assist-200`, §7.2).
+  iframe surface is the **seed of the AI-apps toolbelt** (`assist-320`, §7.2).
   <a href="https://github.com/bldrs-ai/Share/issues/1386" target="_blank" rel="noopener noreferrer">#1386</a> (iframe integration broken; its test suite disabled) graduates from
   dormant bug to pivot blocker — the sandbox foundation must work before anything
   is built on it (§7.4 AI.0).
@@ -617,7 +661,7 @@ Third-party (and dogfooded) apps add capabilities to Share via a stable API.
 **Epic `apps-110`: XYZ demo app (dogfood v0.1 API)** ✔
 *PDF Apps.1 — done in PDF.*
 
-**Epic `apps-200`: v1.0 Public API + docs + IDE integration** 🔮
+**Epic `apps-300`: v1.0 Public API + docs + IDE integration** 🔮
 *PDF Apps.3 (🥇 MLP).*
 - Never started as a programmatic surface; the `WidgetApi/` directory is the seed.
 - **Re-scoped by the AI pivot (§7):** the public API's first consumers are the
@@ -625,10 +669,10 @@ Third-party (and dogfooded) apps add capabilities to Share via a stable API.
   (Track T11) — external IDE/embedding consumers and the internal toolbelt share
   one tool contract instead of us maintaining two APIs.
 
-**Epic `apps-210`: Bldrs Integrate (CI + ArchiCAD/Speckle)** 🔮
+**Epic `apps-310`: Bldrs Integrate (CI + ArchiCAD/Speckle)** 🔮
 *PDF Apps.2.*
 - Never started. Server-side IFC validation pipeline running IDS rules per commit
-  (preview of view-230 IDS).
+  (preview of view-220 IDS).
 - **Absorbed by the AI pivot (§7):** agent-driven model checks become the delivery
   vehicle — an AI-app in the toolbelt (T11) rather than a bespoke CI product.
 
@@ -681,17 +725,7 @@ hypotheses** (what share of users hit the threshold; of those, who pays vs.
 churns) instrumented well enough to produce decision-grade conversion evidence —
 not just a revenue trickle.*
 
-**Epic `subscribe-130`: Ads on free tier** 🟡
-- Track dependency: T7 Ads (<a href="https://github.com/bldrs-ai/Share/issues/1524" target="_blank" rel="noopener noreferrer">#1524</a>). Phase 1 activation in flight (<a href="https://github.com/bldrs-ai/Share/issues/1523" target="_blank" rel="noopener noreferrer">#1523</a>).
-- Open: Phases 2 (manual slots) + 3 (responsive) + 4 (consent gating).
-- **Required for Pro-MVP** — the free tier monetisation path.
-- Scope note: T7 is **on-site AdSense** (revenue). The Google Ads **acquisition**
-  campaigns (Smart→Search rebuild, keywords, geo, bidding) are out of repo scope —
-  owned in the private bizdev growth-strategy doc §4. The in-repo dependency runs
-  the other way: those campaigns need `grow-100` landing pages as destinations and
-  `grow-120` events to bid against.
-
-**Epic `subscribe-300`: Pricing tiers + feature manager** ⬜ (NEW)
+**Epic `subscribe-100`: Pricing tiers + feature manager** ⬜ (NEW)
 - Tasks: enumerate features per tier; ship a `tier`-aware capability map; UI in <a href="https://github.com/bldrs-ai/Share/issues/1421" target="_blank" rel="noopener noreferrer">#1421</a>
   mock dialog form.
 - Tier axis (v0.4): small models stay free and unlimited; the Pro boundary is
@@ -700,14 +734,14 @@ not just a revenue trickle.*
   distribution from telemetry before it's picked.
 - **Required for Pro-MVP.**
 
-**Epic `subscribe-310`: Stripe checkout + portal** ⬜ (NEW)
+**Epic `subscribe-110`: Stripe checkout + portal** ⬜ (NEW)
 - Tasks: `create-portal-session` Netlify Function exists already (per identity
   decoupling decisions doc — model pattern for new functions). Add
   `create-checkout-session`; webhook for status changes; persist Pro flag against
   Auth0 `sub`.
 - **Required for Pro-MVP.**
 
-**Epic `subscribe-320`: Quota tracking** ⬜ (NEW)
+**Epic `subscribe-120`: Quota tracking** ⬜ (NEW)
 - Tasks: server-side counter keyed by Auth0 `sub` (per identity-decoupling-decisions
   §Q4 Open Question on "Quota tracking"); enforcement points in (a) GLB writer
   Phase-5 share upload, (b) per-connection refresh-token mint, (c) public-share
@@ -719,6 +753,16 @@ not just a revenue trickle.*
   for threshold-hit, upgrade-prompt-shown, converted/churned, so the quota run
   yields decision-grade evidence either way.
 - **Required for Pro-MVP.**
+
+**Epic `subscribe-130`: Ads on free tier** 🟡
+- Track dependency: T7 Ads (<a href="https://github.com/bldrs-ai/Share/issues/1524" target="_blank" rel="noopener noreferrer">#1524</a>). Phase 1 activation in flight (<a href="https://github.com/bldrs-ai/Share/issues/1523" target="_blank" rel="noopener noreferrer">#1523</a>).
+- Open: Phases 2 (manual slots) + 3 (responsive) + 4 (consent gating).
+- **Required for Pro-MVP** — the free tier monetisation path.
+- Scope note: T7 is **on-site AdSense** (revenue). The Google Ads **acquisition**
+  campaigns (Smart→Search rebuild, keywords, geo, bidding) are out of repo scope —
+  owned in the private bizdev growth-strategy doc §4. The in-repo dependency runs
+  the other way: those campaigns need `grow-100` landing pages as destinations and
+  `grow-120` events to bid against.
 
 **Epic `subscribe-400`: Enterprise tier definition** ⬜ (NEW, v0.5)
 - Placeholder for the enterprise packaging the ai-strategy synthesis points at:
@@ -758,18 +802,6 @@ which channel *reaches* that audience is the open GTM question owned bizdev-side
   campaigns land on the homepage, which is a viewer, not a pitch.
 - **Phase G.**
 
-**Epic `grow-110`: Rich share-link previews (OG cards)** ⬜ (NEW)
-- A shared `/share/*` link should unfurl in Slack/WhatsApp/LinkedIn/Teams with a
-  model thumbnail + title — both loop fuel (recipient trust/CTR) and SEO.
-- Supersedes the intent of <a href="https://github.com/bldrs-ai/Share/issues/1315" target="_blank" rel="noopener noreferrer">#1315</a>: the marketing routes got SSG in PR #1519, but
-  `/share/*` stays SPA, so per-model OG tags need edge/function injection (or
-  pre-render at share time — e.g. write the OG image alongside the T2 GLB share
-  artifact). Design call in Phase G.
-- Recipient landing experience rides along: a shared view should offer "Open your
-  own model" / "What is this?" affordances so recipients convert to sharers.
-- **Phase G** (metadata + affordances); OG image generation may slip to Phase C
-  where it pairs with the T2 Phase 5 share artifact.
-
 **Epic `grow-120`: Funnel instrumentation + analytics hygiene** ⬜ (NEW)
 - Instrument the funnel stages the growth doc defines (§3 there):
   `share_link_created`, `share_link_opened`, `model_interacted` events in Share;
@@ -782,12 +814,24 @@ which channel *reaches* that audience is the open GTM question owned bizdev-side
 - Channel-grouping + dashboard slices are bizdev-side config; the Share-side
   deliverable is the events existing and firing.
 - v0.4 addition: capture **model size/complexity** (bucketed — bytes, element
-  count) on the model-open event, so (a) the `subscribe-300` quota threshold is
+  count) on the model-open event, so (a) the `subscribe-100` quota threshold is
   picked from real distribution data, not guessed, and (b) large-model users —
   the segment that matters — become visible in the funnel instead of drowned in
   commodity traffic.
 - **Phase G — first slice.** Blocks conversion-based bidding, loop metrics, and
   any honest read of a launch/Show-HN spike.
+
+**Epic `grow-200`: Rich share-link previews (OG cards)** ⬜ (NEW)
+- A shared `/share/*` link should unfurl in Slack/WhatsApp/LinkedIn/Teams with a
+  model thumbnail + title — both loop fuel (recipient trust/CTR) and SEO.
+- Supersedes the intent of <a href="https://github.com/bldrs-ai/Share/issues/1315" target="_blank" rel="noopener noreferrer">#1315</a>: the marketing routes got SSG in PR #1519, but
+  `/share/*` stays SPA, so per-model OG tags need edge/function injection (or
+  pre-render at share time — e.g. write the OG image alongside the T2 GLB share
+  artifact). Design call in Phase G.
+- Recipient landing experience rides along: a shared view should offer "Open your
+  own model" / "What is this?" affordances so recipients convert to sharers.
+- **Phase G** (metadata + affordances); OG image generation may slip to Phase C
+  where it pairs with the T2 Phase 5 share artifact.
 
 **Epic `grow-400`: Large-model + data-sovereignty positioning** ⬜ (NEW, v0.4)
 - The positioning surface for the audience that pays: a page (marketing SSG
@@ -815,7 +859,7 @@ collaborates with teammates in the same conversation, and accumulates AI-built
 tools. This group is the Epic-level decomposition of the §7 pivot; read §7 for the
 vision, architecture, and sequencing. Design doc to draft: `design/new/ai-workspace.md`.
 
-**Epic `assist-100`: Workspace shell — left drawer, projects + org nav** ⬜ (NEW)
+**Epic `assist-300`: Workspace shell — left drawer, projects + org nav** ⬜ (NEW)
 - A modification of the existing UI adding a **left drawer** for workspace-level
   navigation: projects (models, conversations, shared artifacts, recents) and
   company-level nav (org, members, settings). Makes Share feel like a workspace
@@ -825,7 +869,7 @@ vision, architecture, and sequencing. Design doc to draft: `design/new/ai-worksp
 - Interacts with: `open-300` Sources tab (accounts live in the same nav), T4
   sharing (shared-with-me listing), `identity-300` profile drawer.
 
-**Epic `assist-110`: Conversational agent panel (single-user)** ⬜ (NEW)
+**Epic `assist-310`: Conversational agent panel (single-user)** ⬜ (NEW)
 - A Claude-Code-like conversation panel over the open project/model: prompt →
   agent loop → tool calls against the viewer → streamed response. The viewer
   exposes its operations (load, camera, select, isolate/hide, properties/psets,
@@ -833,23 +877,23 @@ vision, architecture, and sequencing. Design doc to draft: `design/new/ai-worksp
   consumer.
 - Single user, one conversation per project/model. This is the demo that sells
   the pivot (§7.4 AI.2).
-- Absorbs `search-210`'s NL-QA ambition; T10 owns the runtime + conversation
+- Absorbs `search-310`'s NL-QA ambition; T10 owns the runtime + conversation
   persistence.
 
-**Epic `assist-200`: AI-apps toolbelt (right drawer)** ⬜ (NEW)
+**Epic `assist-320`: AI-apps toolbelt (right drawer)** ⬜ (NEW)
 - The existing right-drawer AppsDrawer, upgraded: code the agent generates can be
   **saved, versioned, and run** in a sandboxed iframe that talks to the main app
   context over an **MCP bridge** (postMessage transport) — the same tool surface
   the agent uses (T11). Users accumulate personal/team toolbelts of generated
   apps.
-- This is the user-generated-app story `apps-100`/`apps-200` always pointed at,
-  with the agent as the author. `apps-210`-style model checks become toolbelt
+- This is the user-generated-app story `apps-100`/`apps-300` always pointed at,
+  with the agent as the author. `apps-310`-style model checks become toolbelt
   apps.
 - Pre-condition: fix <a href="https://github.com/bldrs-ai/Share/issues/1386" target="_blank" rel="noopener noreferrer">#1386</a> (iframe widget integration broken, suite disabled).
 - Storage/versioning candidate: the user's own hosting via T3/T4 providers (apps
   are files too), keeping the BYOS shape of the rest of the product.
 
-**Epic `assist-300`: Multi-user channels + AI participation modes** ⬜ (NEW)
+**Epic `assist-400`: Multi-user channels + AI participation modes** ⬜ (NEW)
 - The conversation becomes a shared channel. The key mechanic:
   - **Direct replies addressed to the AI** are commands — handled exactly as the
     single-user panel handles a prompt (full agent loop + tool calls).
@@ -895,7 +939,7 @@ same list-item order: What, Status, Unblocks, Pro-MVP impact, Doc.
   `?feature=look` (default off)** — the default still renders the legacy look. To
   go live: flip the flag default + regenerate the screenshot baselines (one PR).
   See `design/new/viewer-replacement.md` §6e.
-- **Unblocks:** `view-100`, `view-110`, `view-200`, `view-130`, `view-220`, T2.
+- **Unblocks:** `view-100`, `view-110`, `view-200`, `view-130`, `view-300`, T2.
 - **Pro-MVP impact:** Required — public-launch gate.
 - **Doc:** `design/new/viewer-replacement.md`.
 
@@ -906,7 +950,7 @@ same list-item order: What, Status, Unblocks, Pro-MVP impact, Doc.
   key, extension split, picker fix, BLDRS_* extensions) landed.
 - **Status:** Phases 4 (Notes + view-states v0.1 round-trip), 5 (originator share
   flow), 6 (shared cache tier — Drive/Firebase) open.
-- **Unblocks:** `share-110`, `notes-210`, `view-130` perf wins.
+- **Unblocks:** `share-110`, `notes-300`, `view-130` perf wins.
 - **Pro-MVP impact:** Phase 5 (originator share flow) — required. Phase 4 — required
   (so notes survive cache hits). Phase 6 — post-MVP optimisation.
 - **Doc:** `design/new/glb-model-sharing.md`.
@@ -920,7 +964,7 @@ same list-item order: What, Status, Unblocks, Pro-MVP impact, Doc.
 - **Status:** PR1 (provider scaffolding + Functions) merged. PR2 (SourcesTab UI
   integration, recents migration) + PR3 (switchover + flag retire) open.
 - **Unblocks:** `identity-110`, `identity-120`, `identity-300`, `open-300`,
-  `share-310`, `subscribe-320` (quota keying), and T4 PR3 (GH sharing).
+  `share-200`, `subscribe-120` (quota keying), and T4 PR3 (GH sharing).
 - **Pro-MVP impact:** PR2 + PR3 required.
 - **Docs:** `design/new/identity-decoupling.md` + `identity-decoupling-decisions.md`.
 
@@ -933,7 +977,7 @@ same list-item order: What, Status, Unblocks, Pro-MVP impact, Doc.
 - **Status:** PR1 (provider scaffolding) merged. PR2 (Drive Share dialog UI), PR3 (GH
   sharing adapter), PR4 (folder boundary routes) open. PR5 (GH token-health parity)
   and PR6 (flag retire) follow.
-- **Unblocks:** `share-300`, `share-310`, `share-400`, `notes-210`, `versions-210`.
+- **Unblocks:** `share-130`, `share-200`, `share-400`, `notes-300`, `versions-310`.
 - **Pro-MVP impact:** PR2 + PR3 required (private sharing is a paid feature). PR4
   post-MVP. PR5 nice-to-have.
 - **Docs:** `design/new/multi-user-sharing.md` + `design/new/sharing-pr3-github.md`.
@@ -944,7 +988,7 @@ same list-item order: What, Status, Unblocks, Pro-MVP impact, Doc.
 - **What:** Pre-flight Drive metadata check on recents click; typed `FileUnreachable`
   alert variants.
 - **Status:** Proposed. Not started.
-- **Unblocks:** `open-130`. Pattern reusable for GH recents once `githubAsSource`
+- **Unblocks:** `open-200`. Pattern reusable for GH recents once `githubAsSource`
   lands.
 - **Pro-MVP impact:** Polish; not strictly required for paid launch but the support
   cost of "Failed to parse model" on dead recents is real.
@@ -956,7 +1000,7 @@ same list-item order: What, Status, Unblocks, Pro-MVP impact, Doc.
 - **What:** Provider-neutral JSON sidecar formats for notes + versions, round-tripping
   between Drive snapshots and git issues/commits.
 - **Status:** Not started.
-- **Unblocks:** `notes-210`, `notes-200` (BCF can be derived), `versions-210`.
+- **Unblocks:** `notes-300`, `notes-200` (BCF can be derived), `versions-310`.
 - **Pro-MVP impact:** Post-MVP. Quarter-scale work.
 - **Doc:** `multi-user-sharing.md` §Stretch (Q1–Q4).
 
@@ -977,7 +1021,7 @@ same list-item order: What, Status, Unblocks, Pro-MVP impact, Doc.
   plumbing throughout the app.
 - **Status:** Not started. Existing seeds: `netlify/functions/create-portal-session.js`,
   `netlify/functions/unlink-identity.js` (pattern reuse).
-- **Unblocks:** `subscribe-300`, `subscribe-310`, `subscribe-320`. Forward-looking:
+- **Unblocks:** `subscribe-100`, `subscribe-110`, `subscribe-120`. Forward-looking:
   the same quota/metering rails are what §7 AI usage metering hangs off — design
   the counter keying with that consumer in mind.
 - **Quota axis (v0.4):** model size/complexity, never model count — the paywall
@@ -999,7 +1043,7 @@ same list-item order: What, Status, Unblocks, Pro-MVP impact, Doc.
 - **Status:** Not started in-repo. The enabling substrate (Next.js SSG marketing
   build, PR #1519) is landed; strategy + attribution live in the private bizdev
   docs.
-- **Unblocks:** `grow-100`, `grow-110`, `grow-120`, `grow-400`; honest measurement
+- **Unblocks:** `grow-100`, `grow-200`, `grow-120`, `grow-400`; honest measurement
   of every outreach move in `community-210`; conversion-based bidding for the
   (out-of-repo) acquisition campaigns; the Phase D quota-threshold pick.
 - **Pro-MVP impact:** Phase G — parallel, starts now. Cheap relative to everything
@@ -1011,13 +1055,13 @@ same list-item order: What, Status, Unblocks, Pro-MVP impact, Doc.
 ### Track T10: Agent runtime & conversation store (NEW)
 
 - **What:** The conversational core of the §7 pivot: agent loop (LLM calls, tool
-  dispatch, streaming), conversation persistence, and — for `assist-300` — a
+  dispatch, streaming), conversation persistence, and — for `assist-400` — a
   shared store with realtime sync and the direct-address vs channel-awareness
   routing.
 - **Status:** Not started. Design questions (runtime placement client vs broker,
   provider strategy, store choice, relation to Notes) go to
   `design/new/ai-workspace.md` first — see §7.4 AI.0 and §10 open questions.
-- **Unblocks:** `assist-110`, `assist-300`, `search-210` (as retrieval), and the
+- **Unblocks:** `assist-310`, `assist-400`, `search-310` (as retrieval), and the
   §7 AI-metering upsell.
 - **Pro-MVP impact:** None (pivot arc). Must not destabilise Phases A–E.
 - **Doc:** TBD — `design/new/ai-workspace.md`.
@@ -1034,7 +1078,7 @@ same list-item order: What, Status, Unblocks, Pro-MVP impact, Doc.
 - **Status:** Not started. Seeds: `WidgetApi/` + AppsDrawer (`apps-100`), the
   `IfcModelService` query surface (T1). Known debt: <a href="https://github.com/bldrs-ai/Share/issues/1386" target="_blank" rel="noopener noreferrer">#1386</a> iframe integration
   broken with its suite disabled — repair is the first slice.
-- **Unblocks:** `assist-200`, `apps-200` (MCP-first public API), `apps-210`
+- **Unblocks:** `assist-320`, `apps-300` (MCP-first public API), `apps-310`
   (checks as toolbelt apps).
 - **Pro-MVP impact:** None (pivot arc), except the #1386 repair which is
   independently worthwhile.
@@ -1050,7 +1094,41 @@ This is a phased plan, not a sprint schedule. Each phase ends with a green CI + 
 public canary. Phases A–B can overlap; C–E sequence. **Phase G is new in v0.3 and
 runs in parallel starting now** — it's small, mostly independent of the viewer and
 identity arcs, and it's the only work in this plan that grows the top of the
-funnel. Rationale: the growth-strategy attribution work showed we currently earn
+funnel.
+
+
+### 6.0 The MVP bar (v0.6)
+
+MVP is a milestone, not a launch event: **a steady trickle of paying
+customers, arriving week after week without hand-holding, with CAC estimable
+as ad spend ÷ paid conversions from the `grow-120` funnel, on top of a steady
+trickle of signups.** One paying customer is an anecdote; the trickle is the
+evidence. Thresholds/targets live in the private bizdev docs.
+
+The open 100-band work, exhaustively — this list IS the MVP; everything else
+in this plan is opportunistic until the trickle exists:
+
+1. **The viewer holds** (Phase A): T1 public-launch gate, on-demand rendering,
+   the `view-130` bug list (#1561, #1545, #1249), STEP verification #1569.
+2. **Identity is billable** (Phase B): T3 PR2/PR3 (`identity-110`), auth
+   disambiguation #1422 (`identity-120`) — so the quota key and the card
+   belong to the same person.
+3. **The paid offer exists** (Phase C): private link sharing (`share-130`, T4
+   PR2/PR3) + the extended Share/Login flow (`share-120`, #1421 — the paywall
+   surface) + originator save/share (`share-110`, T2 Ph4+5).
+4. **It bills** (Phase D): `subscribe-100` tiers, `subscribe-110` Stripe,
+   `subscribe-120` size/complexity quota with experiment events.
+5. **The free tier monetises and acquires** (Phase D): T7 ads
+   (`subscribe-130`) — also the campaign engine CAC is measured against.
+6. **It's measurable and findable** (Phase G): `grow-120` funnel events + GA
+   hygiene (the CAC denominator), `grow-100` `/viewer/ifc` + `/viewer/step`
+   landing pages (the campaign targets), `community-110` feedback affordance.
+
+Demoted out of the MVP band in the v0.6 pass — still scheduled where phases
+already cover them, but explicitly *not* load-bearing for the trickle: recents
+reliability (`open-200`), per-principal grants (`share-200`), OG link previews
+(`grow-200`), and the entire Assist/AI arc (`assist-3xx`/`assist-400` — the
+pivot follows the trickle, §7.4). Rationale: the growth-strategy attribution work showed we currently earn
 almost no traffic (organic ≈ zero) while the one earned channel that does work —
 shared links — is uninvested; and the paid acquisition rebuild needs landing pages
 and conversion events from this repo before it can optimise. Launching Pro (D/E)
@@ -1068,7 +1146,7 @@ landing page — before the Pro launch needs any of it.
 - `grow-100`: `/viewer/ifc` + `/viewer/step` landing pages on the marketing SSG
   build (then `/viewer/stl`, `/viewer/obj`, …). Unblocks the acquisition-campaign
   landing targets.
-- `grow-110`: OG/Twitter metadata on share URLs so links unfurl with a model
+- `grow-200`: OG/Twitter metadata on share URLs so links unfurl with a model
   thumbnail; recipient "Open your own model" affordance. Per-model OG image
   generation may pair with T2 Phase 5 in Phase C if edge injection is the chosen
   route.
@@ -1129,10 +1207,10 @@ recents are correctly attributed per-connection; commit author = Sources GH iden
 - T4 PR5 (GH token-health parity) — small.
 - T2 Phase 4 (Notes + view-states v0.1 in artifact).
 - T2 Phase 5 (Originator share flow: drop IFC → GLB → upload artifact → link). Wires
-  the Share dialog from `share-200` (<a href="https://github.com/bldrs-ai/Share/issues/1421" target="_blank" rel="noopener noreferrer">#1421</a>) on top.
-- `share-300` private link sharing surfaces in the dialog.
-- `share-310` people-grants surface in the dialog.
-- `grow-110` completion: per-model OG image written alongside the T2 Phase 5 share
+  the Share dialog from `share-120` (<a href="https://github.com/bldrs-ai/Share/issues/1421" target="_blank" rel="noopener noreferrer">#1421</a>) on top.
+- `share-130` private link sharing surfaces in the dialog.
+- `share-200` people-grants surface in the dialog.
+- `grow-200` completion: per-model OG image written alongside the T2 Phase 5 share
   artifact (if that's the chosen mechanism), so every share link unfurls with a
   real thumbnail. The share loop is our best earned channel — this phase is where
   it gets its polish.
@@ -1154,14 +1232,14 @@ models stay free and unlimited.
   definitions + the experiment's hypotheses/threshold before code. Threshold
   picked from the `grow-120` size-distribution telemetry (Phase G), not
   guessed.
-- `subscribe-300` pricing tiers + feature-gate map.
-- `subscribe-310` Stripe checkout + portal Netlify Functions. Pattern from
+- `subscribe-100` pricing tiers + feature-gate map.
+- `subscribe-110` Stripe checkout + portal Netlify Functions. Pattern from
   `unlink-identity.js`.
-- `subscribe-320` quota tracking — instrument the three enforcement points (GLB
+- `subscribe-120` quota tracking — instrument the three enforcement points (GLB
   upload, refresh-token mint, public-share retention).
 - T7 Phase 2 + 3 ad slots on `/about`, `/privacy`, `/tos`, `/blog/*`.
 - `subscribe-130` ads wired to free-tier-only gate.
-- `share-200` Extended Share dialog (<a href="https://github.com/bldrs-ai/Share/issues/1421" target="_blank" rel="noopener noreferrer">#1421</a>) wires Pro upsell into the share flow.
+- `share-120` Extended Share dialog (<a href="https://github.com/bldrs-ai/Share/issues/1421" target="_blank" rel="noopener noreferrer">#1421</a>) wires Pro upsell into the share flow.
 
 **Exit:** a free user hits the size/complexity threshold and can upgrade in two
 clicks; ads serve on text routes only; the experiment dashboard answers the
@@ -1222,12 +1300,12 @@ around a conversational core rather than building beside them.
 
 ### 7.2 Architecture: three surfaces
 
-1. **Left drawer — workspace nav (`assist-100`).** A modification of the existing
+1. **Left drawer — workspace nav (`assist-300`).** A modification of the existing
    UI: a left drawer tracking **projects** (models, conversations, shared
    artifacts) and **company-level nav** (org, members, settings). The container
    that turns Share from a single-document viewer into a workspace. Pure
    UI/routing work; ships behind a flag with no AI-runtime dependency.
-2. **Conversational panel (`assist-110`, `assist-300`).** A Claude-Code-like
+2. **Conversational panel (`assist-310`, `assist-400`).** A Claude-Code-like
    conversation over the open project/model. The multi-user mechanic:
    - **Direct replies addressed to the AI are commands** — treated exactly as
      Claude Code treats a prompt today: agent loop, tool calls against the
@@ -1236,7 +1314,7 @@ around a conversational core rather than building beside them.
      context and can participate **comment-only**. A channel message never
      triggers the tool-using agent loop; only direct address does.
    The split keeps the agent useful in a group without it hijacking every thread.
-3. **Right drawer — AI-apps toolbelt (`assist-200`).** The existing right-drawer
+3. **Right drawer — AI-apps toolbelt (`assist-320`).** The existing right-drawer
    AppsDrawer, upgraded: code the agent generates is **saved, versioned, and
    run** in a sandboxed iframe that interacts with the main window/app context
    over an **MCP bridge** (postMessage transport). Users accumulate personal and
@@ -1245,7 +1323,7 @@ around a conversational core rather than building beside them.
 The unifying piece: the main window exposes the viewer as an **MCP server**
 (selection, camera, isolation, properties, notes, model queries — Track T11).
 The conversational agent and the sandboxed apps consume the *same* tool surface —
-one contract, two consumers — and `apps-200`'s public API becomes a third
+one contract, two consumers — and `apps-300`'s public API becomes a third
 consumer of it later, for free.
 
 Two v0.4 constraints on that architecture:
@@ -1271,10 +1349,10 @@ Two v0.4 constraints on that architecture:
 
 ### 7.3 What it absorbs
 
-- `search-210` Knowledge graph → the retrieval layer behind conversational QA.
-- `apps-200` v1.0 Public API → designed MCP-first; external IDE/embed consumers
+- `search-310` Knowledge graph → the retrieval layer behind conversational QA.
+- `apps-300` v1.0 Public API → designed MCP-first; external IDE/embed consumers
   and the internal toolbelt share one contract.
-- `apps-210` Bldrs Integrate → agent-run model checks as toolbelt apps.
+- `apps-310` Bldrs Integrate → agent-run model checks as toolbelt apps.
 - `notes-*` / channels → need one coherent story: an anchored note thread and a
   channel message are close cousins (open question, §10).
 
@@ -1290,18 +1368,18 @@ can't destabilise the launch may start earlier behind flags.
   broker), provider strategy, conversation-store choice, sandbox/MCP security
   model, Notes/channels relationship. Fix <a href="https://github.com/bldrs-ai/Share/issues/1386" target="_blank" rel="noopener noreferrer">#1386</a> and re-enable the iframe
   suite — the sandbox foundation must hold weight before anything is built on it.
-- **AI.1 — Workspace shell.** `assist-100` left drawer behind
+- **AI.1 — Workspace shell.** `assist-300` left drawer behind
   `?feature=workspace`. No AI dependency; can overlap Pro-MVP phases.
-- **AI.2 — Agent v0, single-user.** `assist-110`: viewer MCP tool surface (T11) +
+- **AI.2 — Agent v0, single-user.** `assist-310`: viewer MCP tool surface (T11) +
   agent loop (T10) + conversation panel. One user, one conversation per
   project/model. **This is the demo that sells the pivot — and it must be run
   on a large model** (one that defeats the alternatives), because
   "conversational AI over a small IFC" is replicable by anyone, while the same
   loop on a model nobody else can open is the moat made visible. Refresh
   `grow-400` with this demo when it exists.
-- **AI.3 — Toolbelt.** `assist-200`: generate → save → version → run in the
+- **AI.3 — Toolbelt.** `assist-320`: generate → save → version → run in the
   sandbox over the same MCP surface.
-- **AI.4 — Multi-user.** `assist-300`: shared channels, direct-address vs
+- **AI.4 — Multi-user.** `assist-400`: shared channels, direct-address vs
   comment-only mechanics, presence. Depends on the shared conversation store —
   the largest new backend piece.
 - **AI.5 — Editing loop (north star).** Agent-driven model *modification*
@@ -1329,9 +1407,9 @@ Held over for after Phase E. Items marked **→ §7** are absorbed by the AI piv
 and leave this queue — they ride the pivot sequencing instead. Order roughly
 reflects current product-pull:
 
-1. **`view-220` ETL / Table view** 🔮 (❤️ Markus). The "10$/mo by itself" loveable.
+1. **`view-300` ETL / Table view** 🔮 (❤️ Markus). The "10$/mo by itself" loveable.
    Pre-cond mostly done via T1.
-2. **`open-200` Multi-IFC overlay session** (<a href="https://github.com/bldrs-ai/Share/issues/1251" target="_blank" rel="noopener noreferrer">#1251</a>). Conway+GLB make this tractable.
+2. **`open-210` Multi-IFC overlay session** (<a href="https://github.com/bldrs-ai/Share/issues/1251" target="_blank" rel="noopener noreferrer">#1251</a>). Conway+GLB make this tractable.
 3. **`view-200` Persistent visibility URL encoding** (<a href="https://github.com/bldrs-ai/Share/issues/1250" target="_blank" rel="noopener noreferrer">#1250</a>). Last slice on top of
    T1 isolate routing.
 4. **`view-210` Selection-based camera + measurement** (<a href="https://github.com/bldrs-ai/Share/issues/1044" target="_blank" rel="noopener noreferrer">#1044</a>, <a href="https://github.com/bldrs-ai/Share/issues/1047" target="_blank" rel="noopener noreferrer">#1047</a>).
@@ -1339,19 +1417,19 @@ reflects current product-pull:
 6. **T4 PR4 Folder-scoped routes**.
 7. **`notes-200` BCF round-trip**.
 8. **T6 Stretch Q1–Q4 portable notes/versions** for Drive parity with GH.
-9. **`view-230` Common view ops**: nav-cube, explode, undo/redo. IDS validation
+9. **`view-220` Common view ops**: nav-cube, explode, undo/redo. IDS validation
    separately.
-10. **`view-240` Maps-style filtering UI on top of Placemarks** 🔮 — Placemark
+10. **`view-230` Maps-style filtering UI on top of Placemarks** 🔮 — Placemark
     primitive itself is 🟡 with polish slated for Phase C (see Epic). The filter
     chips + cluster rendering visualization on top is the post-MVP loveable.
     Pairs with T6 Q1.
-11. **`search-200` Cross-repo search** 🔮 (❤️ Oleg). An agent with repo-source
+11. **`search-300` Cross-repo search** 🔮 (❤️ Oleg). An agent with repo-source
     tools may deliver this as a §7 by-product — reassess once AI.2 exists.
-12. **`apps-210` Bldrs Integrate (CI server-side IDS)** → §7 (toolbelt apps).
-13. **`apps-200` v1.0 Public API + IDE** 🔮 → §7 (MCP-first, T11).
-14. **`search-210` Knowledge Graph** 🔮 (❤️ Johannes) → §7 (retrieval behind
-    `assist-110`).
-15. **`versions-200` Diff between versions**.
+12. **`apps-310` Bldrs Integrate (CI server-side IDS)** → §7 (toolbelt apps).
+13. **`apps-300` v1.0 Public API + IDE** 🔮 → §7 (MCP-first, T11).
+14. **`search-310` Knowledge Graph** 🔮 (❤️ Johannes) → §7 (retrieval behind
+    `assist-310`).
+15. **`versions-300` Diff between versions**.
 16. **PDF "Smart Components & Templates"** 🔮 (❤️ Pablo). Massive scope; will warrant
     its own Epic group when started.
 17. **PDF "Hangouts" (Miro, FPV, WebXR Bonanza)** — out of scope until use-case
@@ -1392,7 +1470,7 @@ without sign-off.
 
 ## 10. Open questions
 
-- **Pro tier feature gate definition.** §4.9 sketches `subscribe-300`; the v0.4
+- **Pro tier feature gate definition.** §4.9 sketches `subscribe-100`; the v0.4
   anchor is decided — the Pro boundary is **model size/complexity** — with
   private link sharing, ad-free, multi-account, cache retention, and quota
   uplift around it. Confirm the full list before the T8 design doc.
@@ -1402,7 +1480,7 @@ without sign-off.
   engine-benchmark data, not by feel. (ai-strategy §9.3.)
 - **Free-tier quota numbers.** Public anonymous share TTL (3 days? 5 days?), public
   hosting size ceiling (PDF <a href="https://github.com/bldrs-ai/Share/issues/1421" target="_blank" rel="noopener noreferrer">#1421</a> says <10MB), refresh-token-mint rate. Needs a call
-  before `subscribe-320`.
+  before `subscribe-120`.
 - **Auth0 enforcement on Netlify Functions.** Flagged in
   `identity-decoupling-decisions.md` §Open Implementation Details. Needs to be
   resolved before Phase D quota tracking ships (the quota key is meaningless if the
@@ -1423,7 +1501,7 @@ without sign-off.
   property edits only at first? geometry?), where the edit log lives, and how
   round-tripping back to IFC/STEP works. Needs a Conway-side design doc; the
   answer decides how soon the headline capability is honest.
-- **AI pivot — conversation store.** `assist-300` needs shared, realtime-ish
+- **AI pivot — conversation store.** `assist-400` needs shared, realtime-ish
   conversation state. Candidates: GitHub-issue-backed (Notes-style, free, slow),
   Firebase/Firestore (already floated for T2 Phase 6), or a purpose-built
   backend. Also: are channels and Notes one primitive or two? (An anchored note
@@ -1435,7 +1513,7 @@ without sign-off.
   user-facing name for the workspace/agent is unpicked.
 - **Growth — OG image mechanism.** Edge-function injection on `/share/*` vs
   pre-rendering the OG image at share time next to the T2 artifact. Decides
-  whether `grow-110` finishes in Phase G or pairs with Phase C.
+  whether `grow-200` finishes in Phase G or pairs with Phase C.
 - **Maintenance of this doc.** Cadence: bump on every Epic state change? Or quarterly
   rollup? My recommendation: amend per-PR when an Epic moves status; quarterly review
   to catch drift.
@@ -1450,14 +1528,15 @@ without sign-off.
 - **When a track lands a slice:** update the Status line of the track in §3.2 and §5.
   If the track is "done" it becomes a one-line entry pointing at its design doc.
 - **When a new Epic emerges:** add it to §4 under the appropriate verb group, in
-  the **tier band the capability belongs to** (§2.1: 100s MVP, 200s MLP, 300s Pro,
-  400s Enterprise), at the next free ten within that band (e.g. the next MVP-tier
-  Open epic is `open-140`). Add the matching row to §3.1, keeping rows tier-sorted
-  within the group. Don't renumber existing IDs — the v0.5 renorm was a one-time
-  exception, and its old→new map lives in §2.1.
-- **When an Epic changes tier** (promoted to Pro, or an MLP item turns out to be
-  MVP): that *is* a renumber — do it deliberately, one epic at a time, and append
-  the old→new pair to the §2.1 map.
+  the **milestone band it's needed for** (§2.1: 100s MVP, 200s MLP, 300s Pro,
+  400s Enterprise), at the next free ten within that band (e.g. the next
+  MVP-band Open epic is `open-130`). Add the matching row to §3.1, keeping rows
+  tier-sorted within the group. Don't renumber existing IDs outside a deliberate
+  tier change — the v0.5/v0.6 renorms are recorded in the §2.1 lineage table.
+- **When an Epic changes tier** (promoted into the MVP band, or demoted out):
+  that *is* a renumber — do it deliberately, one epic at a time, and add the row
+  (or a new column entry) to the §2.1 lineage table. If it enters or leaves the
+  100 band, update the §6.0 MVP checklist in the same commit.
 - **Don't delete done Epics.** They stay in §4 as the historical record of what
   shipped, which is what §8 "Post-MVP backlog" is measured against.
 - **Privacy firewall.** This doc is public. Growth/traffic *numbers* (spend, CAC,

--- a/design/roadmap.md
+++ b/design/roadmap.md
@@ -1,7 +1,7 @@
 # Bldrs Share Roadmap
 
-**Status:** Draft v0.3 — growth-strategy reconciliation + AI-workspace pivot
-**Date:** 2026-07-02
+**Status:** Draft v0.4 — AI-strategy synthesis folded in (quota axis, moat framing)
+**Date:** 2026-07-03
 **Owner:** Pablo
 **Source baseline:** `Share Requirements` Google Doc (Aug 2021, last updated Nov 2022). PDF
 extract preserved in this commit's history; key Epic list inlined in §4.
@@ -31,6 +31,32 @@ top-down review, surfaces the work that landed without story tracking, and lays 
    multi-user, with user-generated AI-app toolbelts. New Epic group §4.11
    (Assist), Tracks T10–T11, plan in §7. Several long-held loveables
    (`search-120`, `apps-130`, `apps-120`) are absorbed into it.
+
+**v0.4 (2026-07-03)** reconciles against the AI-strategy synthesis
+(`bldrs-ai/bizdev` `docs/ai-strategy.md` — **private**: MAU/revenue/fundraise
+figures and competitor analysis stay there). The public-safe conclusions that
+re-cut this roadmap:
+
+- **Commodity/moat split.** Viewing *small* models is a commodity — free
+  alternatives everywhere, near-zero willingness to pay. Handling *large,
+  real-world* models client-side, fast, with a full structured IFC/STEP API is
+  where Share is in a different class — and it's the substrate an interactive
+  AI loop on real models requires. The engine is the foundation; **"AI iterates
+  on models nobody else can even open"** is the headline (not "fastest
+  viewer").
+- **Quota by size/complexity, not model count.** Free tier keeps small models
+  unlimited (the funnel is demand-gen); the paywall sits at the threshold where
+  Share is the only thing that works. Phase D runs as an **instrumented
+  experiment** with stated hypotheses, not a revenue switch. Reflected in
+  `subscribe-100`/`subscribe-120` and Phase D.
+- **Data sovereignty is a first-class feature.** "Runs in-browser, your model
+  never leaves your machine" is an enterprise wedge, not a privacy nicety — and
+  it constrains §7 architecture (the agent loop must not silently break the
+  no-upload story). New epic `grow-130` for the positioning surface; §7.2 for
+  the constraint.
+- **De-prioritised:** chasing more cheap small-model traffic; "fastest engine"
+  as headline positioning. Phase G stays (it's demand-gen + loop + measurement,
+  all cheap) but doesn't grow beyond that.
 
 It is the single source of truth for Epic/Story/Track structure. The wiki page
 `Planning:-Requirements` and the `epic`-labeled GitHub issues mirror this doc; when they
@@ -140,6 +166,7 @@ cross-references that connect them. The detailed bodies live in §4 (Epics) and 
 | Grow | `grow-100` | SEO format landing pages `/viewer/*` (NEW) | ⬜ | G | T9 |
 | Grow | `grow-110` | Rich share-link previews / OG cards (NEW) | ⬜ | G | T9 |
 | Grow | `grow-120` | Funnel instrumentation + GA hygiene (NEW) | ⬜ | G | T9 |
+| Grow | `grow-130` | Large-model + data-sovereignty positioning (NEW) | ⬜ | G | T9 |
 | Assist | `assist-100` | Workspace shell: left drawer projects + org nav (NEW) | ⬜ | AI | — |
 | Assist | `assist-110` | Conversational agent panel, single-user (NEW) | ⬜ | AI | T10, T11 |
 | Assist | `assist-120` | Multi-user channels + AI participation modes (NEW) | ⬜ | AI | T10 |
@@ -593,9 +620,22 @@ available.
 here from the existing `Mock Share Dialog B` in <a href="https://github.com/bldrs-ai/Share/issues/1421" target="_blank" rel="noopener noreferrer">#1421</a> ("Pro Subscription ($25/mo)") and
 the quota-tracking notes in `identity-decoupling-decisions.md`.*
 
+*v0.4 framing (from the ai-strategy synthesis): the paid boundary must align with
+the moat, not against it. **Quota by model size/complexity, never by model
+count** — a per-model quota taxes exactly the commodity users we'd rather keep as
+free funnel, while a size/complexity threshold charges the user for whom Share is
+the only thing that works. And Phase D ships as an **experiment with stated
+hypotheses** (what share of users hit the threshold; of those, who pays vs.
+churns) instrumented well enough to produce decision-grade conversion evidence —
+not just a revenue trickle.*
+
 **Epic `subscribe-100`: Pricing tiers + feature manager** ⬜ (NEW)
 - Tasks: enumerate features per tier; ship a `tier`-aware capability map; UI in <a href="https://github.com/bldrs-ai/Share/issues/1421" target="_blank" rel="noopener noreferrer">#1421</a>
   mock dialog form.
+- Tier axis (v0.4): small models stay free and unlimited; the Pro boundary is
+  **model size/complexity** (plus private sharing, multi-account, ad-free).
+  Threshold placement is a §10 open question — it wants the model-size
+  distribution from telemetry before it's picked.
 - **Required for Pro-MVP.**
 
 **Epic `subscribe-110`: Stripe checkout + portal** ⬜ (NEW)
@@ -609,7 +649,13 @@ the quota-tracking notes in `identity-decoupling-decisions.md`.*
 - Tasks: server-side counter keyed by Auth0 `sub` (per identity-decoupling-decisions
   §Q4 Open Question on "Quota tracking"); enforcement points in (a) GLB writer
   Phase-5 share upload, (b) per-connection refresh-token mint, (c) public-share
-  retention sweep.
+  retention sweep — **plus (d) the size/complexity gate at model load/parse**,
+  which is the moat-aligned boundary (v0.4). Note (d) is client-observable
+  (parse happens in-browser), so enforcement is a product/UX gate + account
+  state, not a hard server wall — fine for an experiment, revisit if abused.
+- Experiment instrumentation is part of the epic, not an afterthought: events
+  for threshold-hit, upgrade-prompt-shown, converted/churned, so the quota run
+  yields decision-grade evidence either way.
 - **Required for Pro-MVP.**
 
 **Epic `subscribe-130`: Ads on free tier** 🟡
@@ -631,6 +677,14 @@ the v0.3 note above: organic ≈ zero, the share loop is the best earned channel
 have, and the acquisition campaigns need real landing targets and funnel events.
 Quantitative targets live in the **private** bizdev doc; only event names and
 mechanisms are recorded here.
+
+*v0.4 scope check: this group is **free-tier demand-gen + measurement**, and it
+stays cheap. The broad "open X file online" audience is the commodity segment —
+it feeds the funnel and the share loop but it is not where willingness-to-pay
+lives, so Phase G doesn't grow beyond the epics below. The audience that pays
+(large-model, enterprise-profile) gets its own positioning surface (`grow-130`);
+which channel *reaches* that audience is the open GTM question owned bizdev-side
+(ai-strategy §6).*
 
 **Epic `grow-100`: SEO format landing pages** ⬜ (NEW)
 - Programmatic per-format pages — `/viewer/ifc`, `/viewer/step`, `/viewer/stl`,
@@ -667,8 +721,31 @@ mechanisms are recorded here.
   e2e runs ship the prod measurement ID.)
 - Channel-grouping + dashboard slices are bizdev-side config; the Share-side
   deliverable is the events existing and firing.
+- v0.4 addition: capture **model size/complexity** (bucketed — bytes, element
+  count) on the model-open event, so (a) the `subscribe-100` quota threshold is
+  picked from real distribution data, not guessed, and (b) large-model users —
+  the segment that matters — become visible in the funnel instead of drowned in
+  commodity traffic.
 - **Phase G — first slice.** Blocks conversion-based bidding, loop metrics, and
   any honest read of a launch/Show-HN spike.
+
+**Epic `grow-130`: Large-model + data-sovereignty positioning** ⬜ (NEW, v0.4)
+- The positioning surface for the audience that pays: a page (marketing SSG
+  build) that leads with **"AI iterates on models nobody else can even open"**
+  and the two proof points behind it — large-model handling that defeats
+  proprietary and open-source alternatives, and **no-upload data sovereignty**
+  ("runs in-browser; your model never leaves your machine" — written to be
+  quoted in a security review, e.g. what does/doesn't leave the browser, where
+  tokens live, what the share flow uploads and only when asked).
+- A large-model live demo deep link is the centerpiece — show, don't claim.
+  Benchmark specifics stay qualitative here and quantitative in the private
+  strategy doc; the public page can carry whatever benchmark we're happy to
+  defend publicly.
+- Distinct from `grow-100`: format pages target commodity search intent
+  (demand-gen); this page is where enterprise-profile visitors land from
+  outbound/community/DevRel motion and from "what makes Bldrs different" links.
+- **Phase G** (it's one page on the existing SSG build), refreshed at §7 AI.2
+  when the AI-on-large-model demo exists.
 
 
 ### 4.11 Assist (NEW Epic group — the AI workspace)
@@ -842,6 +919,10 @@ same list-item order: What, Status, Unblocks, Pro-MVP impact, Doc.
 - **Unblocks:** `subscribe-100`, `subscribe-110`, `subscribe-120`. Forward-looking:
   the same quota/metering rails are what §7 AI usage metering hangs off — design
   the counter keying with that consumer in mind.
+- **Quota axis (v0.4):** model size/complexity, never model count — the paywall
+  aligns with the moat (small models free + unlimited; the threshold sits where
+  Share is the only thing that works). Phase D runs as an instrumented
+  experiment; see §4.9.
 - **Pro-MVP impact:** Required end-to-end.
 - **Doc:** TBD — to be drafted in `design/new/pro-billing.md`.
 
@@ -849,19 +930,21 @@ same list-item order: What, Status, Unblocks, Pro-MVP impact, Doc.
 ### Track T9: Growth funnel & SEO surfaces (NEW)
 
 - **What:** The Share-side infrastructure the growth strategy needs: funnel events
-  (`share_link_created` / `share_link_opened` / `model_interacted`), analytics
-  hygiene (webdriver + hostname guard on GA init), OG/link-preview metadata on
-  share URLs, and the `/viewer/<format>` landing pages on the marketing SSG build.
+  (`share_link_created` / `share_link_opened` / `model_interacted`, plus v0.4
+  size/complexity buckets on model-open), analytics hygiene (webdriver + hostname
+  guard on GA init), OG/link-preview metadata on share URLs, the
+  `/viewer/<format>` landing pages, and the `grow-130` large-model +
+  data-sovereignty positioning page — all on the marketing SSG build.
 - **Status:** Not started in-repo. The enabling substrate (Next.js SSG marketing
   build, PR #1519) is landed; strategy + attribution live in the private bizdev
-  doc.
-- **Unblocks:** `grow-100`, `grow-110`, `grow-120`; honest measurement of every
-  outreach move in `community-130`; conversion-based bidding for the (out-of-repo)
-  acquisition campaigns.
+  docs.
+- **Unblocks:** `grow-100`, `grow-110`, `grow-120`, `grow-130`; honest measurement
+  of every outreach move in `community-130`; conversion-based bidding for the
+  (out-of-repo) acquisition campaigns; the Phase D quota-threshold pick.
 - **Pro-MVP impact:** Phase G — parallel, starts now. Cheap relative to everything
   else in §6 and the only work that grows the top of the funnel.
-- **Docs:** `bldrs-ai/bizdev` `docs/growth-strategy.md` (**private** — numbers stay
-  there) + `design/new/ads.md` (on-site ads only).
+- **Docs:** `bldrs-ai/bizdev` `docs/growth-strategy.md` + `docs/ai-strategy.md`
+  (**private** — numbers stay there) + `design/new/ads.md` (on-site ads only).
 
 
 ### Track T10: Agent runtime & conversation store (NEW)
@@ -884,7 +967,9 @@ same list-item order: What, Status, Unblocks, Pro-MVP impact, Doc.
 - **What:** The viewer's operations exposed as one **MCP tool surface** (selection,
   camera, isolate/hide, properties, notes, model queries), consumed by two
   clients: the T10 agent in-process, and sandboxed iframe apps over a postMessage
-  MCP transport. Plus app storage/versioning for the toolbelt.
+  MCP transport. Plus app storage/versioning for the toolbelt. Forward scope
+  (v0.4): **write/edit tools** — the AI editing loop (§7.4 AI.5) rides this same
+  contract but is gated on a Conway-side write path that doesn't exist yet.
 - **Status:** Not started. Seeds: `WidgetApi/` + AppsDrawer (`apps-100`), the
   `IfcModelService` query surface (T1). Known debt: <a href="https://github.com/bldrs-ai/Share/issues/1386" target="_blank" rel="noopener noreferrer">#1386</a> iframe integration
   broken with its suite disabled — repair is the first slice.
@@ -926,9 +1011,13 @@ landing page — before the Pro launch needs any of it.
   thumbnail; recipient "Open your own model" affordance. Per-model OG image
   generation may pair with T2 Phase 5 in Phase C if edge injection is the chosen
   route.
+- `grow-120` v0.4 slice: size/complexity buckets on the model-open event — the
+  data the Phase D quota threshold gets picked from.
+- `grow-130`: the large-model + data-sovereignty positioning page.
 
-**Exit:** funnel dashboard shows clean stage-by-stage counts; a shared link
-unfurls with a thumbnail in Slack; both format pages indexed.
+**Exit:** funnel dashboard shows clean stage-by-stage counts (with large-model
+users visible as a segment); a shared link unfurls with a thumbnail in Slack;
+format pages + positioning page indexed.
 
 
 ### Phase A: Stabilise the rebuilt viewer (foundation)
@@ -994,9 +1083,16 @@ it was pasted.
 
 
 ### Phase D: Subscribe
-**Goal:** the Pro tier exists and bills.
+**Goal:** the Pro tier exists and bills — run as an **instrumented experiment**
+(v0.4): hypotheses stated up front (share of users hitting the size threshold;
+of those, pay vs. churn), events in place to answer them, and the outcome
+treated as evidence about where willingness-to-pay lives even if revenue is
+small. The quota axis is **model size/complexity**, never model count — small
+models stay free and unlimited.
 - T8 design doc (`design/new/pro-billing.md`) drafted first — locks in tier
-  definitions before code.
+  definitions + the experiment's hypotheses/threshold before code. Threshold
+  picked from the `grow-120` size-distribution telemetry (Phase G), not
+  guessed.
 - `subscribe-100` pricing tiers + feature-gate map.
 - `subscribe-110` Stripe checkout + portal Netlify Functions. Pattern from
   `unlink-identity.js`.
@@ -1006,8 +1102,9 @@ it was pasted.
 - `subscribe-130` ads wired to free-tier-only gate.
 - `share-150` Extended Share dialog (<a href="https://github.com/bldrs-ai/Share/issues/1421" target="_blank" rel="noopener noreferrer">#1421</a>) wires Pro upsell into the share flow.
 
-**Exit:** a free user hits a quota wall and can upgrade in two clicks; ads serve on
-text routes only.
+**Exit:** a free user hits the size/complexity threshold and can upgrade in two
+clicks; ads serve on text routes only; the experiment dashboard answers the
+stated hypotheses.
 
 
 ### Phase E: Public-launch checklist
@@ -1044,6 +1141,18 @@ agent that can see and operate the viewer (load, navigate, select, isolate,
 annotate, query properties and structure), collaborates with teammates inside the
 same conversation, and accumulates reusable AI-built tools.
 
+**The strategic frame (v0.4, from the ai-strategy synthesis):** the engine is the
+moat *because* it is the substrate an AI loop on real models requires — holding a
+large, real-world model client-side, fast, with a full structured IFC/STEP API.
+Tools that take minutes just to load such a model can't put it into an
+interactive AI loop at all. So the headline is **"AI iterates on models nobody
+else can even open"** — not "fastest browser engine" (that framing sells a
+viewer). What compounds on top: the semantic IFC/STEP API as the agent-binding
+layer (MCP, T11), no-upload data sovereignty, and the toolbelt flywheel. The
+pivot's success metric is correspondingly concrete: **a handful of large-model,
+enterprise-profile users doing AI-on-a-model they can do nowhere else — and
+paying** — outweighs any amount of free small-model traffic.
+
 Everything shipped to date is the substrate, not a detour: Conway-direct gives
 structured model access (the `IfcModelService` query surface), Notes give anchored
 discussion, the AppsDrawer + `WidgetApi` give an embedding surface, T3/T4 give
@@ -1078,6 +1187,27 @@ The conversational agent and the sandboxed apps consume the *same* tool surface 
 one contract, two consumers — and `apps-130`'s public API becomes a third
 consumer of it later, for free.
 
+Two v0.4 constraints on that architecture:
+
+- **Data sovereignty is load-bearing.** "Your model never leaves your machine"
+  is an enterprise wedge (`grow-130`), and the agent must not silently break
+  it. Model bytes stay client-side; what crosses the wire to the LLM provider
+  is the conversation plus tool *results* (which can contain model-derived
+  data — names, properties, geometry summaries). That boundary needs to be
+  explicit, documented, and ideally user-visible ("what the AI can see").
+  Design treatment in `ai-workspace.md`; it also weighs on the runtime-placement
+  question (§10) — a broker that proxies model content wholesale would forfeit
+  the story.
+- **Read first, edit as the north star.** The tool surface above is
+  read/annotate (query, navigate, notes). The headline capability is the AI
+  **editing** loop — the agent modifying the model, not just inspecting it.
+  That is gated on an engine write path (Conway-side: mutate + re-emit
+  geometry/semantics), which doesn't exist yet and is the biggest open
+  technical question in the pivot (§10). Sequence honestly: AI.2 ships the
+  read/annotate loop on large models (already beyond what anyone else can do);
+  editing lands as AI.5 when the engine supports it — don't let the headline
+  claim outrun the write path.
+
 ### 7.3 What it absorbs
 
 - `search-120` Knowledge graph → the retrieval layer behind conversational QA.
@@ -1103,15 +1233,33 @@ can't destabilise the launch may start earlier behind flags.
   `?feature=workspace`. No AI dependency; can overlap Pro-MVP phases.
 - **AI.2 — Agent v0, single-user.** `assist-110`: viewer MCP tool surface (T11) +
   agent loop (T10) + conversation panel. One user, one conversation per
-  project/model. **This is the demo that sells the pivot.**
+  project/model. **This is the demo that sells the pivot — and it must be run
+  on a large model** (one that defeats the alternatives), because
+  "conversational AI over a small IFC" is replicable by anyone, while the same
+  loop on a model nobody else can open is the moat made visible. Refresh
+  `grow-130` with this demo when it exists.
 - **AI.3 — Toolbelt.** `assist-130`: generate → save → version → run in the
   sandbox over the same MCP surface.
 - **AI.4 — Multi-user.** `assist-120`: shared channels, direct-address vs
   comment-only mechanics, presence. Depends on the shared conversation store —
-  the largest new backend piece, so it goes last.
+  the largest new backend piece.
+- **AI.5 — Editing loop (north star).** Agent-driven model *modification*
+  through the same MCP contract. Gated on the Conway write path (§7.2, §10);
+  scope and staging live in `ai-workspace.md` + a Conway-side design doc once
+  the write path is scoped.
 
 Each stage is a shippable, demoable increment; AI.2 is the earliest point at
 which the pivot is publicly visible.
+
+### 7.5 What proves it
+
+The benchmark proves the engine; it doesn't prove the business. The pivot's
+validation target: **large-model, enterprise-profile users running the AI loop
+on models they can't use anywhere else — paying**. Instrumentation to watch for
+them: the `grow-120` size buckets (are large models showing up at all?), the
+Phase D experiment (do size-threshold users convert?), and direct design-partner
+outreach (bizdev-owned). A few of these users are worth more than any aggregate
+traffic number, for both revenue and the company narrative.
 
 
 ## 8. Post-MVP backlog (loveable)
@@ -1183,10 +1331,14 @@ without sign-off.
 
 ## 10. Open questions
 
-- **Pro tier feature gate definition.** §4.9 sketches `subscribe-100` but the actual
-  list of "this is Pro" features needs your call. Working hypothesis: private link
-  sharing, ad-free, multi-account, larger model cache retention, quota uplift. Confirm
-  before T8 design doc.
+- **Pro tier feature gate definition.** §4.9 sketches `subscribe-100`; the v0.4
+  anchor is decided — the Pro boundary is **model size/complexity** — with
+  private link sharing, ad-free, multi-account, cache retention, and quota
+  uplift around it. Confirm the full list before the T8 design doc.
+- **Quota threshold placement.** *Where* the size/complexity threshold sits is
+  open — it should fall where free alternatives stop working and Share doesn't.
+  Pick from the `grow-120` size-distribution telemetry (Phase G) + the
+  engine-benchmark data, not by feel. (ai-strategy §9.3.)
 - **Free-tier quota numbers.** Public anonymous share TTL (3 days? 5 days?), public
   hosting size ceiling (PDF <a href="https://github.com/bldrs-ai/Share/issues/1421" target="_blank" rel="noopener noreferrer">#1421</a> says <10MB), refresh-token-mint rate. Needs a call
   before `subscribe-120`.
@@ -1199,8 +1351,17 @@ without sign-off.
 - **AI pivot — agent runtime placement.** Client-direct LLM calls (user's key /
   our key in the browser) vs a server-side broker (Netlify Functions or a real
   backend). The broker is where quota enforcement (T8) and key custody naturally
-  live, but it's new server surface for a to-date-static product. Decide in
+  live, but it's new server surface for a to-date-static product — and (v0.4)
+  the **data-sovereignty constraint** cuts against anything that proxies model
+  content wholesale: model bytes stay client-side, only conversation + tool
+  results cross the wire, and that boundary should be user-visible. Decide in
   `design/new/ai-workspace.md` before AI.2.
+- **AI pivot — engine write path.** The editing loop (§7.4 AI.5) needs Conway to
+  support model mutation + re-emission (geometry and semantics), which today it
+  doesn't. Biggest open technical question in the pivot: scope (parametric edits?
+  property edits only at first? geometry?), where the edit log lives, and how
+  round-tripping back to IFC/STEP works. Needs a Conway-side design doc; the
+  answer decides how soon the headline capability is honest.
 - **AI pivot — conversation store.** `assist-120` needs shared, realtime-ish
   conversation state. Candidates: GitHub-issue-backed (Notes-style, free, slow),
   Firebase/Firestore (already floated for T2 Phase 6), or a purpose-built

--- a/design/roadmap.md
+++ b/design/roadmap.md
@@ -1,7 +1,7 @@
 # Bldrs Share Roadmap
 
-**Status:** Draft v0.2 — initial reconciliation
-**Date:** 2026-05-28
+**Status:** Draft v0.3 — growth-strategy reconciliation + AI-workspace pivot
+**Date:** 2026-07-02
 **Owner:** Pablo
 **Source baseline:** `Share Requirements` Google Doc (Aug 2021, last updated Nov 2022). PDF
 extract preserved in this commit's history; key Epic list inlined in §4.
@@ -9,6 +9,28 @@ extract preserved in this commit's history; key Epic list inlined in §4.
 This doc normalizes the legacy Epic list against ~2 years of execution since the last
 top-down review, surfaces the work that landed without story tracking, and lays out the
 **Pro/billing-ready MVP** plan plus the loveable backlog beyond it.
+
+**v0.3 (2026-07-02) folds in three things:**
+
+1. **Implementation drift since v0.2** — the `conway-web-ifc-adapter` shim retired
+   (`design/new/adapter-removal.md`), the GPU-instancing/`BatchedMesh` render arc
+   behind `?feature=batchedMesh`, STEP metadata extraction (conway #345 arc), and
+   the marketing site's move to Next.js SSG. Reflected in §3–§5.
+2. **Growth-strategy reconciliation** — priorities re-cut against the funnel
+   attribution work in `bldrs-ai/bizdev` `docs/growth-strategy.md`. That doc is
+   **private** (spend, CAC, geo, raw traffic stay there — only qualitative
+   conclusions and instrumentation *shape* are mirrored here). Headline
+   conclusions: paid search is currently the only channel delivering real
+   authored-model opens; organic discovery is effectively zero; shared links are
+   the highest-quality earned traffic we have. Consequence: funnel
+   instrumentation, SEO landing surfaces, and share-loop polish move from
+   "post-MVP polish" into an active parallel phase — §4.10 (Grow), Track T9,
+   §6 Phase G.
+3. **The AI-workspace pivot** — the product direction after (and partly alongside)
+   the Pro-MVP: a Claude-Code-like conversational workspace over CAD/BIM models,
+   multi-user, with user-generated AI-app toolbelts. New Epic group §4.11
+   (Assist), Tracks T10–T11, plan in §7. Several long-held loveables
+   (`search-120`, `apps-130`, `apps-120`) are absorbed into it.
 
 It is the single source of truth for Epic/Story/Track structure. The wiki page
 `Planning:-Requirements` and the `epic`-labeled GitHub issues mirror this doc; when they
@@ -30,7 +52,7 @@ disagree, this doc wins and the others get updated.
 The original PDF interleaved capability lists and implementation notes. This doc keeps
 them split: §3 is the master overview (one row per Epic and Track), §4 is the Epic
 catalogue, §5 is the Track catalogue, §6 is the Pro-MVP sequencing across both, §7 is
-what's loveable but post-MVP.
+the AI-workspace pivot plan, §8 is what's loveable but post-MVP.
 
 
 ## 2. Status legend
@@ -51,8 +73,12 @@ intent. New work added since the PDF is marked `(NEW)`.
 
 - **A–E** = phase in the Pro-MVP plan (§6). A = stabilise viewer, B = identity +
   multi-account, C = sharing v1, D = subscribe + ads, E = launch checklist.
+- **G** = growth-funnel phase (§6 Phase G) — runs **parallel** to A–C and starts
+  now; small, high-leverage, mostly independent of the viewer/identity arcs.
+- **AI** = AI-workspace pivot arc (§7) — sequenced after the Pro-MVP launch, with
+  flagged foundations allowed to start earlier (see §7.4).
 - **—** = already shipped; no Pro-MVP work pending.
-- **Post** = held in §7 Post-MVP backlog.
+- **Post** = held in §8 Post-MVP backlog.
 
 
 ## 3. Status overview
@@ -94,15 +120,15 @@ cross-references that connect them. The detailed bodies live in §4 (Epics) and 
 | Versions | `versions-120` | Portable versions for Drive | 🔮 | Post | T6 |
 | Search | `search-100` | Search current model | 🟡 | — | — |
 | Search | `search-110` | Search across GitHub repos (❤️ Oleg) | 🔮 | Post | — |
-| Search | `search-120` | Knowledge graph (🥇, ❤️ Johannes) | 🔮 | Post | — |
+| Search | `search-120` | Knowledge graph (🥇, ❤️ Johannes) | 🔮 | AI | T10 |
 | Identity | `identity-100` | Auth0 primary login | ✔ | — | — |
 | Identity | `identity-110` | GitHub as Sources peer | 🟡 | B | T3 |
 | Identity | `identity-120` | Auth disambiguation (<a href="https://github.com/bldrs-ai/Share/issues/1422" target="_blank" rel="noopener noreferrer">#1422</a>) | 🟡 | B | — |
 | Identity | `identity-130` | Profile drawer + multi-account picker | ⬜ | B | T3 |
 | Apps | `apps-100` | Browse + select app (AppsDrawer) | ✔ | — | — |
 | Apps | `apps-110` | XYZ demo app (v0.1 API dogfood) | ✔ | — | — |
-| Apps | `apps-120` | Bldrs Integrate (CI + ArchiCAD/Speckle) | 🔮 | Post | — |
-| Apps | `apps-130` | v1.0 Public API + IDE (🥇) | 🔮 | Post | — |
+| Apps | `apps-120` | Bldrs Integrate (CI + ArchiCAD/Speckle) | 🔮 | AI | T11 |
+| Apps | `apps-130` | v1.0 Public API + IDE (🥇) | 🔮 | AI | T11 |
 | Community | `community-100` | Welcome dialog + onboarding | ✔ | — | — |
 | Community | `community-110` | Analytics + survey + thumbs feedback | 🟡 | E | — |
 | Community | `community-120` | Bug report w/ screenshot + session state | ⬜ | Post | — |
@@ -111,6 +137,13 @@ cross-references that connect them. The detailed bodies live in §4 (Epics) and 
 | Subscribe | `subscribe-110` | Stripe checkout + portal (NEW) | ⬜ | D | T8 |
 | Subscribe | `subscribe-120` | Quota tracking (NEW) | ⬜ | D | T8, T3 |
 | Subscribe | `subscribe-130` | Ads on free tier | 🟡 | D | T7 |
+| Grow | `grow-100` | SEO format landing pages `/viewer/*` (NEW) | ⬜ | G | T9 |
+| Grow | `grow-110` | Rich share-link previews / OG cards (NEW) | ⬜ | G | T9 |
+| Grow | `grow-120` | Funnel instrumentation + GA hygiene (NEW) | ⬜ | G | T9 |
+| Assist | `assist-100` | Workspace shell: left drawer projects + org nav (NEW) | ⬜ | AI | — |
+| Assist | `assist-110` | Conversational agent panel, single-user (NEW) | ⬜ | AI | T10, T11 |
+| Assist | `assist-120` | Multi-user channels + AI participation modes (NEW) | ⬜ | AI | T10 |
+| Assist | `assist-130` | AI-apps toolbelt: save/version/run + MCP (NEW) | ⬜ | AI | T11 |
 
 ### 3.2 Tracks
 
@@ -123,7 +156,10 @@ cross-references that connect them. The detailed bodies live in §4 (Epics) and 
 | T5 | Drive Recents HEAD-check | ⬜ | E (polish) | `open-150` |
 | T6 | Notes & Versions sidecar formats | ⬜ | Post | `notes-110`, `notes-120`, `versions-120` |
 | T7 | Ads | 🟡 | D | `subscribe-130` |
-| T8 | Pro/Billing (NEW) | ⬜ | D | `subscribe-100`, `subscribe-110`, `subscribe-120` |
+| T8 | Pro/Billing (NEW) | ⬜ | D | `subscribe-100`, `subscribe-110`, `subscribe-120`, §7 AI metering |
+| T9 | Growth funnel & SEO surfaces (NEW) | ⬜ | G | `grow-100`, `grow-110`, `grow-120` |
+| T10 | Agent runtime & conversation store (NEW) | ⬜ | AI (§7) | `assist-110`, `assist-120`, `search-120` |
+| T11 | App sandbox + MCP bridge (NEW) | ⬜ | AI (§7) | `assist-130`, `apps-130`, `apps-120` |
 
 
 ## 4. Normalized Epic catalogue
@@ -172,6 +208,9 @@ original list; landed via `googleDrive` flag now default-on).
 **Epic `open-150`: Recents reliability** 🟡 (NEW)
 *Not in PDF — surfaced by support friction.*
 - Track dependency: T5 Drive recents HEAD-check (proposed).
+- Open: <a href="https://github.com/bldrs-ai/Share/issues/1548" target="_blank" rel="noopener noreferrer">#1548</a> local recent fails hard after a cache clear — needs a typed
+  "file no longer available" alert (T5's pre-flight pattern applied to the
+  OPFS/local case, not just Drive).
 - Story to file: `open-150: Recents show typed unreachable alert + remove-recent`.
 
 
@@ -204,6 +243,19 @@ slice, and isolation controls expected of a BIM viewer.
   `step-metadata-nist.md`); Share-side design +
   remaining follow-ups (permalink encoding, per-occurrence isolate) in
   `design/new/step-occurrence-selection.md`. PRs #1573 + #1575, E2E over `as1-oc-214.stp`.
+- STEP metadata: NavTree names + Properties 🟡 (NEW). Conway now extracts AP214/AP242
+  product structure + properties and emits them through the `web-ifc` compat surface
+  in the exact shapes Share consumes (conway #345 arc), so a STEP file lights up the
+  NavTree + Properties panel with no Share code change. Share-side follow-through:
+  <a href="https://github.com/bldrs-ai/Share/issues/1569" target="_blank" rel="noopener noreferrer">#1569</a> (verify against the NIST corpus after the next Conway release bump;
+  generalize the selection/permalink key to the occurrence path) and
+  <a href="https://github.com/bldrs-ai/Share/issues/1570" target="_blank" rel="noopener noreferrer">#1570</a> (pin down the `{value}`-handle + reference-graph contract `ifclib`
+  imposes on the engine; defensive `reifyName`; possible re-home to conway).
+- Open bugs feeding Phase A stabilisation: <a href="https://github.com/bldrs-ai/Share/issues/1561" target="_blank" rel="noopener noreferrer">#1561</a> camera fit keys off "last scene
+  child" instead of a named primary-model reference; <a href="https://github.com/bldrs-ai/Share/issues/1545" target="_blank" rel="noopener noreferrer">#1545</a> `getSelectedElementsProps`
+  passes an expressID where a type code is expected (wrong/empty type in the
+  Properties panel); <a href="https://github.com/bldrs-ai/Share/issues/1249" target="_blank" rel="noopener noreferrer">#1249</a> (critical) selection/properties don't hydrate when a
+  private model is opened from an element permalink.
 
 **Epic `view-110`: Cut planes** ✔
 *PDF View.3 — Cut sub-item ✔.*
@@ -233,9 +285,23 @@ slice, and isolation controls expected of a BIM viewer.
 multi-worker; etc.*
 - Closed (effectively, via Tracks T1 + T2): OPFS cache, GLB cache, Conway-direct,
   per-instance picking, perf monitor (`?feature=perf`), DRACO compression unblocked.
+- Landed since v0.2:
+  - **Adapter removal ✔ (2026-06).** The `conway-web-ifc-adapter` shim is retired;
+    Share depends on `@bldrs-ai/conway` directly via the `@bldrs-ai/conway/web-ifc`
+    subpath export, and the release chain collapsed to Conway → Share (no more
+    three-hop republish / 22-minor-version lag). Real-`web-ifc` engine-swap
+    comparison retained. See `design/new/adapter-removal.md`.
+  - **GPU-instancing arc 🟡 (behind `?feature=batchedMesh`).** Grouper + measured
+    analysis (#1568: ~60% vertex-memory reduction on instancing-dense Revit models,
+    ~26% on STEP), `BatchedMesh` render path with recolor-based highlight, isolate,
+    and BVH picking (#1571), and a batched→merged GLB-cache bake so cached
+    artifacts stay byte-compatible with the merged reader (#1574). Always-on flip
+    deferred pending smoke-test. See `viewer-replacement.md` §3b.iv.
 - Open: on-demand rendering (dirty-flag, currently 60Hz unconditional — `viewer-
   replacement.md` §3c.iv "Open perf items"); hover-pick throttling tuning; per-product
-  Mesh emission spike.
+  Mesh emission spike; `batchedMesh` always-on flip + per-occurrence selection
+  narrowing on the batched path; `EXT_mesh_gpu_instancing` batched-native GLB cache
+  (§3b.v) so the round-trip stays instanced and the artifact shrinks.
 - Pre-public-launch gate: 4-angle screenshot harness + GLB bit-level diff (called out
   in `viewer-replacement.md` §3b.iii final paragraph). **Required for Pro-MVP.**
 
@@ -312,7 +378,7 @@ visualization on top (post-MVP loveable):
   **Phase C** alongside Notes work in the share flow — sharing a model with a
   pin-anchored discussion is a strong demo, and the URL-sync bug (<a href="https://github.com/bldrs-ai/Share/issues/930" target="_blank" rel="noopener noreferrer">#930</a>) blocks
   the share-a-note flow today.
-- Maps-style filtering UI itself is **Post-MVP loveable** (§7 item 10).
+- Maps-style filtering UI itself is **Post-MVP loveable** (§8 item 10).
 
 
 ### 4.3 Share (split out of legacy Collab)
@@ -423,7 +489,10 @@ data graph.
 *PDF Search.3 (🥇 MLP).*
 - Never started. Natural-language QA over building data with citations back to the
   model.
-- **Post-MVP loveable.** Johannes is the design partner.
+- **Absorbed by the AI pivot (§7).** Natural-language QA over the model is the
+  first-class job of the conversational panel (`assist-110`); the knowledge-graph
+  substrate becomes its retrieval layer (Track T10). Johannes stays the design
+  partner.
 
 
 ### 4.6 Identity & Account (NEW Epic group — implicit in PDF "Federated authentication")
@@ -460,7 +529,11 @@ Third-party (and dogfooded) apps add capabilities to Share via a stable API.
 
 **Epic `apps-100`: Browse + select app (AppsDrawer)** ✔
 - Closed: <a href="https://github.com/bldrs-ai/Share/issues/1282" target="_blank" rel="noopener noreferrer">#1282</a> Apps 100.
-- Open: nothing immediate. Surface exists; consumers are sparse.
+- Open: nothing immediate as a free-standing Epic — but the AppsDrawer + `WidgetApi/`
+  iframe surface is the **seed of the AI-apps toolbelt** (`assist-130`, §7.2).
+  <a href="https://github.com/bldrs-ai/Share/issues/1386" target="_blank" rel="noopener noreferrer">#1386</a> (iframe integration broken; its test suite disabled) graduates from
+  dormant bug to pivot blocker — the sandbox foundation must work before anything
+  is built on it (§7.4 AI.0).
 
 **Epic `apps-110`: XYZ demo app (dogfood v0.1 API)** ✔
 *PDF Apps.1 — done in PDF.*
@@ -469,12 +542,16 @@ Third-party (and dogfooded) apps add capabilities to Share via a stable API.
 *PDF Apps.2.*
 - Never started. Server-side IFC validation pipeline running IDS rules per commit
   (preview of view-170 IDS).
-- **Post-MVP.**
+- **Absorbed by the AI pivot (§7):** agent-driven model checks become the delivery
+  vehicle — an AI-app in the toolbelt (T11) rather than a bespoke CI product.
 
 **Epic `apps-130`: v1.0 Public API + docs + IDE integration** 🔮
 *PDF Apps.3 (🥇 MLP).*
 - Never started as a programmatic surface; the `WidgetApi/` directory is the seed.
-- **Post-MVP loveable.**
+- **Re-scoped by the AI pivot (§7):** the public API's first consumers are the
+  in-app agent and the AI-apps sandbox, so the surface is designed **MCP-first**
+  (Track T11) — external IDE/embedding consumers and the internal toolbelt share
+  one tool contract instead of us maintaining two APIs.
 
 
 ### 4.8 Community & Onboarding
@@ -499,7 +576,11 @@ User finds out about Bldrs, gets oriented, leaves feedback, and finds product he
 
 **Epic `community-130`: AEC outreach (Stack Overflow, Twitter)** 🔮
 *PDF Community.3 (🥇 MLP — ❤️ Kate?).*
-- Out of repo scope. Tracked here for completeness.
+- Out of repo scope. Now owned by the bizdev growth-strategy doc (§7 there:
+  community channels, Show HN, DevRel around git-based model versioning; channel
+  prioritisation follows the private attribution data). Tracked here for
+  completeness; the in-repo dependency is §6 Phase G instrumentation landing
+  first so a traffic spike is measurable.
 
 
 ### 4.9 Subscribe (NEW Epic group)
@@ -535,6 +616,113 @@ the quota-tracking notes in `identity-decoupling-decisions.md`.*
 - Track dependency: T7 Ads (<a href="https://github.com/bldrs-ai/Share/issues/1524" target="_blank" rel="noopener noreferrer">#1524</a>). Phase 1 activation in flight (<a href="https://github.com/bldrs-ai/Share/issues/1523" target="_blank" rel="noopener noreferrer">#1523</a>).
 - Open: Phases 2 (manual slots) + 3 (responsive) + 4 (consent gating).
 - **Required for Pro-MVP** — the free tier monetisation path.
+- Scope note: T7 is **on-site AdSense** (revenue). The Google Ads **acquisition**
+  campaigns (Smart→Search rebuild, keywords, geo, bidding) are out of repo scope —
+  owned in the private bizdev growth-strategy doc §4. The in-repo dependency runs
+  the other way: those campaigns need `grow-100` landing pages as destinations and
+  `grow-120` events to bid against.
+
+
+### 4.10 Grow (NEW Epic group)
+
+Users find Bldrs without us paying for every visit, and shared links convert
+recipients into new users. Driven by the growth-strategy conclusions summarised in
+the v0.3 note above: organic ≈ zero, the share loop is the best earned channel we
+have, and the acquisition campaigns need real landing targets and funnel events.
+Quantitative targets live in the **private** bizdev doc; only event names and
+mechanisms are recorded here.
+
+**Epic `grow-100`: SEO format landing pages** ⬜ (NEW)
+- Programmatic per-format pages — `/viewer/ifc`, `/viewer/step`, `/viewer/stl`,
+  `/viewer/obj`, … — each a real static page (title, copy, demo-model deep link,
+  FAQ) targeting "open/view X file online" queries.
+- Foundation already landed: the marketing site is Next.js SSG (PR #1519 —
+  `marketing/`, crawlable HTML, sitemap/robots/RSS). These pages are new routes in
+  that build, not SPA work. IFC + STEP first (STEP support is now real via T1 and
+  is the second acquisition campaign's landing target), then STL/OBJ/FBX.
+- Doubles as the destination for paid Search (bizdev §4) — until these exist the
+  campaigns land on the homepage, which is a viewer, not a pitch.
+- **Phase G.**
+
+**Epic `grow-110`: Rich share-link previews (OG cards)** ⬜ (NEW)
+- A shared `/share/*` link should unfurl in Slack/WhatsApp/LinkedIn/Teams with a
+  model thumbnail + title — both loop fuel (recipient trust/CTR) and SEO.
+- Supersedes the intent of <a href="https://github.com/bldrs-ai/Share/issues/1315" target="_blank" rel="noopener noreferrer">#1315</a>: the marketing routes got SSG in PR #1519, but
+  `/share/*` stays SPA, so per-model OG tags need edge/function injection (or
+  pre-render at share time — e.g. write the OG image alongside the T2 GLB share
+  artifact). Design call in Phase G.
+- Recipient landing experience rides along: a shared view should offer "Open your
+  own model" / "What is this?" affordances so recipients convert to sharers.
+- **Phase G** (metadata + affordances); OG image generation may slip to Phase C
+  where it pairs with the T2 Phase 5 share artifact.
+
+**Epic `grow-120`: Funnel instrumentation + analytics hygiene** ⬜ (NEW)
+- Instrument the funnel stages the growth doc defines (§3 there):
+  `share_link_created`, `share_link_opened`, `model_interacted` events in Share;
+  the derived `real_model_open` key event (built on `select_content` +
+  `stats_preprocessorVersion`) is GA4 config, not code.
+- Hygiene: skip GA init when `navigator.webdriver === true` or when
+  `location.hostname !== 'bldrs.ai'` — one guard cleans CI/e2e, localhost, and
+  preview-deploy pollution out of prod analytics. (Also: confirm whether scheduled
+  e2e runs ship the prod measurement ID.)
+- Channel-grouping + dashboard slices are bizdev-side config; the Share-side
+  deliverable is the events existing and firing.
+- **Phase G — first slice.** Blocks conversion-based bidding, loop metrics, and
+  any honest read of a launch/Show-HN spike.
+
+
+### 4.11 Assist (NEW Epic group — the AI workspace)
+
+User works *with an AI agent* on their models and projects: converses with it,
+collaborates with teammates in the same conversation, and accumulates AI-built
+tools. This group is the Epic-level decomposition of the §7 pivot; read §7 for the
+vision, architecture, and sequencing. Design doc to draft: `design/new/ai-workspace.md`.
+
+**Epic `assist-100`: Workspace shell — left drawer, projects + org nav** ⬜ (NEW)
+- A modification of the existing UI adding a **left drawer** for workspace-level
+  navigation: projects (models, conversations, shared artifacts, recents) and
+  company-level nav (org, members, settings). Makes Share feel like a workspace
+  rather than a single-document viewer — the Claude-Code chrome around the canvas.
+- Pure UI + routing + state work; no AI-runtime dependency. Ships behind
+  `?feature=workspace`.
+- Interacts with: `open-130` Sources tab (accounts live in the same nav), T4
+  sharing (shared-with-me listing), `identity-130` profile drawer.
+
+**Epic `assist-110`: Conversational agent panel (single-user)** ⬜ (NEW)
+- A Claude-Code-like conversation panel over the open project/model: prompt →
+  agent loop → tool calls against the viewer → streamed response. The viewer
+  exposes its operations (load, camera, select, isolate/hide, properties/psets,
+  notes, search) as an **MCP tool surface** (Track T11); the agent is its first
+  consumer.
+- Single user, one conversation per project/model. This is the demo that sells
+  the pivot (§7.4 AI.2).
+- Absorbs `search-120`'s NL-QA ambition; T10 owns the runtime + conversation
+  persistence.
+
+**Epic `assist-120`: Multi-user channels + AI participation modes** ⬜ (NEW)
+- The conversation becomes a shared channel. The key mechanic:
+  - **Direct replies addressed to the AI** are commands — handled exactly as the
+    single-user panel handles a prompt (full agent loop + tool calls).
+  - **General channel discussion** is human↔human; the AI is aware of it as
+    context and may participate **comment-only** — it can contribute
+    observations, but a channel message never triggers the tool-using loop.
+    Only direct address does.
+- Depends on a shared conversation store with realtime sync (T10) and T4
+  sharing/grants for channel membership. Largest new backend piece — last in the
+  pivot sequence (§7.4 AI.4).
+
+**Epic `assist-130`: AI-apps toolbelt (right drawer)** ⬜ (NEW)
+- The existing right-drawer AppsDrawer, upgraded: code the agent generates can be
+  **saved, versioned, and run** in a sandboxed iframe that talks to the main app
+  context over an **MCP bridge** (postMessage transport) — the same tool surface
+  the agent uses (T11). Users accumulate personal/team toolbelts of generated
+  apps.
+- This is the user-generated-app story `apps-100`/`apps-130` always pointed at,
+  with the agent as the author. `apps-120`-style model checks become toolbelt
+  apps.
+- Pre-condition: fix <a href="https://github.com/bldrs-ai/Share/issues/1386" target="_blank" rel="noopener noreferrer">#1386</a> (iframe widget integration broken, suite disabled).
+- Storage/versioning candidate: the user's own hosting via T3/T4 providers (apps
+  are files too), keeping the BYOS shape of the rest of the product.
 
 
 ## 5. Cross-cutting Tracks
@@ -551,9 +739,17 @@ same list-item order: What, Status, Unblocks, Pro-MVP impact, Doc.
   also parses **STEP / AP214** assemblies, with per-occurrence NavTree↔scene selection
   and hide keyed on the occurrence path (`design/new/step-occurrence-selection.md`).
 - **Status:** Phases 0–4 + 5a + 5b landed. `conwayDirectIfc` + `glb` default-on.
-  Remaining: Phase 5 cleanup (drop wit-three entirely), perf items (on-demand
-  rendering, hover-pick throttle), per-product mesh emission spike, **public-launch
-  test gate** (4-angle screenshots + GLB bit-level diff harness).
+  **Adapter removal landed (2026-06)** — the `conway-web-ifc-adapter` shim is
+  retired; Share consumes `@bldrs-ai/conway/web-ifc` directly and the release
+  chain is Conway → Share (`design/new/adapter-removal.md`). **GPU instancing
+  active (§3b.iv):** grouper analysis (#1568), `BatchedMesh` render path behind
+  `?feature=batchedMesh` (#1571), batched→merged GLB-cache bake (#1574).
+  **STEP metadata** extraction landed conway-side (conway #345 arc); Share
+  verification + occurrence-path permalink key are open (#1569, #1570).
+  Remaining: perf items (on-demand rendering, hover-pick throttle), per-product
+  mesh emission spike, `batchedMesh` always-on flip, `EXT_mesh_gpu_instancing`
+  cache schema (§3b.v), **public-launch test gate** (4-angle screenshots + GLB
+  bit-level diff harness).
 - **Render look (§6e):** the filmic/PBR look — uniform `MeshStandardMaterial` +
   sRGB albedo, gradient studio IBL, Khronos-Neutral tone-mapping, retuned lights,
   a user-facing **Neutral / Flat** render-mode toggle in the profile menu, plus a
@@ -643,9 +839,60 @@ same list-item order: What, Status, Unblocks, Pro-MVP impact, Doc.
   plumbing throughout the app.
 - **Status:** Not started. Existing seeds: `netlify/functions/create-portal-session.js`,
   `netlify/functions/unlink-identity.js` (pattern reuse).
-- **Unblocks:** `subscribe-100`, `subscribe-110`, `subscribe-120`.
+- **Unblocks:** `subscribe-100`, `subscribe-110`, `subscribe-120`. Forward-looking:
+  the same quota/metering rails are what §7 AI usage metering hangs off — design
+  the counter keying with that consumer in mind.
 - **Pro-MVP impact:** Required end-to-end.
 - **Doc:** TBD — to be drafted in `design/new/pro-billing.md`.
+
+
+### Track T9: Growth funnel & SEO surfaces (NEW)
+
+- **What:** The Share-side infrastructure the growth strategy needs: funnel events
+  (`share_link_created` / `share_link_opened` / `model_interacted`), analytics
+  hygiene (webdriver + hostname guard on GA init), OG/link-preview metadata on
+  share URLs, and the `/viewer/<format>` landing pages on the marketing SSG build.
+- **Status:** Not started in-repo. The enabling substrate (Next.js SSG marketing
+  build, PR #1519) is landed; strategy + attribution live in the private bizdev
+  doc.
+- **Unblocks:** `grow-100`, `grow-110`, `grow-120`; honest measurement of every
+  outreach move in `community-130`; conversion-based bidding for the (out-of-repo)
+  acquisition campaigns.
+- **Pro-MVP impact:** Phase G — parallel, starts now. Cheap relative to everything
+  else in §6 and the only work that grows the top of the funnel.
+- **Docs:** `bldrs-ai/bizdev` `docs/growth-strategy.md` (**private** — numbers stay
+  there) + `design/new/ads.md` (on-site ads only).
+
+
+### Track T10: Agent runtime & conversation store (NEW)
+
+- **What:** The conversational core of the §7 pivot: agent loop (LLM calls, tool
+  dispatch, streaming), conversation persistence, and — for `assist-120` — a
+  shared store with realtime sync and the direct-address vs channel-awareness
+  routing.
+- **Status:** Not started. Design questions (runtime placement client vs broker,
+  provider strategy, store choice, relation to Notes) go to
+  `design/new/ai-workspace.md` first — see §7.4 AI.0 and §10 open questions.
+- **Unblocks:** `assist-110`, `assist-120`, `search-120` (as retrieval), and the
+  §7 AI-metering upsell.
+- **Pro-MVP impact:** None (pivot arc). Must not destabilise Phases A–E.
+- **Doc:** TBD — `design/new/ai-workspace.md`.
+
+
+### Track T11: App sandbox + MCP bridge (NEW)
+
+- **What:** The viewer's operations exposed as one **MCP tool surface** (selection,
+  camera, isolate/hide, properties, notes, model queries), consumed by two
+  clients: the T10 agent in-process, and sandboxed iframe apps over a postMessage
+  MCP transport. Plus app storage/versioning for the toolbelt.
+- **Status:** Not started. Seeds: `WidgetApi/` + AppsDrawer (`apps-100`), the
+  `IfcModelService` query surface (T1). Known debt: <a href="https://github.com/bldrs-ai/Share/issues/1386" target="_blank" rel="noopener noreferrer">#1386</a> iframe integration
+  broken with its suite disabled — repair is the first slice.
+- **Unblocks:** `assist-130`, `apps-130` (MCP-first public API), `apps-120`
+  (checks as toolbelt apps).
+- **Pro-MVP impact:** None (pivot arc), except the #1386 repair which is
+  independently worthwhile.
+- **Doc:** TBD — `design/new/ai-workspace.md` (sandbox/security section).
 
 
 ## 6. Pro-MVP plan
@@ -654,7 +901,34 @@ Goal: ship the **paid tier** publicly. Free + Pro coexist; anonymous use stays
 possible; private sharing + multi-account + quota are paid; ads run on free.
 
 This is a phased plan, not a sprint schedule. Each phase ends with a green CI + a
-public canary. Phases 1–2 can overlap; phases 3–5 sequence.
+public canary. Phases A–B can overlap; C–E sequence. **Phase G is new in v0.3 and
+runs in parallel starting now** — it's small, mostly independent of the viewer and
+identity arcs, and it's the only work in this plan that grows the top of the
+funnel. Rationale: the growth-strategy attribution work showed we currently earn
+almost no traffic (organic ≈ zero) while the one earned channel that does work —
+shared links — is uninvested; and the paid acquisition rebuild needs landing pages
+and conversion events from this repo before it can optimise. Launching Pro (D/E)
+into a funnel with no earned channels wastes the launch.
+
+
+### Phase G (parallel, starts now): Growth funnel + SEO surfaces
+**Goal:** the funnel is measurable, share links unfurl, and search intent has a
+landing page — before the Pro launch needs any of it.
+- `grow-120` first slice: GA hygiene guard (`navigator.webdriver` +
+  hostname check on GA init) — cleans CI/e2e/preview pollution out of prod data.
+- `grow-120` events: `share_link_created`, `share_link_opened`,
+  `model_interacted` wired into the share flow + viewer; `real_model_open`
+  derived key event configured GA4-side.
+- `grow-100`: `/viewer/ifc` + `/viewer/step` landing pages on the marketing SSG
+  build (then `/viewer/stl`, `/viewer/obj`, …). Unblocks the acquisition-campaign
+  landing targets.
+- `grow-110`: OG/Twitter metadata on share URLs so links unfurl with a model
+  thumbnail; recipient "Open your own model" affordance. Per-model OG image
+  generation may pair with T2 Phase 5 in Phase C if edge injection is the chosen
+  route.
+
+**Exit:** funnel dashboard shows clean stage-by-stage counts; a shared link
+unfurls with a thumbnail in Slack; both format pages indexed.
 
 
 ### Phase A: Stabilise the rebuilt viewer (foundation)
@@ -663,13 +937,24 @@ public canary. Phases 1–2 can overlap; phases 3–5 sequence.
   - `IfcViewsManager` deletion (§3c.iv slice 1).
   - On-demand rendering (dirty-flag) — biggest framerate win available.
   - Per-product Mesh emission spike — measure cost.
+- Flag-flip decisions (each is one PR + baseline regen once smoke-tested):
+  - `?feature=batchedMesh` always-on (§3b.iv — needs per-occurrence narrowing on
+    the batched path first, or an accepted gap).
+  - `?feature=look` default-on (§6e render look — flip + regenerate screenshot
+    baselines).
+- Correctness bugs on the rebuilt path: <a href="https://github.com/bldrs-ai/Share/issues/1561" target="_blank" rel="noopener noreferrer">#1561</a> camera-fit "last scene child"
+  heuristic, <a href="https://github.com/bldrs-ai/Share/issues/1545" target="_blank" rel="noopener noreferrer">#1545</a> wrong arg to `getIfcType`, <a href="https://github.com/bldrs-ai/Share/issues/1249" target="_blank" rel="noopener noreferrer">#1249</a> (critical) element-permalink
+  hydration on private models.
+- STEP follow-through: Conway release bump + <a href="https://github.com/bldrs-ai/Share/issues/1569" target="_blank" rel="noopener noreferrer">#1569</a> NavTree/Properties verification
+  over the NIST corpus; occurrence-path permalink key.
 - T1 **public-launch gate**: 4-angle screenshot harness + GLB bit-level diff against
   golden artifacts. Runs in CI. This is the "we won't regress on the things that
   worked" insurance.
-- Stretch in this phase: hover-pick throttle tuning; subset-pool unification.
+- Stretch in this phase: hover-pick throttle tuning; subset-pool unification;
+  `EXT_mesh_gpu_instancing` cache schema (§3b.v).
 
 **Exit:** screenshot harness green on the fixture corpus; on-demand rendering shipped
-default-on.
+default-on; flag-flip decisions made (shipped or explicitly deferred).
 
 
 ### Phase B: Identity + Sources, multi-account
@@ -697,10 +982,15 @@ recents are correctly attributed per-connection; commit author = Sources GH iden
   the Share dialog from `share-150` (<a href="https://github.com/bldrs-ai/Share/issues/1421" target="_blank" rel="noopener noreferrer">#1421</a>) on top.
 - `share-120` private link sharing surfaces in the dialog.
 - `share-130` people-grants surface in the dialog.
+- `grow-110` completion: per-model OG image written alongside the T2 Phase 5 share
+  artifact (if that's the chosen mechanism), so every share link unfurls with a
+  real thumbnail. The share loop is our best earned channel — this phase is where
+  it gets its polish.
 - Retire `sharing` flag once metrics + canary look clean.
 
 **Exit:** a user can click Share on a model, invite a teammate by email/login, and the
-teammate opens the link in <2s.
+teammate opens the link in <2s — and the link unfurls with a model thumbnail where
+it was pasted.
 
 
 ### Phase D: Subscribe
@@ -723,20 +1013,112 @@ text routes only.
 ### Phase E: Public-launch checklist
 **Goal:** the public site is ready for cold traffic.
 - T7 Phase 4 (consent gating) if EU consent landscape requires.
-- T5 Drive recents HEAD-check (and GH equivalent) — UX polish; reduces "WTF
-  failures."
+- T5 Drive recents HEAD-check (and GH + local/OPFS equivalents — <a href="https://github.com/bldrs-ai/Share/issues/1548" target="_blank" rel="noopener noreferrer">#1548</a>) — UX
+  polish; reduces "WTF failures."
 - `community-110` thumbs feedback widget.
-- Sentry + GA dashboards confirmed; runbook for typical failure modes.
+- Sentry + GA dashboards confirmed; runbook for typical failure modes. Funnel
+  events (Phase G) reviewed against a week of real traffic.
 - Pricing page + ToS + Privacy updated.
 - Decision: drop T5 of the legacy Auth0-federated GH path, or leave for one more
   release.
+- Outreach readiness: the Show HN moment (bizdev doc §7) waits for this phase —
+  spike traffic against an uninstrumented funnel is wasted; with Phase G landed
+  it's the launch amplifier.
 
 **Exit:** Pro launch announcement.
 
 
-## 7. Post-MVP backlog (loveable)
+## 7. The AI-workspace pivot
 
-Held over for after Phase E. Order roughly reflects current product-pull:
+**Status:** direction agreed (2026-07). Design doc to draft at
+`design/new/ai-workspace.md` before implementation starts. This section is the
+roadmap-level summary: the vision, the three architecture surfaces, what existing
+work it absorbs, and how it sequences against the Pro-MVP.
+
+### 7.1 Vision
+
+Share pivots from "viewer with collaboration features" to an **AI-native workspace
+for built-environment models** — the Claude-Code experience, where the working
+context is a CAD/BIM project instead of a repo checkout. The user talks to an
+agent that can see and operate the viewer (load, navigate, select, isolate,
+annotate, query properties and structure), collaborates with teammates inside the
+same conversation, and accumulates reusable AI-built tools.
+
+Everything shipped to date is the substrate, not a detour: Conway-direct gives
+structured model access (the `IfcModelService` query surface), Notes give anchored
+discussion, the AppsDrawer + `WidgetApi` give an embedding surface, T3/T4 give
+identity and sharing, T8 gives the metering rails. The pivot recomposes these
+around a conversational core rather than building beside them.
+
+### 7.2 Architecture: three surfaces
+
+1. **Left drawer — workspace nav (`assist-100`).** A modification of the existing
+   UI: a left drawer tracking **projects** (models, conversations, shared
+   artifacts) and **company-level nav** (org, members, settings). The container
+   that turns Share from a single-document viewer into a workspace. Pure
+   UI/routing work; ships behind a flag with no AI-runtime dependency.
+2. **Conversational panel (`assist-110`, `assist-120`).** A Claude-Code-like
+   conversation over the open project/model. The multi-user mechanic:
+   - **Direct replies addressed to the AI are commands** — treated exactly as
+     Claude Code treats a prompt today: agent loop, tool calls against the
+     viewer, streamed responses.
+   - **General channel discussion is human↔human** — the AI is aware of it as
+     context and can participate **comment-only**. A channel message never
+     triggers the tool-using agent loop; only direct address does.
+   The split keeps the agent useful in a group without it hijacking every thread.
+3. **Right drawer — AI-apps toolbelt (`assist-130`).** The existing right-drawer
+   AppsDrawer, upgraded: code the agent generates is **saved, versioned, and
+   run** in a sandboxed iframe that interacts with the main window/app context
+   over an **MCP bridge** (postMessage transport). Users accumulate personal and
+   team toolbelts of generated apps.
+
+The unifying piece: the main window exposes the viewer as an **MCP server**
+(selection, camera, isolation, properties, notes, model queries — Track T11).
+The conversational agent and the sandboxed apps consume the *same* tool surface —
+one contract, two consumers — and `apps-130`'s public API becomes a third
+consumer of it later, for free.
+
+### 7.3 What it absorbs
+
+- `search-120` Knowledge graph → the retrieval layer behind conversational QA.
+- `apps-130` v1.0 Public API → designed MCP-first; external IDE/embed consumers
+  and the internal toolbelt share one contract.
+- `apps-120` Bldrs Integrate → agent-run model checks as toolbelt apps.
+- `notes-*` / channels → need one coherent story: an anchored note thread and a
+  channel message are close cousins (open question, §10).
+
+### 7.4 Sequencing
+
+The pivot **follows the Pro-MVP**: Phases B–D give it identity, sharing, and the
+billing/quota rails that AI usage metering hangs off — metered agent usage is the
+natural Pro anchor, a cleaner upsell than private links alone. Foundations that
+can't destabilise the launch may start earlier behind flags.
+
+- **AI.0 — Design doc + seed repair (can start now).** Draft
+  `design/new/ai-workspace.md`: agent runtime placement (client-direct vs server
+  broker), provider strategy, conversation-store choice, sandbox/MCP security
+  model, Notes/channels relationship. Fix <a href="https://github.com/bldrs-ai/Share/issues/1386" target="_blank" rel="noopener noreferrer">#1386</a> and re-enable the iframe
+  suite — the sandbox foundation must hold weight before anything is built on it.
+- **AI.1 — Workspace shell.** `assist-100` left drawer behind
+  `?feature=workspace`. No AI dependency; can overlap Pro-MVP phases.
+- **AI.2 — Agent v0, single-user.** `assist-110`: viewer MCP tool surface (T11) +
+  agent loop (T10) + conversation panel. One user, one conversation per
+  project/model. **This is the demo that sells the pivot.**
+- **AI.3 — Toolbelt.** `assist-130`: generate → save → version → run in the
+  sandbox over the same MCP surface.
+- **AI.4 — Multi-user.** `assist-120`: shared channels, direct-address vs
+  comment-only mechanics, presence. Depends on the shared conversation store —
+  the largest new backend piece, so it goes last.
+
+Each stage is a shippable, demoable increment; AI.2 is the earliest point at
+which the pivot is publicly visible.
+
+
+## 8. Post-MVP backlog (loveable)
+
+Held over for after Phase E. Items marked **→ §7** are absorbed by the AI pivot
+and leave this queue — they ride the pivot sequencing instead. Order roughly
+reflects current product-pull:
 
 1. **`view-160` ETL / Table view** 🔮 (❤️ Markus). The "10$/mo by itself" loveable.
    Pre-cond mostly done via T1.
@@ -754,10 +1136,12 @@ Held over for after Phase E. Order roughly reflects current product-pull:
     primitive itself is 🟡 with polish slated for Phase C (see Epic). The filter
     chips + cluster rendering visualization on top is the post-MVP loveable.
     Pairs with T6 Q1.
-11. **`search-110` Cross-repo search** 🔮 (❤️ Oleg).
-12. **`apps-120` Bldrs Integrate (CI server-side IDS)**.
-13. **`apps-130` v1.0 Public API + IDE** 🔮.
-14. **`search-120` Knowledge Graph** 🔮 (❤️ Johannes).
+11. **`search-110` Cross-repo search** 🔮 (❤️ Oleg). An agent with repo-source
+    tools may deliver this as a §7 by-product — reassess once AI.2 exists.
+12. **`apps-120` Bldrs Integrate (CI server-side IDS)** → §7 (toolbelt apps).
+13. **`apps-130` v1.0 Public API + IDE** 🔮 → §7 (MCP-first, T11).
+14. **`search-120` Knowledge Graph** 🔮 (❤️ Johannes) → §7 (retrieval behind
+    `assist-110`).
 15. **`versions-110` Diff between versions**.
 16. **PDF "Smart Components & Templates"** 🔮 (❤️ Pablo). Massive scope; will warrant
     its own Epic group when started.
@@ -766,7 +1150,7 @@ Held over for after Phase E. Order roughly reflects current product-pull:
 18. **PDF "Social Updates" (ActivityPub federation)** — interesting; no current pull.
 
 
-## 8. Migration to GH issues + wiki
+## 9. Migration to GH issues + wiki
 
 Once this doc lands, the backfill order:
 
@@ -774,7 +1158,10 @@ Once this doc lands, the backfill order:
    For each Epic in §4 with status 🟡 or ⬜ and `Pro-MVP impact: required`, create an
    `epic`-labeled GH issue with the body content from the Epic block. Stable ID
    becomes the issue title prefix (e.g. `epic: open-130: SourcesTab with parallel GH +
-   Drive accounts`). One pass; expect ~12–15 new Epic issues.
+   Drive accounts`). One pass; expect ~12–15 new Epic issues. The v0.3 groups ride
+   the same pass: one `epic` issue per `grow-*` (Phase G starts now) and per
+   `assist-*` (so pivot discussion has a home), even though the `assist-*` bodies
+   will initially just point at §7 + the forthcoming `ai-workspace.md`.
 2. **GitHub issues — Stories under Epics.**
    For each open story already in §3.1 (e.g. <a href="https://github.com/bldrs-ai/Share/issues/1421" target="_blank" rel="noopener noreferrer">#1421</a>, <a href="https://github.com/bldrs-ai/Share/issues/1422" target="_blank" rel="noopener noreferrer">#1422</a>, <a href="https://github.com/bldrs-ai/Share/issues/1250" target="_blank" rel="noopener noreferrer">#1250</a>, <a href="https://github.com/bldrs-ai/Share/issues/1251" target="_blank" rel="noopener noreferrer">#1251</a>, <a href="https://github.com/bldrs-ai/Share/issues/1254" target="_blank" rel="noopener noreferrer">#1254</a>, <a href="https://github.com/bldrs-ai/Share/issues/850" target="_blank" rel="noopener noreferrer">#850</a>,
    <a href="https://github.com/bldrs-ai/Share/issues/890" target="_blank" rel="noopener noreferrer">#890</a>, <a href="https://github.com/bldrs-ai/Share/issues/892" target="_blank" rel="noopener noreferrer">#892</a>), use `mcp__github__sub_issue_write` to attach them under the right
@@ -794,7 +1181,7 @@ I'll draft each batch and review with you before creating GH issues — won't bu
 without sign-off.
 
 
-## 9. Open questions
+## 10. Open questions
 
 - **Pro tier feature gate definition.** §4.9 sketches `subscribe-100` but the actual
   list of "this is Pro" features needs your call. Working hypothesis: private link
@@ -808,13 +1195,31 @@ without sign-off.
   resolved before Phase D quota tracking ships (the quota key is meaningless if the
   functions are anonymous).
 - **BCF priority.** Industry-credibility win vs. cost. If we want it for Pro-MVP it
-  becomes Phase C scope; otherwise it slips to post-MVP per §7 item 7.
+  becomes Phase C scope; otherwise it slips to post-MVP per §8 item 7.
+- **AI pivot — agent runtime placement.** Client-direct LLM calls (user's key /
+  our key in the browser) vs a server-side broker (Netlify Functions or a real
+  backend). The broker is where quota enforcement (T8) and key custody naturally
+  live, but it's new server surface for a to-date-static product. Decide in
+  `design/new/ai-workspace.md` before AI.2.
+- **AI pivot — conversation store.** `assist-120` needs shared, realtime-ish
+  conversation state. Candidates: GitHub-issue-backed (Notes-style, free, slow),
+  Firebase/Firestore (already floated for T2 Phase 6), or a purpose-built
+  backend. Also: are channels and Notes one primitive or two? (An anchored note
+  thread and a channel message are close cousins.)
+- **AI pivot — sandbox security model.** Toolbelt apps run generated code:
+  iframe origin isolation, MCP tool permissioning (which tools does an app get,
+  who approves), and versioned-app provenance all need a design pass (T11).
+- **AI pivot — naming.** "Assist" is the working Epic-group verb; the
+  user-facing name for the workspace/agent is unpicked.
+- **Growth — OG image mechanism.** Edge-function injection on `/share/*` vs
+  pre-rendering the OG image at share time next to the T2 artifact. Decides
+  whether `grow-110` finishes in Phase G or pairs with Phase C.
 - **Maintenance of this doc.** Cadence: bump on every Epic state change? Or quarterly
   rollup? My recommendation: amend per-PR when an Epic moves status; quarterly review
   to catch drift.
 
 
-## 10. Doc maintenance
+## 11. Doc maintenance
 
 - **When an Epic ships:** update its row in §3.1 and its block in §4 from 🟡 → ✔.
   Move it out of the Pro-MVP phase list in §6 if it was there.
@@ -826,4 +1231,8 @@ without sign-off.
   stable ID one above the highest existing in that group (e.g. `open-160`), and add
   the matching row to §3.1. Don't renumber existing IDs.
 - **Don't delete done Epics.** They stay in §4 as the historical record of what
-  shipped, which is what §7 "Post-MVP backlog" is measured against.
+  shipped, which is what §8 "Post-MVP backlog" is measured against.
+- **Privacy firewall.** This doc is public. Growth/traffic *numbers* (spend, CAC,
+  geo, raw counts) never land here — they stay in the private bizdev
+  growth-strategy doc. Event names, funnel stage definitions, and qualitative
+  conclusions are fine.

--- a/design/roadmap.md
+++ b/design/roadmap.md
@@ -1,6 +1,6 @@
 # Bldrs Share Roadmap
 
-**Status:** Draft v0.4 — AI-strategy synthesis folded in (quota axis, moat framing)
+**Status:** Draft v0.5 — tier renumbering (100 MVP / 200 MLP / 300 Pro / 400 Enterprise)
 **Date:** 2026-07-03
 **Owner:** Pablo
 **Source baseline:** `Share Requirements` Google Doc (Aug 2021, last updated Nov 2022). PDF
@@ -30,7 +30,7 @@ top-down review, surfaces the work that landed without story tracking, and lays 
    the Pro-MVP: a Claude-Code-like conversational workspace over CAD/BIM models,
    multi-user, with user-generated AI-app toolbelts. New Epic group §4.11
    (Assist), Tracks T10–T11, plan in §7. Several long-held loveables
-   (`search-120`, `apps-130`, `apps-120`) are absorbed into it.
+   (`search-210`, `apps-200`, `apps-210`) are absorbed into it.
 
 **v0.4 (2026-07-03)** reconciles against the AI-strategy synthesis
 (`bldrs-ai/bizdev` `docs/ai-strategy.md` — **private**: MAU/revenue/fundraise
@@ -48,15 +48,21 @@ re-cut this roadmap:
   unlimited (the funnel is demand-gen); the paywall sits at the threshold where
   Share is the only thing that works. Phase D runs as an **instrumented
   experiment** with stated hypotheses, not a revenue switch. Reflected in
-  `subscribe-100`/`subscribe-120` and Phase D.
+  `subscribe-300`/`subscribe-320` and Phase D.
 - **Data sovereignty is a first-class feature.** "Runs in-browser, your model
   never leaves your machine" is an enterprise wedge, not a privacy nicety — and
   it constrains §7 architecture (the agent loop must not silently break the
-  no-upload story). New epic `grow-130` for the positioning surface; §7.2 for
+  no-upload story). New epic `grow-400` for the positioning surface; §7.2 for
   the constraint.
 - **De-prioritised:** chasing more cheap small-model traffic; "fastest engine"
   as headline positioning. Phase G stays (it's demand-gen + loop + measurement,
   all cheap) but doesn't grow beyond that.
+
+**v0.5 (2026-07-03)** renorms Epic numbering so the hundreds digit encodes the
+**tier**, matching the convention the story issues already use ("Open 200",
+"View 200", "Share (200)"): **100s = MVP, 200s = MLP, 300s = Pro, 400s =
+Enterprise**. Rubric + old→new mapping in §2.1. One-time renumber; the
+maintenance rules (§11) forbid doing it again.
 
 It is the single source of truth for Epic/Story/Track structure. The wiki page
 `Planning:-Requirements` and the `epic`-labeled GitHub issues mirror this doc; when they
@@ -95,6 +101,46 @@ Per the PDF: 🥉 = MVP, 🥇 = MLP (Minimum Loveable Product), ❤️ = persona
 those markers in §4 next to the original ranking so we don't lose the people-attached
 intent. New work added since the PDF is marked `(NEW)`.
 
+### 2.1 Tier rubric (Epic ID numbering, v0.5)
+
+The hundreds digit of every Epic ID encodes the **product tier** of the
+capability; sub-steps (110, 120, …) order epics within a tier. This matches the
+story-title convention already in the issues ("Open 200", "View 200",
+"Share (200)") and the PDF's 🥉/🥇 split.
+
+| Range | Tier | Meaning |
+|---|---|---|
+| 100–199 | **MVP** | As tight as possible — our best guess of the minimum product. Free tier. Roughly the PDF's 🥉. |
+| 200–299 | **MLP** | Minimum Loveable — opportunistic stretch on 100-level implementations. Roughly the PDF's 🥇. |
+| 300–399 | **Pro** | Paid-tier capabilities (private sharing, multi-account, quota uplift, subscription machinery). |
+| 400–499 | **Enterprise** | Org-scale: data-sovereignty posture, folder/team boundaries, security-review readiness. |
+
+Tier is **not** schedule: a 300-level epic can be in an early Pro-MVP phase
+(private sharing is Phase C) and a 400-level page can ship in Phase G. The
+Pro-MVP column carries the schedule; the ID carries the tier.
+
+**v0.5 renumbering map** (unchanged IDs omitted — everything already 100-level
+MVP kept its number):
+
+| Old → New | Old → New | Old → New |
+|---|---|---|
+| open-130 → open-300 | view-180 → view-240 | search-120 → search-210 |
+| open-140 → open-200 | share-120 → share-300 | identity-130 → identity-300 |
+| open-150 → open-130 | share-130 → share-310 | apps-120 → apps-210 |
+| view-130 → view-200 | share-140 → share-400 | apps-130 → apps-200 |
+| view-140 → view-210 | share-150 → share-200 | community-120 → community-200 |
+| view-150 → view-130 | notes-110 → notes-200 | community-130 → community-210 |
+| view-160 → view-220 | notes-120 → notes-210 | subscribe-100 → subscribe-300 |
+| view-170 → view-230 | versions-110 → versions-200 | subscribe-110 → subscribe-310 |
+| — | versions-120 → versions-210 | subscribe-120 → subscribe-320 |
+| — | search-110 → search-200 | grow-130 → grow-400 |
+| — | assist-130 → assist-200 | assist-120 → assist-300 |
+
+⚠ Two numbers were **reused for a different epic** than before the renorm:
+`open-130` (now Recents reliability; was multi-account Sources) and `view-130`
+(now Performance/large-model; was persistent visibility). When reading pre-v0.5
+branches, issues, or PR descriptions, check this table before trusting an ID.
+
 **Pro-MVP column legend** (used in §3 and §5):
 
 - **A–E** = phase in the Pro-MVP plan (§6). A = stabilise viewer, B = identity +
@@ -120,73 +166,74 @@ cross-references that connect them. The detailed bodies live in §4 (Epics) and 
 | Open | `open-100` | Open from local file system | ✔ | — | — |
 | Open | `open-110` | Open from GitHub URL / UI | ✔ | — | — |
 | Open | `open-120` | Open from Google Drive | ✔ | — | — |
-| Open | `open-130` | Multi-account Sources tab | 🟡 | B | T3 |
-| Open | `open-140` | Open multiple IFCs in one session | ⬜ | Post | — |
-| Open | `open-150` | Recents reliability | 🟡 | E | T5 |
+| Open | `open-130` | Recents reliability | 🟡 | E | T5 |
+| Open | `open-200` | Open multiple IFCs in one session | ⬜ | Post | — |
+| Open | `open-300` | Multi-account Sources tab | 🟡 | B | T3 |
 | View | `view-100` | 3D + NavTree + Properties | ✔ | — | T1, T2 |
 | View | `view-110` | Cut planes | ✔ | — | T1 |
 | View | `view-120` | Shareable camera position | ✔ | — | — |
-| View | `view-130` | Persistent visibility / Isolate | 🟡 | Post | T1 |
-| View | `view-140` | Selection-based camera + measurement | ⬜ | Post | — |
-| View | `view-150` | Performance + large-model viewing | 🟡 | A | T1, T2 |
-| View | `view-160` | ETL / Table view (❤️ Markus) | 🔮 | Post | T1 |
-| View | `view-170` | Common view ops (nav-cube, explode, undo, IDS) | ⬜ | Post | — |
-| View | `view-180` | Placemarks + maps-style issues w/filtering (🥇) | 🟡 | C, Post | T1, T6 |
+| View | `view-130` | Performance + large-model viewing | 🟡 | A | T1, T2 |
+| View | `view-200` | Persistent visibility / Isolate | 🟡 | Post | T1 |
+| View | `view-210` | Selection-based camera + measurement | ⬜ | Post | — |
+| View | `view-220` | ETL / Table view (❤️ Markus) | 🔮 | Post | T1 |
+| View | `view-230` | Common view ops (nav-cube, explode, undo, IDS) | ⬜ | Post | — |
+| View | `view-240` | Placemarks + maps-style issues w/filtering (🥇) | 🟡 | C, Post | T1, T6 |
 | Share | `share-100` | Share link to current view | ✔ | — | — |
 | Share | `share-110` | Save model to user's hosting (originator share) | 🟡 | C | T2 |
-| Share | `share-120` | Private link sharing + visibility chip | 🟡 | C | T4 |
-| Share | `share-130` | Grant/revoke per-principal sharing | 🟡 | C | T4 |
-| Share | `share-140` | Folder-scoped boundaries | ⬜ | Post | T4 |
-| Share | `share-150` | Extended Share/Login flow (<a href="https://github.com/bldrs-ai/Share/issues/1421" target="_blank" rel="noopener noreferrer">#1421</a>) | 🟡 | C, D | — |
+| Share | `share-200` | Extended Share/Login flow (<a href="https://github.com/bldrs-ai/Share/issues/1421" target="_blank" rel="noopener noreferrer">#1421</a>) | 🟡 | C, D | — |
+| Share | `share-300` | Private link sharing + visibility chip | 🟡 | C | T4 |
+| Share | `share-310` | Grant/revoke per-principal sharing | 🟡 | C | T4 |
+| Share | `share-400` | Folder-scoped boundaries | ⬜ | Post | T4 |
 | Notes | `notes-100` | Anchored notes (GitHub-backed) | ✔ | — | — |
-| Notes | `notes-110` | BCF round-trip | ⬜ | Post | — |
-| Notes | `notes-120` | Drive-backed notes (NotesProvider) | 🔮 | Post | T4, T6 |
+| Notes | `notes-200` | BCF round-trip | ⬜ | Post | — |
+| Notes | `notes-210` | Drive-backed notes (NotesProvider) | 🔮 | Post | T4, T6 |
 | Versions | `versions-100` | Show specific version + branch/commit nav | 🟡 | — | — |
-| Versions | `versions-110` | Diff between versions | ⬜ | Post | — |
-| Versions | `versions-120` | Portable versions for Drive | 🔮 | Post | T6 |
+| Versions | `versions-200` | Diff between versions | ⬜ | Post | — |
+| Versions | `versions-210` | Portable versions for Drive | 🔮 | Post | T6 |
 | Search | `search-100` | Search current model | 🟡 | — | — |
-| Search | `search-110` | Search across GitHub repos (❤️ Oleg) | 🔮 | Post | — |
-| Search | `search-120` | Knowledge graph (🥇, ❤️ Johannes) | 🔮 | AI | T10 |
+| Search | `search-200` | Search across GitHub repos (❤️ Oleg) | 🔮 | Post | — |
+| Search | `search-210` | Knowledge graph (🥇, ❤️ Johannes) | 🔮 | AI | T10 |
 | Identity | `identity-100` | Auth0 primary login | ✔ | — | — |
 | Identity | `identity-110` | GitHub as Sources peer | 🟡 | B | T3 |
 | Identity | `identity-120` | Auth disambiguation (<a href="https://github.com/bldrs-ai/Share/issues/1422" target="_blank" rel="noopener noreferrer">#1422</a>) | 🟡 | B | — |
-| Identity | `identity-130` | Profile drawer + multi-account picker | ⬜ | B | T3 |
+| Identity | `identity-300` | Profile drawer + multi-account picker | ⬜ | B | T3 |
 | Apps | `apps-100` | Browse + select app (AppsDrawer) | ✔ | — | — |
 | Apps | `apps-110` | XYZ demo app (v0.1 API dogfood) | ✔ | — | — |
-| Apps | `apps-120` | Bldrs Integrate (CI + ArchiCAD/Speckle) | 🔮 | AI | T11 |
-| Apps | `apps-130` | v1.0 Public API + IDE (🥇) | 🔮 | AI | T11 |
+| Apps | `apps-200` | v1.0 Public API + IDE (🥇) | 🔮 | AI | T11 |
+| Apps | `apps-210` | Bldrs Integrate (CI + ArchiCAD/Speckle) | 🔮 | AI | T11 |
 | Community | `community-100` | Welcome dialog + onboarding | ✔ | — | — |
 | Community | `community-110` | Analytics + survey + thumbs feedback | 🟡 | E | — |
-| Community | `community-120` | Bug report w/ screenshot + session state | ⬜ | Post | — |
-| Community | `community-130` | AEC outreach (🥇) | 🔮 | Post | — |
-| Subscribe | `subscribe-100` | Pricing tiers + feature manager (NEW) | ⬜ | D | T8 |
-| Subscribe | `subscribe-110` | Stripe checkout + portal (NEW) | ⬜ | D | T8 |
-| Subscribe | `subscribe-120` | Quota tracking (NEW) | ⬜ | D | T8, T3 |
+| Community | `community-200` | Bug report w/ screenshot + session state | ⬜ | Post | — |
+| Community | `community-210` | AEC outreach (🥇) | 🔮 | Post | — |
 | Subscribe | `subscribe-130` | Ads on free tier | 🟡 | D | T7 |
+| Subscribe | `subscribe-300` | Pricing tiers + feature manager (NEW) | ⬜ | D | T8 |
+| Subscribe | `subscribe-310` | Stripe checkout + portal (NEW) | ⬜ | D | T8 |
+| Subscribe | `subscribe-320` | Quota tracking (NEW) | ⬜ | D | T8, T3 |
+| Subscribe | `subscribe-400` | Enterprise tier definition (NEW) | ⬜ | Post | T8 |
 | Grow | `grow-100` | SEO format landing pages `/viewer/*` (NEW) | ⬜ | G | T9 |
 | Grow | `grow-110` | Rich share-link previews / OG cards (NEW) | ⬜ | G | T9 |
 | Grow | `grow-120` | Funnel instrumentation + GA hygiene (NEW) | ⬜ | G | T9 |
-| Grow | `grow-130` | Large-model + data-sovereignty positioning (NEW) | ⬜ | G | T9 |
+| Grow | `grow-400` | Large-model + data-sovereignty positioning (NEW) | ⬜ | G | T9 |
 | Assist | `assist-100` | Workspace shell: left drawer projects + org nav (NEW) | ⬜ | AI | — |
 | Assist | `assist-110` | Conversational agent panel, single-user (NEW) | ⬜ | AI | T10, T11 |
-| Assist | `assist-120` | Multi-user channels + AI participation modes (NEW) | ⬜ | AI | T10 |
-| Assist | `assist-130` | AI-apps toolbelt: save/version/run + MCP (NEW) | ⬜ | AI | T11 |
+| Assist | `assist-200` | AI-apps toolbelt: save/version/run + MCP (NEW) | ⬜ | AI | T11 |
+| Assist | `assist-300` | Multi-user channels + AI participation modes (NEW) | ⬜ | AI | T10 |
 
 ### 3.2 Tracks
 
 | ID | Name | Status | Pro-MVP | Unblocks |
 |---|---|---|---|---|
-| T1 | Viewer Replacement | 🟡 | A (launch gate) | `view-100`, `view-110`, `view-130`, `view-150`, `view-160`, T2 |
-| T2 | GLB Model Sharing | 🟡 | C (Ph 4 + 5) | `share-110`, `notes-120`, `view-150` |
-| T3 | Identity Decoupling | 🟡 | B (PR2 + PR3) | `identity-110`, `identity-120`, `identity-130`, `open-130`, `share-130`, `subscribe-120`, T4 PR3 |
-| T4 | Multi-User Sharing | 🟡 | C (PR2 + PR3) | `share-120`, `share-130`, `share-140`, `notes-120`, `versions-120` |
-| T5 | Drive Recents HEAD-check | ⬜ | E (polish) | `open-150` |
-| T6 | Notes & Versions sidecar formats | ⬜ | Post | `notes-110`, `notes-120`, `versions-120` |
+| T1 | Viewer Replacement | 🟡 | A (launch gate) | `view-100`, `view-110`, `view-200`, `view-130`, `view-220`, T2 |
+| T2 | GLB Model Sharing | 🟡 | C (Ph 4 + 5) | `share-110`, `notes-210`, `view-130` |
+| T3 | Identity Decoupling | 🟡 | B (PR2 + PR3) | `identity-110`, `identity-120`, `identity-300`, `open-300`, `share-310`, `subscribe-320`, T4 PR3 |
+| T4 | Multi-User Sharing | 🟡 | C (PR2 + PR3) | `share-300`, `share-310`, `share-400`, `notes-210`, `versions-210` |
+| T5 | Drive Recents HEAD-check | ⬜ | E (polish) | `open-130` |
+| T6 | Notes & Versions sidecar formats | ⬜ | Post | `notes-200`, `notes-210`, `versions-210` |
 | T7 | Ads | 🟡 | D | `subscribe-130` |
-| T8 | Pro/Billing (NEW) | ⬜ | D | `subscribe-100`, `subscribe-110`, `subscribe-120`, §7 AI metering |
+| T8 | Pro/Billing (NEW) | ⬜ | D | `subscribe-300`, `subscribe-310`, `subscribe-320`, §7 AI metering |
 | T9 | Growth funnel & SEO surfaces (NEW) | ⬜ | G | `grow-100`, `grow-110`, `grow-120` |
-| T10 | Agent runtime & conversation store (NEW) | ⬜ | AI (§7) | `assist-110`, `assist-120`, `search-120` |
-| T11 | App sandbox + MCP bridge (NEW) | ⬜ | AI (§7) | `assist-130`, `apps-130`, `apps-120` |
+| T10 | Agent runtime & conversation store (NEW) | ⬜ | AI (§7) | `assist-110`, `assist-300`, `search-210` |
+| T11 | App sandbox + MCP bridge (NEW) | ⬜ | AI (§7) | `assist-200`, `apps-200`, `apps-210` |
 
 
 ## 4. Normalized Epic catalogue
@@ -211,7 +258,7 @@ loader. Recent stability work via OPFS caching (`src/OPFS/`) and Conway-direct p
 **Epic `open-110`: Open from GitHub URL / UI** ✔
 *PDF Open.2 (the open-the-model half).* Done.
 - Closed: <a href="https://github.com/bldrs-ai/Share/issues/765" target="_blank" rel="noopener noreferrer">#765</a> GH URL, <a href="https://github.com/bldrs-ai/Share/issues/1159" target="_blank" rel="noopener noreferrer">#1159</a> GH via UI, <a href="https://github.com/bldrs-ai/Share/issues/1190" target="_blank" rel="noopener noreferrer">#1190</a> Tabbed Open dialog.
-- Open: <a href="https://github.com/bldrs-ai/Share/issues/761" target="_blank" rel="noopener noreferrer">#761</a>/<a href="https://github.com/bldrs-ai/Share/issues/768" target="_blank" rel="noopener noreferrer">#768</a> file-browser polish — superseded by `open-130`.
+- Open: <a href="https://github.com/bldrs-ai/Share/issues/761" target="_blank" rel="noopener noreferrer">#761</a>/<a href="https://github.com/bldrs-ai/Share/issues/768" target="_blank" rel="noopener noreferrer">#768</a> file-browser polish — superseded by `open-300`.
 
 **Epic `open-120`: Open from Google Drive** ✔ (NEW since PDF — Drive wasn't in the
 original list; landed via `googleDrive` flag now default-on).
@@ -219,26 +266,26 @@ original list; landed via `googleDrive` flag now default-on).
 - Open: needs Drive Save (mirrors GitHub Save flow) — captured under `share-110`.
 - Track dependency: T3 Identity Decoupling for the multi-account case.
 
-**Epic `open-130`: Multiple sources / multi-account Sources tab** 🟡
-*PDF didn't anticipate multi-account; absorbed from T3 Identity Decoupling.*
-- Open: Drive multi-account works today; GitHub multi-account is the deliverable of
-  T3's PR2/PR3.
-- Story to file: `open-130: SourcesTab with parallel GitHub + Drive accounts`.
+**Epic `open-130`: Recents reliability** 🟡 (NEW)
+*Not in PDF — surfaced by support friction.*
+- Track dependency: T5 Drive recents HEAD-check (proposed).
+- Open: <a href="https://github.com/bldrs-ai/Share/issues/1548" target="_blank" rel="noopener noreferrer">#1548</a> local recent fails hard after a cache clear — needs a typed
+  "file no longer available" alert (T5's pre-flight pattern applied to the
+  OPFS/local case, not just Drive).
+- Story to file: `open-130: Recents show typed unreachable alert + remove-recent`.
 
-**Epic `open-140`: Open multiple IFCs in one session** ⬜
+**Epic `open-200`: Open multiple IFCs in one session** ⬜
 *PDF Open.3 — never started.*
 - Open: <a href="https://github.com/bldrs-ai/Share/issues/1251" target="_blank" rel="noopener noreferrer">#1251</a> Open 200: import and overlay multiple models.
 - Pre-condition: Conway-direct + GLB cache are stable per-model (✔ via T1/T2), so
   scaling to N models is now a UI + state-management problem, not an engine problem.
 - **Not in Pro-MVP.** Loveable post-MVP.
 
-**Epic `open-150`: Recents reliability** 🟡 (NEW)
-*Not in PDF — surfaced by support friction.*
-- Track dependency: T5 Drive recents HEAD-check (proposed).
-- Open: <a href="https://github.com/bldrs-ai/Share/issues/1548" target="_blank" rel="noopener noreferrer">#1548</a> local recent fails hard after a cache clear — needs a typed
-  "file no longer available" alert (T5's pre-flight pattern applied to the
-  OPFS/local case, not just Drive).
-- Story to file: `open-150: Recents show typed unreachable alert + remove-recent`.
+**Epic `open-300`: Multiple sources / multi-account Sources tab** 🟡
+*PDF didn't anticipate multi-account; absorbed from T3 Identity Decoupling.*
+- Open: Drive multi-account works today; GitHub multi-account is the deliverable of
+  T3's PR2/PR3.
+- Story to file: `open-300: SourcesTab with parallel GitHub + Drive accounts`.
 
 
 ### 4.2 View
@@ -295,19 +342,7 @@ slice, and isolation controls expected of a BIM viewer.
 - Open: dropdown-share-button details from <a href="https://github.com/bldrs-ai/Share/issues/1043" target="_blank" rel="noopener noreferrer">#1043</a> (QR code, toggle camera) — see also
   `share-100` below.
 
-**Epic `view-130`: Persistent visibility / Isolate** 🟡
-*PDF "View element subsets" — partial.*
-- Open: <a href="https://github.com/bldrs-ai/Share/issues/1250" target="_blank" rel="noopener noreferrer">#1250</a> View 200 Implement persistent visibility (URL-encoded
-  `hiddenExpressIDs[]`).
-- Track dependency: T1 §3b.iii isolate routing through IfcInstanceMap (landed).
-  Persistence to URL is the remaining slice.
-
-**Epic `view-140`: Selection-based camera + measurement** ⬜
-- Open: <a href="https://github.com/bldrs-ai/Share/issues/1044" target="_blank" rel="noopener noreferrer">#1044</a> View 200 Selection-based camera control; <a href="https://github.com/bldrs-ai/Share/issues/1047" target="_blank" rel="noopener noreferrer">#1047</a> View 200 Distance
-  measurement between elements.
-- **Post-MVP.** Useful for the loveable target but not blocking.
-
-**Epic `view-150`: Performance and large-model viewing** 🟡
+**Epic `view-130`: Performance and large-model viewing** 🟡
 *PDF View "design" section — loaded model is stored/cached for fast re-open;
 multi-worker; etc.*
 - Closed (effectively, via Tracks T1 + T2): OPFS cache, GLB cache, Conway-direct,
@@ -332,7 +367,19 @@ multi-worker; etc.*
 - Pre-public-launch gate: 4-angle screenshot harness + GLB bit-level diff (called out
   in `viewer-replacement.md` §3b.iii final paragraph). **Required for Pro-MVP.**
 
-**Epic `view-160`: ETL / Table view / element subsets** 🔮 (❤️ Markus)
+**Epic `view-200`: Persistent visibility / Isolate** 🟡
+*PDF "View element subsets" — partial.*
+- Open: <a href="https://github.com/bldrs-ai/Share/issues/1250" target="_blank" rel="noopener noreferrer">#1250</a> View 200 Implement persistent visibility (URL-encoded
+  `hiddenExpressIDs[]`).
+- Track dependency: T1 §3b.iii isolate routing through IfcInstanceMap (landed).
+  Persistence to URL is the remaining slice.
+
+**Epic `view-210`: Selection-based camera + measurement** ⬜
+- Open: <a href="https://github.com/bldrs-ai/Share/issues/1044" target="_blank" rel="noopener noreferrer">#1044</a> View 200 Selection-based camera control; <a href="https://github.com/bldrs-ai/Share/issues/1047" target="_blank" rel="noopener noreferrer">#1047</a> View 200 Distance
+  measurement between elements.
+- **Post-MVP.** Useful for the loveable target but not blocking.
+
+**Epic `view-220`: ETL / Table view / element subsets** 🔮 (❤️ Markus)
 *PDF View.2 — never started.*
 - The original loveable: select a model subset, choose attributes (psets, geometry,
   location), export CSV or stream to an API. Mapping tables across projects.
@@ -341,13 +388,13 @@ multi-worker; etc.*
   service (mostly done), the ETL layer is a UI-level Epic on top.
 - **Post-MVP loveable.** Markus is the design partner here.
 
-**Epic `view-170`: Common view operations** ⬜
+**Epic `view-230`: Common view operations** ⬜
 *PDF View.3 — partially done (Cut ✔). Still missing:*
 - Nav-cube, Explode, undo/redo.
 - IDS (was MVD) — quality-check rules for the IFC. Discussed in PDF page 4–5.
 - **Post-MVP.** IDS is a non-trivial spec implementation.
 
-**Epic `view-180`: Placemarks + maps-style view of issues w/filtering** 🟡
+**Epic `view-240`: Placemarks + maps-style view of issues w/filtering** 🟡
 *PDF View.4 (🥇 MLP). Placemarks are the in-scene-pin primitive on which the
 loveable maps-style filtering visualization will sit. The PDF treats them as one
 Epic and we keep that pairing here.*
@@ -355,7 +402,7 @@ Epic and we keep that pairing here.*
 The placemark primitive has two creation modes:
 - **Transient** — created in-app, lives only in the URL hash (`#m:x,y,z`), no
   backing storage. Sharable as a bare permalink. This mode is why Placemarks
-  belongs under `view-180` rather than `notes-*` — the primitive doesn't require
+  belongs under `view-240` rather than `notes-*` — the primitive doesn't require
   Notes (or any storage layer) to exist.
 - **Anchored to a Note** — persisted via the GitHub Issue store; the note's
   share-URL carries the placemark hash so the recipient lands on the pin with
@@ -427,29 +474,29 @@ publicly — and the recipient sees what was intended.
 - Track dependency: T2 Phase 5 (originator share flow: drop IFC → GLB written
   locally → upload artifact to Drive/GitHub/Firebase → link).
 
-**Epic `share-120`: Private link sharing + visibility chip** 🟡 (NEW)
+**Epic `share-200`: Extended Share/Login flow (one-click)** 🟡 (NEW)
+- Open: <a href="https://github.com/bldrs-ai/Share/issues/1421" target="_blank" rel="noopener noreferrer">#1421</a> Share (200) Extended login flow — the dialog that picks between
+  anonymous-public-5-day, free-public-long-term, Pro-private, etc. This is the
+  surface where the Pro pricing tiers become visible.
+- **Required for Pro-MVP** (it's where the upgrade prompt lives).
+
+**Epic `share-300`: Private link sharing + visibility chip** 🟡 (NEW)
 *Not in PDF except as "Private hosting" sub-bullet under Open.1.*
 - Track dependency: T4 Multi-User Sharing PR1 (landed: provider scaffolding + Drive
   adapter); PR2 (Drive Share dialog UI); PR3 (GitHub sharing adapter).
 - Open: feature flag `sharing` is off; turn-on once PR2 lands.
 - **Required for Pro-MVP** (private sharing is a paid feature per <a href="https://github.com/bldrs-ai/Share/issues/1421" target="_blank" rel="noopener noreferrer">#1421</a>).
 
-**Epic `share-130`: Grant/revoke per-principal sharing** 🟡 (NEW)
+**Epic `share-310`: Grant/revoke per-principal sharing** 🟡 (NEW)
 *Not in PDF.*
 - Track dependency: T4 PR2/PR3 (Share dialog People panel — invites people/teams).
-- Open: same `sharing` flag as `share-120`.
+- Open: same `sharing` flag as `share-300`.
 - **Pro-MVP**: Pro feature.
 
-**Epic `share-140`: Folder-scoped boundaries** ⬜ (NEW)
+**Epic `share-400`: Folder-scoped boundaries** ⬜ (NEW)
 *Not in PDF.*
 - Track dependency: T4 PR4 (route schema extension + in-app boundary enforcement).
 - **Post-MVP.** Useful but not blocking the paid launch.
-
-**Epic `share-150`: Extended Share/Login flow (one-click)** 🟡 (NEW)
-- Open: <a href="https://github.com/bldrs-ai/Share/issues/1421" target="_blank" rel="noopener noreferrer">#1421</a> Share (200) Extended login flow — the dialog that picks between
-  anonymous-public-5-day, free-public-long-term, Pro-private, etc. This is the
-  surface where the Pro pricing tiers become visible.
-- **Required for Pro-MVP** (it's where the upgrade prompt lives).
 
 
 ### 4.4 Notes & Versions (split out of legacy Collab)
@@ -465,15 +512,15 @@ a specific version of the model.
 - Open: <a href="https://github.com/bldrs-ai/Share/issues/892" target="_blank" rel="noopener noreferrer">#892</a> Notes 200 Anchor a note to an element — the Notes-side flow for
   binding a placemark to a note; data path works. The Placemark primitive and
   its open polish issues (<a href="https://github.com/bldrs-ai/Share/issues/928" target="_blank" rel="noopener noreferrer">#928</a>/<a href="https://github.com/bldrs-ai/Share/issues/929" target="_blank" rel="noopener noreferrer">#929</a>/<a href="https://github.com/bldrs-ai/Share/issues/930" target="_blank" rel="noopener noreferrer">#930</a>/<a href="https://github.com/bldrs-ai/Share/issues/931" target="_blank" rel="noopener noreferrer">#931</a>/<a href="https://github.com/bldrs-ai/Share/issues/932" target="_blank" rel="noopener noreferrer">#932</a>/<a href="https://github.com/bldrs-ai/Share/issues/985" target="_blank" rel="noopener noreferrer">#985</a>/<a href="https://github.com/bldrs-ai/Share/issues/998" target="_blank" rel="noopener noreferrer">#998</a>) are tracked under
-  `view-180`.
+  `view-240`.
 
-**Epic `notes-110`: BCF round-trip** ⬜
+**Epic `notes-200`: BCF round-trip** ⬜
 *PDF Collab.2 — "GitHub then BCF at some point".*
 - Never started. Round-trip BCF v2 (XML format) so issues authored in Bldrs are
   consumable in Solibri / Navisworks / Tekla and vice versa.
 - **Post-MVP.** Strong for AEC industry credibility.
 
-**Epic `notes-120`: Drive-backed notes (provider-neutral NotesProvider)** 🔮 (NEW)
+**Epic `notes-210`: Drive-backed notes (provider-neutral NotesProvider)** 🔮 (NEW)
 *Not in original PDF; introduced in `multi-user-sharing.md` Stretch §Q1-Q4.*
 - Track dependency: T4 Stretch (sidecar formats, NotesProvider abstraction).
 - **Post-MVP**: Q1–Q4 of T4 Stretch arc.
@@ -485,12 +532,12 @@ a specific version of the model.
   Versions 200 Delete a version (UI + flow not landed).
 - **Pro-MVP**: enough is done for free-tier; Delete + branch UX polish slot post-MVP.
 
-**Epic `versions-110`: Diff between versions** ⬜
+**Epic `versions-200`: Diff between versions** ⬜
 *PDF Collab table — "Showing Diffs?"*
 - Never started; needs a structural-diff between two IFC versions.
 - **Post-MVP.** Significant scope.
 
-**Epic `versions-120`: Portable versions for Drive (Versions manifest)** 🔮 (NEW)
+**Epic `versions-210`: Portable versions for Drive (Versions manifest)** 🔮 (NEW)
 - Track dependency: T4 Stretch Q3.
 - **Post-MVP.**
 
@@ -506,13 +553,13 @@ data graph.
 - Open: <a href="https://github.com/bldrs-ai/Share/issues/1254" target="_blank" rel="noopener noreferrer">#1254</a> Search 100 Search model based on element name (highlighting in scene).
 - Story to file: cover NavTree + scene highlighting under the same E2E.
 
-**Epic `search-110`: Search across GitHub repos** 🔮 (❤️ Oleg)
+**Epic `search-200`: Search across GitHub repos** 🔮 (❤️ Oleg)
 *PDF Search.2.*
 - Never started. Cross-repo search for "all walls with `LoadBearing=true` across my
   org's repos".
 - **Post-MVP loveable.** Oleg is the design partner.
 
-**Epic `search-120`: Knowledge graph / ask questions** 🔮 (❤️ Johannes)
+**Epic `search-210`: Knowledge graph / ask questions** 🔮 (❤️ Johannes)
 *PDF Search.3 (🥇 MLP).*
 - Never started. Natural-language QA over building data with citations back to the
   model.
@@ -544,7 +591,7 @@ changes (Google → GitHub or vice versa).
 - **Required for Pro-MVP** (otherwise users with two GH accounts can't tell what
   they're billed under).
 
-**Epic `identity-130`: Profile drawer + multi-account picker** ⬜
+**Epic `identity-300`: Profile drawer + multi-account picker** ⬜
 - Implicit in T3 PR2 design.
 - **Required for Pro-MVP** — the "Saving as X — GitHub" footer in the Save dialog
   (`identity-decoupling-decisions.md` §Q4).
@@ -557,7 +604,7 @@ Third-party (and dogfooded) apps add capabilities to Share via a stable API.
 **Epic `apps-100`: Browse + select app (AppsDrawer)** ✔
 - Closed: <a href="https://github.com/bldrs-ai/Share/issues/1282" target="_blank" rel="noopener noreferrer">#1282</a> Apps 100.
 - Open: nothing immediate as a free-standing Epic — but the AppsDrawer + `WidgetApi/`
-  iframe surface is the **seed of the AI-apps toolbelt** (`assist-130`, §7.2).
+  iframe surface is the **seed of the AI-apps toolbelt** (`assist-200`, §7.2).
   <a href="https://github.com/bldrs-ai/Share/issues/1386" target="_blank" rel="noopener noreferrer">#1386</a> (iframe integration broken; its test suite disabled) graduates from
   dormant bug to pivot blocker — the sandbox foundation must work before anything
   is built on it (§7.4 AI.0).
@@ -565,20 +612,20 @@ Third-party (and dogfooded) apps add capabilities to Share via a stable API.
 **Epic `apps-110`: XYZ demo app (dogfood v0.1 API)** ✔
 *PDF Apps.1 — done in PDF.*
 
-**Epic `apps-120`: Bldrs Integrate (CI + ArchiCAD/Speckle)** 🔮
-*PDF Apps.2.*
-- Never started. Server-side IFC validation pipeline running IDS rules per commit
-  (preview of view-170 IDS).
-- **Absorbed by the AI pivot (§7):** agent-driven model checks become the delivery
-  vehicle — an AI-app in the toolbelt (T11) rather than a bespoke CI product.
-
-**Epic `apps-130`: v1.0 Public API + docs + IDE integration** 🔮
+**Epic `apps-200`: v1.0 Public API + docs + IDE integration** 🔮
 *PDF Apps.3 (🥇 MLP).*
 - Never started as a programmatic surface; the `WidgetApi/` directory is the seed.
 - **Re-scoped by the AI pivot (§7):** the public API's first consumers are the
   in-app agent and the AI-apps sandbox, so the surface is designed **MCP-first**
   (Track T11) — external IDE/embedding consumers and the internal toolbelt share
   one tool contract instead of us maintaining two APIs.
+
+**Epic `apps-210`: Bldrs Integrate (CI + ArchiCAD/Speckle)** 🔮
+*PDF Apps.2.*
+- Never started. Server-side IFC validation pipeline running IDS rules per commit
+  (preview of view-230 IDS).
+- **Absorbed by the AI pivot (§7):** agent-driven model checks become the delivery
+  vehicle — an AI-app in the toolbelt (T11) rather than a bespoke CI product.
 
 
 ### 4.8 Community & Onboarding
@@ -595,13 +642,13 @@ User finds out about Bldrs, gets oriented, leaves feedback, and finds product he
 - Open: 👍/👎 exit feedback widget; in-app Google Forms survey link.
 - **Pro-MVP**: at least one feedback affordance is needed for the public launch.
 
-**Epic `community-120`: Bug report w/ screenshot + session state** ⬜
+**Epic `community-200`: Bug report w/ screenshot + session state** ⬜
 *PDF Community.2 (MVP).*
 - Never started. The closest seed is `?feature=perf` for diagnostics; structured bug
   capture + auto-redaction of model bytes is the missing piece.
 - **Post-MVP** unless Pro-MVP support burden makes it Day-1 critical.
 
-**Epic `community-130`: AEC outreach (Stack Overflow, Twitter)** 🔮
+**Epic `community-210`: AEC outreach (Stack Overflow, Twitter)** 🔮
 *PDF Community.3 (🥇 MLP — ❤️ Kate?).*
 - Out of repo scope. Now owned by the bizdev growth-strategy doc (§7 there:
   community channels, Show HN, DevRel around git-based model versioning; channel
@@ -629,7 +676,17 @@ hypotheses** (what share of users hit the threshold; of those, who pays vs.
 churns) instrumented well enough to produce decision-grade conversion evidence —
 not just a revenue trickle.*
 
-**Epic `subscribe-100`: Pricing tiers + feature manager** ⬜ (NEW)
+**Epic `subscribe-130`: Ads on free tier** 🟡
+- Track dependency: T7 Ads (<a href="https://github.com/bldrs-ai/Share/issues/1524" target="_blank" rel="noopener noreferrer">#1524</a>). Phase 1 activation in flight (<a href="https://github.com/bldrs-ai/Share/issues/1523" target="_blank" rel="noopener noreferrer">#1523</a>).
+- Open: Phases 2 (manual slots) + 3 (responsive) + 4 (consent gating).
+- **Required for Pro-MVP** — the free tier monetisation path.
+- Scope note: T7 is **on-site AdSense** (revenue). The Google Ads **acquisition**
+  campaigns (Smart→Search rebuild, keywords, geo, bidding) are out of repo scope —
+  owned in the private bizdev growth-strategy doc §4. The in-repo dependency runs
+  the other way: those campaigns need `grow-100` landing pages as destinations and
+  `grow-120` events to bid against.
+
+**Epic `subscribe-300`: Pricing tiers + feature manager** ⬜ (NEW)
 - Tasks: enumerate features per tier; ship a `tier`-aware capability map; UI in <a href="https://github.com/bldrs-ai/Share/issues/1421" target="_blank" rel="noopener noreferrer">#1421</a>
   mock dialog form.
 - Tier axis (v0.4): small models stay free and unlimited; the Pro boundary is
@@ -638,14 +695,14 @@ not just a revenue trickle.*
   distribution from telemetry before it's picked.
 - **Required for Pro-MVP.**
 
-**Epic `subscribe-110`: Stripe checkout + portal** ⬜ (NEW)
+**Epic `subscribe-310`: Stripe checkout + portal** ⬜ (NEW)
 - Tasks: `create-portal-session` Netlify Function exists already (per identity
   decoupling decisions doc — model pattern for new functions). Add
   `create-checkout-session`; webhook for status changes; persist Pro flag against
   Auth0 `sub`.
 - **Required for Pro-MVP.**
 
-**Epic `subscribe-120`: Quota tracking** ⬜ (NEW)
+**Epic `subscribe-320`: Quota tracking** ⬜ (NEW)
 - Tasks: server-side counter keyed by Auth0 `sub` (per identity-decoupling-decisions
   §Q4 Open Question on "Quota tracking"); enforcement points in (a) GLB writer
   Phase-5 share upload, (b) per-connection refresh-token mint, (c) public-share
@@ -658,15 +715,13 @@ not just a revenue trickle.*
   yields decision-grade evidence either way.
 - **Required for Pro-MVP.**
 
-**Epic `subscribe-130`: Ads on free tier** 🟡
-- Track dependency: T7 Ads (<a href="https://github.com/bldrs-ai/Share/issues/1524" target="_blank" rel="noopener noreferrer">#1524</a>). Phase 1 activation in flight (<a href="https://github.com/bldrs-ai/Share/issues/1523" target="_blank" rel="noopener noreferrer">#1523</a>).
-- Open: Phases 2 (manual slots) + 3 (responsive) + 4 (consent gating).
-- **Required for Pro-MVP** — the free tier monetisation path.
-- Scope note: T7 is **on-site AdSense** (revenue). The Google Ads **acquisition**
-  campaigns (Smart→Search rebuild, keywords, geo, bidding) are out of repo scope —
-  owned in the private bizdev growth-strategy doc §4. The in-repo dependency runs
-  the other way: those campaigns need `grow-100` landing pages as destinations and
-  `grow-120` events to bid against.
+**Epic `subscribe-400`: Enterprise tier definition** ⬜ (NEW, v0.5)
+- Placeholder for the enterprise packaging the ai-strategy synthesis points at:
+  the no-upload/data-sovereignty posture productised (security-review pack,
+  what-leaves-the-browser documentation), org/team administration, folder
+  boundaries (`share-400`), SSO. Deliberately thin until a design-partner pulls
+  on it — the §7.5 validation work decides what actually goes in here.
+- **Post-MVP.** Its marketing face (`grow-400`) ships much earlier, in Phase G.
 
 
 ### 4.10 Grow (NEW Epic group)
@@ -682,7 +737,7 @@ mechanisms are recorded here.
 stays cheap. The broad "open X file online" audience is the commodity segment —
 it feeds the funnel and the share loop but it is not where willingness-to-pay
 lives, so Phase G doesn't grow beyond the epics below. The audience that pays
-(large-model, enterprise-profile) gets its own positioning surface (`grow-130`);
+(large-model, enterprise-profile) gets its own positioning surface (`grow-400`);
 which channel *reaches* that audience is the open GTM question owned bizdev-side
 (ai-strategy §6).*
 
@@ -722,14 +777,14 @@ which channel *reaches* that audience is the open GTM question owned bizdev-side
 - Channel-grouping + dashboard slices are bizdev-side config; the Share-side
   deliverable is the events existing and firing.
 - v0.4 addition: capture **model size/complexity** (bucketed — bytes, element
-  count) on the model-open event, so (a) the `subscribe-100` quota threshold is
+  count) on the model-open event, so (a) the `subscribe-300` quota threshold is
   picked from real distribution data, not guessed, and (b) large-model users —
   the segment that matters — become visible in the funnel instead of drowned in
   commodity traffic.
 - **Phase G — first slice.** Blocks conversion-based bidding, loop metrics, and
   any honest read of a launch/Show-HN spike.
 
-**Epic `grow-130`: Large-model + data-sovereignty positioning** ⬜ (NEW, v0.4)
+**Epic `grow-400`: Large-model + data-sovereignty positioning** ⬜ (NEW, v0.4)
 - The positioning surface for the audience that pays: a page (marketing SSG
   build) that leads with **"AI iterates on models nobody else can even open"**
   and the two proof points behind it — large-model handling that defeats
@@ -762,8 +817,8 @@ vision, architecture, and sequencing. Design doc to draft: `design/new/ai-worksp
   rather than a single-document viewer — the Claude-Code chrome around the canvas.
 - Pure UI + routing + state work; no AI-runtime dependency. Ships behind
   `?feature=workspace`.
-- Interacts with: `open-130` Sources tab (accounts live in the same nav), T4
-  sharing (shared-with-me listing), `identity-130` profile drawer.
+- Interacts with: `open-300` Sources tab (accounts live in the same nav), T4
+  sharing (shared-with-me listing), `identity-300` profile drawer.
 
 **Epic `assist-110`: Conversational agent panel (single-user)** ⬜ (NEW)
 - A Claude-Code-like conversation panel over the open project/model: prompt →
@@ -773,10 +828,23 @@ vision, architecture, and sequencing. Design doc to draft: `design/new/ai-worksp
   consumer.
 - Single user, one conversation per project/model. This is the demo that sells
   the pivot (§7.4 AI.2).
-- Absorbs `search-120`'s NL-QA ambition; T10 owns the runtime + conversation
+- Absorbs `search-210`'s NL-QA ambition; T10 owns the runtime + conversation
   persistence.
 
-**Epic `assist-120`: Multi-user channels + AI participation modes** ⬜ (NEW)
+**Epic `assist-200`: AI-apps toolbelt (right drawer)** ⬜ (NEW)
+- The existing right-drawer AppsDrawer, upgraded: code the agent generates can be
+  **saved, versioned, and run** in a sandboxed iframe that talks to the main app
+  context over an **MCP bridge** (postMessage transport) — the same tool surface
+  the agent uses (T11). Users accumulate personal/team toolbelts of generated
+  apps.
+- This is the user-generated-app story `apps-100`/`apps-200` always pointed at,
+  with the agent as the author. `apps-210`-style model checks become toolbelt
+  apps.
+- Pre-condition: fix <a href="https://github.com/bldrs-ai/Share/issues/1386" target="_blank" rel="noopener noreferrer">#1386</a> (iframe widget integration broken, suite disabled).
+- Storage/versioning candidate: the user's own hosting via T3/T4 providers (apps
+  are files too), keeping the BYOS shape of the rest of the product.
+
+**Epic `assist-300`: Multi-user channels + AI participation modes** ⬜ (NEW)
 - The conversation becomes a shared channel. The key mechanic:
   - **Direct replies addressed to the AI** are commands — handled exactly as the
     single-user panel handles a prompt (full agent loop + tool calls).
@@ -787,19 +855,6 @@ vision, architecture, and sequencing. Design doc to draft: `design/new/ai-worksp
 - Depends on a shared conversation store with realtime sync (T10) and T4
   sharing/grants for channel membership. Largest new backend piece — last in the
   pivot sequence (§7.4 AI.4).
-
-**Epic `assist-130`: AI-apps toolbelt (right drawer)** ⬜ (NEW)
-- The existing right-drawer AppsDrawer, upgraded: code the agent generates can be
-  **saved, versioned, and run** in a sandboxed iframe that talks to the main app
-  context over an **MCP bridge** (postMessage transport) — the same tool surface
-  the agent uses (T11). Users accumulate personal/team toolbelts of generated
-  apps.
-- This is the user-generated-app story `apps-100`/`apps-130` always pointed at,
-  with the agent as the author. `apps-120`-style model checks become toolbelt
-  apps.
-- Pre-condition: fix <a href="https://github.com/bldrs-ai/Share/issues/1386" target="_blank" rel="noopener noreferrer">#1386</a> (iframe widget integration broken, suite disabled).
-- Storage/versioning candidate: the user's own hosting via T3/T4 providers (apps
-  are files too), keeping the BYOS shape of the rest of the product.
 
 
 ## 5. Cross-cutting Tracks
@@ -834,7 +889,7 @@ same list-item order: What, Status, Unblocks, Pro-MVP impact, Doc.
   `?feature=look` (default off)** — the default still renders the legacy look. To
   go live: flip the flag default + regenerate the screenshot baselines (one PR).
   See `design/new/viewer-replacement.md` §6e.
-- **Unblocks:** `view-100`, `view-110`, `view-130`, `view-150`, `view-160`, T2.
+- **Unblocks:** `view-100`, `view-110`, `view-200`, `view-130`, `view-220`, T2.
 - **Pro-MVP impact:** Required — public-launch gate.
 - **Doc:** `design/new/viewer-replacement.md`.
 
@@ -845,7 +900,7 @@ same list-item order: What, Status, Unblocks, Pro-MVP impact, Doc.
   key, extension split, picker fix, BLDRS_* extensions) landed.
 - **Status:** Phases 4 (Notes + view-states v0.1 round-trip), 5 (originator share
   flow), 6 (shared cache tier — Drive/Firebase) open.
-- **Unblocks:** `share-110`, `notes-120`, `view-150` perf wins.
+- **Unblocks:** `share-110`, `notes-210`, `view-130` perf wins.
 - **Pro-MVP impact:** Phase 5 (originator share flow) — required. Phase 4 — required
   (so notes survive cache hits). Phase 6 — post-MVP optimisation.
 - **Doc:** `design/new/glb-model-sharing.md`.
@@ -858,8 +913,8 @@ same list-item order: What, Status, Unblocks, Pro-MVP impact, Doc.
   Auth0-federated path retained for migration.
 - **Status:** PR1 (provider scaffolding + Functions) merged. PR2 (SourcesTab UI
   integration, recents migration) + PR3 (switchover + flag retire) open.
-- **Unblocks:** `identity-110`, `identity-120`, `identity-130`, `open-130`,
-  `share-130`, `subscribe-120` (quota keying), and T4 PR3 (GH sharing).
+- **Unblocks:** `identity-110`, `identity-120`, `identity-300`, `open-300`,
+  `share-310`, `subscribe-320` (quota keying), and T4 PR3 (GH sharing).
 - **Pro-MVP impact:** PR2 + PR3 required.
 - **Docs:** `design/new/identity-decoupling.md` + `identity-decoupling-decisions.md`.
 
@@ -872,7 +927,7 @@ same list-item order: What, Status, Unblocks, Pro-MVP impact, Doc.
 - **Status:** PR1 (provider scaffolding) merged. PR2 (Drive Share dialog UI), PR3 (GH
   sharing adapter), PR4 (folder boundary routes) open. PR5 (GH token-health parity)
   and PR6 (flag retire) follow.
-- **Unblocks:** `share-120`, `share-130`, `share-140`, `notes-120`, `versions-120`.
+- **Unblocks:** `share-300`, `share-310`, `share-400`, `notes-210`, `versions-210`.
 - **Pro-MVP impact:** PR2 + PR3 required (private sharing is a paid feature). PR4
   post-MVP. PR5 nice-to-have.
 - **Docs:** `design/new/multi-user-sharing.md` + `design/new/sharing-pr3-github.md`.
@@ -883,7 +938,7 @@ same list-item order: What, Status, Unblocks, Pro-MVP impact, Doc.
 - **What:** Pre-flight Drive metadata check on recents click; typed `FileUnreachable`
   alert variants.
 - **Status:** Proposed. Not started.
-- **Unblocks:** `open-150`. Pattern reusable for GH recents once `githubAsSource`
+- **Unblocks:** `open-130`. Pattern reusable for GH recents once `githubAsSource`
   lands.
 - **Pro-MVP impact:** Polish; not strictly required for paid launch but the support
   cost of "Failed to parse model" on dead recents is real.
@@ -895,7 +950,7 @@ same list-item order: What, Status, Unblocks, Pro-MVP impact, Doc.
 - **What:** Provider-neutral JSON sidecar formats for notes + versions, round-tripping
   between Drive snapshots and git issues/commits.
 - **Status:** Not started.
-- **Unblocks:** `notes-120`, `notes-110` (BCF can be derived), `versions-120`.
+- **Unblocks:** `notes-210`, `notes-200` (BCF can be derived), `versions-210`.
 - **Pro-MVP impact:** Post-MVP. Quarter-scale work.
 - **Doc:** `multi-user-sharing.md` §Stretch (Q1–Q4).
 
@@ -916,7 +971,7 @@ same list-item order: What, Status, Unblocks, Pro-MVP impact, Doc.
   plumbing throughout the app.
 - **Status:** Not started. Existing seeds: `netlify/functions/create-portal-session.js`,
   `netlify/functions/unlink-identity.js` (pattern reuse).
-- **Unblocks:** `subscribe-100`, `subscribe-110`, `subscribe-120`. Forward-looking:
+- **Unblocks:** `subscribe-300`, `subscribe-310`, `subscribe-320`. Forward-looking:
   the same quota/metering rails are what §7 AI usage metering hangs off — design
   the counter keying with that consumer in mind.
 - **Quota axis (v0.4):** model size/complexity, never model count — the paywall
@@ -933,13 +988,13 @@ same list-item order: What, Status, Unblocks, Pro-MVP impact, Doc.
   (`share_link_created` / `share_link_opened` / `model_interacted`, plus v0.4
   size/complexity buckets on model-open), analytics hygiene (webdriver + hostname
   guard on GA init), OG/link-preview metadata on share URLs, the
-  `/viewer/<format>` landing pages, and the `grow-130` large-model +
+  `/viewer/<format>` landing pages, and the `grow-400` large-model +
   data-sovereignty positioning page — all on the marketing SSG build.
 - **Status:** Not started in-repo. The enabling substrate (Next.js SSG marketing
   build, PR #1519) is landed; strategy + attribution live in the private bizdev
   docs.
-- **Unblocks:** `grow-100`, `grow-110`, `grow-120`, `grow-130`; honest measurement
-  of every outreach move in `community-130`; conversion-based bidding for the
+- **Unblocks:** `grow-100`, `grow-110`, `grow-120`, `grow-400`; honest measurement
+  of every outreach move in `community-210`; conversion-based bidding for the
   (out-of-repo) acquisition campaigns; the Phase D quota-threshold pick.
 - **Pro-MVP impact:** Phase G — parallel, starts now. Cheap relative to everything
   else in §6 and the only work that grows the top of the funnel.
@@ -950,13 +1005,13 @@ same list-item order: What, Status, Unblocks, Pro-MVP impact, Doc.
 ### Track T10: Agent runtime & conversation store (NEW)
 
 - **What:** The conversational core of the §7 pivot: agent loop (LLM calls, tool
-  dispatch, streaming), conversation persistence, and — for `assist-120` — a
+  dispatch, streaming), conversation persistence, and — for `assist-300` — a
   shared store with realtime sync and the direct-address vs channel-awareness
   routing.
 - **Status:** Not started. Design questions (runtime placement client vs broker,
   provider strategy, store choice, relation to Notes) go to
   `design/new/ai-workspace.md` first — see §7.4 AI.0 and §10 open questions.
-- **Unblocks:** `assist-110`, `assist-120`, `search-120` (as retrieval), and the
+- **Unblocks:** `assist-110`, `assist-300`, `search-210` (as retrieval), and the
   §7 AI-metering upsell.
 - **Pro-MVP impact:** None (pivot arc). Must not destabilise Phases A–E.
 - **Doc:** TBD — `design/new/ai-workspace.md`.
@@ -973,7 +1028,7 @@ same list-item order: What, Status, Unblocks, Pro-MVP impact, Doc.
 - **Status:** Not started. Seeds: `WidgetApi/` + AppsDrawer (`apps-100`), the
   `IfcModelService` query surface (T1). Known debt: <a href="https://github.com/bldrs-ai/Share/issues/1386" target="_blank" rel="noopener noreferrer">#1386</a> iframe integration
   broken with its suite disabled — repair is the first slice.
-- **Unblocks:** `assist-130`, `apps-130` (MCP-first public API), `apps-120`
+- **Unblocks:** `assist-200`, `apps-200` (MCP-first public API), `apps-210`
   (checks as toolbelt apps).
 - **Pro-MVP impact:** None (pivot arc), except the #1386 repair which is
   independently worthwhile.
@@ -1013,7 +1068,7 @@ landing page — before the Pro launch needs any of it.
   route.
 - `grow-120` v0.4 slice: size/complexity buckets on the model-open event — the
   data the Phase D quota threshold gets picked from.
-- `grow-130`: the large-model + data-sovereignty positioning page.
+- `grow-400`: the large-model + data-sovereignty positioning page.
 
 **Exit:** funnel dashboard shows clean stage-by-stage counts (with large-model
 users visible as a segment); a shared link unfurls with a thumbnail in Slack;
@@ -1054,7 +1109,7 @@ hang off.
 - T3 PR2 follow-up: gate connect actions behind Auth0 primary auth (per decisions doc
   §PR2 "Gate connection actions behind Auth0").
 - `identity-120`: <a href="https://github.com/bldrs-ai/Share/issues/1422" target="_blank" rel="noopener noreferrer">#1422</a> Auth disambiguation chooser.
-- `identity-130`: profile drawer multi-account picker + "Saving as X" footer.
+- `identity-300`: profile drawer multi-account picker + "Saving as X" footer.
 - T3 PR3 switchover; retire `githubAsSource` flag.
 
 **Exit:** a user logged-in via Google can browse and save to two GitHub accounts;
@@ -1068,9 +1123,9 @@ recents are correctly attributed per-connection; commit author = Sources GH iden
 - T4 PR5 (GH token-health parity) — small.
 - T2 Phase 4 (Notes + view-states v0.1 in artifact).
 - T2 Phase 5 (Originator share flow: drop IFC → GLB → upload artifact → link). Wires
-  the Share dialog from `share-150` (<a href="https://github.com/bldrs-ai/Share/issues/1421" target="_blank" rel="noopener noreferrer">#1421</a>) on top.
-- `share-120` private link sharing surfaces in the dialog.
-- `share-130` people-grants surface in the dialog.
+  the Share dialog from `share-200` (<a href="https://github.com/bldrs-ai/Share/issues/1421" target="_blank" rel="noopener noreferrer">#1421</a>) on top.
+- `share-300` private link sharing surfaces in the dialog.
+- `share-310` people-grants surface in the dialog.
 - `grow-110` completion: per-model OG image written alongside the T2 Phase 5 share
   artifact (if that's the chosen mechanism), so every share link unfurls with a
   real thumbnail. The share loop is our best earned channel — this phase is where
@@ -1093,14 +1148,14 @@ models stay free and unlimited.
   definitions + the experiment's hypotheses/threshold before code. Threshold
   picked from the `grow-120` size-distribution telemetry (Phase G), not
   guessed.
-- `subscribe-100` pricing tiers + feature-gate map.
-- `subscribe-110` Stripe checkout + portal Netlify Functions. Pattern from
+- `subscribe-300` pricing tiers + feature-gate map.
+- `subscribe-310` Stripe checkout + portal Netlify Functions. Pattern from
   `unlink-identity.js`.
-- `subscribe-120` quota tracking — instrument the three enforcement points (GLB
+- `subscribe-320` quota tracking — instrument the three enforcement points (GLB
   upload, refresh-token mint, public-share retention).
 - T7 Phase 2 + 3 ad slots on `/about`, `/privacy`, `/tos`, `/blog/*`.
 - `subscribe-130` ads wired to free-tier-only gate.
-- `share-150` Extended Share dialog (<a href="https://github.com/bldrs-ai/Share/issues/1421" target="_blank" rel="noopener noreferrer">#1421</a>) wires Pro upsell into the share flow.
+- `share-200` Extended Share dialog (<a href="https://github.com/bldrs-ai/Share/issues/1421" target="_blank" rel="noopener noreferrer">#1421</a>) wires Pro upsell into the share flow.
 
 **Exit:** a free user hits the size/complexity threshold and can upgrade in two
 clicks; ads serve on text routes only; the experiment dashboard answers the
@@ -1166,7 +1221,7 @@ around a conversational core rather than building beside them.
    artifacts) and **company-level nav** (org, members, settings). The container
    that turns Share from a single-document viewer into a workspace. Pure
    UI/routing work; ships behind a flag with no AI-runtime dependency.
-2. **Conversational panel (`assist-110`, `assist-120`).** A Claude-Code-like
+2. **Conversational panel (`assist-110`, `assist-300`).** A Claude-Code-like
    conversation over the open project/model. The multi-user mechanic:
    - **Direct replies addressed to the AI are commands** — treated exactly as
      Claude Code treats a prompt today: agent loop, tool calls against the
@@ -1175,7 +1230,7 @@ around a conversational core rather than building beside them.
      context and can participate **comment-only**. A channel message never
      triggers the tool-using agent loop; only direct address does.
    The split keeps the agent useful in a group without it hijacking every thread.
-3. **Right drawer — AI-apps toolbelt (`assist-130`).** The existing right-drawer
+3. **Right drawer — AI-apps toolbelt (`assist-200`).** The existing right-drawer
    AppsDrawer, upgraded: code the agent generates is **saved, versioned, and
    run** in a sandboxed iframe that interacts with the main window/app context
    over an **MCP bridge** (postMessage transport). Users accumulate personal and
@@ -1184,13 +1239,13 @@ around a conversational core rather than building beside them.
 The unifying piece: the main window exposes the viewer as an **MCP server**
 (selection, camera, isolation, properties, notes, model queries — Track T11).
 The conversational agent and the sandboxed apps consume the *same* tool surface —
-one contract, two consumers — and `apps-130`'s public API becomes a third
+one contract, two consumers — and `apps-200`'s public API becomes a third
 consumer of it later, for free.
 
 Two v0.4 constraints on that architecture:
 
 - **Data sovereignty is load-bearing.** "Your model never leaves your machine"
-  is an enterprise wedge (`grow-130`), and the agent must not silently break
+  is an enterprise wedge (`grow-400`), and the agent must not silently break
   it. Model bytes stay client-side; what crosses the wire to the LLM provider
   is the conversation plus tool *results* (which can contain model-derived
   data — names, properties, geometry summaries). That boundary needs to be
@@ -1210,10 +1265,10 @@ Two v0.4 constraints on that architecture:
 
 ### 7.3 What it absorbs
 
-- `search-120` Knowledge graph → the retrieval layer behind conversational QA.
-- `apps-130` v1.0 Public API → designed MCP-first; external IDE/embed consumers
+- `search-210` Knowledge graph → the retrieval layer behind conversational QA.
+- `apps-200` v1.0 Public API → designed MCP-first; external IDE/embed consumers
   and the internal toolbelt share one contract.
-- `apps-120` Bldrs Integrate → agent-run model checks as toolbelt apps.
+- `apps-210` Bldrs Integrate → agent-run model checks as toolbelt apps.
 - `notes-*` / channels → need one coherent story: an anchored note thread and a
   channel message are close cousins (open question, §10).
 
@@ -1237,10 +1292,10 @@ can't destabilise the launch may start earlier behind flags.
   on a large model** (one that defeats the alternatives), because
   "conversational AI over a small IFC" is replicable by anyone, while the same
   loop on a model nobody else can open is the moat made visible. Refresh
-  `grow-130` with this demo when it exists.
-- **AI.3 — Toolbelt.** `assist-130`: generate → save → version → run in the
+  `grow-400` with this demo when it exists.
+- **AI.3 — Toolbelt.** `assist-200`: generate → save → version → run in the
   sandbox over the same MCP surface.
-- **AI.4 — Multi-user.** `assist-120`: shared channels, direct-address vs
+- **AI.4 — Multi-user.** `assist-300`: shared channels, direct-address vs
   comment-only mechanics, presence. Depends on the shared conversation store —
   the largest new backend piece.
 - **AI.5 — Editing loop (north star).** Agent-driven model *modification*
@@ -1268,29 +1323,29 @@ Held over for after Phase E. Items marked **→ §7** are absorbed by the AI piv
 and leave this queue — they ride the pivot sequencing instead. Order roughly
 reflects current product-pull:
 
-1. **`view-160` ETL / Table view** 🔮 (❤️ Markus). The "10$/mo by itself" loveable.
+1. **`view-220` ETL / Table view** 🔮 (❤️ Markus). The "10$/mo by itself" loveable.
    Pre-cond mostly done via T1.
-2. **`open-140` Multi-IFC overlay session** (<a href="https://github.com/bldrs-ai/Share/issues/1251" target="_blank" rel="noopener noreferrer">#1251</a>). Conway+GLB make this tractable.
-3. **`view-130` Persistent visibility URL encoding** (<a href="https://github.com/bldrs-ai/Share/issues/1250" target="_blank" rel="noopener noreferrer">#1250</a>). Last slice on top of
+2. **`open-200` Multi-IFC overlay session** (<a href="https://github.com/bldrs-ai/Share/issues/1251" target="_blank" rel="noopener noreferrer">#1251</a>). Conway+GLB make this tractable.
+3. **`view-200` Persistent visibility URL encoding** (<a href="https://github.com/bldrs-ai/Share/issues/1250" target="_blank" rel="noopener noreferrer">#1250</a>). Last slice on top of
    T1 isolate routing.
-4. **`view-140` Selection-based camera + measurement** (<a href="https://github.com/bldrs-ai/Share/issues/1044" target="_blank" rel="noopener noreferrer">#1044</a>, <a href="https://github.com/bldrs-ai/Share/issues/1047" target="_blank" rel="noopener noreferrer">#1047</a>).
+4. **`view-210` Selection-based camera + measurement** (<a href="https://github.com/bldrs-ai/Share/issues/1044" target="_blank" rel="noopener noreferrer">#1044</a>, <a href="https://github.com/bldrs-ai/Share/issues/1047" target="_blank" rel="noopener noreferrer">#1047</a>).
 5. **T2 Phase 6 Shared cache tier** (Firebase/Drive sidecar).
 6. **T4 PR4 Folder-scoped routes**.
-7. **`notes-110` BCF round-trip**.
+7. **`notes-200` BCF round-trip**.
 8. **T6 Stretch Q1–Q4 portable notes/versions** for Drive parity with GH.
-9. **`view-170` Common view ops**: nav-cube, explode, undo/redo. IDS validation
+9. **`view-230` Common view ops**: nav-cube, explode, undo/redo. IDS validation
    separately.
-10. **`view-180` Maps-style filtering UI on top of Placemarks** 🔮 — Placemark
+10. **`view-240` Maps-style filtering UI on top of Placemarks** 🔮 — Placemark
     primitive itself is 🟡 with polish slated for Phase C (see Epic). The filter
     chips + cluster rendering visualization on top is the post-MVP loveable.
     Pairs with T6 Q1.
-11. **`search-110` Cross-repo search** 🔮 (❤️ Oleg). An agent with repo-source
+11. **`search-200` Cross-repo search** 🔮 (❤️ Oleg). An agent with repo-source
     tools may deliver this as a §7 by-product — reassess once AI.2 exists.
-12. **`apps-120` Bldrs Integrate (CI server-side IDS)** → §7 (toolbelt apps).
-13. **`apps-130` v1.0 Public API + IDE** 🔮 → §7 (MCP-first, T11).
-14. **`search-120` Knowledge Graph** 🔮 (❤️ Johannes) → §7 (retrieval behind
+12. **`apps-210` Bldrs Integrate (CI server-side IDS)** → §7 (toolbelt apps).
+13. **`apps-200` v1.0 Public API + IDE** 🔮 → §7 (MCP-first, T11).
+14. **`search-210` Knowledge Graph** 🔮 (❤️ Johannes) → §7 (retrieval behind
     `assist-110`).
-15. **`versions-110` Diff between versions**.
+15. **`versions-200` Diff between versions**.
 16. **PDF "Smart Components & Templates"** 🔮 (❤️ Pablo). Massive scope; will warrant
     its own Epic group when started.
 17. **PDF "Hangouts" (Miro, FPV, WebXR Bonanza)** — out of scope until use-case
@@ -1305,7 +1360,7 @@ Once this doc lands, the backfill order:
 1. **GitHub issues — Epics first.**
    For each Epic in §4 with status 🟡 or ⬜ and `Pro-MVP impact: required`, create an
    `epic`-labeled GH issue with the body content from the Epic block. Stable ID
-   becomes the issue title prefix (e.g. `epic: open-130: SourcesTab with parallel GH +
+   becomes the issue title prefix (e.g. `epic: open-300: SourcesTab with parallel GH +
    Drive accounts`). One pass; expect ~12–15 new Epic issues. The v0.3 groups ride
    the same pass: one `epic` issue per `grow-*` (Phase G starts now) and per
    `assist-*` (so pivot discussion has a home), even though the `assist-*` bodies
@@ -1331,7 +1386,7 @@ without sign-off.
 
 ## 10. Open questions
 
-- **Pro tier feature gate definition.** §4.9 sketches `subscribe-100`; the v0.4
+- **Pro tier feature gate definition.** §4.9 sketches `subscribe-300`; the v0.4
   anchor is decided — the Pro boundary is **model size/complexity** — with
   private link sharing, ad-free, multi-account, cache retention, and quota
   uplift around it. Confirm the full list before the T8 design doc.
@@ -1341,7 +1396,7 @@ without sign-off.
   engine-benchmark data, not by feel. (ai-strategy §9.3.)
 - **Free-tier quota numbers.** Public anonymous share TTL (3 days? 5 days?), public
   hosting size ceiling (PDF <a href="https://github.com/bldrs-ai/Share/issues/1421" target="_blank" rel="noopener noreferrer">#1421</a> says <10MB), refresh-token-mint rate. Needs a call
-  before `subscribe-120`.
+  before `subscribe-320`.
 - **Auth0 enforcement on Netlify Functions.** Flagged in
   `identity-decoupling-decisions.md` §Open Implementation Details. Needs to be
   resolved before Phase D quota tracking ships (the quota key is meaningless if the
@@ -1362,7 +1417,7 @@ without sign-off.
   property edits only at first? geometry?), where the edit log lives, and how
   round-tripping back to IFC/STEP works. Needs a Conway-side design doc; the
   answer decides how soon the headline capability is honest.
-- **AI pivot — conversation store.** `assist-120` needs shared, realtime-ish
+- **AI pivot — conversation store.** `assist-300` needs shared, realtime-ish
   conversation state. Candidates: GitHub-issue-backed (Notes-style, free, slow),
   Firebase/Firestore (already floated for T2 Phase 6), or a purpose-built
   backend. Also: are channels and Notes one primitive or two? (An anchored note
@@ -1388,9 +1443,15 @@ without sign-off.
   should reference `roadmap.md` if the change moves an Epic state.
 - **When a track lands a slice:** update the Status line of the track in §3.2 and §5.
   If the track is "done" it becomes a one-line entry pointing at its design doc.
-- **When a new Epic emerges:** add it to §4 under the appropriate verb group with a
-  stable ID one above the highest existing in that group (e.g. `open-160`), and add
-  the matching row to §3.1. Don't renumber existing IDs.
+- **When a new Epic emerges:** add it to §4 under the appropriate verb group, in
+  the **tier band the capability belongs to** (§2.1: 100s MVP, 200s MLP, 300s Pro,
+  400s Enterprise), at the next free ten within that band (e.g. the next MVP-tier
+  Open epic is `open-140`). Add the matching row to §3.1, keeping rows tier-sorted
+  within the group. Don't renumber existing IDs — the v0.5 renorm was a one-time
+  exception, and its old→new map lives in §2.1.
+- **When an Epic changes tier** (promoted to Pro, or an MLP item turns out to be
+  MVP): that *is* a renumber — do it deliberately, one epic at a time, and append
+  the old→new pair to the §2.1 map.
 - **Don't delete done Epics.** They stay in §4 as the historical record of what
   shipped, which is what §8 "Post-MVP backlog" is measured against.
 - **Privacy firewall.** This doc is public. Growth/traffic *numbers* (spend, CAC,

--- a/design/roadmap.md
+++ b/design/roadmap.md
@@ -10,70 +10,6 @@ This doc normalizes the legacy Epic list against ~2 years of execution since the
 top-down review, surfaces the work that landed without story tracking, and lays out the
 **MVP plan** (billing-ready by definition — §2.1) plus the loveable backlog beyond it.
 
-**v0.3 (2026-07-02) folds in three things:**
-
-1. **Implementation drift since v0.2** — the `conway-web-ifc-adapter` shim retired
-   (`design/new/adapter-removal.md`), the GPU-instancing/`BatchedMesh` render arc
-   behind `?feature=batchedMesh`, STEP metadata extraction (conway #345 arc), and
-   the marketing site's move to Next.js SSG. Reflected in §3–§5.
-2. **Growth-strategy reconciliation** — priorities re-cut against the funnel
-   attribution work in `bldrs-ai/bizdev` `docs/growth-strategy.md`. That doc is
-   **private** (spend, CAC, geo, raw traffic stay there — only qualitative
-   conclusions and instrumentation *shape* are mirrored here). Headline
-   conclusions: paid search is currently the only channel delivering real
-   authored-model opens; organic discovery is effectively zero; shared links are
-   the highest-quality earned traffic we have. Consequence: funnel
-   instrumentation, SEO landing surfaces, and share-loop polish move from
-   "post-MVP polish" into an active parallel phase — §4.10 (Grow), Track T9,
-   §6 Phase G.
-3. **The AI-workspace pivot** — the product direction after (and partly alongside)
-   the MVP: a Claude-Code-like conversational workspace over CAD/BIM models,
-   multi-user, with user-generated AI-app toolbelts. New Epic group §4.11
-   (Assist), Tracks T10–T11, plan in §7. Several long-held loveables
-   (`search-310`, `apps-300`, `apps-310`) are absorbed into it.
-
-**v0.4 (2026-07-03)** reconciles against the AI-strategy synthesis
-(`bldrs-ai/bizdev` `docs/ai-strategy.md` — **private**: MAU/revenue/fundraise
-figures and competitor analysis stay there). The public-safe conclusions that
-re-cut this roadmap:
-
-- **Commodity/moat split.** Viewing *small* models is a commodity — free
-  alternatives everywhere, near-zero willingness to pay. Handling *large,
-  real-world* models client-side, fast, with a full structured IFC/STEP API is
-  where Share is in a different class — and it's the substrate an interactive
-  AI loop on real models requires. The engine is the foundation; **"AI iterates
-  on models nobody else can even open"** is the headline (not "fastest
-  viewer").
-- **Quota by size/complexity, not model count.** Free tier keeps small models
-  unlimited (the funnel is demand-gen); the paywall sits at the threshold where
-  Share is the only thing that works. Phase D runs as an **instrumented
-  experiment** with stated hypotheses, not a revenue switch. Reflected in
-  `subscribe-100`/`subscribe-120` and Phase D.
-- **Data sovereignty is a first-class feature.** "Runs in-browser, your model
-  never leaves your machine" is an enterprise wedge, not a privacy nicety — and
-  it constrains §7 architecture (the agent loop must not silently break the
-  no-upload story). New epic `grow-400` for the positioning surface; §7.2 for
-  the constraint.
-- **De-prioritised:** chasing more cheap small-model traffic; "fastest engine"
-  as headline positioning. Phase G stays (it's demand-gen + loop + measurement,
-  all cheap) but doesn't grow beyond that.
-
-**v0.5 (2026-07-03)** renorms Epic numbering so the hundreds digit encodes the
-**tier**, matching the convention the story issues already use ("Open 200",
-"View 200", "Share (200)"): **100s = MVP, 200s = MLP, 300s = Pro, 400s =
-Enterprise**.
-
-**v0.6 (2026-07-03)** redefines the tiers as **business milestones** rather
-than capability levels — MVP = a steady *trickle* of paying customers with CAC
-estimable from the Ads funnel; MLP = respectable acceleration by building out
-the basics; Pro = power features earning feature-level positive feedback;
-Enterprise = an operating business with validated ICPs — and re-passes the
-numbering against that. Big movers: billing and funnel measurement *into* the
-MVP band, the Assist/AI arc *out* to the Pro band. Rubric + full ID lineage in
-§2.1; the exhaustive open-MVP checklist is §6.0. The "Pro-MVP plan" is renamed
-to just the **MVP plan** — under this rubric the MVP *is* the paying launch, so
-the prefix was redundant (and collided with the 300-band "Pro" milestone).
-
 It is the single source of truth for Epic/Story/Track structure. The wiki page
 `Planning:-Requirements` and the `epic`-labeled GitHub issues mirror this doc; when they
 disagree, this doc wins and the others get updated.
@@ -111,7 +47,7 @@ Per the PDF: 🥉 = MVP, 🥇 = MLP (Minimum Loveable Product), ❤️ = persona
 those markers in §4 next to the original ranking so we don't lose the people-attached
 intent. New work added since the PDF is marked `(NEW)`.
 
-### 2.1 Tier rubric (Epic ID numbering, v0.6 — milestone-based)
+### 2.1 Tier rubric (Epic ID numbering)
 
 The hundreds digit of every Epic ID encodes the **business milestone the epic
 is needed for** — not a feature-fanciness scale. An epic's tier is the earliest
@@ -126,77 +62,6 @@ unchanged.
 | 200–299 | **MLP** | Significant strides on that trickle by **building out the basics** — signup/paid growth accelerating at a respectable rate. |
 | 300–399 | **Pro** | Confidence stage: **power features** shipping and earning **positive feedback at the feature level**. |
 | 400–499 | **Enterprise** | A fully up-and-running business: validated **ideal customer personas**, breadth of positive feedback, org-scale packaging (sovereignty posture, admin, boundaries). |
-
-What the milestone reading changes (the v0.6 re-pass):
-
-- **Billing is MVP.** No trickle of payers without pricing tiers, checkout, and
-  the size/complexity quota — `subscribe-100/110/120` return to the 100 band
-  (their original numbers, as it happens).
-- **Measurement is MVP.** CAC is not estimable without the `grow-120` funnel
-  events, and the steady signup trickle needs `grow-100` landing targets.
-- **The paid offer is MVP.** The extended share flow (`share-120`) is the
-  paywall surface; private link sharing (`share-130`) is the headline paid
-  feature beside the size quota.
-- **AI is the Pro arc.** The Assist epics move to `assist-3xx` (multi-user
-  channels to 400) — §7's pivot sequencing is unchanged; only the band signal
-  moved. Nothing AI is required for the MVP trickle.
-
-Tier is **not** schedule: the Phase column carries sequencing; the ID
-carries the milestone. §6.0 enumerates the open 100-band work exhaustively.
-
-**ID lineage** — every epic that has ever been renumbered (all other IDs have
-been stable since v0.2). Resolve any ID you meet in an older branch, issue, or
-PR description through this table; several numbers were reused across
-revisions (`share-120`, `share-130`, `share-200`, `open-200`, `view-130`,
-`view-220`, `view-230`, `assist-300`), and `subscribe-100/110/120` were
-restored to their original meanings.
-
-| Epic (current name) | v0.2–v0.4 | v0.5 | v0.6 (current) |
-|---|---|---|---|
-| Recents reliability | open-150 | open-130 | `open-200` |
-| Open multiple IFCs in one session | open-140 | open-200 | `open-210` |
-| Multi-account Sources tab | open-130 | open-300 | `open-300` |
-| Persistent visibility / Isolate | view-130 | view-200 | `view-200` |
-| Selection camera + measurement | view-140 | view-210 | `view-210` |
-| Performance + large-model viewing | view-150 | view-130 | `view-130` |
-| Common view operations | view-170 | view-230 | `view-220` |
-| Placemarks + maps-style filtering | view-180 | view-240 | `view-230` |
-| ETL / Table view | view-160 | view-220 | `view-300` |
-| Extended Share/Login flow | share-150 | share-200 | `share-120` |
-| Private link sharing | share-120 | share-300 | `share-130` |
-| Grant/revoke per-principal | share-130 | share-310 | `share-200` |
-| Folder-scoped boundaries | share-140 | share-400 | `share-400` |
-| BCF round-trip | notes-110 | notes-200 | `notes-200` |
-| Drive-backed notes | notes-120 | notes-210 | `notes-300` |
-| Diff between versions | versions-110 | versions-200 | `versions-300` |
-| Portable versions for Drive | versions-120 | versions-210 | `versions-310` |
-| Cross-repo search | search-110 | search-200 | `search-300` |
-| Knowledge graph | search-120 | search-210 | `search-310` |
-| Profile drawer + multi-account picker | identity-130 | identity-300 | `identity-300` |
-| v1.0 Public API + IDE | apps-130 | apps-200 | `apps-300` |
-| Bldrs Integrate | apps-120 | apps-210 | `apps-310` |
-| Bug report w/ screenshot | community-120 | community-200 | `community-200` |
-| AEC outreach | community-130 | community-210 | `community-210` |
-| Pricing tiers + feature manager | subscribe-100 | subscribe-300 | `subscribe-100` |
-| Stripe checkout + portal | subscribe-110 | subscribe-310 | `subscribe-110` |
-| Quota tracking | subscribe-120 | subscribe-320 | `subscribe-120` |
-| Rich share-link previews (OG) | grow-110 (v0.3) | grow-110 | `grow-200` |
-| Large-model + sovereignty positioning | grow-130 (v0.4) | grow-400 | `grow-400` |
-| Workspace shell (left drawer) | assist-100 (v0.3) | assist-100 | `assist-300` |
-| Conversational agent panel | assist-110 (v0.3) | assist-110 | `assist-310` |
-| AI-apps toolbelt | assist-130 (v0.3) | assist-200 | `assist-320` |
-| Multi-user channels + AI modes | assist-120 (v0.3) | assist-300 | `assist-400` |
-
-**Phase column legend** (used in §3 and §5):
-
-- **A–E** = phase in the MVP plan (§6). A = stabilise viewer, B = identity +
-  multi-account, C = sharing v1, D = subscribe + ads, E = launch checklist.
-- **G** = growth-funnel phase (§6 Phase G) — runs **parallel** to A–C and starts
-  now; small, high-leverage, mostly independent of the viewer/identity arcs.
-- **AI** = AI-workspace pivot arc (§7) — sequenced after the MVP launch, with
-  flagged foundations allowed to start earlier (see §7.4).
-- **—** = already shipped; no MVP work pending.
-- **Post** = held in §8 Post-MVP backlog.
 
 
 ## 3. Status overview
@@ -1552,3 +1417,69 @@ without sign-off.
   geo, raw counts) never land here — they stay in the private bizdev
   growth-strategy doc. Event names, funnel stage definitions, and qualitative
   conclusions are fine.
+
+
+# Changelog
+**v0.3 (2026-07-02) folds in three things:**
+
+1. **Implementation drift since v0.2** — the `conway-web-ifc-adapter` shim retired
+   (`design/new/adapter-removal.md`), the GPU-instancing/`BatchedMesh` render arc
+   behind `?feature=batchedMesh`, STEP metadata extraction (conway #345 arc), and
+   the marketing site's move to Next.js SSG. Reflected in §3–§5.
+2. **Growth-strategy reconciliation** — priorities re-cut against the funnel
+   attribution work in `bldrs-ai/bizdev` `docs/growth-strategy.md`. That doc is
+   **private** (spend, CAC, geo, raw traffic stay there — only qualitative
+   conclusions and instrumentation *shape* are mirrored here). Headline
+   conclusions: paid search is currently the only channel delivering real
+   authored-model opens; organic discovery is effectively zero; shared links are
+   the highest-quality earned traffic we have. Consequence: funnel
+   instrumentation, SEO landing surfaces, and share-loop polish move from
+   "post-MVP polish" into an active parallel phase — §4.10 (Grow), Track T9,
+   §6 Phase G.
+3. **The AI-workspace pivot** — the product direction after (and partly alongside)
+   the MVP: a Claude-Code-like conversational workspace over CAD/BIM models,
+   multi-user, with user-generated AI-app toolbelts. New Epic group §4.11
+   (Assist), Tracks T10–T11, plan in §7. Several long-held loveables
+   (`search-310`, `apps-300`, `apps-310`) are absorbed into it.
+
+**v0.4 (2026-07-03)** reconciles against the AI-strategy synthesis
+(`bldrs-ai/bizdev` `docs/ai-strategy.md` — **private**: MAU/revenue/fundraise
+figures and competitor analysis stay there). The public-safe conclusions that
+re-cut this roadmap:
+
+- **Commodity/moat split.** Viewing *small* models is a commodity — free
+  alternatives everywhere, near-zero willingness to pay. Handling *large,
+  real-world* models client-side, fast, with a full structured IFC/STEP API is
+  where Share is in a different class — and it's the substrate an interactive
+  AI loop on real models requires. The engine is the foundation; **"AI iterates
+  on models nobody else can even open"** is the headline (not "fastest
+  viewer").
+- **Quota by size/complexity, not model count.** Free tier keeps small models
+  unlimited (the funnel is demand-gen); the paywall sits at the threshold where
+  Share is the only thing that works. Phase D runs as an **instrumented
+  experiment** with stated hypotheses, not a revenue switch. Reflected in
+  `subscribe-100`/`subscribe-120` and Phase D.
+- **Data sovereignty is a first-class feature.** "Runs in-browser, your model
+  never leaves your machine" is an enterprise wedge, not a privacy nicety — and
+  it constrains §7 architecture (the agent loop must not silently break the
+  no-upload story). New epic `grow-400` for the positioning surface; §7.2 for
+  the constraint.
+- **De-prioritised:** chasing more cheap small-model traffic; "fastest engine"
+  as headline positioning. Phase G stays (it's demand-gen + loop + measurement,
+  all cheap) but doesn't grow beyond that.
+
+**v0.5 (2026-07-03)** renorms Epic numbering so the hundreds digit encodes the
+**tier**, matching the convention the story issues already use ("Open 200",
+"View 200", "Share (200)"): **100s = MVP, 200s = MLP, 300s = Pro, 400s =
+Enterprise**.
+
+**v0.6 (2026-07-03)** redefines the tiers as **business milestones** rather
+than capability levels — MVP = a steady *trickle* of paying customers with CAC
+estimable from the Ads funnel; MLP = respectable acceleration by building out
+the basics; Pro = power features earning feature-level positive feedback;
+Enterprise = an operating business with validated ICPs — and re-passes the
+numbering against that. Big movers: billing and funnel measurement *into* the
+MVP band, the Assist/AI arc *out* to the Pro band. Rubric + full ID lineage in
+§2.1; the exhaustive open-MVP checklist is §6.0. The "Pro-MVP plan" is renamed
+to just the **MVP plan** — under this rubric the MVP *is* the paying launch, so
+the prefix was redundant (and collided with the 300-band "Pro" milestone).


### PR DESCRIPTION
## Summary

Full strategic re-cut of `design/roadmap.md` across four revisions (v0.3 → v0.6), plus the matching CLAUDE.md router-row update.

## v0.3 — implementation drift + growth reconciliation + AI pivot

- **Drift since v0.2 folded in:** adapter removal landed (`design/new/adapter-removal.md`; Conway → Share release chain), GPU-instancing/`BatchedMesh` arc behind `?feature=batchedMesh` with the merged-GLB cache bake, STEP metadata extraction (conway #345 arc; #1569/#1570 follow-through), new Phase-A bugs (#1561, #1545, #1249, #1548).
- **New Grow epic group + Track T9 + parallel Phase G** (starts now): SEO format landing pages (`/viewer/ifc`, `/viewer/step`, …), OG/link-preview cards on share URLs, funnel events (`share_link_created`/`share_link_opened`/`model_interacted`) + GA hygiene guard. Qualitative conclusions only — quantitative data stays in the private bizdev docs per their firewall notes.
- **New Assist epic group + §7 AI-workspace pivot plan:** left-drawer workspace nav, Claude-Code-like conversational panel with the multi-user direct-address-vs-comment-only mechanic, right-drawer AI-apps toolbelt (save/version/run generated code in a sandboxed iframe over an MCP bridge). Tracks T10 (agent runtime + conversation store) and T11 (viewer MCP tool surface + app sandbox). Knowledge graph, public API, and Integrate are absorbed/re-scoped into the pivot.

## v0.4 — AI-strategy synthesis folded in

- **Commodity/moat framing:** the engine is the substrate an AI loop on real models requires; headline is "AI iterates on models nobody else can even open," not "fastest viewer."
- **Quota by model size/complexity, never model count** — small models stay free (funnel/demand-gen); Phase D runs as an instrumented experiment with stated hypotheses; threshold picked from new size-bucket telemetry in `grow-120`.
- **New sovereignty-positioning epic** (now `grow-400`): large-model + data-sovereignty page for the enterprise-profile audience.
- **§7 constraints:** data sovereignty is load-bearing on agent architecture (model bytes stay client-side; LLM egress boundary explicit + user-visible); tool surface is read-first with the editing loop as AI.5 north star, gated on a Conway write path (new open question). AI.2 demo pinned to a large model; new §7.5 validation criteria.

## v0.5 — tier renumbering

- Epic ID hundreds digit encodes tier, matching the story-title convention already in issues ("Open 200", "View 200", "Share (200)").

## v0.6 — milestone-based tiers + the MVP bar

- **Tiers redefined as business milestones:** 100/MVP = a steady *trickle* of paying customers with CAC estimable from the Ads funnel; 200/MLP = respectable acceleration by building out the basics; 300/Pro = power features earning feature-level positive feedback; 400/Enterprise = an operating business with validated ICPs and breadth of feedback.
- **Movers:** billing (`subscribe-100/110/120`, original numbers restored) and funnel measurement (`grow-100/120`) into the MVP band; the paid offer (`share-120` extended flow, `share-130` private links) is MVP; the Assist/AI arc out to the Pro band (`assist-3xx`, multi-user channels `assist-400`) — §7 pivot sequencing unchanged. Demoted from MVP: recents reliability, per-principal grants, OG previews, ETL.
- **New §6.0 "The MVP bar":** states the milestone and enumerates the open 100-band work exhaustively (viewer holds; identity billable; paid offer exists; it bills; free tier monetises + acquires; measurable + findable). Everything else is explicitly opportunistic until the trickle exists.
- **§2.1 rewritten** with the milestone rubric and a full ID lineage table (v0.2–v0.4 / v0.5 / v0.6) covering every renumbered epic and the reused numbers.

## Post-merge drift amendments

- Occurrence-path permalinks round-trip landed (PR #1581) and STEP selection on SRR-attached-brep exports fixed (PR #1580) — STEP follow-up status updated accordingly; branch merged up to main.

Companion private-repo PR: bldrs-ai/bizdev#262 (ai-strategy synthesis doc + growth-doc cross-link).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012fe8FyrYDskLCbFP31pTCk