### PR TITLE
Stream the GLB element-properties capture (fixed-memory writer)

### DIFF
--- a/src/loader/GlbWriterService.js
+++ b/src/loader/GlbWriterService.js
@@ -86,7 +86,11 @@ function getWorker() {
  *   the underlying ArrayBuffer
  * @param {string|null} args.mode container mode tag — draco/meshopt/null
  * @param {Array<object>} args.extensions extension payloads to inject;
- *   each entry is `{name, data, compress?}` matching `injectGlbExtensions`
+ *   each entry is `{name, data, compress?, precompressed?}` matching
+ *   `injectGlbExtensions`. A `precompressed` Uint8Array rides through
+ *   the structured clone intact (deliberately NOT in the transfer
+ *   list — the caller's inline fallback after a worker failure must
+ *   still see an attached buffer)
  * @param {object} [args.sceneExtras] optional small string-keyed
  *   metadata merged into `scenes[0].extras` in the same inject pass
  *   (see `injectGlbExtensions`)

--- a/src/loader/bldrsElementProperties.js
+++ b/src/loader/bldrsElementProperties.js
@@ -186,72 +186,122 @@ function collectSpatialTreeIds(root) {
 
 /**
  * Capture the element-properties closure for a model from an
- * IfcManager-like source. Tries the fast sync-bulk path first
- * (`captureBldrsElementPropertiesFast` — reaches into the Conway
- * adapter's parsed model and iterates synchronously), falling back
- * to the slow per-entity async BFS for environments that don't
- * expose the adapter internals (tests, non-Conway loaders).
+ * IfcManager-like source. Tries the streaming sync-bulk path first
+ * (`captureBldrsElementPropertiesStreaming` — reaches into the Conway
+ * adapter's parsed model, iterates synchronously, and gzips the wire
+ * JSON incrementally so the full property closure is never resident
+ * as one JS object graph), falling back to the slow per-entity async
+ * BFS for environments that don't expose the adapter internals
+ * (tests, non-Conway loaders).
  *
- * The two paths produce the same output shape so the cached
- * artifact is identical regardless of which path ran. The fast
- * path is ~100× faster on large IFCs because it skips Promise-per-
- * entity overhead: ~10 min → ~10 s on a 100MB Snowdon IFC.
+ * Both paths produce the same decoded wire JSON (same entity set,
+ * same pset index) so the cached artifact is equivalent regardless
+ * of which path ran. The streaming path is ~100× faster on large
+ * IFCs (no Promise per entity) AND fixed-memory: peak retained heap
+ * is O(reachable ids + one record) instead of O(all parsed records).
  *
- * Returns the wire-format payload, or `null` when no manager is
- * available (non-IFC sources, cache-hit GLB with no live parser).
+ * Return shape is a discriminated union:
+ *   - `{compressedBytes: Uint8Array}` — streaming path; already the
+ *     gzipped wire JSON, ready to embed as a bufferView payload
+ *     (pass to `injectGlbExtensions` as `precompressed`).
+ *   - `{itemProperties, propertySets}` — slow path; the decoded wire
+ *     object, compressed later by the inject step (`compress: true`).
+ *   - `null` — no manager available (non-IFC sources, cache-hit GLB
+ *     with no live parser).
  *
  * @param {object|null|undefined} ifcManager IfcManager-like.
  * @param {number} modelID
  * @param {object|null|undefined} spatialTree the JSON tree
  *   `captureBldrsSpatialTree` returned. Acts as the BFS seed for the
- *   slow path; the fast path ignores it (iterates all entities).
+ *   slow path; the streaming path ignores it (scans all entities).
  * @return {Promise<object|null>}
  */
 export async function captureBldrsElementProperties(ifcManager, modelID, spatialTree) {
   if (!ifcManager) {
     return null
   }
-  const fastResult = await captureBldrsElementPropertiesFast(ifcManager, modelID)
-  if (fastResult !== null) {
-    return fastResult
+  const compressedBytes = await captureBldrsElementPropertiesStreaming(ifcManager, modelID)
+  if (compressedBytes !== null) {
+    return {compressedBytes}
   }
   return await captureBldrsElementPropertiesSlow(ifcManager, modelID, spatialTree)
 }
 
 
+// Text-buffer flush threshold for the streaming deflate. Records are
+// concatenated into a small string buffer and pushed into pako's
+// streaming Deflate in ~64KB slabs — per-record push calls would pay
+// deflate-call overhead millions of times; one giant join would
+// recreate the whole-payload-resident problem the streaming path
+// exists to avoid.
+const STREAM_FLUSH_CHARS = 65536
+
+// How many `getLine` materialisations between conway entity-cache
+// releases during the streaming sweep. Each getLine populates conway's
+// per-entity descriptor cache; on a ~9M-entity IFC letting the sweep
+// run uncapped re-pins ~1GB of descriptors that the post-load
+// `ReleaseEntityCache` had just dropped. Releasing every 200k touched
+// entities bounds the transient to ~20-40MB. Safe mid-iteration: the
+// model iterator is a bare index loop that re-derives each descriptor
+// from the parse index, and dropped descriptors rematerialise on next
+// access.
+const RELEASE_CACHE_EVERY = 200_000
+
+
 /**
- * Fast sync-bulk capture path. Reaches into the Conway adapter's
+ * Streaming sync-bulk capture path. Reaches into the Conway adapter's
  * internal `IfcApiProxyIfc` to get the upstream Conway `IfcStepModel`
- * and iterates it synchronously — `for (const entity of stepModel)`
- * walks every parsed entity without any async overhead. For each,
- * `proxy.getLine(expressID)` synchronously converts the raw STEP
- * tape into the wit-three-shape object (the exact shape consumers
- * expect; same as what `ifcManager.getItemProperties` returns,
- * minus the async wrapping). Property-set indexing happens in the
- * same loop by detecting `IfcRelDefinesByProperties` entities and
- * walking their `RelatingPropertyDefinition` / `RelatedObjects`
- * fields — no second pass needed.
+ * and walks it synchronously, gzipping the wire JSON incrementally —
+ * the full property closure is NEVER resident as one JS object graph.
+ * Peak retained memory is O(reachable ids + pset index + one record +
+ * compressed output) instead of the old fast path's O(every parsed
+ * record) (~GBs on 100MB-class IFCs before the reachability filter
+ * could prune).
+ *
+ * Two sweeps, identical decoded output to the old capture-then-filter
+ * fast path:
+ *   1. Linear scan of every parsed entity via sync `proxy.getLine`.
+ *      IfcRoot-derived entities (`GlobalId` present — products, rels,
+ *      psets) are serialized into the stream immediately and their
+ *      non-geometric refs queued. `IfcRelDefinesByProperties` entities
+ *      additionally feed the product→psetIds index in the same pass.
+ *      Records not kept are dropped on the spot.
+ *   2. Ref-closure drain: queued ids (non-root entities reachable from
+ *      a root — property values, materials, owner history etc.) are
+ *      fetched by id, serialized, and their refs queued in turn.
+ *      `collectRefIds` skips the geometric backbone (Representation /
+ *      ObjectPlacement / RepresentationContexts / Representations) at
+ *      the entity top level, so the closure stops at the geometric
+ *      boundary — same ~2.7M → ~50k entity cut as before on Snowdon.
+ *
+ * Memory discipline during the sweep:
+ *   - `stepModel.elementMemoization` is turned off so conway doesn't
+ *     pin an extracted entity object per descriptor (restored after).
+ *   - conway's entity/descriptor cache is released every
+ *     `RELEASE_CACHE_EVERY` materialisations and once at the end
+ *     (`proxy.releaseEntityCache`, conway ≥1.373 — optional-chained
+ *     no-op on older versions).
  *
  * Returns `null` (so the caller falls back to the slow path) when:
  *   - the adapter surface isn't accessible (test stubs without
  *     `ifcAPI.getPassthrough`, non-Conway IFC backends)
  *   - the proxy's internal `model` field isn't where we expect
- *   - the iteration would yield zero entities (parser state empty)
+ *   - the iteration yields zero entities (parser state empty)
+ *   - the streaming deflate reports an error
  *
  * Coupling notes: this reaches `ifcAPI.getPassthrough(modelID)` and
  * then `proxy.model[0]` (the IfcStepModel) — both are stable on
  * the current adapter (see `ifc_api.js:53` and `ifc_api_proxy_ifc.js:154`)
- * but neither is part of the formal public API. We file a Conway PR
- * to expose them officially (parse-only `OpenModel` flag + bulk
- * iteration accessor); until then this is the seam. The fallback to
+ * but neither is part of the formal public API. The fallback to
  * the slow path keeps tests + non-Conway sources working.
  *
  * @param {object} ifcManager IfcManager-like with `.ifcAPI`.
  * @param {number} modelID
- * @return {object|null} `{itemProperties, propertySets}` or `null`
- *   when the fast path is unavailable.
+ * @return {Promise<Uint8Array|null>} gzipped wire JSON (the exact
+ *   bytes a reader `pako.ungzip` + `JSON.parse` expects) or `null`
+ *   when the streaming path is unavailable.
  */
-async function captureBldrsElementPropertiesFast(ifcManager, modelID) {
+async function captureBldrsElementPropertiesStreaming(ifcManager, modelID) {
   const ifcAPI = ifcManager.ifcAPI
   if (!ifcAPI || typeof ifcAPI.getPassthrough !== 'function') {
     return null
@@ -267,189 +317,223 @@ async function captureBldrsElementPropertiesFast(ifcManager, modelID) {
   }
 
   const startMs = Date.now()
-  const itemProperties = {}
+  const deflator = new pako.Deflate({gzip: true})
+  let textBuf = []
+  let textLen = 0
+  const flushText = () => {
+    if (textLen > 0) {
+      deflator.push(textBuf.join(''), false)
+      textBuf = []
+      textLen = 0
+    }
+  }
+  const pushText = (chunk) => {
+    textBuf.push(chunk)
+    textLen += chunk.length
+    if (textLen >= STREAM_FLUSH_CHARS) {
+      flushText()
+    }
+  }
+  let emittedCount = 0
+  const emitRecord = (id, props) => {
+    // Same wire JSON as `JSON.stringify({itemProperties: {...}})`
+    // would produce for this entry — numeric-string key, record value.
+    // Key ORDER differs from the legacy one-shot stringify (BFS
+    // discovery order vs ascending-integer), which is byte-different
+    // but decode-identical: the reader JSON.parses into a plain object
+    // and every consumer looks entries up by id.
+    pushText(`${emittedCount === 0 ? '' : ','}"${id}":${JSON.stringify(props)}`)
+    emittedCount++
+  }
+
+  // `visited` = "serialized or queued for serialization" — every id
+  // added is emitted exactly once (roots inline during the scan,
+  // ref-closure entities during the drain; a root first discovered as
+  // someone's ref drains from the queue instead and the scan skips it).
+  const visited = new Set()
+  const queue = []
+  let queueHead = 0
   const propertySets = {}
-  let captured = 0
+  let sawEntity = false
   let psetRelCount = 0
   // Cooperative-yield counter — see ENTITIES_PER_YIELD comment.
   // Counted on every iteration (not just kept entities) so the yield
   // cadence is independent of the percentage filtered out.
   let iterCount = 0
+  let sinceRelease = 0
+  const releaseTick = () => {
+    if (++sinceRelease >= RELEASE_CACHE_EVERY) {
+      sinceRelease = 0
+      proxy.releaseEntityCache?.()
+    }
+  }
 
-  for (const entity of stepModel) {
-    if (++iterCount % ENTITIES_PER_YIELD === 0) {
-      // Yield to the browser between chunks. The fast-path scan is
-      // pure JS object construction (no I/O, no Promise per entity),
-      // so without explicit yields it would block the main thread for
-      // the entire ~10s walk on a 100MB IFC. The user feels this as a
-      // hover-pick freeze immediately post-render. yieldToBrowser =
-      // setTimeout(0) wrapped in a Promise — one event-loop turn per
-      // yield, ~ms-scale overhead in aggregate.
-      await yieldToBrowser()
-    }
-    const expressID = entity?.expressID
-    if (typeof expressID !== 'number') {
-      continue
-    }
-    let props
-    try {
-      // Sync — no Promise allocation, no microtask hop. This is the
-      // 10-min-to-10-sec win on Snowdon: ~576k entities × ~10µs each
-      // instead of × ~1ms each through the async manager surface.
-      props = proxy.getLine(expressID)
-    } catch (e) {
-      // Per-entity failures are non-fatal — skip and continue. The
-      // wit-three slow path swallows the same way (one entity gap
-      // means one missing Properties row; not a cache abort).
-      continue
-    }
-    if (!props || typeof props !== 'object') {
-      continue
-    }
-    itemProperties[expressID] = props
-    captured++
+  const hadMemoization = stepModel.elementMemoization
+  stepModel.elementMemoization = false
+  try {
+    pushText('{"itemProperties":{')
 
-    // Inline pset-index extraction. An IfcRelDefinesByProperties
-    // entity has `RelatedObjects` (an array of {type:5, value:productId}
-    // refs to products) + `RelatingPropertyDefinition` ({type:5, value:psetId}
-    // ref to the pset). Detect by numeric `type` (the IFC type code
-    // — stable across wit-three's FromTape variants). An earlier
-    // version of this code used `constructor.name` which silently
-    // failed on Snowdon — `FromTape` does not always produce a
-    // class with a usable `name` property, so the check missed every
-    // rel. Wit-three's stock `getPropertySets(modelID, productID)`
-    // does the same walk one product at a time over an async API —
-    // building the index here in the same pass costs us nothing.
-    if (props.type === IFCRELDEFINESBYPROPERTIES) {
-      psetRelCount++
-      const psetRef = props.RelatingPropertyDefinition
-      const psetId = psetRef && typeof psetRef === 'object' ? psetRef.value : null
-      const relatedObjects = props.RelatedObjects
-      if (typeof psetId === 'number' && Array.isArray(relatedObjects)) {
-        for (const obj of relatedObjects) {
-          if (!obj || typeof obj !== 'object') {
-            continue
-          }
-          const productId = obj.value
-          if (typeof productId !== 'number') {
-            continue
-          }
-          let list = propertySets[productId]
-          if (!list) {
-            list = []
-            propertySets[productId] = list
-          }
-          // De-dup defensively — IFCs occasionally double-register.
-          if (!list.includes(psetId)) {
-            list.push(psetId)
+    // Sweep 1: linear scan — emit IfcRoot seeds, build the pset
+    // index, queue the ref frontier.
+    for (const entity of stepModel) {
+      if (++iterCount % ENTITIES_PER_YIELD === 0) {
+        // Yield to the browser between chunks. The scan is pure JS
+        // object construction (no I/O, no Promise per entity), so
+        // without explicit yields it would block the main thread for
+        // the entire ~10s walk on a 100MB IFC. The user feels this as
+        // a hover-pick freeze immediately post-render.
+        await yieldToBrowser()
+      }
+      releaseTick()
+      const expressID = entity?.expressID
+      if (typeof expressID !== 'number') {
+        continue
+      }
+      let props
+      try {
+        // Sync — no Promise allocation, no microtask hop. This is the
+        // 10-min-to-10-sec win on Snowdon: ~576k entities × ~10µs each
+        // instead of × ~1ms each through the async manager surface.
+        props = proxy.getLine(expressID)
+      } catch (e) {
+        // Per-entity failures are non-fatal — skip and continue. The
+        // wit-three slow path swallows the same way (one entity gap
+        // means one missing Properties row; not a cache abort).
+        continue
+      }
+      if (!props || typeof props !== 'object') {
+        continue
+      }
+      sawEntity = true
+
+      // Inline pset-index extraction. An IfcRelDefinesByProperties
+      // entity has `RelatedObjects` (an array of {type:5, value:productId}
+      // refs to products) + `RelatingPropertyDefinition` ({type:5, value:psetId}
+      // ref to the pset). Detect by numeric `type` (the IFC type code
+      // — stable across wit-three's FromTape variants). An earlier
+      // version of this code used `constructor.name` which silently
+      // failed on Snowdon — `FromTape` does not always produce a
+      // class with a usable `name` property, so the check missed every
+      // rel. Wit-three's stock `getPropertySets(modelID, productID)`
+      // does the same walk one product at a time over an async API —
+      // building the index here in the same pass costs us nothing.
+      if (props.type === IFCRELDEFINESBYPROPERTIES) {
+        psetRelCount++
+        const psetRef = props.RelatingPropertyDefinition
+        const psetId = psetRef && typeof psetRef === 'object' ? psetRef.value : null
+        const relatedObjects = props.RelatedObjects
+        if (typeof psetId === 'number' && Array.isArray(relatedObjects)) {
+          for (const obj of relatedObjects) {
+            if (!obj || typeof obj !== 'object') {
+              continue
+            }
+            const productId = obj.value
+            if (typeof productId !== 'number') {
+              continue
+            }
+            let list = propertySets[productId]
+            if (!list) {
+              list = []
+              propertySets[productId] = list
+            }
+            // De-dup defensively — IFCs occasionally double-register.
+            if (!list.includes(psetId)) {
+              list.push(psetId)
+            }
           }
         }
       }
-    }
-  }
 
-  if (captured === 0) {
-    // Parser state must have been empty / not the expected shape.
-    // Let the slow path try; it'll log the right cause.
-    return null
-  }
-
-  // Filter to entities reachable from IfcRoot via non-geometric refs.
-  // The bulk iteration above captured every parsed entity (millions
-  // for big IFCs, mostly geometric primitives). The Properties panel
-  // only needs IfcRoot-derived entities (products, rels, psets — all
-  // have `GlobalId`) plus their non-geometric ref closure
-  // (HasProperties, Quantities, materials, classifications, owner
-  // history etc.). `collectRefIds` skips the geometric backbone
-  // (Representation / ObjectPlacement / RepresentationContexts /
-  // Representations) at the entity's top-level, so the BFS naturally
-  // stops at the geometric boundary. Reduces Snowdon's captured set
-  // from ~2.7M entities to ~50k; cache payload from ~35MB compressed
-  // to ~1MB compressed.
-  const filterStartMs = Date.now()
-  const {filtered, prunedCount} = await filterReachableFromRoots(itemProperties)
-  const filteredCount = Object.keys(filtered).length
-
-  glbInfo(
-    `${BLDRS_ELEMENT_PROPERTIES_EXTENSION_NAME}: fast-path captured ${captured} entities ` +
-    `(${psetRelCount} IfcRelDefinesByProperties → ${Object.keys(propertySets).length} ` +
-    `products with psets) in ${Date.now() - startMs}ms; ` +
-    `filtered to ${filteredCount} reachable-from-IfcRoot ` +
-    `(pruned ${prunedCount} geometric primitives) in ${Date.now() - filterStartMs}ms`)
-
-  return {itemProperties: filtered, propertySets}
-}
-
-
-/**
- * BFS over the captured itemProperties map, keeping only entities
- * reachable from `IfcRoot`-derived entities (those with `GlobalId`)
- * via non-geometric refs. Unreachable entities — the geometric
- * primitives hanging off Representation / ObjectPlacement chains —
- * are dropped. The Properties panel never displays them; carrying
- * them in the cache costs ~30× the necessary payload size.
- *
- * `collectRefIds` (shared with the slow path) already skips
- * geometric field names at the entity's top level, so the BFS
- * frontier never expands into the geometric backbone. Property-
- * specific chains (HasProperties, Quantities, NominalValue refs,
- * Material*, Classification*, OwnerHistory) ARE followed because
- * those field names aren't in `GEOMETRIC_FIELD_NAMES`.
- *
- * @param {object} itemProperties the unfiltered map
- * @return {object} `{filtered: object, prunedCount: number}`
- */
-async function filterReachableFromRoots(itemProperties) {
-  const reachable = new Set()
-  const queue = []
-
-  // Seed: entities with `GlobalId`. IfcRoot mandates it, so this is
-  // the canonical "selectable entity" test — no whitelist of types
-  // needed. Covers products, processes, controls, resources, actors,
-  // groups, ALL `IfcRelXxx`, `IfcPropertySetDefinition`-derived
-  // entities (which includes `IfcPropertySet` / `IfcElementQuantity`),
-  // and any future IFC schema additions automatically.
-  let seedIter = 0
-  for (const idStr of Object.keys(itemProperties)) {
-    if (++seedIter % ENTITIES_PER_YIELD === 0) {
-      await yieldToBrowser()
-    }
-    const props = itemProperties[idStr]
-    if (props && props.GlobalId !== undefined) {
-      const id = Number(idStr)
-      reachable.add(id)
-      queue.push(id)
-    }
-  }
-
-  // BFS via non-geometric refs.
-  let bfsIter = 0
-  while (queue.length > 0) {
-    if (++bfsIter % ENTITIES_PER_YIELD === 0) {
-      await yieldToBrowser()
-    }
-    const id = queue.shift()
-    const props = itemProperties[id]
-    if (!props) {
-      continue
-    }
-    const refs = []
-    collectRefIds(props, refs)
-    for (const refId of refs) {
-      if (!reachable.has(refId) && itemProperties[refId] !== undefined) {
-        reachable.add(refId)
-        queue.push(refId)
+      // Seed test: entities with `GlobalId`. IfcRoot mandates it, so
+      // this is the canonical "selectable entity" test — no whitelist
+      // of types needed. Covers products, processes, controls,
+      // resources, actors, groups, ALL `IfcRelXxx`,
+      // `IfcPropertySetDefinition`-derived entities (which includes
+      // `IfcPropertySet` / `IfcElementQuantity`), and any future IFC
+      // schema additions automatically. Non-root entities are dropped
+      // here; the ones reachable from a root get re-fetched by id in
+      // the drain sweep.
+      if (props.GlobalId === undefined || visited.has(expressID)) {
+        continue
+      }
+      visited.add(expressID)
+      emitRecord(expressID, props)
+      const refs = []
+      collectRefIds(props, refs)
+      for (const refId of refs) {
+        if (!visited.has(refId)) {
+          visited.add(refId)
+          queue.push(refId)
+        }
       }
     }
-  }
 
-  // Filter into a new map.
-  const filtered = {}
-  for (const id of reachable) {
-    filtered[id] = itemProperties[id]
+    if (!sawEntity) {
+      // Parser state must have been empty / not the expected shape.
+      // Let the slow path try; it'll log the right cause.
+      return null
+    }
+
+    // Sweep 2: drain the ref closure. `collectRefIds` (shared with
+    // the slow path) skips geometric field names at the entity's top
+    // level, so the frontier never expands into the geometric
+    // backbone. Property-specific chains (HasProperties, Quantities,
+    // NominalValue refs, Material*, Classification*, OwnerHistory)
+    // ARE followed because those field names aren't in
+    // `GEOMETRIC_FIELD_NAMES`.
+    while (queueHead < queue.length) {
+      if (++iterCount % ENTITIES_PER_YIELD === 0) {
+        await yieldToBrowser()
+      }
+      releaseTick()
+      const id = queue[queueHead++]
+      let props
+      try {
+        props = proxy.getLine(id)
+      } catch (e) {
+        continue
+      }
+      if (!props || typeof props !== 'object') {
+        // Dangling ref (id not in the file) — same skip the legacy
+        // filter applied via its `itemProperties[refId] !== undefined`
+        // existence check.
+        continue
+      }
+      emitRecord(id, props)
+      const refs = []
+      collectRefIds(props, refs)
+      for (const refId of refs) {
+        if (!visited.has(refId)) {
+          visited.add(refId)
+          queue.push(refId)
+        }
+      }
+    }
+
+    pushText(`},"propertySets":${JSON.stringify(propertySets)}}`)
+    flushText()
+    deflator.push('', true)
+    if (deflator.err) {
+      glbInfo(
+        `${BLDRS_ELEMENT_PROPERTIES_EXTENSION_NAME}: streaming deflate error ` +
+        `${deflator.err} (${deflator.msg}); falling back to slow path`)
+      return null
+    }
+
+    glbInfo(
+      `${BLDRS_ELEMENT_PROPERTIES_EXTENSION_NAME}: streamed ${emittedCount} ` +
+      `reachable-from-IfcRoot entities (of ${iterCount} scanned; ` +
+      `${psetRelCount} IfcRelDefinesByProperties → ` +
+      `${Object.keys(propertySets).length} products with psets) into ` +
+      `${deflator.result.byteLength}B gzip in ${Date.now() - startMs}ms`)
+
+    return deflator.result
+  } finally {
+    stepModel.elementMemoization = hadMemoization
+    // Drop the descriptors the sweep materialised; they rematerialise
+    // transparently on the next property access.
+    proxy.releaseEntityCache?.()
   }
-  const prunedCount = Object.keys(itemProperties).length - reachable.size
-  return {filtered, prunedCount}
 }
 
 

--- a/src/loader/bldrsElementProperties.test.js
+++ b/src/loader/bldrsElementProperties.test.js
@@ -14,14 +14,31 @@ import {
 
 
 describe('loader/bldrsElementProperties', () => {
-  describe('captureBldrsElementProperties — fast path via Conway adapter', () => {
-    // The fast path reaches into `ifcAPI.getPassthrough(modelID)` and
-    // iterates the upstream Conway `IfcStepModel` synchronously,
+  describe('captureBldrsElementProperties — streaming path via Conway adapter', () => {
+    // The streaming path reaches into `ifcAPI.getPassthrough(modelID)`
+    // and iterates the upstream Conway `IfcStepModel` synchronously,
     // calling `proxy.getLine(expressID)` per entity to convert raw
     // STEP-tape data to the wit-three-shape object consumers expect.
-    // Pset extraction happens inline — `IfcRelDefinesByProperties`
-    // entities encountered during the walk build the
-    // product→psetIds index in one pass. No spatial tree needed.
+    // Records are gzipped into the wire JSON incrementally (never all
+    // resident at once), so the capture returns `{compressedBytes}` —
+    // tests decode it back to assert on content. Pset extraction
+    // happens inline — `IfcRelDefinesByProperties` entities
+    // encountered during the walk build the product→psetIds index in
+    // one pass. No spatial tree needed.
+
+    /**
+     * Decode a streaming-path capture result back to the wire object
+     * so assertions can run on content. Asserts the discriminated-
+     * union shape on the way through.
+     *
+     * @param {object} result `{compressedBytes: Uint8Array}`
+     * @return {object} `{itemProperties, propertySets}`
+     */
+    function decodeCaptured(result) {
+      expect(result).not.toBeNull()
+      expect(result.compressedBytes).toBeInstanceOf(Uint8Array)
+      return JSON.parse(pako.ungzip(result.compressedBytes, {to: 'string'}))
+    }
 
     /**
      * Build a fake ifcManager that mimics the adapter surface:
@@ -77,7 +94,7 @@ describe('loader/bldrsElementProperties', () => {
         },
       }
       const mgr = makeFastMgr(entities)
-      const captured = await captureBldrsElementProperties(mgr, 0, /* unused */ null)
+      const captured = decodeCaptured(await captureBldrsElementProperties(mgr, 0, /* unused */ null))
       expect(Object.keys(captured.itemProperties).sort()).toEqual(['100', '101', '102'])
       expect(captured.itemProperties[100]).toEqual(entities[100])
       // Pset index is empty when no IfcRelDefinesByProperties entities exist.
@@ -132,17 +149,19 @@ describe('loader/bldrsElementProperties', () => {
         999: relAB,
       }
       const mgr = makeFastMgr(entities)
-      const captured = await captureBldrsElementProperties(mgr, 0, null)
+      const captured = decodeCaptured(await captureBldrsElementProperties(mgr, 0, null))
       // Walls 100 and 101 share pset 500 (via the same rel). Wall 102
       // gets pset 501 from a different rel. The pset entities
       // themselves (500, 501) and the rel entities (998, 999) also
       // land in itemProperties so the reader can deref them.
+      // (Structural equality, not identity — the wire round-trip
+      // JSON-serialises class instances to plain objects.)
       expect(captured.propertySets[100]).toEqual([500])
       expect(captured.propertySets[101]).toEqual([500])
       expect(captured.propertySets[102]).toEqual([501])
       expect(captured.itemProperties[500]).toBeDefined()
-      expect(captured.itemProperties[998]).toBe(relC)
-      expect(captured.itemProperties[999]).toBe(relAB)
+      expect(captured.itemProperties[998]).toEqual({...relC})
+      expect(captured.itemProperties[999]).toEqual({...relAB})
     })
 
     it('detects IfcRelDefinesByProperties by numeric type, not constructor.name', async () => {
@@ -177,7 +196,7 @@ describe('loader/bldrsElementProperties', () => {
         getLine: (id) => entities[id],
       }
       const mgr = {ifcAPI: {getPassthrough: () => proxy}}
-      const captured = await captureBldrsElementProperties(mgr, 0, null)
+      const captured = decodeCaptured(await captureBldrsElementProperties(mgr, 0, null))
       // Pre-fix: this returned `{}` because `constructor.name` was
       // 'Object'. Post-fix: type check matches, pset index built.
       expect(captured.propertySets[100]).toEqual([500])
@@ -208,7 +227,7 @@ describe('loader/bldrsElementProperties', () => {
         999: rel,
       }
       const mgr = makeFastMgr(entities)
-      const captured = await captureBldrsElementProperties(mgr, 0, null)
+      const captured = decodeCaptured(await captureBldrsElementProperties(mgr, 0, null))
       expect(captured.propertySets[100]).toEqual([500])
     })
 
@@ -234,7 +253,7 @@ describe('loader/bldrsElementProperties', () => {
         getLine: (id) => entities[id],
       }
       const mgr = {ifcAPI: {getPassthrough: () => proxy}}
-      const captured = await captureBldrsElementProperties(mgr, 0, null)
+      const captured = decodeCaptured(await captureBldrsElementProperties(mgr, 0, null))
       expect(captured.itemProperties[100]).toBeDefined()
       expect(captured.itemProperties[101]).toBeUndefined()
       expect(captured.itemProperties[102]).toBeDefined()
@@ -260,7 +279,7 @@ describe('loader/bldrsElementProperties', () => {
         },
       }
       const mgr = {ifcAPI: {getPassthrough: () => proxy}}
-      const captured = await captureBldrsElementProperties(mgr, 0, null)
+      const captured = decodeCaptured(await captureBldrsElementProperties(mgr, 0, null))
       expect(captured.itemProperties[100]).toBeUndefined()
       expect(captured.itemProperties[101]).toBeDefined()
     })
@@ -291,7 +310,7 @@ describe('loader/bldrsElementProperties', () => {
         1001: {expressID: 1001, type: 1, Name: {type: 1, value: 'IfcRepresentation'}},
       }
       const mgr = makeFastMgr(entities)
-      const captured = await captureBldrsElementProperties(mgr, 0, null)
+      const captured = decodeCaptured(await captureBldrsElementProperties(mgr, 0, null))
       expect(captured.itemProperties[100]).toBeDefined() // root
       expect(captured.itemProperties[500]).toBeDefined() // reached via HasProperties
       expect(captured.itemProperties[999]).toBeUndefined() // orphan, pruned
@@ -317,6 +336,56 @@ describe('loader/bldrsElementProperties', () => {
       }
       const captured = await captureBldrsElementProperties(mgr, 0, null)
       expect(captured).toBeNull()
+    })
+
+    it('disables conway entity memoization during the sweep and restores it after', async () => {
+      // Fixed-memory discipline pin: with memoization on, conway pins
+      // one extracted entity object per descriptor for every getLine —
+      // O(all parsed entities) retained for the sweep's duration. The
+      // streaming path must run with it OFF and put the caller's value
+      // back afterwards.
+      const flagDuringGetLine = []
+      const stepModel = {
+        elementMemoization: true,
+        * [Symbol.iterator]() {
+          yield {expressID: 100}
+          yield {expressID: 101}
+        },
+      }
+      const proxy = {
+        model: [stepModel],
+        getLine: (id) => {
+          flagDuringGetLine.push(stepModel.elementMemoization)
+          return {expressID: id, type: 1, GlobalId: {type: 1, value: `g${id}`}}
+        },
+        releaseEntityCache: jest.fn(),
+      }
+      const mgr = {ifcAPI: {getPassthrough: () => proxy}}
+      const captured = decodeCaptured(await captureBldrsElementProperties(mgr, 0, null))
+      expect(flagDuringGetLine).toEqual([false, false])
+      expect(stepModel.elementMemoization).toBe(true)
+      // Sweep residue dropped at the end (conway ≥1.373 surface;
+      // optional-chained so its absence on older versions is fine —
+      // pinned here so a refactor doesn't silently lose the release).
+      expect(proxy.releaseEntityCache).toHaveBeenCalled()
+      expect(Object.keys(captured.itemProperties).sort()).toEqual(['100', '101'])
+    })
+
+    it('restores entity memoization even when the sweep throws', async () => {
+      const stepModel = {
+        elementMemoization: true,
+        * [Symbol.iterator]() {
+          yield {expressID: 100}
+          throw new Error('iterator exploded')
+        },
+      }
+      const proxy = {
+        model: [stepModel],
+        getLine: (id) => ({expressID: id, GlobalId: {type: 1, value: 'g'}}),
+      }
+      const mgr = {ifcAPI: {getPassthrough: () => proxy}}
+      await expect(captureBldrsElementProperties(mgr, 0, null)).rejects.toThrow('iterator exploded')
+      expect(stepModel.elementMemoization).toBe(true)
     })
 
     it('falls back to slow path when adapter surface is absent (test stubs etc)', async () => {
@@ -702,6 +771,63 @@ describe('loader/bldrsElementProperties', () => {
   })
 
   describe('end-to-end: capture → inject → reader → decode', () => {
+    it('streams an adapter capture through precompressed inject + reader decode', async () => {
+      // The streaming writer's full production pipeline: adapter
+      // capture emits gzipped wire bytes → injectGlbExtensions embeds
+      // them verbatim as `precompressed` → the reader's single decode
+      // branch (ungzip + JSON.parse) recovers the same tables the
+      // legacy object-capture path produced.
+      const entities = {
+        100: {
+          expressID: 100, type: 3124254112,
+          GlobalId: {type: 1, value: 'g100'},
+          HasProperties: [{type: 5, value: 500}],
+        },
+        500: {expressID: 500, type: 1660063152, Name: {type: 1, value: 'Pset_WallCommon'}},
+        999: {
+          expressID: 999, type: 4186316022, // IFCRELDEFINESBYPROPERTIES
+          GlobalId: {type: 1, value: 'g999'},
+          RelatedObjects: [{type: 5, value: 100}],
+          RelatingPropertyDefinition: {type: 5, value: 500},
+        },
+      }
+      const ids = Object.keys(entities).map(Number)
+      const stepModel = {
+        * [Symbol.iterator]() {
+          for (const id of ids) {
+            yield {expressID: id}
+          }
+        },
+      }
+      const proxy = {model: [stepModel], getLine: (id) => entities[id]}
+      const mgr = {ifcAPI: {getPassthrough: () => proxy}}
+
+      const captured = await captureBldrsElementProperties(mgr, 0, null)
+      expect(captured.compressedBytes).toBeInstanceOf(Uint8Array)
+
+      const baseGlb = serializeGlb(
+        {asset: {version: '2.0'}, buffers: [{byteLength: 4}]},
+        new Uint8Array(4))
+      const {bytes: withExt} = injectGlbExtensions(baseGlb, [
+        {name: BLDRS_ELEMENT_PROPERTIES_EXTENSION_NAME, precompressed: captured.compressedBytes},
+      ])
+
+      const {json, bin} = parseGlb(withExt)
+      const buffer = bin.buffer.slice(bin.byteOffset, bin.byteOffset + bin.byteLength)
+      const reader = new BldrsElementPropertiesReader({
+        json,
+        getDependency: () => Promise.resolve(buffer),
+      })
+      const gltf = {scene: {userData: {}}}
+      await reader.afterRoot(gltf)
+      const decoded = gltf.scene.userData.bldrsElementProperties.decode()
+
+      expect(Object.keys(decoded.itemProperties).sort()).toEqual(['100', '500', '999'])
+      expect(decoded.itemProperties[100]).toEqual(entities[100])
+      expect(decoded.itemProperties[500]).toEqual(entities[500])
+      expect(decoded.propertySets).toEqual({100: [500]})
+    })
+
     it('preserves the captured map through write + read', async () => {
       const tree = {
         expressID: 1, type: 'IFCPROJECT', children: [

--- a/src/loader/glbExport.js
+++ b/src/loader/glbExport.js
@@ -337,12 +337,16 @@ export async function exportAndCacheGlb({model, kindLabel, cacheKeyArgs, ifcMana
     const faceIdsData = faceIds ? buildFaceIdsExtensionData(faceIds) : null
     // Dispatch the JSON.stringify + pako.gzip + extension injection +
     // container packing to the GlbWriter worker. On Schependomlaan-
-    // class IFCs the element-properties payload is multi-MB; running
-    // its `JSON.stringify` + `pako.gzip` on the main thread costs
-    // ~300-500ms of frozen hover-pick. Moving them to the worker
+    // class IFCs the spatial-tree / face-ids payloads are multi-MB;
+    // running their `JSON.stringify` + `pako.gzip` on the main thread
+    // costs ~300-500ms of frozen hover-pick. Moving them to the worker
     // eliminates that block — the main thread only pays the
     // structured-clone cost across postMessage (~50ms on a
     // Schependomlaan payload, scales sublinearly with size).
+    // (The element-properties payload usually arrives already gzipped
+    // from the streaming capture — see below — so for it the worker
+    // only splices bytes; the stringify+gzip offload still applies to
+    // its slow-path object form and to the other extensions.)
     //
     // The fallback path runs everything inline (no worker) — used
     // when the worker fails to construct (Safari edge cases,

--- a/src/loader/glbExport.js
+++ b/src/loader/glbExport.js
@@ -349,9 +349,18 @@ export async function exportAndCacheGlb({model, kindLabel, cacheKeyArgs, ifcMana
     // module-worker support detection failure). Same result either
     // way; the only observable difference is main-thread freeze
     // duration.
+    // The element-properties capture is a discriminated union: the
+    // streaming path (Conway adapter available) hands back already-
+    // gzipped wire bytes — pass them through as `precompressed` so
+    // neither this thread nor the worker re-materialises the payload;
+    // the slow path hands back the decoded object, compressed by the
+    // inject step as before.
+    const elementPropertiesExt = elementProperties?.compressedBytes instanceof Uint8Array ?
+      {name: BLDRS_ELEMENT_PROPERTIES_EXTENSION_NAME, precompressed: elementProperties.compressedBytes} :
+      {name: BLDRS_ELEMENT_PROPERTIES_EXTENSION_NAME, data: elementProperties, compress: true}
     const extensionsForInject = [
       {name: BLDRS_SPATIAL_TREE_EXTENSION_NAME, data: spatialTree, compress: true},
-      {name: BLDRS_ELEMENT_PROPERTIES_EXTENSION_NAME, data: elementProperties, compress: true},
+      elementPropertiesExt,
       {name: BLDRS_FACE_IDS_EXTENSION_NAME, data: faceIdsData, compress: true},
     ]
     // Scene-level metadata that rides along in the same inject pass

--- a/src/loader/injectGlbExtensions.js
+++ b/src/loader/injectGlbExtensions.js
@@ -216,8 +216,17 @@ export function serializeGlb(json, bin) {
  * non-empty input, we still parse+serialize so the new keys land in
  * the output.
  *
+ * **precompressed**: an extension entry may carry `precompressed`
+ * (a Uint8Array of already-gzipped wire JSON) instead of `data`.
+ * The bytes are embedded verbatim as the bufferView payload and the
+ * extension entry is recorded with `compressed: true` — exactly what
+ * the `{data, compress: true}` path would have produced, minus the
+ * stringify+gzip. This is the seam for streaming writers
+ * (`bldrsElementProperties.js`'s streaming capture) that compress
+ * incrementally instead of materialising the whole payload object.
+ *
  * @param {Uint8Array} glbBytes
- * @param {Array} extensions list of `{name: string, data: object|null|undefined, compress?: boolean}`
+ * @param {Array} extensions list of `{name: string, data: object|null|undefined, compress?: boolean, precompressed?: Uint8Array}`
  * @param {object} [sceneExtras] optional `{key: value, ...}` to merge
  *   into `scenes[json.scene ?? 0].extras`. Each value must be a
  *   JSON-serialisable scalar / object; entries with `null`/`undefined`
@@ -235,7 +244,8 @@ export function serializeGlb(json, bin) {
  *   without inspecting the byte stream.
  */
 export function injectGlbExtensions(glbBytes, extensions, sceneExtras) {
-  const active = (extensions ?? []).filter((e) => e && e.data !== null && e.data !== undefined)
+  const active = (extensions ?? []).filter((e) =>
+    e && ((e.data !== null && e.data !== undefined) || e.precompressed instanceof Uint8Array))
   const sceneExtraEntries = sceneExtras ?
     Object.entries(sceneExtras).filter(([, v]) => v !== null && v !== undefined) :
     []
@@ -331,11 +341,22 @@ export function injectGlbExtensions(glbBytes, extensions, sceneExtras) {
   let nextOffset = pad4(json.buffers[0].byteLength)
   let dataEnd = nextOffset
   const additions = []
-  for (const {name, data, compress = true} of toInject) {
-    const jsonText = JSON.stringify(data)
-    const raw = new TextEncoder().encode(jsonText)
-    const payload = compress ? pako.gzip(raw) : raw
-    additions.push({name, payload, byteOffset: nextOffset, compressed: compress})
+  for (const {name, data, compress = true, precompressed} of toInject) {
+    let payload
+    let compressed
+    if (precompressed instanceof Uint8Array) {
+      // Already-gzipped bytes from a streaming writer — embed
+      // verbatim; the reader's decode path is identical to the
+      // compress-here branch below.
+      payload = precompressed
+      compressed = true
+    } else {
+      const jsonText = JSON.stringify(data)
+      const raw = new TextEncoder().encode(jsonText)
+      payload = compress ? pako.gzip(raw) : raw
+      compressed = compress
+    }
+    additions.push({name, payload, byteOffset: nextOffset, compressed})
     dataEnd = nextOffset + payload.byteLength
     nextOffset += pad4(payload.byteLength)
   }

--- a/src/loader/injectGlbExtensions.test.js
+++ b/src/loader/injectGlbExtensions.test.js
@@ -175,6 +175,40 @@ describe('loader/injectGlbExtensions', () => {
     })
   })
 
+  describe('injectGlbExtensions — precompressed payloads', () => {
+    it('embeds precompressed bytes verbatim and records compressed: true', () => {
+      // Streaming-writer seam: bytes arrive already gzipped, so the
+      // inject step must skip its own stringify+gzip and the on-disk
+      // result must be indistinguishable from the {data, compress:true}
+      // path — the reader has one decode branch.
+      const wire = {itemProperties: {100: {expressID: 100}}, propertySets: {}}
+      const precompressed = pako.gzip(JSON.stringify(wire))
+      const glb = makeMinimalGlb()
+      const {bytes, stats} = injectGlbExtensions(glb, [
+        {name: 'BLDRS_test_stream', precompressed},
+      ])
+      expect(stats.addedExtensions).toBe(1)
+      const {json, bin} = parseGlb(bytes)
+      const ext = json.extensions.BLDRS_test_stream
+      expect(ext.compressed).toBe(true)
+      const bv = json.bufferViews[ext.bufferView]
+      expect(bv.byteLength).toBe(precompressed.byteLength)
+      const embedded = bin.subarray(bv.byteOffset, bv.byteOffset + bv.byteLength)
+      expect(Array.from(embedded)).toEqual(Array.from(precompressed))
+      expect(JSON.parse(pako.ungzip(embedded, {to: 'string'}))).toEqual(wire)
+    })
+
+    it('treats an entry with only precompressed (no data) as active, and null data alone as inactive', () => {
+      const glb = makeMinimalGlb()
+      const precompressed = pako.gzip(JSON.stringify({a: 1}))
+      const {stats} = injectGlbExtensions(glb, [
+        {name: 'BLDRS_active', precompressed, data: null},
+        {name: 'BLDRS_inactive', data: null},
+      ])
+      expect(stats.addedExtensions).toBe(1)
+    })
+  })
+
   describe('injectGlbExtensions — multiple extensions', () => {
     it('lays out each new bufferView at a 4-aligned offset, in order', () => {
       const glb = makeMinimalGlb({binBytes: 4})


### PR DESCRIPTION
## What

Step 2 of the lazy/incremental properties track (follows #1588): make the GLB cache writer fixed-memory instead of manifesting the whole property tree before serializing.

The fast capture path in `bldrsElementProperties.js` materialized **every** parsed entity into one big `itemProperties` object (millions of records on 100MB-class IFCs — multi-GB transient JS heap) and only then filtered down to the reachable-from-IfcRoot closure (~50k entities on Snowdon). This replaces it with a streaming sweep that gzips the wire JSON incrementally:

- **Sweep 1** scans entities via sync `proxy.getLine`, serializes IfcRoot seeds (GlobalId-bearing) straight into a pako streaming `Deflate`, builds the product→psetIds index inline, and queues non-geometric refs. Records not kept are dropped on the spot.
- **Sweep 2** drains the ref closure by id — fetch, serialize, release.
- conway entity memoization is disabled during the sweep (restored after, throw-safe), and the entity/descriptor cache is released every 200k materialisations plus once at the end (`proxy.releaseEntityCache`, conway ≥1.373 — optional-chained no-op on older versions; this branch stays on 1.372 and works either way).
- Peak retained memory: **O(reachable ids + pset index + one record + compressed output)** instead of O(all parsed records).

## Wire compatibility

The on-disk format is unchanged — same gzipped `{itemProperties, propertySets}` JSON the existing reader already decodes (key order differs from the legacy one-shot stringify; decode-identical). No reader changes, no cache-schema bump, old GLBs keep working.

Plumbing: the capture now returns a discriminated union — `{compressedBytes}` from the streaming path, the legacy object from the slow fallback (tests/non-Conway loaders) — and `injectGlbExtensions` accepts a `precompressed` payload it embeds verbatim with `compressed: true`, so neither the main thread nor the GlbWriter worker re-materializes/re-compresses the payload.

## Testing

- Adapter-path suite migrated to decode the streamed bytes and assert the same content (seeds, pset index, geometric pruning, error tolerance).
- New pins: memoization off during sweep + restored after (including on throw), cache release invoked, `precompressed` inject round-trip, and a full streaming capture → inject → reader decode end-to-end.
- Full Share suite green (208 suites, 1830+ passed) via the pre-push hook.

Related: conway#372 (SoA descriptors), conway#373 ('names' spatial tree), #1588 (load-path flip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S6gTXmrq1GbhqknPqQMRuz

---
_Generated by [Claude Code](https://claude.ai/code/session_01S6gTXmrq1GbhqknPqQMRuz)_