### PR TITLE
Lazy properties step 1: load spatial tree in 'names' mode + release entity cache

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@babel/plugin-syntax-import-assertions": "7.18.6",
     "@babel/preset-env": "7.18.10",
     "@babel/preset-react": "7.18.6",
-    "@bldrs-ai/conway": "1.372.1179",
+    "@bldrs-ai/conway": "1.373.1180",
     "@bldrs-ai/ifclib": "5.3.3",
     "@emotion/react": "11.10.0",
     "@emotion/styled": "11.10.0",

--- a/src/Components/Properties/Properties.jsx
+++ b/src/Components/Properties/Properties.jsx
@@ -54,10 +54,10 @@ export default function Properties() {
       if (model && element) {
         // Resolve `element` to the full IFC entity before rendering.
         // `selectedElement` is a spatial-tree node — for cache-miss
-        // IFC it carries full IFC properties (wit-three's
-        // `getSpatialStructure(0, true)` inlines them); for cache-hit
-        // GLB it's the slim whitelist {expressID, type, Name,
-        // LongName, children} captured by `bldrsSpatialTree.js`.
+        // IFC it carries only Name/LongName/GlobalId handles
+        // (CadView loads the tree with Conway's `'names'` mode); for
+        // cache-hit GLB it's the slim whitelist {expressID, type,
+        // Name, LongName, children} captured by `bldrsSpatialTree.js`.
         // `model.getItemProperties(expressID)` returns the full entity
         // in both cases (wit-three's IFCModel prototype on cache-miss;
         // the cached BLDRS_element_properties closure on cache-hit),

--- a/src/Containers/CadView.jsx
+++ b/src/Containers/CadView.jsx
@@ -600,10 +600,17 @@ export default function CadView({
     // entity/descriptor caches (the 'names' walk + type sweep touched
     // O(products) entities). Entities rematerialise transparently on the
     // next property access (Properties panel, GLB cache writer), so this
-    // only bounds memory. Conway extension — optional-chained so cache-hit
-    // GLB models (no parser) and older conway versions no-op.
+    // only bounds memory. Conway extension — optional-chained so older
+    // conway versions no-op. The IsModelOpen gate keeps cache-hit GLB
+    // loads silent: they share the live conway ifcAPI via
+    // `viewer.IFC.loader.ifcManager` without ever opening model 0, and
+    // an ungated release would log a spurious model-undefined error.
+    const conwayApi = m.ifcManager?.ifcAPI
     // eslint-disable-next-line new-cap
-    m.ifcManager?.ifcAPI?.ReleaseEntityCache?.(0)
+    if (conwayApi?.ReleaseEntityCache && conwayApi.IsModelOpen?.(0)) {
+      // eslint-disable-next-line new-cap
+      conwayApi.ReleaseEntityCache(0)
+    }
   }
 
 

--- a/src/Containers/CadView.jsx
+++ b/src/Containers/CadView.jsx
@@ -554,18 +554,29 @@ export default function CadView({
       //      tree). `hasOwnProperty` discriminates this from wit-three's
       //      `IFCModel.prototype.getSpatialStructure` which takes no args
       //      and would silently drop `withProperties=true`.
-      //   2. Wit-three's `m.ifcManager.getSpatialStructure(0, true)` —
+      //   2. Wit-three's `m.ifcManager.getSpatialStructure(0, ...)` —
       //      legacy fallback. Post-Slice-5b this won't work for IFC
       //      parses (wit-three's `state.models[modelID]` is empty
       //      because we skipped its parse), but the branch stays as a
       //      defensive fallback for non-IFC models that decorated with
       //      `ifcManager` shims via `convertToShareModel`.
+      //
+      // `'names'` (Conway extension) fetches the tree with only the
+      // Name/LongName/GlobalId handles each load-time consumer here
+      // actually reads (setupLookupAndParentLinks: expressID;
+      // SearchIndex + reifyName: Name/LongName/GlobalId/type;
+      // groupElementsByTypes: Name/LongName/type) instead of the old
+      // `true`, which flattened and retained every spatial node's FULL
+      // attribute record — O(products) memory pinned for the session
+      // that the Properties panel re-fetches on demand anyway. The
+      // cache-hit GLB closure ignores the flag (tree pre-serialised);
+      // wit-three's legacy shim treats any truthy value as `true`.
       const hasOwnSpatialStructure =
         Object.prototype.hasOwnProperty.call(m, 'getSpatialStructure')
       if (hasOwnSpatialStructure) {
-        rootElt = await m.getSpatialStructure(0, true)
+        rootElt = await m.getSpatialStructure(0, 'names')
       } else {
-        rootElt = await m.ifcManager.getSpatialStructure(0, true)
+        rootElt = await m.ifcManager.getSpatialStructure(0, 'names')
       }
     } catch (e) {
       setAlert('Could not read full model structure.  Only model geometry will be available.')
@@ -585,6 +596,14 @@ export default function CadView({
     rootElt.LongName = rootProps.LongName
     setRootElement(rootElt)
     setElementTypesMap(groupElementsByTypes(rootElt))
+    // Load-time property reads are done: drop Conway's materialised
+    // entity/descriptor caches (the 'names' walk + type sweep touched
+    // O(products) entities). Entities rematerialise transparently on the
+    // next property access (Properties panel, GLB cache writer), so this
+    // only bounds memory. Conway extension — optional-chained so cache-hit
+    // GLB models (no parser) and older conway versions no-op.
+    // eslint-disable-next-line new-cap
+    m.ifcManager?.ifcAPI?.ReleaseEntityCache?.(0)
   }
 
 

--- a/src/viewer/ifc/conwayDirectIfcLoader.js
+++ b/src/viewer/ifc/conwayDirectIfcLoader.js
@@ -297,16 +297,21 @@ export function attachConwayDirectModelMethods(ifcModel, ifcAPI, modelID) {
   //   - `(modelID, withProps)` — CadView.jsx, ShareViewer.getByFloor,
   //     IfcIsolator (mirrors `ifcManager.getSpatialStructure` shape)
   //   - `(withProps)` — cache-hit closure pattern
-  // We accept both: if the first arg is a boolean (and only one arg
-  // was passed), it's the `withProperties` flag; otherwise the leading
-  // modelID is ignored and `withProperties` is the second arg. The
-  // model's bound modelID is always used — closures are per-model.
+  // We accept both: if the first arg is a boolean or Conway's `'names'`
+  // mode (and only one arg was passed), it's the `withProperties` flag;
+  // otherwise the leading modelID is ignored and `withProperties` is
+  // the second arg. `'names'` must pass through un-coerced — Conway's
+  // shim reads it as the light per-node Name/LongName/GlobalId mode; a
+  // bare boolean coercion here would silently upgrade it back to the
+  // full-record `true` visit this mode exists to avoid. The model's
+  // bound modelID is always used — closures are per-model.
   ifcModel.getSpatialStructure = function getSpatialStructure(...args) {
+    const isMode = (v) => typeof v === 'boolean' || v === 'names'
     let withProps = false
-    if (args.length === 1 && typeof args[0] === 'boolean') {
+    if (args.length === 1 && isMode(args[0])) {
       withProps = args[0]
     } else if (args.length >= 2) {
-      withProps = !!args[1]
+      withProps = isMode(args[1]) ? args[1] : Boolean(args[1])
     }
     return ifcAPI.properties.getSpatialStructure(modelID, withProps)
   }

--- a/src/viewer/ifc/conwayDirectIfcLoader.test.js
+++ b/src/viewer/ifc/conwayDirectIfcLoader.test.js
@@ -191,6 +191,22 @@ describe('viewer/ifc/conwayDirectIfcLoader', () => {
       expect(ifcAPI.properties.getSpatialStructure).toHaveBeenCalledWith(0, true)
     })
 
+    it('getSpatialStructure passes Conway\'s \'names\' mode through un-coerced', async () => {
+      // Regression pin: 'names' must reach Conway as the string, not be
+      // boolean-coerced — a truthy coercion would silently upgrade the
+      // light Name/LongName/GlobalId walk back to the full-record visit
+      // that 'names' mode exists to avoid (CadView.jsx load path).
+      const ifcAPI = makeIfcAPI()
+      const ifcModel = new Mesh()
+      decorateConwayDirectIfcModel(ifcModel, ifcAPI, 7)
+      // Two-arg manager shape (CadView.jsx): (modelID, 'names').
+      await ifcModel.getSpatialStructure(0, 'names')
+      expect(ifcAPI.properties.getSpatialStructure).toHaveBeenCalledWith(7, 'names')
+      // Single-arg cache-hit closure shape: ('names').
+      await ifcModel.getSpatialStructure('names')
+      expect(ifcAPI.properties.getSpatialStructure).toHaveBeenLastCalledWith(7, 'names')
+    })
+
     it('getIfcType is an identity over the spatial-tree node\'s string type', () => {
       // Regression pin: SearchIndex (`src/search/SearchIndex.js#indexElement`)
       // calls `Ifc.getType(model, elt)` → `model.properties.getIfcType(elt.type)`

--- a/yarn.lock
+++ b/yarn.lock
@@ -2473,10 +2473,10 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@bldrs-ai/conway@1.372.1179":
-  version "1.372.1179"
-  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.372.1179.tgz#2cc92a513d1adea1eac2206299071b682a02669a"
-  integrity sha512-FnOtv74vhxblSs4rGtjVHj8nwOETar+l7ODphFKtmh/5mAEw1Q+JN0BraUl/h/eh9WNLD1adF1bo3zHDD5ioeA==
+"@bldrs-ai/conway@1.373.1180":
+  version "1.373.1180"
+  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.373.1180.tgz#e3ee5f9ac92ae40142899561a0006d46f77eb453"
+  integrity sha512-/MvwMq9imcVKXTdUW/HP/2sWJGjGarzKqELd39WZwXjTqYwRavW0yJwaRgT9pp+QqizvRbRMWsHCyJ/MWRFC/g==
   dependencies:
     gl-matrix "3.4.3"
     seedrandom "3.0.5"


### PR DESCRIPTION
## What

First step of the lazy/incremental property-load track. The eager full-property visit on model load is vestigial from the web-ifc days — conway's parse-time index already backs on-demand access, so the load path only needs the node names.

- Bumps `@bldrs-ai/conway` to **1.373.1180**, which includes [conway#373](https://github.com/bldrs-ai/conway/pull/373): `getSpatialStructure(modelID, 'names')` returns per-node `Name`/`LongName`/`GlobalId` value handles only (no recursive property inlining), plus `IfcAPI.ReleaseEntityCache(modelID)` to drop the entity-descriptor cache after load.
- `CadView.jsx`: `getSpatialStructure(0, true)` → `getSpatialStructure(0, 'names')` on both load branches, then calls `ReleaseEntityCache(0)` once the element-types map is built.
- `conwayDirectIfcLoader.js`: the `getSpatialStructure` argument-forwarding closure now passes `'names'` through instead of boolean-coercing it (the old `!!args[1]` would have silently degraded `'names'` → `true`, keeping the eager visit).

## Why

On large models the eager visit materializes every entity record at load just to inline properties the UI may never open. With 'names' mode the tree carries only what NavTree/search need; everything else stays behind conway's on-demand API (Properties panel, ifclib deref per opened branch — unchanged). Combined with the cache release this removes the largest post-load JS heap resident and cuts load time.

Consumer audit (all load-path consumers of the spatial tree verified against the names shape): `setupLookupAndParentLinks`, `SearchIndex`, `reifyName`, `groupElementsByTypes`, NavTree, `IfcIsolator`, cache-hit closure capture, GLB writers, `getByFloor` (deliberately untouched — still requests full props on demand since it needs `Elevation`).

## Testing

- Full Share suite green: 208 suites, 1830 passed.
- conway#373 carries its own parity tests (names ↔ full-mode value agreement, ReleaseEntityCache round-trip) and shipped with byte-identical geometry regression green.
- Needs a manual smoke test on a large model (NavTree names, search, Properties panel on-demand, floor isolation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S6gTXmrq1GbhqknPqQMRuz

---
_Generated by [Claude Code](https://claude.ai/code/session_01S6gTXmrq1GbhqknPqQMRuz)_