### PR TITLE
Fix type lookup in getSelectedElementsProps to use type code, not expressID

### DIFF
--- a/src/viewer/ShareViewer.js
+++ b/src/viewer/ShareViewer.js
@@ -722,9 +722,19 @@ export class ShareViewer {
     const results = []
     for (const expressID of hits) {
       const props = await this.IFC.getProperties(modelID, expressID, false, false)
-
-      props.type = manager.getIfcType(modelID, expressID)
-
+      // getProperties honors a null contract (null/undefined ids → null);
+      // skip rather than deref (#1545).
+      if (!props) {
+        continue
+      }
+      // Conway's getItemProperties (via getLine) returns the entity with
+      // `type` as the numeric IFC type code; `getIfcType` maps that code
+      // to its name (e.g. 1095909175 → 'IFCWALL'). Passing the expressID
+      // here — the pre-#1545 behavior — looked up the wrong key. Guarded
+      // on number so an already-stringified type passes through intact.
+      if (typeof props.type === 'number') {
+        props.type = manager.getIfcType(modelID, props.type)
+      }
       results.push({modelID, expressID, props})
     }
     return results

--- a/src/viewer/ShareViewer.test.js
+++ b/src/viewer/ShareViewer.test.js
@@ -458,6 +458,65 @@ function makeResolverViewer(model) {
 }
 
 
+describe('viewer/ShareViewer getSelectedElementsProps', () => {
+  const IFCWALL_TYPE_CODE = 1095909175
+
+  /**
+   * @param {object} propsById expressID → props object returned by getProperties
+   * @return {object} ShareViewer-prototype-bound stand-in
+   */
+  function makePropsViewer(propsById) {
+    const viewer = Object.create(ShareViewer.prototype)
+    viewer.IFC = {
+      getProperties: jest.fn((modelID, id) => Promise.resolve(propsById[id] ?? null)),
+      loader: {
+        ifcManager: {
+          // Conway contract: type-code → name lookup (ShareIfcManager
+          // ignores modelID and forwards to Conway's global map).
+          getIfcType: jest.fn((_modelID, typeCode) =>
+            (typeCode === IFCWALL_TYPE_CODE ? 'IFCWALL' : undefined)),
+        },
+      },
+    }
+    return viewer
+  }
+
+  it('resolves the type name from the fetched props\' type code, not the expressID (#1545)', async () => {
+    const viewer = makePropsViewer({42: {expressID: 42, type: IFCWALL_TYPE_CODE}})
+
+    const results = await ShareViewer.prototype.getSelectedElementsProps.call(viewer, [42])
+
+    const manager = viewer.IFC.loader.ifcManager
+    expect(manager.getIfcType).toHaveBeenCalledWith(0, IFCWALL_TYPE_CODE)
+    expect(manager.getIfcType).not.toHaveBeenCalledWith(0, 42)
+    expect(results).toEqual([
+      {modelID: 0, expressID: 42, props: {expressID: 42, type: 'IFCWALL'}},
+    ])
+  })
+
+  it('skips elements whose getProperties returns null instead of throwing (#1545)', async () => {
+    const viewer = makePropsViewer({42: {expressID: 42, type: IFCWALL_TYPE_CODE}})
+
+    const results = await ShareViewer.prototype.getSelectedElementsProps.call(
+      viewer, [7, 42])
+
+    expect(results).toHaveLength(1)
+    expect(results[0].expressID).toBe(42)
+    // The null-props element must not reach the type lookup.
+    expect(viewer.IFC.loader.ifcManager.getIfcType).toHaveBeenCalledTimes(1)
+  })
+
+  it('leaves an already-stringified type untouched', async () => {
+    const viewer = makePropsViewer({42: {expressID: 42, type: 'IFCWALL'}})
+
+    const results = await ShareViewer.prototype.getSelectedElementsProps.call(viewer, [42])
+
+    expect(viewer.IFC.loader.ifcManager.getIfcType).not.toHaveBeenCalled()
+    expect(results[0].props.type).toBe('IFCWALL')
+  })
+})
+
+
 describe('viewer/ShareViewer getInstanceIdsForOccurrencePath', () => {
   it('resolves a leaf occurrence path to exactly its own instance(s)', () => {
     // One reused part-type (parent 100) placed at two occurrences; the paths


### PR DESCRIPTION
## Summary
Fixes a bug in `ShareViewer.getSelectedElementsProps` where the IFC type name lookup was incorrectly using the `expressID` instead of the numeric `type` code from the fetched properties. This caused type resolution to fail or return incorrect results.

## Changes
- **ShareViewer.js**: Updated `getSelectedElementsProps` to:
  - Add null-check for `getProperties` results to skip elements that don't exist (fixes #1545)
  - Pass `props.type` (the numeric IFC type code) to `manager.getIfcType()` instead of `expressID`
  - Guard the type lookup on `typeof props.type === 'number'` to preserve already-stringified types
  - Added detailed comments explaining the Conway API contract and the fix rationale

- **ShareViewer.test.js**: Added comprehensive test suite for `getSelectedElementsProps`:
  - Verifies type name is resolved from the numeric type code, not expressID
  - Confirms null-returning properties are skipped without attempting type lookup
  - Ensures already-stringified types pass through unchanged

## Implementation Details
The fix addresses a pre-existing misunderstanding of the Conway API: `getProperties` returns entities where `type` is a numeric IFC type code (e.g., `1095909175` for `IFCWALL`), which must be mapped to its string name via `getIfcType(modelID, typeCode)`. The previous code incorrectly passed `expressID` to this lookup, causing wrong or missing type information in the results.

https://claude.ai/code/session_01TAKDRvm2CoZSwmvnDAdGMK