### PR TITLE
Decouple model load from auth resolution, add bounded grace window

### DIFF
--- a/src/BaseRoutes.jsx
+++ b/src/BaseRoutes.jsx
@@ -1,5 +1,5 @@
 import {jwtDecode} from 'jwt-decode'
-import React, {useEffect, useState} from 'react'
+import React, {useCallback, useEffect, useRef, useState} from 'react'
 import {Outlet, Route, Routes, useLocation, useNavigate} from 'react-router-dom'
 import {Button, CssBaseline, Dialog, DialogActions, DialogContent, DialogTitle, ThemeProvider} from '@mui/material'
 import * as Sentry from '@sentry/react'
@@ -58,6 +58,65 @@ export default function BaseRoutes({testElt = null}) {
   const [reauthScope, setReauthScope] = useState('')
   const OAUTH_2_CLIENT_ID = process.env.OAUTH2_CLIENT_ID
 
+  // The background fresh-claims pass below must run once per page load, not
+  // once per effect run — the auth effect re-fires on every navigation
+  // (`location` dep), and an unguarded cacheMode:'off' call there would
+  // reintroduce a network token exchange per SPA route change.
+  const freshClaimsRequestedRef = useRef(false)
+
+  /**
+   * Apply a resolved Auth0 access token to app state: reauth-modal short
+   * circuits from app_metadata, appMetadata store, GitHub identity → octokit
+   * init + accessToken. Shared by the boot-time cached-token fast path and
+   * the background fresh-claims pass; idempotent, so processing the same
+   * token twice is harmless. useCallback (all deps are stable setters) so
+   * the auth effect below can depend on it without re-firing per render.
+   */
+  const processAccessToken = useCallback((token) => {
+    if (token === '') {
+      initializeOctoKitUnauthenticated()
+      setAccessToken(token)
+      return
+    }
+
+    const decodedToken = jwtDecode(token)
+    const appData = decodedToken['https://bldrs.ai/app_metadata']
+
+    // Reauth-modal short circuits: show the modal and stop — leave
+    // identity/token state as it was.
+    if (appData?.subscriptionStatus === 'shareProPendingReauth') {
+      setReauthScope('repo')
+      setReauthModalOpen(true)
+      return
+    }
+    if (appData?.subscriptionStatus === 'freePendingReauth') {
+      setReauthScope('public_repo')
+      setReauthModalOpen(true)
+      return
+    }
+
+    // Only overwrite store appMetadata when the JWT actually carries
+    // one — tests (e.g. Subscription.spec) inject appMetadata directly
+    // before login and expect it to stick.
+    if (appData) {
+      setAppMetadata(appData)
+    }
+
+    const identities = decodedToken['https://bldrs.ai/identities'] || decodedToken.identities || []
+    if (identities.length > 0) {
+      const hasGitHubIdentity = identities.some((identity) => identity.connection === 'github')
+      if (hasGitHubIdentity) {
+        initializeOctoKitAuthenticated()
+        setAccessToken(token)
+        setHasGithubIdentity(true)
+      } else {
+        initializeOctoKitUnauthenticated()
+        setAccessToken('')
+        setHasGithubIdentity(false)
+      }
+    }
+  }, [setAccessToken, setAppMetadata, setHasGithubIdentity])
+
   useEffect(() => {
     setAppPrefix(appPrefix)
 
@@ -94,7 +153,7 @@ export default function BaseRoutes({testElt = null}) {
     } else if (!isLoading && !isAuthenticated) {
       setIsAuthResolved(true)
     } else if (!isLoading && isAuthenticated) {
-      getAccessTokenSilently({
+      const tokenFetchOpts = {
         authorizationParams: {
           // audience: 'https://bldrs.us.auth0.com/userinfo',
           audience: 'https://api.github.com/',
@@ -106,57 +165,13 @@ export default function BaseRoutes({testElt = null}) {
         // every page load, and CadView#onViewer serializes the first model
         // load behind this resolution — so a slow exchange (cross-tab lock
         // stall, timed-out first attempt) froze the viewer for ~10s before
-        // any progress UI appeared. Freshness after login/reauth is not a
-        // concern: those flows run through the popup callback, which updates
-        // the same localstorage cache (PopupCallback sets 'refreshAuth' →
-        // ProfileControl's storage listener re-reads the token).
+        // any progress UI appeared. The background pass below covers claims
+        // freshness off the critical path.
         cacheMode: 'on',
         useRefreshTokens: true,
-      })
-        .then((token) => {
-          if (token === '') {
-            initializeOctoKitUnauthenticated()
-            setAccessToken(token)
-            return
-          }
-
-          const decodedToken = jwtDecode(token)
-          const appData = decodedToken['https://bldrs.ai/app_metadata']
-
-          // Reauth-modal short circuits: show the modal and stop — leave
-          // identity/token state as it was.
-          if (appData?.subscriptionStatus === 'shareProPendingReauth') {
-            setReauthScope('repo')
-            setReauthModalOpen(true)
-            return
-          }
-          if (appData?.subscriptionStatus === 'freePendingReauth') {
-            setReauthScope('public_repo')
-            setReauthModalOpen(true)
-            return
-          }
-
-          // Only overwrite store appMetadata when the JWT actually carries
-          // one — tests (e.g. Subscription.spec) inject appMetadata directly
-          // before login and expect it to stick.
-          if (appData) {
-            setAppMetadata(appData)
-          }
-
-          const identities = decodedToken['https://bldrs.ai/identities'] || decodedToken.identities || []
-          if (identities.length > 0) {
-            const hasGitHubIdentity = identities.some((identity) => identity.connection === 'github')
-            if (hasGitHubIdentity) {
-              initializeOctoKitAuthenticated()
-              setAccessToken(token)
-              setHasGithubIdentity(true)
-            } else {
-              initializeOctoKitUnauthenticated()
-              setAccessToken('')
-              setHasGithubIdentity(false)
-            }
-          }
-        })
+      }
+      getAccessTokenSilently(tokenFetchOpts)
+        .then(processAccessToken)
         .catch((err) => {
           if (err.error === 'invalid_grant') {
             logout({returnTo: window.location.origin})
@@ -167,6 +182,30 @@ export default function BaseRoutes({testElt = null}) {
         .finally(() => {
           setIsAuthResolved(true)
         })
+
+      // Background fresh-claims pass. Cached tokens carry JWT claims frozen
+      // at mint time, so a boot that only reads the cache would miss
+      // anything set server-side since: the Stripe webhook flipping
+      // app_metadata.subscriptionStatus to a pendingReauth state (the modal
+      // would never open), a revoked refresh token / Auth0 session (the
+      // invalid_grant → logout path would never fire), or an out-of-band
+      // identity link/unlink. Force one refresh-grant per page load —
+      // exactly what cacheMode:'off' used to do — but off the load-blocking
+      // path: it doesn't gate isAuthResolved, and processAccessToken
+      // re-applies whatever it learns when it lands.
+      if (!freshClaimsRequestedRef.current) {
+        freshClaimsRequestedRef.current = true
+        getAccessTokenSilently({...tokenFetchOpts, cacheMode: 'off'})
+          .then(processAccessToken)
+          .catch((err) => {
+            if (err.error === 'invalid_grant') {
+              logout({returnTo: window.location.origin})
+            }
+            // Anything else is non-fatal here: the cached-token pass above
+            // already established a working session; this pass only exists
+            // to refresh claims.
+          })
+      }
     }
   }, [
     appPrefix,
@@ -183,6 +222,7 @@ export default function BaseRoutes({testElt = null}) {
     setHasGithubIdentity,
     setIsAuthResolved,
     logout,
+    processAccessToken,
   ])
 
   return (

--- a/src/BaseRoutes.jsx
+++ b/src/BaseRoutes.jsx
@@ -100,7 +100,17 @@ export default function BaseRoutes({testElt = null}) {
           audience: 'https://api.github.com/',
           scope: 'openid profile email offline_access',
         },
-        cacheMode: 'off',
+        // 'on', not 'off': resolve from the SDK's localstorage token cache
+        // (ms) and only hit the network when the cached token has expired.
+        // 'off' forced a refresh-grant round trip to auth0's /oauth/token on
+        // every page load, and CadView#onViewer serializes the first model
+        // load behind this resolution — so a slow exchange (cross-tab lock
+        // stall, timed-out first attempt) froze the viewer for ~10s before
+        // any progress UI appeared. Freshness after login/reauth is not a
+        // concern: those flows run through the popup callback, which updates
+        // the same localstorage cache (PopupCallback sets 'refreshAuth' →
+        // ProfileControl's storage listener re-reads the token).
+        cacheMode: 'on',
         useRefreshTokens: true,
       })
         .then((token) => {

--- a/src/BaseRoutes.test.jsx
+++ b/src/BaseRoutes.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import {render, waitFor} from '@testing-library/react'
+import {render, screen, waitFor} from '@testing-library/react'
 import {MemoryRouter} from 'react-router-dom'
 import {
   mockedUseAuth0,
@@ -166,5 +166,61 @@ describe('BaseRoutes - auth resolution', () => {
     })
     const state = await renderAndResolve()
     expect(state.accessToken).toBe('')
+  })
+
+  // The boot path reads the SDK's token cache (cacheMode 'on') so model load
+  // isn't serialized behind a network exchange; a background cacheMode 'off'
+  // pass restores claims freshness (pendingReauth from the Stripe webhook,
+  // invalid_grant revocation, identity link/unlink) off the critical path.
+  it('authenticated: runs one cached-token pass and one background fresh-claims pass', async () => {
+    const token = 'github-jwt'
+    tokenClaims[token] = {
+      'https://bldrs.ai/identities': [{connection: 'github', provider: 'github', user_id: '1'}],
+    }
+    const getToken = jest.fn().mockResolvedValue(token)
+    mockedUseAuth0.mockReturnValue({
+      ...mockedUserLoggedIn,
+      getAccessTokenSilently: getToken,
+    })
+    await renderAndResolve()
+    await waitFor(() => {
+      const cacheModes = getToken.mock.calls.map(([opts]) => opts.cacheMode)
+      expect(cacheModes).toContain('on')
+      expect(cacheModes).toContain('off')
+    })
+    // Once per page load, not per effect re-run
+    expect(getToken.mock.calls.filter(([opts]) => opts.cacheMode === 'off').length).toBe(1)
+  })
+
+  it('background pass surfaces pendingReauth that the cached token missed', async () => {
+    const staleToken = 'stale-jwt'
+    const freshToken = 'fresh-jwt'
+    tokenClaims[staleToken] = {
+      'https://bldrs.ai/app_metadata': {subscriptionStatus: null},
+      'https://bldrs.ai/identities': [{connection: 'github', provider: 'github', user_id: '1'}],
+    }
+    tokenClaims[freshToken] = {
+      'https://bldrs.ai/app_metadata': {subscriptionStatus: 'shareProPendingReauth'},
+    }
+    const getToken = jest.fn((opts) =>
+      Promise.resolve(opts.cacheMode === 'off' ? freshToken : staleToken))
+    mockedUseAuth0.mockReturnValue({
+      ...mockedUserLoggedIn,
+      getAccessTokenSilently: getToken,
+    })
+    render(
+      <MemoryRouter initialEntries={['/about']}>
+        <HelmetThemeCtx>
+          <BaseRoutes/>
+        </HelmetThemeCtx>
+      </MemoryRouter>,
+    )
+    // Cached pass establishes the session…
+    await waitFor(() => expect(useStore.getState().isAuthResolved).toBe(true))
+    expect(useStore.getState().accessToken).toBe(staleToken)
+    // …and the fresh pass opens the reauth modal the stale claims hid.
+    await waitFor(() => {
+      expect(screen.getByText('Reauthentication Required')).toBeInTheDocument()
+    })
   })
 })

--- a/src/Components/Versions/useVersions.jsx
+++ b/src/Components/Versions/useVersions.jsx
@@ -1,6 +1,6 @@
 import {useEffect, useState} from 'react'
-import {useAuth0} from '../../Auth0/Auth0Proxy'
 import {getCommitsForFile} from '../../net/github/Commits'
+import useStore from '../../store/useStore'
 import {assertDefined} from '../../utils/assert'
 
 
@@ -8,7 +8,7 @@ import {assertDefined} from '../../utils/assert'
 export default function useVersions({repository, filePath, accessToken}) {
   assertDefined(accessToken, repository.orgName, repository.name, filePath)
 
-  const {isAuthenticated} = useAuth0()
+  const isAuthResolved = useStore((state) => state.isAuthResolved)
 
   const [commits, setCommits] = useState([])
   const [loading, setLoading] = useState(false)
@@ -16,9 +16,14 @@ export default function useVersions({repository, filePath, accessToken}) {
 
   useEffect(() => {
     const fetchCommits = async () => {
-      if (isAuthenticated && accessToken === '') {
-        // TODO(pablo): seen these in dev
-        console.warn('Unauthed flow while user is logged-in')
+      // Wait for BaseRoutes to settle auth before touching the API. Before
+      // resolution, isAuthenticated is still false even for logged-in users,
+      // so this hook used to fire an anonymous fetch on page load and a
+      // second, authed one when the token landed — a duplicate request that
+      // also burned the anonymous rate limit. Post-resolution, an empty
+      // accessToken is a legitimate state (logged-out or Google-only users)
+      // and the anonymous fetch is correct for public repos.
+      if (!isAuthResolved) {
         return
       }
       setLoading(true)
@@ -44,7 +49,7 @@ export default function useVersions({repository, filePath, accessToken}) {
       }
     }
     fetchCommits()
-  }, [accessToken, filePath, isAuthenticated, repository])
+  }, [accessToken, filePath, isAuthResolved, repository])
 
   return {commits, loading, error}
 }

--- a/src/Components/Versions/useVersions.test.jsx
+++ b/src/Components/Versions/useVersions.test.jsx
@@ -1,15 +1,31 @@
-import {renderHook, waitFor} from '@testing-library/react'
+import {act, renderHook, waitFor} from '@testing-library/react'
+import useStore from '../../store/useStore'
 import useVersions from './useVersions'
 import {MOCK_COMMITS} from '../../net/github/Commits.fixture'
 
 
 describe('useVersions', () => {
-  it('fetches and returns commits', async () => {
+  it('fetches and returns commits once auth is resolved', async () => {
+    await act(() => useStore.setState({isAuthResolved: true}))
     const {result} = renderHook(() => useVersions(TEST_PARAMS))
     await waitFor(() => expect(result.current.loading).toBe(true))
     await waitFor(() => expect(result.current.loading).toBe(false))
     expect(result.current.commits.length).toEqual(MOCK_COMMITS.data.length)
     expect(result.current.error).toBe(null)
+  })
+
+  // Pre-resolution fetches fired anonymously (isAuthenticated is still false
+  // while the token exchange runs) and then re-fired authed — duplicate
+  // requests that burned anonymous rate limit. The hook now waits.
+  it('does not fetch until auth is resolved, then fetches on the flip', async () => {
+    await act(() => useStore.setState({isAuthResolved: false}))
+    const {result} = renderHook(() => useVersions(TEST_PARAMS))
+    expect(result.current.loading).toBe(false)
+    expect(result.current.commits).toEqual([])
+
+    await act(() => useStore.setState({isAuthResolved: true}))
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.commits.length).toEqual(MOCK_COMMITS.data.length)
   })
 })
 

--- a/src/Containers/CadView.jsx
+++ b/src/Containers/CadView.jsx
@@ -35,15 +35,15 @@ import Picker from '../viewer/three/Picker'
 import {DEFAULT_LOOK} from '../viewer/looks'
 import RootLandscape from './RootLandscape'
 import ViewerContainer from './ViewerContainer'
-import {elementSelection} from './selection'
-import {partsToPath} from './urls'
-import {initViewer} from './viewer'
 import {
   AUTH_SETTLE_GRACE_MS,
   AUTH_SETTLE_RETRY_MS,
   isAuthShapedLoadError,
   waitForAuthSettled,
 } from './authLoadGate'
+import {elementSelection} from './selection'
+import {partsToPath} from './urls'
+import {initViewer} from './viewer'
 
 
 let count = 0
@@ -260,9 +260,20 @@ export default function CadView({
     setSnackMessage('Loading model...')
 
     // Only GitHub-hosted models use the Auth0-brokered token; local files,
-    // external URLs, and Drive (its own connection tokens) shouldn't wait
-    // on it at all.
-    const needsGithubAuth = Boolean(modelPath.gitpath && modelPath.gitpath !== 'external')
+    // other external URLs, and Drive (its own connection tokens) shouldn't
+    // wait on it at all. Mirror Loader#load's own detection
+    // (`pathUrl.host === 'github.com'`) rather than testing `gitpath`:
+    // /share/v/gh routes carry a github.com downloadUrl AND a gitpath, but a
+    // generic /share/v/u route can point at github.com too and has no
+    // gitpath — it still goes through the token-authed Contents API in the
+    // loader, so it needs the same grace + authed retry. Non-URL targets
+    // (local paths, upload UUIDs) throw in the URL constructor → not GitHub.
+    let needsGithubAuth = false
+    try {
+      needsGithubAuth = new URL(modelPath.downloadUrl || modelPath.filepath).host.toLowerCase() === 'github.com'
+    } catch {
+      // Relative/local path — not GitHub-hosted.
+    }
     const isAuthSettledBeforeLoad = needsGithubAuth ?
       await waitForAuthSettled(AUTH_SETTLE_GRACE_MS) :
       true
@@ -300,13 +311,19 @@ export default function CadView({
       console.error(e)
       captureException(e)
       return
+    } finally {
+      // Whatever the outcome, this load attempt is over. The overlay/snack
+      // may still be up (set before the grace wait above, or re-set by the
+      // authed-retry path after loadModel's own finally cleared it) — a
+      // load that ends in an alert must not leave the LoadingBackdrop
+      // blocking the error dialog.
+      setIsModelLoading(false)
+      setSnackMessage(null)
     }
     if (!tmpModelRef && !isOOM) {
       setAlert('Failed to parse model')
       return
     }
-    setIsModelLoading(false)
-    setSnackMessage(null)
 
     debug().log('CadView#onViewer: pathToLoad(${pathToLoad}), tmpModelRef: ', tmpModelRef)
     await onModel(tmpModelRef)

--- a/src/Containers/CadView.jsx
+++ b/src/Containers/CadView.jsx
@@ -32,6 +32,12 @@ import ViewerContainer from './ViewerContainer'
 import {elementSelection} from './selection'
 import {partsToPath} from './urls'
 import {initViewer} from './viewer'
+import {
+  AUTH_SETTLE_GRACE_MS,
+  AUTH_SETTLE_RETRY_MS,
+  isAuthShapedLoadError,
+  waitForAuthSettled,
+} from './authLoadGate'
 
 
 let count = 0
@@ -93,11 +99,12 @@ export default function CadView({
   // Two useEffects below can each trigger `onViewer()` — the
   // [viewer]-dep effect fires when `onModelPath` sets a new viewer, and the
   // [isAuthLoading, …]-dep effect fires (with an `!isViewerLoaded` guard) so
-  // a model whose initial `onViewer` returned early on auth-not-ready
-  // retries once auth settles. If auth settles WHILE the first onViewer is
-  // mid-`loadModel`, `isViewerLoaded` is still false (it's only set at the
-  // end), so both fire end-to-end → double load. This in-flight ref
-  // dedupes overlapping calls; whichever effect tick wins, the other skips.
+  // a model whose initial `onViewer` returned early on OPFS-status-unknown
+  // retries once availability lands, and again on auth-state changes. If
+  // auth settles WHILE the first onViewer is mid-`loadModel`,
+  // `isViewerLoaded` is still false (it's only set at the end), so both
+  // fire end-to-end → double load. This in-flight ref dedupes overlapping
+  // calls; whichever effect tick wins, the other skips.
   const onViewerInFlightRef = useRef(false)
 
   // IFCSlice
@@ -191,13 +198,10 @@ export default function CadView({
       return
     }
 
-    // Wait only while auth is still being resolved. Once resolved, proceed
-    // regardless of whether a GitHub token landed — Google-only users
-    // legitimately have accessToken='' and hasGithubIdentity=false.
-    if (isAuthLoading || (isAuthenticated && !isAuthResolved)) {
-      debug().warn('Auth not yet resolved, waiting.')
-      return
-    }
+    // NB: no auth precondition here. onViewerInternal itself waits a bounded
+    // grace for auth to settle (GitHub loads only) and retries authed when an
+    // anonymous attempt fails auth-shaped — so a slow Auth0 exchange can no
+    // longer hold the load (and its progress UI) hostage.
 
     // Past the early returns — we're actually going to load. The in-flight
     // guard sits HERE (not at the effect-callback level) so two effect ticks
@@ -241,10 +245,26 @@ export default function CadView({
     }
 
     debug().log('CadView#onViewer: modelPath:', modelPath)
+
+    // Progress overlay up BEFORE any auth/token waiting. Previously the
+    // overlay only appeared once loadModel ran, and loadModel sat behind
+    // full auth resolution — a slow Auth0 exchange meant ~10s of frozen
+    // screen with no feedback. loadModel refines the message once it runs.
+    setIsModelLoading(true)
+    setSnackMessage('Loading model...')
+
+    // Only GitHub-hosted models use the Auth0-brokered token; local files,
+    // external URLs, and Drive (its own connection tokens) shouldn't wait
+    // on it at all.
+    const needsGithubAuth = Boolean(modelPath.gitpath && modelPath.gitpath !== 'external')
+    const isAuthSettledBeforeLoad = needsGithubAuth ?
+      await waitForAuthSettled(AUTH_SETTLE_GRACE_MS) :
+      true
+
     let tmpModelRef
     let isOOM = false
     try {
-      tmpModelRef = await loadModel(modelPath)
+      tmpModelRef = await loadModelWithAuthRetry(modelPath, isAuthSettledBeforeLoad)
     } catch (e) {
       if (isOutOfMemoryError(e)) {
         isOOM = true
@@ -323,6 +343,40 @@ export default function CadView({
 
 
   /**
+   * loadModel wrapper for the auth-slow path: when the attempt went out
+   * before auth settled (grace window in onViewerInternal expired, so
+   * probably no token) and failed auth-shaped — GitHub masks private repos
+   * as 404 to anonymous callers and rate-limits anonymous IPs with 403 —
+   * wait for the token to land and retry once with it. Everything else
+   * rethrows to onViewerInternal's catch unchanged.
+   *
+   * @param {object} routeResult
+   * @param {boolean} isAuthSettledBeforeLoad
+   * @return {object} loaded model
+   */
+  async function loadModelWithAuthRetry(routeResult, isAuthSettledBeforeLoad) {
+    try {
+      return await loadModel(routeResult)
+    } catch (error) {
+      if (isAuthSettledBeforeLoad || !isAuthShapedLoadError(error)) {
+        throw error
+      }
+      // loadModel's finally just cleared the overlay; keep it up while we
+      // wait for the token — to the user this is still the same load.
+      setIsModelLoading(true)
+      await waitForAuthSettled(AUTH_SETTLE_RETRY_MS)
+      if (!useStore.getState().accessToken) {
+        // Auth settled without a GitHub token (logged out, Google-only) —
+        // the anonymous failure was the real answer.
+        throw error
+      }
+      debug().log('CadView#loadModelWithAuthRetry: anonymous load failed auth-shaped; retrying with token')
+      return await loadModel(routeResult)
+    }
+  }
+
+
+  /**
    * Load IFC helper used by 1) useEffect on path change and 2) upload button
    *
    * @param {object} routeResult
@@ -371,8 +425,13 @@ export default function CadView({
           loadedModel = await load(routeResult.downloadUrl, viewer, onProgress, false, setOpfsFile, '')
         }
       } else {
+        // Read the token at call time, not from the render closure — the
+        // auth grace/retry flow in onViewerInternal can land a token
+        // mid-flight, and the closure would still hold the pre-resolution
+        // (usually empty) value.
+        const tokenNow = useStore.getState().accessToken
         loadedModel = await load(filepath, viewer, onProgress,
-          (gitpath && gitpath === 'external') ? false : isOpfsAvailable, setOpfsFile, accessToken)
+          (gitpath && gitpath === 'external') ? false : isOpfsAvailable, setOpfsFile, tokenNow)
       }
     } catch (error) {
       if (isOutOfMemoryError(error)) {
@@ -850,10 +909,13 @@ export default function CadView({
     if (!isViewerLoaded) {
       debug().log('Auth state changed. isAuthLoading:', isAuthLoading,
         'isAuthenticated:', isAuthenticated, 'isAuthResolved:', isAuthResolved)
-      if (!isAuthLoading && isOpfsAvailable !== null && (!isAuthenticated || isAuthResolved)) {
+      // No auth precondition — onViewerInternal waits (bounded) for auth
+      // itself and retries authed on failure. This effect's remaining jobs:
+      // kick onViewer once OPFS availability lands (the [viewer]-effect may
+      // have fired while it was still null), and re-kick on auth-state
+      // changes (deduped by onViewer's in-flight ref).
+      if (isOpfsAvailable !== null) {
         (async () => {
-          // onViewer's own in-flight guard dedupes when this races the
-          // [viewer]-effect during a mid-load auth resolution.
           await onViewer()
         })()
       }

--- a/src/Containers/authLoadGate.js
+++ b/src/Containers/authLoadGate.js
@@ -1,0 +1,62 @@
+import {HTTP_AUTHORIZATION_REQUIRED, HTTP_FORBIDDEN, HTTP_NOT_FOUND} from '../net/http'
+import useStore from '../store/useStore'
+
+
+// How long CadView#onViewerInternal waits for BaseRoutes to settle auth
+// (isAuthResolved) before starting a GitHub model load with whatever token
+// is in the store — usually none. With BaseRoutes' cacheMode: 'on', a cached
+// token resolves in single-digit ms, so this window exists only for the
+// pathological exchanges (auth0 cross-tab lock stalls, timed-out
+// /oauth/token attempts) — exactly the loads that used to freeze the screen
+// for ~10s with no progress UI. It's a compromise between public models
+// (any wait is wasted) and private ones (starting tokenless costs an
+// anonymous 404 round trip before the authed retry kicks in).
+export const AUTH_SETTLE_GRACE_MS = 2000
+
+// Cap on waiting for the token before the authed retry of an anonymous
+// load that failed auth-shaped. BaseRoutes always flips isAuthResolved in
+// its .finally — even when the token fetch rejects — so this is defensive
+// against that promise never settling at all.
+export const AUTH_SETTLE_RETRY_MS = 60000
+
+
+/**
+ * Resolve once BaseRoutes settles auth (store isAuthResolved), or after
+ * timeoutMs, whichever comes first.
+ *
+ * @param {number} timeoutMs
+ * @return {Promise<boolean>} true iff auth settled within the window
+ */
+export function waitForAuthSettled(timeoutMs) {
+  if (useStore.getState().isAuthResolved) {
+    return Promise.resolve(true)
+  }
+  return new Promise((resolve) => {
+    let timer = null
+    const unsubscribe = useStore.subscribe((state) => {
+      if (state.isAuthResolved) {
+        clearTimeout(timer)
+        unsubscribe()
+        resolve(true)
+      }
+    })
+    timer = setTimeout(() => {
+      unsubscribe()
+      resolve(false)
+    }, timeoutMs)
+  })
+}
+
+
+/**
+ * Loader failures that could mean "you needed the token": GitHub answers
+ * 404 (not 403) for private repos the caller can't see, 403 for anonymous
+ * rate-limit exhaustion, 401 for bad credentials. Octokit RequestErrors
+ * carry the response code on `.status`.
+ *
+ * @param {Error} error
+ * @return {boolean}
+ */
+export function isAuthShapedLoadError(error) {
+  return [HTTP_AUTHORIZATION_REQUIRED, HTTP_FORBIDDEN, HTTP_NOT_FOUND].includes(error?.status)
+}

--- a/src/Containers/authLoadGate.test.js
+++ b/src/Containers/authLoadGate.test.js
@@ -1,0 +1,61 @@
+import {HTTP_AUTHORIZATION_REQUIRED, HTTP_FORBIDDEN, HTTP_NOT_FOUND, HTTP_INTERNAL_SERVER_ERROR} from '../net/http'
+import useStore from '../store/useStore'
+import {isAuthShapedLoadError, waitForAuthSettled} from './authLoadGate'
+
+
+// Comfortably longer than the store flip below — the waiter should resolve
+// on the flip, not the timer.
+const NEVER_EXPIRES_MS = 5000
+
+
+describe('authLoadGate', () => {
+  describe('waitForAuthSettled', () => {
+    beforeEach(() => {
+      useStore.setState({isAuthResolved: false})
+    })
+
+    it('resolves true immediately when auth is already settled', async () => {
+      useStore.setState({isAuthResolved: true})
+      await expect(waitForAuthSettled(0)).resolves.toBe(true)
+    })
+
+    it('resolves true when auth settles within the window', async () => {
+      const settled = waitForAuthSettled(NEVER_EXPIRES_MS)
+      useStore.setState({isAuthResolved: true})
+      await expect(settled).resolves.toBe(true)
+    })
+
+    it('resolves false when the window expires first', async () => {
+      await expect(waitForAuthSettled(10)).resolves.toBe(false)
+    })
+
+    it('a timed-out waiter leaves no dangling subscription behind', async () => {
+      await waitForAuthSettled(10)
+      // Flipping the flag after timeout must not throw or double-resolve —
+      // the subscription was cleaned up on timeout.
+      useStore.setState({isAuthResolved: true})
+      await expect(waitForAuthSettled(0)).resolves.toBe(true)
+    })
+  })
+
+  describe('isAuthShapedLoadError', () => {
+    it.each([
+      HTTP_AUTHORIZATION_REQUIRED,
+      HTTP_FORBIDDEN,
+      HTTP_NOT_FOUND,
+    ])('matches octokit-style errors with status %i', (status) => {
+      const err = new Error('boom')
+      err.status = status
+      expect(isAuthShapedLoadError(err)).toBe(true)
+    })
+
+    it.each([
+      ['a 500', Object.assign(new Error('server'), {status: HTTP_INTERNAL_SERVER_ERROR})],
+      ['a plain Error', new Error('no status')],
+      ['undefined', undefined],
+      ['null', null],
+    ])('does not match %s', (_label, err) => {
+      expect(isAuthShapedLoadError(err)).toBe(false)
+    })
+  })
+})

--- a/src/connections/useGithubLastModified.js
+++ b/src/connections/useGithubLastModified.js
@@ -1,5 +1,4 @@
 import {useEffect} from 'react'
-import {useAuth0} from '../Auth0/Auth0Proxy'
 import {getCommitsForFile} from '../net/github/Commits'
 import useStore from '../store/useStore'
 import {navigateBaseOnModelPath} from '../utils/location'
@@ -14,8 +13,8 @@ import {updateRecentFileLastModified} from './persistence'
  * @param {string} branch Current branch or ref
  */
 export default function useGithubLastModified(modelPath, branch) {
-  const {isAuthenticated} = useAuth0()
   const accessToken = useStore((state) => state.accessToken)
+  const isAuthResolved = useStore((state) => state.isAuthResolved)
   const repository = useStore((state) => state.repository)
 
   useEffect(() => {
@@ -25,7 +24,12 @@ export default function useGithubLastModified(modelPath, branch) {
     if (!repository?.orgName || !repository?.name) {
       return
     }
-    if (isAuthenticated && accessToken === '') {
+    // Wait for BaseRoutes to settle auth so this backfill runs exactly once,
+    // with the right token — not anonymously during page load and then again
+    // authed when the token lands. Post-resolution an empty accessToken is
+    // legitimate (logged-out or Google-only users); anonymous is correct
+    // for public repos then.
+    if (!isAuthResolved) {
       return
     }
 
@@ -41,5 +45,5 @@ export default function useGithubLastModified(modelPath, branch) {
       }
     }
     backfill()
-  }, [accessToken, branch, isAuthenticated, modelPath, repository])
+  }, [accessToken, branch, isAuthResolved, modelPath, repository])
 }

--- a/src/connections/useGithubLastModified.test.js
+++ b/src/connections/useGithubLastModified.test.js
@@ -18,6 +18,7 @@ describe('useGithubLastModified', () => {
     await act(() => {
       result.current.setRepository('testowner', 'testrepo')
       result.current.setAccessToken('')
+      result.current.setIsAuthResolved(true)
     })
   })
 
@@ -50,5 +51,23 @@ describe('useGithubLastModified', () => {
     await new Promise((resolve) => setTimeout(resolve, ASYNC_SETTLE_MS))
     const [entry] = loadRecentFilesBySource('github')
     expect(entry.lastModifiedUtc).toBeNull()
+  })
+
+  // Guard added with the model-loading-perf work: pre-resolution the hook
+  // used to fire anonymously and then again authed once the token landed.
+  it('waits for auth resolution, then back-fills', async () => {
+    await act(() => useStore.setState({isAuthResolved: false}))
+    addRecentFileEntry({id: SHARE_PATH, source: 'github', name: 'model.ifc', lastModifiedUtc: null})
+
+    renderHook(() => useGithubLastModified(MOCK_MODEL_PATH, 'main'))
+
+    await new Promise((resolve) => setTimeout(resolve, ASYNC_SETTLE_MS))
+    expect(loadRecentFilesBySource('github')[0].lastModifiedUtc).toBeNull()
+
+    await act(() => useStore.setState({isAuthResolved: true}))
+    await waitFor(() => {
+      const [entry] = loadRecentFilesBySource('github')
+      expect(entry.lastModifiedUtc).toBe(new Date(COMMIT_DATE).getTime())
+    })
   })
 })

--- a/src/net/http.js
+++ b/src/net/http.js
@@ -8,6 +8,7 @@ export const HTTP_NOT_MODIFIED = 304
 
 export const HTTP_BAD_REQUEST = 400
 export const HTTP_AUTHORIZATION_REQUIRED = 401
+export const HTTP_FORBIDDEN = 403
 export const HTTP_NOT_FOUND = 404
 
 export const HTTP_INTERNAL_SERVER_ERROR = 500


### PR DESCRIPTION
## Summary

Restructure the model-loading flow to eliminate a ~10s freeze when Auth0 token exchange is slow. Previously, `CadView#onViewer` blocked the entire load behind full auth resolution, leaving the UI frozen with no progress feedback. This change introduces a bounded grace window (`AUTH_SETTLE_GRACE_MS = 2000ms`) that allows loads to proceed with whatever token is in the store, and adds an auth-aware retry mechanism for failures that look like missing-token errors (GitHub's 401/403/404 responses).

## Key Changes

- **New module `authLoadGate.js`**: Exports `waitForAuthSettled()` (bounded wait for auth resolution), `isAuthShapedLoadError()` (detects GitHub auth-shaped failures), and grace/retry timeout constants.

- **`CadView#onViewer` refactored**:
  - Removed hard auth-resolution precondition that blocked all loads
  - Added early progress UI (`setIsModelLoading(true)`) before any auth waiting
  - Waits only `AUTH_SETTLE_GRACE_MS` for auth to settle (GitHub models only; local/external/Drive skip the wait entirely)
  - Passes settlement status to new `loadModelWithAuthRetry()` wrapper

- **New `CadView#loadModelWithAuthRetry()` wrapper**:
  - Attempts load with whatever token was available at grace-window expiry
  - On auth-shaped failure (401/403/404) and if auth hadn't settled: waits up to `AUTH_SETTLE_RETRY_MS` for token, then retries once with it
  - Rethrows all other errors unchanged
  - Keeps progress overlay visible during retry wait

- **`BaseRoutes` Auth0 config**: Changed `cacheMode` from `'off'` to `'on'` to resolve cached tokens in single-digit ms instead of forcing a network round trip on every page load. Eliminates the pathological case where slow token exchanges (cross-tab lock stalls, timed-out attempts) froze the viewer.

- **`useVersions` and `useGithubLastModified`**: Replaced `isAuthenticated` guard (which is false during token exchange) with `isAuthResolved` guard. Prevents duplicate anonymous + authed fetches that burned rate limit during page load.

- **Test coverage**: Added `authLoadGate.test.js` with tests for grace-window behavior and error classification. Updated existing tests in `useVersions.test.jsx` and `useGithubLastModified.test.js` to verify no pre-resolution fetches occur.

## Implementation Details

- The grace window is a compromise: public models (any wait is wasted) vs. private ones (starting tokenless costs an anonymous 404 round trip). 2000ms accommodates cached-token resolution and typical Auth0 exchanges; pathological cases (cross-tab lock) still get the retry path.
- Token is read at `loadModel` call time (not from render closure) so mid-flight auth settlement lands the fresh token.
- The in-flight dedup ref in `onViewer` prevents double-loads when both the `[viewer]` effect and `[isAuthLoading, …]` effect fire end-to-end during auth settlement.
- Progress overlay now appears immediately, refined by `loadModel` once it runs — eliminates the frozen-screen period.

https://claude.ai/code/session_01Rg39P12tmur1wfQVZ25CGg