### PR TITLE
Bump @bldrs-ai/conway to 1.372.1179 (SoA entity descriptors)

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@babel/plugin-syntax-import-assertions": "7.18.6",
     "@babel/preset-env": "7.18.10",
     "@babel/preset-react": "7.18.6",
-    "@bldrs-ai/conway": "1.369.1178",
+    "@bldrs-ai/conway": "1.372.1179",
     "@bldrs-ai/ifclib": "5.3.3",
     "@emotion/react": "11.10.0",
     "@emotion/styled": "11.10.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2473,10 +2473,10 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@bldrs-ai/conway@1.369.1178":
-  version "1.369.1178"
-  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.369.1178.tgz#7e3b9dffcde102d524a70afa1f6d9778fce3ac9a"
-  integrity sha512-ygKz2grdBvOgdB9rCBpX/T2+Bl1j1BSZ0lFG0pHoQa8b1iO+sV0DXLxkDCHP7J0efXghre8kHSngPhIz2OLytQ==
+"@bldrs-ai/conway@1.372.1179":
+  version "1.372.1179"
+  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.372.1179.tgz#2cc92a513d1adea1eac2206299071b682a02669a"
+  integrity sha512-FnOtv74vhxblSs4rGtjVHj8nwOETar+l7ODphFKtmh/5mAEw1Q+JN0BraUl/h/eh9WNLD1adF1bo3zHDD5ioeA==
   dependencies:
     gl-matrix "3.4.3"
     seedrandom "3.0.5"


### PR DESCRIPTION
Bumps `@bldrs-ai/conway` `1.369.1178` → `1.372.1179`.

## What's in this conway release
Structure-of-arrays entity descriptors (conway#372): the per-entity parse index is now typed-array columns + a lazily-materialised descriptor cache that `invalidate()` clears, so the ~1 GB+ of descriptor objects large models used to pin for the model's whole life is **reclaimable at render time**. That frees the headroom three.js's scene-build copies need on big models.

Measured (single-thread): post-invalidate JS heap on a 7.8M-entity model **1055 MB → 24 MB (−98%)**; peak unchanged. Geometry is **byte-identical** (full corpus regression digest green), so no visual changes expected.

## Test plan
- [ ] Smoke-test model loads (STEP + IFC), especially large models — confirm no regressions and the memory/response improvement on big files.
- CI build + existing Share checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01S6gTXmrq1GbhqknPqQMRuz)_