### PR TITLE
Bump @bldrs-ai/conway to 1.356.1126

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@babel/plugin-syntax-import-assertions": "7.18.6",
     "@babel/preset-env": "7.18.10",
     "@babel/preset-react": "7.18.6",
-    "@bldrs-ai/conway": "1.355.1122",
+    "@bldrs-ai/conway": "1.356.1126",
     "@bldrs-ai/ifclib": "5.3.3",
     "@emotion/react": "11.10.0",
     "@emotion/styled": "11.10.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2473,10 +2473,10 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@bldrs-ai/conway@1.355.1122":
-  version "1.355.1122"
-  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.355.1122.tgz#37dc55ab22322a1d1499daeea9ad029410367f53"
-  integrity sha512-QHRNWQTu7ZNkub2z8fR94C5u1Sq4dwMso0Y9AWI6Ua9uRE3aiQlgDhWtT/IZ84tMRLtrHIbQou3G85NfotK5RA==
+"@bldrs-ai/conway@1.356.1126":
+  version "1.356.1126"
+  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.356.1126.tgz#573b0cdce033b0ed37d1ec06caf305e821b693b8"
+  integrity sha512-c3bch7kNvartfUpNFbAeM4agAY8Trpk+I45xaRPhrgK/K6JQt7qMWyDA1RNJmrXAMLxO73lE7C4DfpdxS5gTxA==
   dependencies:
     gl-matrix "3.4.3"
     seedrandom "3.0.5"


### PR DESCRIPTION
Brings in the STEP load performance work from bldrs-ai/conway#356 + bldrs-ai/conway-geom#136:

- Geometry extraction on large advanced-BREP STEP models is **~3.8x faster** (Arty_Z7.stp: 152.5s → 40.3s geometry, 154.6s → 47.2s total load on a 4-core container), with **byte-identical** glTF/GLB output.
- Native memory leak fixes in AP214 face extraction (the wasm heap was hitting its 4GB ceiling on large STEP models).
- ThreadPool concurrency fixes (worker serialization, lost-wakeup, cross-round overrun) and worker-safe logging.
- New deferred/parallel face tessellation infrastructure, gated off by default until a thread-scalable wasm allocator ships (see the conway-geom PR for details).

`package.json` + `yarn.lock` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S6gTXmrq1GbhqknPqQMRuz

---
_Generated by [Claude Code](https://claude.ai/code/session_01S6gTXmrq1GbhqknPqQMRuz)_