### PR TITLE
Bump @bldrs-ai/conway to 1.369.1178 (STEP load-perf + memory release)

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@babel/plugin-syntax-import-assertions": "7.18.6",
     "@babel/preset-env": "7.18.10",
     "@babel/preset-react": "7.18.6",
-    "@bldrs-ai/conway": "1.365.1166",
+    "@bldrs-ai/conway": "1.369.1178",
     "@bldrs-ai/ifclib": "5.3.3",
     "@emotion/react": "11.10.0",
     "@emotion/styled": "11.10.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2473,10 +2473,10 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@bldrs-ai/conway@1.365.1166":
-  version "1.365.1166"
-  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.365.1166.tgz#75989bb929897ca7f81443df3befbc8cfe67065d"
-  integrity sha512-0mYTVTo3ry4Zd2OyqP+GwD5KuXGJllmoeqdBa3JgiwgEZ5ZI9nmQ2uzAH/KfoQhe73ikaU6ITTl+UDfSCoucZw==
+"@bldrs-ai/conway@1.369.1178":
+  version "1.369.1178"
+  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.369.1178.tgz#7e3b9dffcde102d524a70afa1f6d9778fce3ac9a"
+  integrity sha512-ygKz2grdBvOgdB9rCBpX/T2+Bl1j1BSZ0lFG0pHoQa8b1iO+sV0DXLxkDCHP7J0efXghre8kHSngPhIz2OLytQ==
   dependencies:
     gl-matrix "3.4.3"
     seedrandom "3.0.5"


### PR DESCRIPTION
Bumps `@bldrs-ai/conway` `1.365.1166` → `1.369.1178`.

## What's in this conway release
- **Weld bit-exact dedup** — Jetenginestep load **263 s → ~15 s** (~17×); the shaft's degenerate coincident-vertex cluster was driving weld O(cluster²).
- **Non-finite CDT guards** — projection-pole faces that ballooned the grow-only wasm heap are dropped up front: Arty_Z7 **4.5 GB → 775 MB**, supercap2/3 **4.1 GB → ~145 MB** transient peaks.
- **`noexcept` glm hashers** — drops the per-node cached-hash overhead in the weld hash table.

All changes are **byte-identical** geometry — the full STEP+IFC regression digest is green on the conway release commit; no geometry output changes, so no visual diffs are expected.

## Test plan
- [ ] Smoke-test model loads in the viewer (STEP + IFC), especially large models (Jetenginestep, Arty, supercap) for the load-time/memory improvement.
- CI build + existing Share checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01S6gTXmrq1GbhqknPqQMRuz)_