### PR TITLE
Fix STEP occurrence selection permalink round-trip

### DIFF
--- a/design/new/step-occurrence-selection.md
+++ b/design/new/step-occurrence-selection.md
@@ -148,23 +148,37 @@ order; BVH permutes only the index buffer, not the numbering).
   now survive a cache-hit reload (the isolator reads the model's own
   `getSpatialStructure` so `canBeHidden` is populated).
 
+- **Permalink (round-trip).** The element-path URL doubles as the occurrence
+  encoding: for STEP, `selectItemsInScene` writes the path segments below the
+  file as `[rootExpressId, ...occurrencePath]` (the elementsById parent-path
+  lookup can't be used — duplicated subtrees share expressIDs so the table
+  holds only the last-visited duplicate, and a scene pick's PDS id isn't a
+  tree node at all). On load, `selectElementBasedOnFilepath` resolves the
+  segments below the root back to an occurrence path when the tree knows the
+  key (`occurrencePathKeySetForTree`), mirrors the NavTree click funnel
+  (`getInstanceIdsForOccurrencePath` + `selectedOccurrencePath`), and falls
+  back to the legacy scalar-id selection for IFC / unknown paths. Two
+  supporting fixes: the pathname→element-path split now matches the file
+  suffix at a path boundary (`fileSuffixBoundaryRegex`) — the bare type-name
+  regex also matched directory segments like `/step/` and silently dropped
+  the element path — and the NavTree row highlight applies to assembly rows,
+  not only leaves. E2E: `src/tests/e2e/navTreePermalink.spec.ts`.
+
 ### Remaining (follow-up)
 
-1. **Permalink.** Extend the `#n:;p:` / element-path URL to encode the occurrence
-   path and resolve it on load.
-2. **Per-occurrence isolate.** Isolate (`I` / temp-isolation) still shows every
+1. **Per-occurrence isolate.** Isolate (`I` / temp-isolation) still shows every
    occurrence of the isolated part type — the same occurrence→instance
    resolution the hide path now uses would make it per-occurrence too.
-3. **Reveal-hidden ghosts skip occurrence hides.** The "reveal hidden" (ghost)
+2. **Reveal-hidden ghosts skip occurrence hides.** The "reveal hidden" (ghost)
    overlay is built from `hiddenIds` (product-type) only, so a per-occurrence
    hide shows no cyan ghost. The hide itself is correct; only the ghost preview
    omits it. Would need the ghost subset to build from the hidden instances.
-4. **Assembly-node eye vs child eyes.** Hiding an assembly occurrence via its
+3. **Assembly-node eye vs child eyes.** Hiding an assembly occurrence via its
    eye hides all descendant geometry but only marks the assembly node's eye
    (the store is keyed by node id); child-leaf eyes still read "shown." Toggling
    the assembly eye is the way to reveal them again. Making descendant eyes
    follow would need per-node hidden-state derived from the occurrence prefix.
-5. **Root-level parts.** A placement directly under the product root has an empty
+4. **Root-level parts.** A placement directly under the product root has an empty
    occurrence path (no NAUO), which `getOccurrencePathByInstance` normalizes to
    `null` — an empty path can't disambiguate anything. So a scene pick of a
    *root-level* part can't reconcile to its NavTree node (the pick reports the
@@ -172,7 +186,7 @@ order; BVH permutes only the index buffer, not the numbering).
    type-level. Harmless when the file has one root assembly (the common case);
    only bites files with several distinct parts placed directly at the root. A
    real fix needs a PDS→product-definition→node reverse map, out of scope here.
-6. **`?feature=batchedMesh`.** The BatchedMesh render path builds no
+5. **`?feature=batchedMesh`.** The BatchedMesh render path builds no
    `IfcInstanceMap`, so per-occurrence (and all per-instance) selection no-ops
    under that flag — a documented gap in `buildBatchedConwayModel`, not a
    regression (NAUO≠PDS meant a STEP node click highlighted nothing there

--- a/src/Components/NavTree/NavTreePanel.jsx
+++ b/src/Components/NavTree/NavTreePanel.jsx
@@ -299,20 +299,23 @@ const RenderRow = ({index, style, data}) => {
   const nodeId = node.nodeId
   const isExpanded = expandedNodeIds.includes(nodeId)
   const hasChildren = node.hasChildren
+  // Assembly rows highlight like leaves — a selected assembly (NavTree click,
+  // scene pick, permalink) must mark its own row, not just its descendants
+  // (an old `!hasChildren` guard here left assembly selections invisible in
+  // the tree). Only the types tree's group rows stay unhighlighted: they have
+  // no expressID (the guard below), and their member elements highlight
+  // individually.
   let isSelected = false
-
-  if (!hasChildren) {
-    // STEP: match on the occurrence path when one is selected — it's the only
-    // key shared with the geometry side (a scene pick reports the part-type's
-    // product_definition_shape id, which never equals this node's NAUO express
-    // id), and it uniquely identifies one occurrence so a reused part lights up
-    // only the clicked/picked node, not every reuse. Falls back to expressID for
-    // IFC and when no occurrence is selected (selectedOccurrencePathKey is null).
-    if (selectedOccurrencePathKey !== null && Array.isArray(node.occurrencePath)) {
-      isSelected = occurrencePathKey(node.occurrencePath) === selectedOccurrencePathKey
-    } else {
-      isSelected = selectedNodeIds.includes(node.expressID.toString())
-    }
+  // STEP: match on the occurrence path when one is selected — it's the only
+  // key shared with the geometry side (a scene pick reports the part-type's
+  // product_definition_shape id, which never equals this node's NAUO express
+  // id), and it uniquely identifies one occurrence so a reused part lights up
+  // only the clicked/picked node, not every reuse. Falls back to expressID for
+  // IFC and when no occurrence is selected (selectedOccurrencePathKey is null).
+  if (selectedOccurrencePathKey !== null && Array.isArray(node.occurrencePath)) {
+    isSelected = occurrencePathKey(node.occurrencePath) === selectedOccurrencePathKey
+  } else if (node.expressID !== undefined) {
+    isSelected = selectedNodeIds.includes(node.expressID.toString())
   }
 
   const rowRef = useRef(null)

--- a/src/Containers/CadView.jsx
+++ b/src/Containers/CadView.jsx
@@ -4,7 +4,7 @@ import {MeshLambertMaterial} from 'three'
 import {Box} from '@mui/material'
 import {useTheme} from '@mui/material/styles'
 import {captureException} from '@sentry/react'
-import {filetypeRegex} from '../Filetype'
+import {fileSuffixBoundaryRegex} from '../Filetype'
 import {useAuth0} from '../Auth0/Auth0Proxy'
 import {onHash} from '../Components/Camera/CameraControl'
 import {gtagEvent} from '../privacy/analytics'
@@ -22,7 +22,13 @@ import {disablePageReloadApprovalCheck} from '../utils/event'
 import {groupElementsByTypes} from '../utils/ifc'
 import {navWith} from '../utils/navigate'
 import {addProperties} from '../utils/objects'
-import {occurrencePathKeySetForTree, trimToTreeOccurrencePath} from '../utils/occurrencePaths'
+import {
+  findNodeByOccurrencePath,
+  occurrencePathKey,
+  occurrencePathKeySetForTree,
+  occurrencePathsEqual,
+  trimToTreeOccurrencePath,
+} from '../utils/occurrencePaths'
 import {isOutOfMemoryError} from '../utils/oom'
 import {setKeydownListeners} from '../utils/shortcutKeys'
 import Picker from '../viewer/three/Picker'
@@ -757,7 +763,20 @@ export default function CadView({
       // Sets the url to the first selected element path.
       if (resultIDs.length > 0 && updateNavigation) {
         const firstId = resultIDs.slice(0, 1)
-        const pathIds = getParentPathIdsForElement(elementsById, parseInt(firstId))
+        // STEP: build the element path from the occurrence path, prepending
+        // the root id (occurrence paths omit the root). The elementsById
+        // lookup can't do it: a reused sub-assembly's duplicated subtrees
+        // share expressIDs, so the table holds only the last-visited
+        // duplicate and the permalink could encode a different occurrence
+        // than the one selected. For a scene pick it misses entirely —
+        // `firstId` is then the geometry-owner product_definition_shape id,
+        // which is not a tree node. Store read is imperative because this
+        // funnel is also called from the once-installed dblclick handler,
+        // whose closure predates the render that set `rootElement`.
+        const rootElt = useStore.getState().rootElement
+        const pathIds = (occurrencePath && occurrencePath.length > 0 && rootElt) ?
+          [rootElt.expressID, ...occurrencePath] :
+          getParentPathIdsForElement(elementsById, parseInt(firstId))
         const repoFilePath = modelPath.gitpath ? modelPath.getRepoPath() : modelPath.filepath
         const enabledFeatures = searchParams.get('feature')
         const elementPath = pathIds.join('/')
@@ -795,6 +814,25 @@ export default function CadView({
     if (parts.length > 1) {
       debug().log('CadView#selectElementBasedOnUrlPath: have path', parts)
       const targetId = parseInt(parts[parts.length - 1])
+      if (!isFinite(targetId)) {
+        return
+      }
+      const state = useStore.getState()
+      // STEP: the element path's ids below the root ARE the selection's
+      // occurrence path (selectItemsInScene writes the URL from
+      // `selectedOccurrencePath`), so resolve it back rather than selecting
+      // the bare trailing id — that id is a NAUO shared by every duplicate of
+      // a reused sub-assembly (under-determined in the tree) and never equals
+      // the product_definition_shape id that owns the geometry (unreachable
+      // in the scene). See design/new/step-occurrence-selection.md. Null for
+      // IFC (the tree carries no occurrence keys) and for element paths the
+      // tree doesn't know — those keep the plain scalar-id selection below.
+      const treeKeys = occurrencePathKeySetForTree(state.rootElement)
+      const eltPathIds = parts.slice(1).map((part) => parseInt(part))
+      const occurrencePath =
+        (treeKeys && treeKeys.size > 0 && eltPathIds.length > 0 &&
+          eltPathIds.every((id) => isFinite(id)) &&
+          treeKeys.has(occurrencePathKey(eltPathIds))) ? eltPathIds : null
       // Skip re-selecting when this element is already the active
       // selection. We consult the store (selectItemsInScene updates it
       // synchronously) and not only viewer.getSelectedIds(), because this
@@ -804,11 +842,30 @@ export default function CadView({
       // getSelectedIds() is still stale. Without the store check the
       // re-selection would funnel through selectItemsInScene again and
       // reset selectedInstanceIds, widening a Conway per-instance scene
-      // pick to the whole element.
-      const alreadySelected =
-        useStore.getState().selectedElements.includes(`${targetId}`) ||
-        viewer.getSelectedIds().includes(targetId)
-      if (isFinite(targetId) && !alreadySelected) {
+      // pick to the whole element. For an occurrence path the identity
+      // check is the path itself, not the trailing id — duplicates share
+      // the id, and a scene pick's selectedElements holds the PDS id, not
+      // this NAUO, though its selection is the same occurrence.
+      const alreadySelected = occurrencePath ?
+        occurrencePathsEqual(occurrencePath, state.selectedOccurrencePath) :
+        (state.selectedElements.includes(`${targetId}`) ||
+          viewer.getSelectedIds().includes(targetId))
+      if (alreadySelected) {
+        return
+      }
+      if (occurrencePath) {
+        // Mirror the NavTree occurrence-click funnel: resolve the path to the
+        // exact instance ids so the scene highlights just this occurrence
+        // (`includeDescendants` per the node's children — an assembly needs
+        // the descendant scan, a leaf takes the exact-key path).
+        const node = findNodeByOccurrencePath(state.rootElement, occurrencePath)
+        const hasChildren = Boolean(node && Array.isArray(node.children) && node.children.length > 0)
+        const instanceIds =
+          typeof viewer.getInstanceIdsForOccurrencePath === 'function' ?
+            viewer.getInstanceIdsForOccurrencePath(
+              0, occurrencePath, {includeDescendants: hasChildren}) : []
+        selectItemsInScene([targetId], false, instanceIds, occurrencePath)
+      } else {
         selectItemsInScene([targetId], false)
       }
     }
@@ -899,7 +956,12 @@ export default function CadView({
   // TODO(pablo): would be nice to have more consistent handling of path parsing.
   useEffect(() => {
     if (rootElement) {
-      const parts = location.pathname.split(filetypeRegex)
+      // Boundary-anchored suffix split: the bare `filetypeRegex` also matches
+      // type names appearing as directory segments (".../main/step/nist/
+      // as1.stp/1/2" splits on the "step" dir → 3 parts), which failed the
+      // part-count check below and silently dropped element-path permalinks
+      // for any model under such a directory.
+      const parts = location.pathname.split(fileSuffixBoundaryRegex)
       const expectedPartCount = 2
       if (parts.length === expectedPartCount && parts[1] !== '') {
         selectElementBasedOnFilepath(parts[1])

--- a/src/Containers/CadView.jsx
+++ b/src/Containers/CadView.jsx
@@ -773,8 +773,21 @@ export default function CadView({
         // which is not a tree node. Store read is imperative because this
         // funnel is also called from the once-installed dblclick handler,
         // whose closure predates the render that set `rootElement`.
+        //
+        // Only tree-known paths are written: `trimToTreeOccurrencePath`
+        // passes a RAW geometry path through unchanged when the tree carries
+        // no occurrence keys (engine skew between geometry stamping and
+        // getSpatialStructure, malformed capture), and minting that into the
+        // URL would both share a dead link and — via the location effect
+        // re-entering selectElementBasedOnFilepath one tick later — clobber
+        // the pick's per-instance highlight. Non-tree paths fall back to the
+        // legacy lookup, which fails into this try/catch for a scene pick's
+        // PDS id, so no navigation happens (the pre-occurrence behavior).
         const rootElt = useStore.getState().rootElement
-        const pathIds = (occurrencePath && occurrencePath.length > 0 && rootElt) ?
+        const isTreeOccurrencePath = Boolean(
+          occurrencePath && occurrencePath.length > 0 && rootElt &&
+          occurrencePathKeySetForTree(rootElt)?.has(occurrencePathKey(occurrencePath)))
+        const pathIds = isTreeOccurrencePath ?
           [rootElt.expressID, ...occurrencePath] :
           getParentPathIdsForElement(elementsById, parseInt(firstId))
         const repoFilePath = modelPath.gitpath ? modelPath.getRepoPath() : modelPath.filepath
@@ -824,15 +837,25 @@ export default function CadView({
       // the bare trailing id — that id is a NAUO shared by every duplicate of
       // a reused sub-assembly (under-determined in the tree) and never equals
       // the product_definition_shape id that owns the geometry (unreachable
-      // in the scene). See design/new/step-occurrence-selection.md. Null for
-      // IFC (the tree carries no occurrence keys) and for element paths the
-      // tree doesn't know — those keep the plain scalar-id selection below.
-      const treeKeys = occurrencePathKeySetForTree(state.rootElement)
+      // in the scene). See design/new/step-occurrence-selection.md.
+      // `findNodeByOccurrencePath` is the single tree-membership gate (a
+      // non-null node ⟺ the tree knows the path) and its node supplies
+      // `hasChildren` for the scene resolution below. Null for IFC (nodes
+      // carry no occurrence paths) and for element paths the tree doesn't
+      // know — those keep the plain scalar-id selection.
+      //
+      // The first segment must be the root id: every app-written element
+      // path starts at the root (both the occurrence branch and
+      // getParentPathIdsForElement), so a hand-trimmed URL whose tail
+      // happens to also be a valid occurrence key must not silently
+      // re-anchor to that different occurrence — it degrades to the
+      // scalar-id selection instead.
       const eltPathIds = parts.slice(1).map((part) => parseInt(part))
-      const occurrencePath =
-        (treeKeys && treeKeys.size > 0 && eltPathIds.length > 0 &&
-          eltPathIds.every((id) => isFinite(id)) &&
-          treeKeys.has(occurrencePathKey(eltPathIds))) ? eltPathIds : null
+      const startsAtRoot =
+        state.rootElement && parseInt(parts[0]) === state.rootElement.expressID
+      const node = startsAtRoot ?
+        findNodeByOccurrencePath(state.rootElement, eltPathIds) : null
+      const occurrencePath = node ? eltPathIds : null
       // Skip re-selecting when this element is already the active
       // selection. We consult the store (selectItemsInScene updates it
       // synchronously) and not only viewer.getSelectedIds(), because this
@@ -842,33 +865,52 @@ export default function CadView({
       // getSelectedIds() is still stale. Without the store check the
       // re-selection would funnel through selectItemsInScene again and
       // reset selectedInstanceIds, widening a Conway per-instance scene
-      // pick to the whole element. For an occurrence path the identity
-      // check is the path itself, not the trailing id — duplicates share
+      // pick to the whole element. When BOTH sides carry an occurrence
+      // path, identity is the path, not the trailing id — duplicates share
       // the id, and a scene pick's selectedElements holds the PDS id, not
-      // this NAUO, though its selection is the same occurrence.
-      const alreadySelected = occurrencePath ?
+      // this NAUO, though its selection is the same occurrence. When the
+      // store side has none (a shift multi-select or types-tree group
+      // reset it to null while the pathname kept the occurrence), fall
+      // back to id membership — otherwise any hash-only location change
+      // (camera rest, panel close) would re-fire this and stomp the
+      // accumulated multi-select back to the URL's single occurrence.
+      const idSelected =
+        state.selectedElements.includes(`${targetId}`) ||
+        viewer.getSelectedIds().includes(targetId)
+      const alreadySelected = (occurrencePath && state.selectedOccurrencePath) ?
         occurrencePathsEqual(occurrencePath, state.selectedOccurrencePath) :
-        (state.selectedElements.includes(`${targetId}`) ||
-          viewer.getSelectedIds().includes(targetId))
+        idSelected
       if (alreadySelected) {
         return
       }
-      if (occurrencePath) {
-        // Mirror the NavTree occurrence-click funnel: resolve the path to the
-        // exact instance ids so the scene highlights just this occurrence
-        // (`includeDescendants` per the node's children — an assembly needs
-        // the descendant scan, a leaf takes the exact-key path).
-        const node = findNodeByOccurrencePath(state.rootElement, occurrencePath)
-        const hasChildren = Boolean(node && Array.isArray(node.children) && node.children.length > 0)
-        const instanceIds =
-          typeof viewer.getInstanceIdsForOccurrencePath === 'function' ?
-            viewer.getInstanceIdsForOccurrencePath(
-              0, occurrencePath, {includeDescendants: hasChildren}) : []
-        selectItemsInScene([targetId], false, instanceIds, occurrencePath)
-      } else {
-        selectItemsInScene([targetId], false)
-      }
+      // Mirror the NavTree occurrence-click funnel: resolve the path to the
+      // exact instance ids so the scene highlights just this occurrence
+      // (`includeDescendants` per the node's children — an assembly needs
+      // the descendant scan, a leaf takes the exact-key path). Empty for the
+      // scalar-id (IFC / unknown-path) case, where occurrencePath is null.
+      const hasChildren = Boolean(node && Array.isArray(node.children) && node.children.length > 0)
+      const instanceIds = occurrencePath ? occurrenceInstanceIds(occurrencePath, hasChildren) : []
+      selectItemsInScene([targetId], false, instanceIds, occurrencePath)
     }
+  }
+
+
+  /**
+   * Resolve a STEP occurrence path to the exact IfcInstanceMap instance ids
+   * to highlight — the single implementation shared by the NavTree click
+   * funnel and the permalink resolver, so the two entry points can't drift
+   * on the resolution contract (modelID, options, the feature-detect for
+   * viewers without the method). Empty array when the viewer can't resolve
+   * (legacy/IFC viewers) so callers fall back to parent-level selection.
+   *
+   * @param {Array<number>} occurrencePath NAUO express ids, root→leaf
+   * @param {boolean} includeDescendants an assembly needs the descendant
+   *   prefix scan; a leaf takes the O(1) exact-key path
+   * @return {Array<number>} synthetic instance ids
+   */
+  function occurrenceInstanceIds(occurrencePath, includeDescendants) {
+    return typeof viewer.getInstanceIdsForOccurrencePath === 'function' ?
+      viewer.getInstanceIdsForOccurrencePath(0, occurrencePath, {includeDescendants}) : []
   }
 
 
@@ -1103,10 +1145,7 @@ export default function CadView({
                 // toggles/accumulates against the current selection (multi-select);
                 // the per-occurrence scene highlight is single-selection only, so
                 // shift keeps its legacy type-level accumulate behavior.
-                const instanceIds =
-                  typeof viewer.getInstanceIdsForOccurrencePath === 'function' ?
-                    viewer.getInstanceIdsForOccurrencePath(
-                      0, occurrencePath, {includeDescendants: hasChildren}) : []
+                const instanceIds = occurrenceInstanceIds(occurrencePath, hasChildren)
                 selectItemsInScene([expressIdOrIds], true, instanceIds, occurrencePath)
               } else {
                 elementSelection(viewer, elementsById, selectItemsInScene, isShiftKeyDown, expressIdOrIds)

--- a/src/Filetype.js
+++ b/src/Filetype.js
@@ -34,6 +34,19 @@ const fileSuffixRegex = new RegExp(`\\.${typeRegexStr}`, 'i')
 
 
 /**
+ * The model file's ".<type>" suffix at a path-segment boundary (followed by
+ * '/' or end-of-string). Use this — not the bare `filetypeRegex` — to split a
+ * URL pathname into (model file, element path): the bare regex also matches
+ * type names appearing as plain directory segments (e.g. the "step" in
+ * ".../test-models/main/step/nist/as1.stp/1/2"), which splits the pathname
+ * into three parts and silently defeats the element-path parse. The lookahead
+ * keeps the match zero-width on the boundary so `String.split` drops only the
+ * suffix itself.
+ */
+export const fileSuffixBoundaryRegex = new RegExp(`\\.${typeRegexStr}(?=/|$)`, 'i')
+
+
+/**
  * @param {string} ext
  * @return {boolean} Is supported
  */

--- a/src/Filetype.test.js
+++ b/src/Filetype.test.js
@@ -2,6 +2,7 @@ import {
   FilenameParseError,
   analyzeHeader,
   analyzeHeaderStr,
+  fileSuffixBoundaryRegex,
   getValidExtension,
   isExtensionSupported,
   pathSuffixSupported,
@@ -48,6 +49,24 @@ describe('Filetype', () => {
       expect(getValidExtension(ext)).toBe(extLower)
       expect(getValidExtension(extLower)).toBe(extLower)
       expect(getValidExtension(extUpper)).toBe(extLower)
+    }
+  })
+
+  it('fileSuffixBoundaryRegex splits pathname into (model file, element path)', () => {
+    // The motivating case: a filetype name ("step") as a plain directory
+    // segment must NOT split — only the file's own dotted suffix at a
+    // path boundary does. Pre-fix, permalinks under such directories
+    // produced a 3-way split and element-path selection never ran.
+    const pathname = '/share/v/gh/bldrs-ai/test-models/main/step/nist/as1-oc-214.stp/5/6217/3804'
+    expect(pathname.split(fileSuffixBoundaryRegex)).toStrictEqual(
+      ['/share/v/gh/bldrs-ai/test-models/main/step/nist/as1-oc-214', '/5/6217/3804'])
+    // No element path → empty trailing part; suffix at end-of-string matches.
+    expect('/share/v/p/index.ifc'.split(fileSuffixBoundaryRegex)).toStrictEqual(['/share/v/p/index', ''])
+    // Mid-filename ".ifc" (no boundary) must not split.
+    expect('/share/v/p/index.ifcx/1'.split(fileSuffixBoundaryRegex)).toStrictEqual(['/share/v/p/index.ifcx/1'])
+    for (const ext of supportedTypes) {
+      expect(`/x/${ext}/y/model.${ext}/1/2`.split(fileSuffixBoundaryRegex)).toStrictEqual(
+        [`/x/${ext}/y/model`, '/1/2'])
     }
   })
 

--- a/src/tests/e2e/navTreePermalink.spec.ts
+++ b/src/tests/e2e/navTreePermalink.spec.ts
@@ -1,0 +1,105 @@
+import {expect, test} from '@playwright/test'
+import {setupVirtualPathIntercept, waitForModelReady} from './models'
+import {homepageSetup, setIsReturningUser} from './utils'
+
+
+/**
+ * NavTree assembly-row highlight + element-path permalink round-trip, against
+ * the NIST `as1-oc-214.stp` assembly (a STEP model that reuses parts across
+ * occurrences). Companion to navTreeOccurrenceSelection.spec.ts; see
+ * design/new/step-occurrence-selection.md.
+ *
+ * What this pins (the two fixes that motivated it):
+ *   - Selecting an ASSEMBLY node marks its own row selected — the row
+ *     highlight was leaf-only (`!hasChildren` guard in NavTreePanel's
+ *     RenderRow), so an assembly click selected in scene/properties but the
+ *     tree showed nothing.
+ *   - The element-path permalink a selection writes actually restores that
+ *     selection on a fresh page load. Two pre-fix failure modes: (a) the
+ *     pathname→element-path split matched filetype names appearing as plain
+ *     directory segments (the "step" in .../main/step/nist/...), so the
+ *     watcher never even parsed the path; (b) the trailing id alone
+ *     under-determines a reused part's occurrence (duplicated subtrees share
+ *     expressIDs) — the path below the root resolves as the occurrence path.
+ *
+ * Node identity is asserted via the `data-node-label` / `data-is-selected` /
+ * `data-is-expanded` hooks on `NavTreeNode` (labels repeat across a reused
+ * part's occurrences; selection is themed via backgroundColor).
+ */
+const {describe} = test
+
+const AS1_PATH = '/share/v/gh/bldrs-ai/test-models/main/step/nist/as1-oc-214.stp'
+// Two full STEP parse + tessellation passes (initial load + permalink reload).
+const TEST_TIMEOUT_MS = 180_000
+const RELOAD_ASSERT_TIMEOUT_MS = 15_000
+
+describe('NavTree assembly selection and element-path permalink', () => {
+  test('assembly click marks its row; permalink restores the per-occurrence selection', async ({page}) => {
+    test.setTimeout(TEST_TIMEOUT_MS)
+    page.on('pageerror', (err) => console.warn(`[pageerror] ${err.message}`))
+
+    await homepageSetup(page)
+    await setIsReturningUser(page.context())
+
+    const {navigateAndWaitForModel} = await setupVirtualPathIntercept(page, AS1_PATH, '')
+    await navigateAndWaitForModel()
+    await waitForModelReady(page)
+
+    // Open the NavTree panel (writes `#n:` to the hash, so the permalink
+    // captured below reopens it on the fresh load).
+    await page.getByTestId('control-button-navigation').click()
+    await expect(page.getByTestId('NavTreePanel')).toBeVisible()
+
+    const node = (label: string) => page.locator(`[data-node-label="${label}"]`)
+    const firstNode = (label: string) => node(label).first()
+    const selectedNodes = page.locator('[data-is-selected="true"]')
+
+    // Expand the assembly root; both reused l-bracket-assembly occurrences show.
+    await expect(firstNode('as1')).toBeVisible()
+    await firstNode('as1').getByTestId('NavTreeNodeToggle').click()
+    await expect(node('l-bracket-assembly')).toHaveCount(2)
+
+    // Fix 1: clicking an ASSEMBLY node highlights its own row — exactly one
+    // row, so the reused second occurrence must not light up with it.
+    await firstNode('l-bracket-assembly').getByTestId('NavTreeNodeLabel').click()
+    await expect(firstNode('l-bracket-assembly')).toHaveAttribute('data-is-selected', 'true')
+    await expect(selectedNodes).toHaveCount(1)
+    // The click wrote an element-path permalink: root id + occurrence path.
+    await expect(page).toHaveURL(/as1-oc-214\.stp\/\d+\/\d+(#|$)/)
+    // Selecting a node auto-expands the path to it (itself included), so the
+    // assembly's children are now revealed — no toggle click (that would
+    // collapse it again).
+    await expect(firstNode('l-bracket-assembly')).toHaveAttribute('data-is-expanded', 'true')
+
+    // Select the l-bracket LEAF under the FIRST assembly — a reused part
+    // whose duplicate (same expressID) sits under the second assembly.
+    await expect(firstNode('l-bracket')).toBeVisible()
+    await firstNode('l-bracket').getByTestId('NavTreeNodeLabel').click()
+    await expect(firstNode('l-bracket')).toHaveAttribute('data-is-selected', 'true')
+    await expect(selectedNodes).toHaveCount(1)
+    await expect(page).toHaveURL(/as1-oc-214\.stp\/\d+\/\d+\/\d+(#|$)/)
+    const permalink = page.url()
+
+    // Fix 2: a fresh full-page load of that permalink restores the selection.
+    await page.goto(permalink, {waitUntil: 'domcontentloaded'})
+    await waitForModelReady(page)
+    await expect(page.getByTestId('NavTreePanel')).toBeVisible()
+
+    // The tree auto-expands the path to the encoded occurrence and highlights
+    // exactly that node.
+    await expect(selectedNodes).toHaveCount(1, {timeout: RELOAD_ASSERT_TIMEOUT_MS})
+    await expect(selectedNodes.first()).toHaveAttribute('data-node-label', 'l-bracket')
+    // The FIRST assembly (the selected occurrence's parent) is open; the
+    // second stays closed — the path encodes which duplicate was meant.
+    await expect(node('l-bracket-assembly').first()).toHaveAttribute('data-is-expanded', 'true')
+    await expect(node('l-bracket-assembly').nth(1)).toHaveAttribute('data-is-expanded', 'false')
+
+    // Open the second assembly: its duplicate l-bracket (same expressID) must
+    // NOT read as selected — the permalink is per-occurrence, not per-id.
+    await node('l-bracket-assembly').nth(1).getByTestId('NavTreeNodeToggle').click()
+    await expect(node('l-bracket')).toHaveCount(2)
+    await expect(node('l-bracket').first()).toHaveAttribute('data-is-selected', 'true')
+    await expect(node('l-bracket').nth(1)).toHaveAttribute('data-is-selected', 'false')
+    await expect(selectedNodes).toHaveCount(1)
+  })
+})

--- a/src/utils/occurrencePaths.js
+++ b/src/utils/occurrencePaths.js
@@ -44,6 +44,39 @@ export function occurrencePathsEqual(a, b) {
 }
 
 
+/**
+ * Find the spatial-tree node whose `occurrencePath` is exactly `path` (DFS).
+ * The permalink resolver uses this to recover the node behind a URL-encoded
+ * occurrence path — its child count decides whether the scene resolution
+ * needs the descendant prefix scan (assembly) or the exact-key lookup (leaf).
+ *
+ * @param {object|null|undefined} rootNode spatial-structure root element
+ * @param {Array<number>|null|undefined} path NAUO express ids, root→leaf
+ * @return {object|null} the matching node, or null
+ */
+export function findNodeByOccurrencePath(rootNode, path) {
+  if (!rootNode || typeof rootNode !== 'object' || !Array.isArray(path) || path.length === 0) {
+    return null
+  }
+  const target = occurrencePathKey(path)
+  const stack = [rootNode]
+  while (stack.length > 0) {
+    const node = stack.pop()
+    if (Array.isArray(node.occurrencePath) && occurrencePathKey(node.occurrencePath) === target) {
+      return node
+    }
+    if (Array.isArray(node.children)) {
+      for (const child of node.children) {
+        if (child && typeof child === 'object') {
+          stack.push(child)
+        }
+      }
+    }
+  }
+  return null
+}
+
+
 // Memoizes the per-tree key set below. Keyed by the root node object so a
 // model reload (new tree object) naturally gets a fresh set, and the old one
 // is GC-able with its tree.

--- a/src/utils/occurrencePaths.test.js
+++ b/src/utils/occurrencePaths.test.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-magic-numbers */
 import {
+  findNodeByOccurrencePath,
   occurrencePathKey,
   occurrencePathKeySetForTree,
   occurrencePathsEqual,
@@ -25,6 +26,37 @@ describe('utils/occurrencePaths', () => {
       expect(occurrencePathsEqual([10, 20], [10])).toBe(false)
       expect(occurrencePathsEqual(null, [10])).toBe(false)
       expect(occurrencePathsEqual([10], undefined)).toBe(false)
+    })
+  })
+
+  describe('findNodeByOccurrencePath', () => {
+    // Duplicated sub-assembly: the leaf NAUO id (20) repeats under two
+    // parent occurrences (10 and 11) — the shape a reused STEP part takes
+    // in the spatial tree, where the scalar expressID under-determines the
+    // node and only the path disambiguates.
+    const dupLeafA = {expressID: 20, occurrencePath: [10, 20], children: []}
+    const dupLeafB = {expressID: 20, occurrencePath: [11, 20], children: []}
+    const tree = {
+      expressID: 1,
+      occurrencePath: [],
+      children: [
+        {expressID: 10, occurrencePath: [10], children: [dupLeafA]},
+        {expressID: 11, occurrencePath: [11], children: [dupLeafB]},
+      ],
+    }
+
+    it('finds the one node for a duplicated expressID by its full path', () => {
+      expect(findNodeByOccurrencePath(tree, [10, 20])).toBe(dupLeafA)
+      expect(findNodeByOccurrencePath(tree, [11, 20])).toBe(dupLeafB)
+      expect(findNodeByOccurrencePath(tree, [11])).toBe(tree.children[1])
+    })
+
+    it('returns null for unknown paths, empty paths, and missing roots', () => {
+      expect(findNodeByOccurrencePath(tree, [12, 20])).toBeNull()
+      expect(findNodeByOccurrencePath(tree, [20])).toBeNull()
+      expect(findNodeByOccurrencePath(tree, [])).toBeNull()
+      expect(findNodeByOccurrencePath(tree, null)).toBeNull()
+      expect(findNodeByOccurrencePath(null, [10])).toBeNull()
     })
   })
 


### PR DESCRIPTION
## Summary

Fixes two bugs preventing element-path permalinks from correctly restoring per-occurrence selections in STEP models with reused parts:

1. **Assembly row highlighting:** NavTree assembly nodes weren't visually marked as selected (only leaf nodes were), even though the selection worked in the scene and properties panel.
2. **Permalink resolution:** Element-path URLs failed to restore selections because:
   - The pathname→element-path split matched filetype names in directory segments (e.g., `/step/` in `/main/step/nist/as1.stp/1/2`), producing a 3-part split that silently defeated the parse.
   - The trailing ID alone under-determines reused parts (duplicated subtrees share expressIDs); the full occurrence path is needed to resolve the correct instance.

## Changes

**src/Filetype.js**
- Added `fileSuffixBoundaryRegex`: matches file suffixes only at path boundaries (`/` or end-of-string), preventing false splits on directory-segment type names.

**src/Filetype.test.js**
- Added test coverage for `fileSuffixBoundaryRegex` with the motivating case (`/main/step/nist/as1.stp/1/2`).

**src/Components/NavTree/NavTreePanel.jsx**
- Removed the `!hasChildren` guard that prevented assembly rows from highlighting. Assembly selections now mark their own row (not just descendants), matching leaf behavior.
- Occurrence-path matching applies to all node types with an expressID, not just leaves.

**src/utils/occurrencePaths.js**
- Added `findNodeByOccurrencePath()`: DFS lookup to recover the spatial-tree node for a URL-encoded occurrence path. Used by the permalink resolver to determine whether the scene resolution needs descendant-prefix scanning (assembly) or exact-key lookup (leaf).

**src/utils/occurrencePaths.test.js**
- Added test coverage for `findNodeByOccurrencePath()` with duplicated sub-assembly scenarios.

**src/CadView.jsx**
- Updated `selectElementBasedOnUrlPath()` to:
  - Parse element-path segments below the root as an occurrence path (when the tree knows the key via `occurrencePathKeySetForTree`).
  - Resolve the path to the exact instance IDs via `getInstanceIdsForOccurrencePath()` (mirroring the NavTree click funnel).
  - Fall back to legacy scalar-ID selection for IFC and unknown paths.
  - Use occurrence-path equality for identity checks (not scalar ID), since duplicates share the ID and scene picks report the PDS ID (not a tree node).
- Updated `selectItemsInScene()` call site to build the element path from the occurrence path when available (not the elementsById parent-path lookup, which can't handle duplicated subtrees).
- Changed pathname split from `filetypeRegex` to `fileSuffixBoundaryRegex`.

**design/new/step-occurrence-selection.md**
- Documented the permalink round-trip mechanism and the two supporting fixes (boundary-anchored suffix split and assembly-row highlighting).
- Moved permalink from "Remaining" to "Completed" section.

**src/tests/e2e/navTreePermalink.spec.ts** (new)
- E2E test against NIST `as1-oc-214.stp` (assembly with reused parts) covering:
  - Assembly click marks its own row (not just descendants).
  - Element-path permalink correctly encodes and restores per-occurrence selections.
  - Duplicated parts (same expressID) under different parent occurrences remain distinct in the tree.

## Implementation Notes

- The occurrence path is the only key shared between the NavTree (NAUO-based) and scene geometry (PDS-based) for STEP models. A scene pick reports the part-type's product_definition_shape ID, which never equals a tree node's NAUO expressID, so occurrence-path matching is essential for round-trip fidelity.
- The pathname split fix is boundary-anchored (`(?=/|$)` lookahead) to keep the match zero-width, so `String.split()`

https://claude.ai/code/session_01E9AYprL6jogPC145dUqucG