### PR TITLE
chore: clear yarn install warnings — prune orphaned lockfile entries, bump conway to 1.355.1122

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@babel/plugin-syntax-import-assertions": "7.18.6",
     "@babel/preset-env": "7.18.10",
     "@babel/preset-react": "7.18.6",
-    "@bldrs-ai/conway": "1.353.1118",
+    "@bldrs-ai/conway": "1.355.1122",
     "@bldrs-ai/ifclib": "5.3.3",
     "@emotion/react": "11.10.0",
     "@emotion/styled": "11.10.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5920,13 +5920,6 @@
   resolved "https://registry.npmjs.org/@types/node/-/node-18.11.18.tgz"
   integrity sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA==
 
-"@types/node@22.5.5":
-  version "22.5.5"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.5.5.tgz#52f939dd0f65fc552a4ad0b392f3c466cc5d7a44"
-  integrity sha512-Xjs4y5UPO/CLdzpgR6GirZJx36yScjh73+2NlLlkFRSoQN8B0DpfXPdZGnvVmLRLOsqDpOfTNv7D9trgGhmOIA==
-  dependencies:
-    undici-types "~6.19.2"
-
 "@types/node@>=8.1.0":
   version "22.13.1"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-22.13.1.tgz#a2a3fefbdeb7ba6b89f40371842162fac0934f33"
@@ -17848,11 +17841,6 @@ typed-array-length@^1.0.7:
     possible-typed-array-names "^1.0.0"
     reflect.getprototypeof "^1.0.6"
 
-typescript@5.6.2:
-  version "5.6.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.6.2.tgz#d1de67b6bef77c41823f822df8f0b3bcff60a5a0"
-  integrity sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==
-
 typescript@5.7.2:
   version "5.7.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.7.2.tgz#3169cf8c4c8a828cde53ba9ecb3d2b1d5dd67be6"
@@ -17914,11 +17902,6 @@ uncrypto@^0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/uncrypto/-/uncrypto-0.1.3.tgz#e1288d609226f2d02d8d69ee861fa20d8348ef2b"
   integrity sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==
-
-undici-types@~6.19.2:
-  version "6.19.8"
-  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.19.8.tgz#35111c9d1437ab83a7cdc0abae2f26d88eda0a02"
-  integrity sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==
 
 undici-types@~6.20.0:
   version "6.20.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2473,14 +2473,14 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@bldrs-ai/conway@1.353.1118":
-  version "1.353.1118"
-  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.353.1118.tgz#ce3e8da5703b70723f2480d67f63b7902dd24df8"
-  integrity sha512-+DjPla0OCbf/f1SwBBbJ95M8stxD7wRP4ewXFurgkF7Fs7aDHN/qxwXvyh8oJjxQOBHmPzs+zjALF2EgMZxrCQ==
+"@bldrs-ai/conway@1.355.1122":
+  version "1.355.1122"
+  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.355.1122.tgz#37dc55ab22322a1d1499daeea9ad029410367f53"
+  integrity sha512-QHRNWQTu7ZNkub2z8fR94C5u1Sq4dwMso0Y9AWI6Ua9uRE3aiQlgDhWtT/IZ84tMRLtrHIbQou3G85NfotK5RA==
   dependencies:
     gl-matrix "3.4.3"
     seedrandom "3.0.5"
-    three "^0.173.0"
+    three "^0.184.0"
     yargs "17.7.1"
 
 "@bldrs-ai/ifclib@5.3.3":
@@ -17521,7 +17521,7 @@ three-mesh-bvh@0.9.10:
   resolved "https://registry.yarnpkg.com/three-mesh-bvh/-/three-mesh-bvh-0.9.10.tgz#6310327967f3e4b3671366ea940bef1f1758a6ad"
   integrity sha512-UOlTgPIeqUURcwaG8knxvBaruwZlC4X3/WSHEFO7rYvMVv/YNUrkfFEszvfj36pXV88dCHoHNnIp0PifkirnTQ==
 
-three@0.184.0, three@^0.173.0:
+three@0.184.0, three@^0.184.0:
   version "0.184.0"
   resolved "https://registry.yarnpkg.com/three/-/three-0.184.0.tgz#5bca0a3851eea5345e4c205567b40dfa49b791b5"
   integrity sha512-wtTRjG92pM5eUg/KuUnHsqSAlPM296brTOcLgMRqEeylYTh/CdtvKUvCyyCQTzFuStieWxvZb8mVTMvdPyUpxg==


### PR DESCRIPTION
## Summary

Two commits that clean up `yarn install` on a fresh checkout:

**1. Prune orphaned yarn.lock entries.** A plain `yarn install` drops three stale lockfile entries that nothing in the dependency tree requests anymore, leaving the working tree dirty on every fresh install. Entries removed (all orphans; the versions actually in use are untouched):
- `@types/node@22.5.5` (exact pin, no remaining requester) — in-use resolutions `22.13.1` / `18.11.18` remain
- `typescript@5.6.2` (exact pin, no remaining requester) — in-use `typescript@5.7.2` remains
- `undici-types@~6.19.2` (was only a dependency of the removed `@types/node@22.5.5`) — in-use `~6.20.0` remains

**2. Bump `@bldrs-ai/conway` 1.353.1118 → 1.355.1122.** conway 1.355.1122 widens its `three` range from `^0.173.0` to `^0.184.0` (bldrs-ai/conway#355), matching this repo's `resolutions` pin, so `yarn install` no longer warns `Resolution field "three@0.184.0" is incompatible with requested version "three@^0.173.0"`. The `resolutions` pin itself stays: it keeps `three` deduped to a single exact copy even if a future `0.184.x` patch would let conway's caret range drift ahead of our exact `0.184.0`. The bump also picks up conway 1.354.1120 (STEP metadata changes from bldrs-ai/conway#354).

Remaining install warnings (`bare-os`/`bare-fs` invalid `bare` engine, `ts-node` unmet `@types/node` peer under netlify-cli) are pre-existing, cosmetic, and out of scope.

## Test plan

- Pre-commit gate (eslint + typecheck + full Jest suite) passed on both commits
- `yarn install` after this change reports `success Already up-to-date`, leaves the tree clean, and no longer emits the three resolution warning (verified with a forced full re-link)
- Lockfile keeps a single deduped `three@0.184.0` entry (`three@0.184.0, three@^0.184.0`)
- CI build + both Playwright runs exercise the bumped conway engine

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HPMxeiDgsUvaEMXyy4f4px