### PR TITLE
Fix STEP selection on models with SRR-attached breps (Arty_Z7)

### DIFF
--- a/design/new/step-occurrence-selection.md
+++ b/design/new/step-occurrence-selection.md
@@ -27,6 +27,45 @@ Share consumes this once it bumps to the Conway release that ships #353.
 
 ## Share side
 
+### Geometry paths can extend below tree leaves (why Arty_Z7 had no highlight)
+
+The tree and geometry agree on NAUO segments, but they are **not always the
+same length**. Conway's geometry walk pushes one occurrence segment per child
+`shape_representation` level; only a CDSR-placed child resolves to a NAUO id —
+for a plain `shape_representation_relationship` child the fallback pushes the
+SRR's *own* express id. Alibre / ST-Developer exports (e.g. the Arty_Z7 board)
+attach every part's brep that way: `SDR → SHAPE_REPRESENTATION` (placement
+axes only) + `SHAPE_REPRESENTATION_RELATIONSHIP(SR, ADVANCED_BREP_SHAPE_REP)`.
+So every geometry instance's path is the tree leaf's path **plus a trailing
+non-NAUO segment** (`[…, 31310, 31242, 38151]` vs the tree's
+`[…, 31310, 31242]`), and an exact-key join between the two sides matches
+nothing. Simpler exports (solids directly in the SDR's representation) have no
+extension, which is why the small-model tests passed while Arty failed.
+
+The symptom pair that identifies this case: **hide works but highlight
+doesn't** — the hide path resolves prefix-inclusively (an extension segment is
+just a deeper key under the node's prefix), while the leaf-click highlight and
+the pick→NavTree reconciliation used exact keys. Two consumer-side fixes
+restore the join without touching the persisted tables (no GLB schema bump —
+caches keep the raw extended paths):
+
+- **Leaf click → scene:** `getInstanceIdsForOccurrencePath`'s
+  `includeDescendants: false` fast path falls back to the prefix scan when the
+  exact key misses. An exact *hit* still skips the scan — when the tree leaf's
+  own key exists, deeper keys belong to other (deeper-NAUO) occurrences.
+- **Scene pick → NavTree:** the pick handler trims the instance's raw path to
+  the deepest tree-known prefix (`trimToTreeOccurrencePath` +
+  `occurrencePathKeySetForTree`, `utils/occurrencePaths.js`) before it enters
+  the store, so the NavTree's exact-key row highlight / scroll / auto-expand
+  and the `H`-toggle's node key (the path's last segment) all see tree-valid
+  paths. No tree keys (IFC, pre-0.9.0 cache) passes the path through; no
+  shared prefix degrades to null = type-level, same as having no path.
+
+A root fix (only push NAUO-backed segments, or expose the segment kind) belongs
+upstream in Conway's `makeThunk` occurrence stamping; the Share-side fixes above
+keep working either way since a NAUO-only geometry path is just the zero-
+extension case.
+
 ### The id-space mismatch (why scalar `expressID` can't join the two sides)
 
 The two surfaces speak **different express-id spaces** for STEP:

--- a/src/Containers/CadView.jsx
+++ b/src/Containers/CadView.jsx
@@ -22,6 +22,7 @@ import {disablePageReloadApprovalCheck} from '../utils/event'
 import {groupElementsByTypes} from '../utils/ifc'
 import {navWith} from '../utils/navigate'
 import {addProperties} from '../utils/objects'
+import {occurrencePathKeySetForTree, trimToTreeOccurrencePath} from '../utils/occurrencePaths'
 import {isOutOfMemoryError} from '../utils/oom'
 import {setKeydownListeners} from '../utils/shortcutKeys'
 import Picker from '../viewer/three/Picker'
@@ -590,8 +591,21 @@ export default function CadView({
         // STEP: the picked instance's occurrence path so the NavTree highlights
         // the one occurrence, not every reuse of the part type. Null on shift
         // (whole element) and for IFC / single-occurrence parts.
-        const occurrencePath = event.shiftKey ? null :
+        //
+        // The geometry path can be deeper than any tree node's — Conway
+        // appends a segment per child shape_representation level, and an
+        // SRR-attached brep (Alibre exports) adds a non-NAUO id below the
+        // leaf — so trim to the deepest tree-known prefix or the NavTree's
+        // exact-key matches (row highlight, scroll) find nothing. The store
+        // is read imperatively: this handler is installed once from
+        // `onModel`, before that render's `rootElement` is set.
+        const rawOccurrencePath = event.shiftKey ? null :
           (mesh.instanceMap.getOccurrencePathByInstance?.(instanceId) ?? null)
+        const occurrencePath = rawOccurrencePath ?
+          trimToTreeOccurrencePath(
+            rawOccurrencePath,
+            occurrencePathKeySetForTree(useStore.getState().rootElement)) :
+          null
         selectItemsInScene([parentExpressId], true, instanceIds, occurrencePath)
         return
       }

--- a/src/utils/occurrencePaths.js
+++ b/src/utils/occurrencePaths.js
@@ -42,3 +42,89 @@ export function occurrencePathsEqual(a, b) {
   }
   return occurrencePathKey(a) === occurrencePathKey(b)
 }
+
+
+// Memoizes the per-tree key set below. Keyed by the root node object so a
+// model reload (new tree object) naturally gets a fresh set, and the old one
+// is GC-able with its tree.
+const treeKeySetCache = new WeakMap()
+
+
+/**
+ * Set of `occurrencePathKey`s for every node of a spatial tree — the "paths
+ * the NavTree actually has" universe that `trimToTreeOccurrencePath` trims
+ * geometry-side paths against. Memoized per root-node object (WeakMap), so
+ * calling this per scene pick costs one tree walk per loaded model, not per
+ * click. Returns null for a missing/invalid root. Empty set (still returned,
+ * and cached) means the tree carries no occurrence paths — IFC, or a pre-0.9.0
+ * cache artifact.
+ *
+ * @param {object|null|undefined} rootNode spatial-structure root element
+ * @return {Set<string>|null}
+ */
+export function occurrencePathKeySetForTree(rootNode) {
+  if (!rootNode || typeof rootNode !== 'object') {
+    return null
+  }
+  const cached = treeKeySetCache.get(rootNode)
+  if (cached) {
+    return cached
+  }
+  const keys = new Set()
+  const stack = [rootNode]
+  while (stack.length > 0) {
+    const node = stack.pop()
+    if (Array.isArray(node.occurrencePath) && node.occurrencePath.length > 0) {
+      keys.add(occurrencePathKey(node.occurrencePath))
+    }
+    if (Array.isArray(node.children)) {
+      for (const child of node.children) {
+        if (child && typeof child === 'object') {
+          stack.push(child)
+        }
+      }
+    }
+  }
+  treeKeySetCache.set(rootNode, keys)
+  return keys
+}
+
+
+/**
+ * Trim a geometry-side occurrence path to the deepest prefix the spatial tree
+ * knows.
+ *
+ * Why geometry and tree paths can differ: Conway stamps geometry with one path
+ * segment per child `shape_representation` level of the assembly walk, and
+ * only CDSR-placed children carry a NAUO id — a part whose brep hangs off its
+ * placement representation through a plain `shape_representation_relationship`
+ * (Alibre / ST-Developer exports, e.g. the Arty_Z7 board) gets the SRR's own
+ * express id appended. The product-structure tree keys nodes on NAUO ids only,
+ * so those geometry paths are strictly deeper than any tree node's path and an
+ * exact-key join misses. Trimming to the deepest tree-known prefix restores
+ * the shared key space (see design/new/step-occurrence-selection.md
+ * §"Geometry paths can extend below tree leaves").
+ *
+ * Returns the path unchanged when the tree has no occurrence keys to trim
+ * against (null/empty set — IFC or an old cache), and null when the path is
+ * empty or shares no prefix with the tree (callers degrade to type-level
+ * selection, same as having no path).
+ *
+ * @param {Array<number>|null|undefined} path geometry-side occurrence path
+ * @param {Set<string>|null|undefined} treeKeys from `occurrencePathKeySetForTree`
+ * @return {Array<number>|null}
+ */
+export function trimToTreeOccurrencePath(path, treeKeys) {
+  if (!Array.isArray(path) || path.length === 0) {
+    return null
+  }
+  if (!treeKeys || treeKeys.size === 0) {
+    return path
+  }
+  for (let len = path.length; len > 0; len--) {
+    if (treeKeys.has(occurrencePathKey(path.slice(0, len)))) {
+      return path.slice(0, len)
+    }
+  }
+  return null
+}

--- a/src/utils/occurrencePaths.test.js
+++ b/src/utils/occurrencePaths.test.js
@@ -1,5 +1,10 @@
 /* eslint-disable no-magic-numbers */
-import {occurrencePathKey, occurrencePathsEqual} from './occurrencePaths'
+import {
+  occurrencePathKey,
+  occurrencePathKeySetForTree,
+  occurrencePathsEqual,
+  trimToTreeOccurrencePath,
+} from './occurrencePaths'
 
 
 describe('utils/occurrencePaths', () => {
@@ -20,6 +25,62 @@ describe('utils/occurrencePaths', () => {
       expect(occurrencePathsEqual([10, 20], [10])).toBe(false)
       expect(occurrencePathsEqual(null, [10])).toBe(false)
       expect(occurrencePathsEqual([10], undefined)).toBe(false)
+    })
+  })
+
+  describe('occurrencePathKeySetForTree', () => {
+    const tree = {
+      expressID: 1,
+      occurrencePath: [],
+      children: [
+        {expressID: 10, occurrencePath: [10], children: [
+          {expressID: 20, occurrencePath: [10, 20], children: []},
+        ]},
+        {expressID: 11, occurrencePath: [11], children: []},
+      ],
+    }
+
+    it('collects a key per node with a non-empty path (root excluded)', () => {
+      const keys = occurrencePathKeySetForTree(tree)
+      expect(keys).toEqual(new Set(['10', '10/20', '11']))
+    })
+
+    it('memoizes per root object and handles missing roots', () => {
+      expect(occurrencePathKeySetForTree(tree)).toBe(occurrencePathKeySetForTree(tree))
+      expect(occurrencePathKeySetForTree(null)).toBeNull()
+      expect(occurrencePathKeySetForTree(undefined)).toBeNull()
+    })
+
+    it('returns an empty set for an IFC-style tree with no occurrence paths', () => {
+      const ifcTree = {expressID: 1, children: [{expressID: 2, children: []}]}
+      expect(occurrencePathKeySetForTree(ifcTree).size).toBe(0)
+    })
+  })
+
+  describe('trimToTreeOccurrencePath', () => {
+    const treeKeys = new Set(['10', '10/20', '11'])
+
+    it('keeps a tree-known path unchanged', () => {
+      expect(trimToTreeOccurrencePath([10, 20], treeKeys)).toEqual([10, 20])
+    })
+
+    it('trims geometry-only extension segments (the SRR-attached-brep case)', () => {
+      // Conway appends the shape_representation_relationship's own id below
+      // the leaf NAUO for Alibre-style exports; the tree only knows [10, 20].
+      expect(trimToTreeOccurrencePath([10, 20, 38151], treeKeys)).toEqual([10, 20])
+      expect(trimToTreeOccurrencePath([11, 500, 501], treeKeys)).toEqual([11])
+    })
+
+    it('does not false-match on numeric prefixes ([1] vs [12])', () => {
+      expect(trimToTreeOccurrencePath([12, 5], new Set(['1']))).toBeNull()
+    })
+
+    it('returns null when nothing matches, passthrough when the tree has no keys', () => {
+      expect(trimToTreeOccurrencePath([99, 98], treeKeys)).toBeNull()
+      expect(trimToTreeOccurrencePath([10, 20, 30], null)).toEqual([10, 20, 30])
+      expect(trimToTreeOccurrencePath([10, 20, 30], new Set())).toEqual([10, 20, 30])
+      expect(trimToTreeOccurrencePath([], treeKeys)).toBeNull()
+      expect(trimToTreeOccurrencePath(null, treeKeys)).toBeNull()
     })
   })
 })

--- a/src/viewer/ShareViewer.js
+++ b/src/viewer/ShareViewer.js
@@ -1046,9 +1046,17 @@ export class ShareViewer {
    * @param {Array<number>} occurrencePath NAUO express ids, root→leaf
    * @param {object} [opts]
    * @param {boolean} [opts.includeDescendants] When false (a leaf node, which
-   *   can have no descendants), take the O(1) exact-key lookup instead of
-   *   scanning every occurrence key on every mesh — the common NavTree click.
-   *   Defaults to true (the assembly case, which needs the prefix scan).
+   *   can have no tree descendants), try the O(1) exact-key lookup first
+   *   instead of scanning every occurrence key on every mesh — the common
+   *   NavTree click. If the exact lookup matches nothing, the prefix scan
+   *   runs anyway: geometry paths can be strictly deeper than the tree
+   *   leaf's when a part's brep is attached through a plain
+   *   `shape_representation_relationship` (Conway appends the SRR's own id
+   *   as a path segment — Alibre/ST-Developer exports like Arty_Z7), so the
+   *   leaf's instances only exist under extended keys. Without the fallback
+   *   a leaf click on such a model highlights nothing while hide (always
+   *   prefix-inclusive) works. Defaults to true (the assembly case, which
+   *   needs the prefix scan).
    * @return {number[]} synthetic instance ids (empty when none)
    */
   getInstanceIdsForOccurrencePath(modelID, occurrencePath, {includeDescendants = true} = {}) {
@@ -1058,32 +1066,43 @@ export class ShareViewer {
     }
     const target = occurrencePathKey(occurrencePath)
     const descendantPrefix = `${target}/`
-    const ids = []
-    model.traverse((obj) => {
-      const byPath = obj.isMesh ? obj.instanceMap?.occurrencePathToInstanceIds : null
-      if (!byPath) {
-        return
-      }
-      if (!includeDescendants) {
-        // Leaf: at most one key can match (a leaf has no descendant paths), so
-        // an O(1) Map lookup replaces the per-key scan on this mesh.
-        const exact = byPath.get(target)
-        if (exact) {
-          for (let i = 0; i < exact.length; i++) {
-            ids.push(exact[i])
+    const collect = (matchDescendants) => {
+      const ids = []
+      model.traverse((obj) => {
+        const byPath = obj.isMesh ? obj.instanceMap?.occurrencePathToInstanceIds : null
+        if (!byPath) {
+          return
+        }
+        if (!matchDescendants) {
+          const exact = byPath.get(target)
+          if (exact) {
+            for (let i = 0; i < exact.length; i++) {
+              ids.push(exact[i])
+            }
+          }
+          return
+        }
+        for (const [key, list] of byPath) {
+          if (key === target || key.startsWith(descendantPrefix)) {
+            for (let i = 0; i < list.length; i++) {
+              ids.push(list[i])
+            }
           }
         }
-        return
+      })
+      return ids
+    }
+    if (!includeDescendants) {
+      const exactIds = collect(false)
+      if (exactIds.length > 0) {
+        return exactIds
       }
-      for (const [key, list] of byPath) {
-        if (key === target || key.startsWith(descendantPrefix)) {
-          for (let i = 0; i < list.length; i++) {
-            ids.push(list[i])
-          }
-        }
-      }
-    })
-    return ids
+      // Exact miss — fall through to the scan for SRR-extended geometry
+      // paths (see the JSDoc). An exact hit above intentionally skips the
+      // scan: when the tree leaf's own key exists, deeper keys belong to
+      // other (deeper-NAUO) occurrences, not to this leaf.
+    }
+    return collect(true)
   }
 
 

--- a/src/viewer/ShareViewer.test.js
+++ b/src/viewer/ShareViewer.test.js
@@ -490,6 +490,26 @@ describe('viewer/ShareViewer getInstanceIdsForOccurrencePath', () => {
       viewer, 0, [10], {includeDescendants: true}).sort()).toEqual([0, 1])
   })
 
+  it('with includeDescendants:false falls back to the prefix scan on an exact miss', () => {
+    // The Arty_Z7 / Alibre shape: a leaf part's brep hangs off its placement
+    // representation through a plain shape_representation_relationship, so
+    // Conway stamps the geometry with the SRR's own id below the leaf NAUO —
+    // every geometry path is strictly deeper than the tree leaf's
+    // ([10, 20, 38151] vs [10, 20]) and the exact key doesn't exist. The leaf
+    // click must still find its instances; hide (always prefix-inclusive)
+    // already did, which was the "hide works but highlight doesn't" asymmetry.
+    const mesh = makeOccurrenceMesh([
+      {parentExpressId: 100, triangleCount: 1, occurrencePath: [10, 20, 38151]},
+      {parentExpressId: 101, triangleCount: 1, occurrencePath: [10, 21, 38152]},
+    ])
+    const viewer = makeResolverViewer(mesh)
+    expect(ShareViewer.prototype.getInstanceIdsForOccurrencePath.call(
+      viewer, 0, [10, 20], {includeDescendants: false})).toEqual([0])
+    // A sibling leaf's extended path must not bleed in.
+    expect(ShareViewer.prototype.getInstanceIdsForOccurrencePath.call(
+      viewer, 0, [10, 21], {includeDescendants: false})).toEqual([1])
+  })
+
   it('is prefix-inclusive: an assembly path lights up every leaf beneath it', () => {
     // Two leaves under assembly-occurrence [10]; a lookup on [10] returns both,
     // a lookup on the exact leaf returns just one.


### PR DESCRIPTION
Fixes the "hide works but highlight doesn't" selection failure on the Arty_Z7 board (and any Alibre / ST-Developer STEP export).

## Root cause

These exports attach each part's brep to its placement `SHAPE_REPRESENTATION` through a plain `SHAPE_REPRESENTATION_RELATIONSHIP` (Arty: 150 SRRs = 102 CDSR placements + 48 brep attachments, one per `ADVANCED_BREP_SHAPE_REPRESENTATION` — matching `parents=48` in the load log). Conway's geometry walk pushes one occurrence segment per child shape-representation level, and a plain-SRR child falls back to the SRR's **own** (non-NAUO) express id. Every geometry instance's occurrence path is therefore strictly deeper than the NavTree's:

```
tree leaf:  [..., 31310, 31242]           (HDMI_socket → HDMI_socket_cover NAUOs)
geometry:   [..., 31310, 31242, 38151]    (+ the SRR id)
```

The exact-key joins from #1575 matched nothing — leaf click highlighted no scene geometry, scene pick reconciled to no tree row — while hide kept working because it resolves prefix-inclusively. The "BVH max depth of 40" console warning was a red herring (three-mesh-bvh perf note; picking provably worked since the Properties panel populated).

Verified headless against the real model with the pinned Conway (1.353.1118): **0/116** distinct geometry paths exactly match a tree node, all 116 extend below one; the old exact-only lookup resolved **116/116 leaf clicks to nothing**; with this fix all 116 resolve, and all 116 picked paths trim to a tree node.

## Fix (consumer-side, no GLB schema bump — caches keep raw paths)

- **`ShareViewer.getInstanceIdsForOccurrencePath`**: the `includeDescendants: false` leaf fast path now falls back to the prefix scan when the exact key misses. An exact hit still skips the scan (deeper keys then belong to other, deeper-NAUO occurrences — pinned by the existing test).
- **`CadView` pick handler**: trims the picked instance's geometry path to the deepest tree-known prefix (new `trimToTreeOccurrencePath` + WeakMap-memoized `occurrencePathKeySetForTree` in `utils/occurrencePaths.js`) before it enters the store, so the NavTree's exact-key row highlight / scroll / auto-expand and the `H`-toggle's node key (the path's last segment) see tree-valid paths. IFC / no-occurrence trees pass through unchanged; an unmatched path degrades to type-level, same as having no path.
- Design doc: new §"Geometry paths can extend below tree leaves" in `design/new/step-occurrence-selection.md`, including the upstream Conway note (only push NAUO-backed segments) — the Share-side fixes keep working either way since a NAUO-only path is the zero-extension case.

## Test with

`/share/v/gh/bldrs-ai/test-models/main/step/grabcad/digilent-arty-z7-xilinx-artix-7-soc-fpga-board-1.snapshot.1/Arty_Z7.stp` — click leaf parts (e.g. HDMI_socket_cover) in the NavTree → scene highlight; double-click parts in the scene → NavTree row highlight + scroll; eye-hide still per-occurrence. Both cache-miss and cache-hit (GLB) paths are covered — no cache invalidation needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012MciSyC89s3iyRkMUfT4nP

---
_Generated by [Claude Code](https://claude.ai/code/session_012MciSyC89s3iyRkMUfT4nP)_