### PR TITLE
Bump @bldrs-ai/conway to 1.379.1191

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@babel/plugin-syntax-import-assertions": "7.18.6",
     "@babel/preset-env": "7.18.10",
     "@babel/preset-react": "7.18.6",
-    "@bldrs-ai/conway": "1.373.1180",
+    "@bldrs-ai/conway": "1.379.1191",
     "@bldrs-ai/ifclib": "5.3.3",
     "@emotion/react": "11.10.0",
     "@emotion/styled": "11.10.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2473,10 +2473,10 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@bldrs-ai/conway@1.373.1180":
-  version "1.373.1180"
-  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.373.1180.tgz#e3ee5f9ac92ae40142899561a0006d46f77eb453"
-  integrity sha512-/MvwMq9imcVKXTdUW/HP/2sWJGjGarzKqELd39WZwXjTqYwRavW0yJwaRgT9pp+QqizvRbRMWsHCyJ/MWRFC/g==
+"@bldrs-ai/conway@1.379.1191":
+  version "1.379.1191"
+  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.379.1191.tgz#28201d830957867ce8ea6a5cbfcd44de593fb36b"
+  integrity sha512-xvfM/DUfa7i9J7A6IFsdNc6F7pPpOA8aGDoY9SW/qdeUgfwDg7sFMsHkC8khfN97c5p5SZAme4G3MLflqeuchQ==
   dependencies:
     gl-matrix "3.4.3"
     seedrandom "3.0.5"


### PR DESCRIPTION
## Summary
Updates the Conway dependency to a newer version that includes upstream improvements and bug fixes.

## Changes
- Upgraded `@bldrs-ai/conway` from `1.373.1180` to `1.379.1191`

## Notes
This is a routine dependency update. The lockfile changes are transitive resolution artifacts from the new Conway version.

https://claude.ai/code/session_01J3A79iKimn7UheESvnumj7