### PR TITLE
Anonymous-geometry permalinks + transient NavTree rows (conway#387)

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@babel/plugin-syntax-import-assertions": "7.18.6",
     "@babel/preset-env": "7.18.10",
     "@babel/preset-react": "7.18.6",
-    "@bldrs-ai/conway": "1.386.1216",
+    "@bldrs-ai/conway": "1.389.1221",
     "@bldrs-ai/ifclib": "5.3.3",
     "@emotion/react": "11.10.0",
     "@emotion/styled": "11.10.0",

--- a/src/Components/NavTree/NavTreePanel.jsx
+++ b/src/Components/NavTree/NavTreePanel.jsx
@@ -7,10 +7,18 @@ import {ToggleButton, ToggleButtonGroup, Tooltip} from '@mui/material'
 import {styled} from '@mui/material/styles'
 import useStore from '../../store/useStore'
 import {assertDefined} from '../../utils/assert'
+import {labelForGeometryId} from '../../utils/geometryLabels'
 import {occurrencePathKey} from '../../utils/occurrencePaths'
 import Panel from '../SideDrawer/Panel'
 import NavTreeNode from './NavTreeNode'
 import {removeHashParams} from './hashState'
+
+
+// Transient rows materialized per "N more…" click (conway#387). Large
+// anonymous sets (an ECAD board's hundreds of pieces) arrive in chunks the
+// virtualized list absorbs without a hitch; the row retires when the
+// advisory remaining count reaches zero.
+const MORE_ROW_BATCH_SIZE = 250
 
 
 /**
@@ -34,6 +42,8 @@ export default function NavTreePanel({
   const selectedElements = useStore((state) => state.selectedElements)
   const selectedOccurrencePath = useStore((state) => state.selectedOccurrencePath)
   const selectedSolidExpressId = useStore((state) => state.selectedSolidExpressId)
+  const transientTreeNodes = useStore((state) => state.transientTreeNodes)
+  const addTransientTreeNodes = useStore((state) => state.addTransientTreeNodes)
   const setExpandedElements = useStore((state) => state.setExpandedElements)
   const setExpandedTypes = useStore((state) => state.setExpandedTypes)
   const viewer = useStore((state) => state.viewer)
@@ -94,9 +104,9 @@ export default function NavTreePanel({
 
   // Flatten the tree into a list of visible nodes
   useEffect(() => {
-    const nodes = getVisibleNodes(treeData, expandedNodeIds, isNavTree, model)
+    const nodes = getVisibleNodes(treeData, expandedNodeIds, isNavTree, model, transientTreeNodes)
     setVisibleNodes(nodes)
-  }, [treeData, expandedNodeIds, isNavTree, model])
+  }, [treeData, expandedNodeIds, isNavTree, model, transientTreeNodes])
 
   // Scroll to selected element
   useEffect(() => {
@@ -188,6 +198,7 @@ export default function NavTreePanel({
               selectedOccurrencePathKey,
               selectedSolidExpressId,
               selectWithShiftClickEvents,
+              addTransientTreeNodes,
               model,
               viewer,
               setItemSize,
@@ -234,9 +245,11 @@ export function compareNodeLabels(a, b) {
  * @param {Array} expandedNodeIds - IDs of expanded nodes
  * @param {boolean} isNavTree - Whether this is a nav tree
  * @param {object} model - The model object
+ * @param {object} [transientTreeNodes] - Session-only anonymous-geometry rows
+ *   (conway#387), keyed by parent occurrence-path key
  * @return {Array} nodes
  */
-function getVisibleNodes(treeData, expandedNodeIds, isNavTree, model) {
+function getVisibleNodes(treeData, expandedNodeIds, isNavTree, model, transientTreeNodes = {}) {
   const visibleNodes = []
 
   // Ordering policy discriminant. An IFC / STEP spatial structure (live
@@ -311,6 +324,52 @@ function getVisibleNodes(treeData, expandedNodeIds, isNavTree, model) {
     if (node.ephemeral === true) {
       mapped.ephemeral = true
     }
+    // Anonymous-geometry affordances (conway#387). Both are session-only
+    // and reconstructed on the fly — nothing here persists to the cache.
+    if (Array.isArray(node.occurrencePath) && node.occurrencePath.length > 0) {
+      const pathKey = occurrencePathKey(node.occurrencePath)
+      // Transient rows: pieces a pick / permalink / "more" expansion
+      // materialized under this part. Rendered as ephemeral solid rows —
+      // (path, geometry id) drives highlight/scroll/eye exactly like the
+      // engine-emitted solid nodes — with a path-scoped nodeId so reused
+      // parts don't alias expansion state.
+      const transientRows = (transientTreeNodes[pathKey] ?? [])
+        .filter((row) => !mapped.children.some((child) => child.expressID === row.expressID))
+        .map((row) => ({
+          nodeId: `${pathKey}:${row.expressID}`,
+          label: row.label,
+          expressID: row.expressID,
+          hasChildren: false,
+          children: [],
+          occurrencePath: node.occurrencePath,
+          ephemeral: true,
+          transient: true,
+        }))
+      if (transientRows.length > 0) {
+        mapped.children = [...mapped.children, ...transientRows]
+        mapped.hasChildren = true
+      }
+      // "N more…" expansion row: the engine reported suppressed solids
+      // (`droppedSolids`) that have no nodes; clicking materializes the next
+      // batch from the instance map. The remaining count is advisory — the
+      // enumeration can also surface face pieces the solid count never
+      // included — and the row retires when it reaches zero.
+      const materialized = transientRows.length
+      const remaining = Math.max((node.droppedSolids ?? 0) - materialized, 0)
+      if (remaining > 0) {
+        const knownIds = mapped.children.map((child) => child.expressID)
+        mapped.children = [...mapped.children, {
+          nodeId: `${pathKey}:__more`,
+          isMoreRow: true,
+          remaining,
+          parentPath: node.occurrencePath,
+          knownIds,
+          hasChildren: false,
+          children: [],
+        }]
+        mapped.hasChildren = true
+      }
+    }
     return mapped
   }
 
@@ -347,6 +406,7 @@ const RenderRow = ({index, style, data}) => {
     selectedOccurrencePathKey,
     selectedSolidExpressId,
     selectWithShiftClickEvents,
+    addTransientTreeNodes,
     model,
     viewer,
     setItemSize,
@@ -356,6 +416,31 @@ const RenderRow = ({index, style, data}) => {
   const {node, depth} = visibleNodes[index]
   const nodeId = node.nodeId
   const isExpanded = expandedNodeIds.includes(nodeId)
+
+  // "N more…" expansion row for anonymous below-product geometry
+  // (conway#387): clicking materializes the next batch of pieces from the
+  // instance map as transient rows. Labels resolve through Conway's
+  // arbitrary-id lookup asynchronously; the store dedups against pieces
+  // that already arrived from a pick or permalink.
+  const handleMoreClick = () => {
+    if (typeof viewer?.getGeometryIdsForOccurrencePath !== 'function') {
+      return
+    }
+    const known = new Set(node.knownIds)
+    const fresh = viewer.getGeometryIdsForOccurrencePath(0, node.parentPath)
+      .filter((geometryExpressId) => !known.has(geometryExpressId))
+      .slice(0, MORE_ROW_BATCH_SIZE)
+    if (fresh.length === 0) {
+      return
+    }
+    const ifcAPI = viewer?.IFC?.loader?.ifcManager?.ifcAPI
+    const pathKey = occurrencePathKey(node.parentPath)
+    Promise.all(fresh.map((geometryExpressId) =>
+      labelForGeometryId(ifcAPI, 0, geometryExpressId)
+        .then((label) => ({expressID: geometryExpressId, label})),
+    )).then((rows) => addTransientTreeNodes(pathKey, rows))
+  }
+
   const hasChildren = node.hasChildren
   // Assembly rows highlight like leaves — a selected assembly (NavTree click,
   // scene pick, permalink) must mark its own row, not just its descendants
@@ -408,6 +493,33 @@ const RenderRow = ({index, style, data}) => {
     }
   }, [index, setItemSize, node.label, model])
 
+  if (node.isMoreRow === true) {
+    const moreIndent = 20
+    return (
+      <div style={{...style}}>
+        <div
+          data-testid='NavTreeMoreRow'
+          onClick={handleMoreClick}
+          onKeyDown={(event) => {
+            if (event.key === 'Enter' || event.key === ' ') {
+              handleMoreClick()
+            }
+          }}
+          role='button'
+          tabIndex={0}
+          style={{
+            paddingLeft: depth * moreIndent,
+            cursor: 'pointer',
+            fontStyle: 'italic',
+            opacity: 0.7,
+          }}
+        >
+          {`${node.remaining} more…`}
+        </div>
+      </div>
+    )
+  }
+
 
   const handleToggle = (event) => {
     event.stopPropagation()
@@ -438,7 +550,12 @@ const RenderRow = ({index, style, data}) => {
   }
 
   let hasHideIcon = false
-  if (node.expressID) {
+  if (node.transient === true) {
+    // Transient anonymous-geometry rows hide through their
+    // (occurrencePath, geometry id) identity — the isolator's canBeHidden
+    // list is built from the spatial tree, which never contains them.
+    hasHideIcon = true
+  } else if (node.expressID) {
     hasHideIcon = viewer.isolator.canBeHidden(node.expressID)
   }
 

--- a/src/Components/NavTree/NavTreePanel.jsx
+++ b/src/Components/NavTree/NavTreePanel.jsx
@@ -326,7 +326,11 @@ function getVisibleNodes(treeData, expandedNodeIds, isNavTree, model, transientT
     }
     // Anonymous-geometry affordances (conway#387). Both are session-only
     // and reconstructed on the fly — nothing here persists to the cache.
-    if (Array.isArray(node.occurrencePath) && node.occurrencePath.length > 0) {
+    // Ephemeral solid rows share their parent part's occurrence path, so
+    // without the `ephemeral` guard every solid of a multibody part would
+    // re-inject the same transient rows the part already carries.
+    if (Array.isArray(node.occurrencePath) && node.occurrencePath.length > 0 &&
+        node.ephemeral !== true) {
       const pathKey = occurrencePathKey(node.occurrencePath)
       // Transient rows: pieces a pick / permalink / "more" expansion
       // materialized under this part. Rendered as ephemeral solid rows —
@@ -433,10 +437,9 @@ const RenderRow = ({index, style, data}) => {
     if (fresh.length === 0) {
       return
     }
-    const ifcAPI = viewer?.IFC?.loader?.ifcManager?.ifcAPI
     const pathKey = occurrencePathKey(node.parentPath)
     Promise.all(fresh.map((geometryExpressId) =>
-      labelForGeometryId(ifcAPI, 0, geometryExpressId)
+      labelForGeometryId(model, geometryExpressId)
         .then((label) => ({expressID: geometryExpressId, label})),
     )).then((rows) => addTransientTreeNodes(pathKey, rows))
   }

--- a/src/Components/NavTree/NavTreePanel.test.jsx
+++ b/src/Components/NavTree/NavTreePanel.test.jsx
@@ -118,3 +118,83 @@ describe('NavTreePanel/getVisibleNodes — scenegraph ordering policy', () => {
     expect(visible.map(({node: n}) => n.label)).toEqual(['Scene'])
   })
 })
+
+
+describe('NavTreePanel/getVisibleNodes — transient anonymous-geometry rows (conway#387)', () => {
+  const model = {getIfcType: (eltType) => eltType}
+  const PART_NAUO = 14107
+  const FACE_ID = 4462
+  const SOLID_ID = 250
+
+  /**
+   * A STEP part node with an occurrence path, in the shape the spatial
+   * tree hands to getVisibleNodes.
+   *
+   * @param {object} [extras] merged onto the node (droppedSolids, children…)
+   * @return {object} tree root with one part under it
+   */
+  function stepTree(extras = {}) {
+    return node(1, 'assembly', [{
+      ...node(PART_NAUO, 'part'),
+      occurrencePath: [PART_NAUO],
+      ...extras,
+    }])
+  }
+
+  it('injects transient rows under their part, as ephemeral solid rows', () => {
+    const transient = {[PART_NAUO]: [{expressID: FACE_ID, label: 'Face #4462'}]}
+    const visible = getVisibleNodes(stepTree(), ['1', `${PART_NAUO}`], true, model, transient)
+    const row = visible.map(({node: n}) => n).find((n) => n.expressID === FACE_ID)
+    expect(row).toBeDefined()
+    expect(row.label).toBe('Face #4462')
+    expect(row.ephemeral).toBe(true)
+    expect(row.transient).toBe(true)
+    // Path-scoped nodeId: reused parts must not alias expansion state, and
+    // the row inherits the part's occurrence path for (path, id) selection.
+    expect(row.nodeId).toBe('14107:4462')
+    expect(row.occurrencePath).toEqual([PART_NAUO])
+  })
+
+  it('does not duplicate a piece the tree already carries as a solid node', () => {
+    const solidChild = {
+      ...node(SOLID_ID, 'Boss-Extrude7'),
+      occurrencePath: [PART_NAUO],
+      ephemeral: true,
+    }
+    const tree = stepTree({children: [solidChild]})
+    const transient = {[PART_NAUO]: [{expressID: SOLID_ID, label: 'Solid #250'}]}
+    const visible = getVisibleNodes(tree, ['1', `${PART_NAUO}`], true, model, transient)
+    const rows = visible.map(({node: n}) => n).filter((n) => n.expressID === SOLID_ID)
+    expect(rows.length).toBe(1)
+    expect(rows[0].transient).toBe(void 0)
+  })
+
+  it('emits a "more" row for droppedSolids and retires it as rows materialize', () => {
+    const twoDropped = getVisibleNodes(
+      stepTree({droppedSolids: 2}), ['1', `${PART_NAUO}`], true, model, {})
+    const moreRow = twoDropped.map(({node: n}) => n).find((n) => n.isMoreRow === true)
+    expect(moreRow).toBeDefined()
+    expect(moreRow.remaining).toBe(2)
+    expect(moreRow.parentPath).toEqual([PART_NAUO])
+    // The known-id set the click handler dedups against covers tree children
+    // AND already-materialized transient rows.
+    const transient = {[PART_NAUO]: [{expressID: FACE_ID, label: 'Item #4462'}]}
+    const oneLeft = getVisibleNodes(
+      stepTree({droppedSolids: 2}), ['1', `${PART_NAUO}`], true, model, transient)
+    const remainingRow = oneLeft.map(({node: n}) => n).find((n) => n.isMoreRow === true)
+    expect(remainingRow.remaining).toBe(1)
+    expect(remainingRow.knownIds).toContain(FACE_ID)
+    // Fully materialized → the row retires.
+    const done = getVisibleNodes(
+      stepTree({droppedSolids: 1}), ['1', `${PART_NAUO}`], true, model, transient)
+    expect(done.map(({node: n}) => n).some((n) => n.isMoreRow === true)).toBe(false)
+  })
+
+  it('leaves IFC nodes (no occurrence path) untouched', () => {
+    const ifcRoot = node(1, 'project', [node(2, 'storey')])
+    const transient = {2: [{expressID: 99, label: 'Item #99'}]}
+    const visible = getVisibleNodes(ifcRoot, ['1', '2'], true, model, transient)
+    expect(visible.length).toBe(2)
+    expect(visible.map(({node: n}) => n).some((n) => n.transient === true)).toBe(false)
+  })
+})

--- a/src/Components/NavTree/NavTreePanel.test.jsx
+++ b/src/Components/NavTree/NavTreePanel.test.jsx
@@ -190,6 +190,28 @@ describe('NavTreePanel/getVisibleNodes — transient anonymous-geometry rows (co
     expect(done.map(({node: n}) => n).some((n) => n.isMoreRow === true)).toBe(false)
   })
 
+  it('injects each transient row once — not under every ephemeral solid', () => {
+    // A multibody part's solid rows share the part's occurrence path; the
+    // path-keyed injection must attach transient rows at the part only,
+    // or the same "Face #…" rows repeat under every expanded solid.
+    const SOLID_B_ID = 251
+    const solids = [SOLID_ID, SOLID_B_ID].map((id) => ({
+      ...node(id, `Boss-Extrude${id}`),
+      occurrencePath: [PART_NAUO],
+      ephemeral: true,
+    }))
+    const tree = stepTree({children: solids})
+    const transient = {[PART_NAUO]: [{expressID: FACE_ID, label: 'Face #4462'}]}
+    const visible = getVisibleNodes(
+      tree, ['1', `${PART_NAUO}`, `${SOLID_ID}`, `${SOLID_B_ID}`], true, model, transient)
+    const faceRows = visible.map(({node: n}) => n).filter((n) => n.expressID === FACE_ID)
+    expect(faceRows.length).toBe(1)
+    // No solid grew synthetic children either.
+    const solidRows = visible.map(({node: n}) => n)
+      .filter((n) => n.ephemeral === true && n.transient !== true)
+    expect(solidRows.every((n) => n.hasChildren === false)).toBe(true)
+  })
+
   it('leaves IFC nodes (no occurrence path) untouched', () => {
     const ifcRoot = node(1, 'project', [node(2, 'storey')])
     const transient = {2: [{expressID: 99, label: 'Item #99'}]}

--- a/src/Components/Properties/Properties.spec.ts
+++ b/src/Components/Properties/Properties.spec.ts
@@ -52,8 +52,12 @@ describe('View 100: Access elements property', () => {
       const propertiesTable = propertiesPanel.locator('table')
       await expect(propertiesTable).toBeVisible()
 
-      const ifcTypeRow = propertiesPanel.locator('tr').filter({hasText: 'IFC Type'})
-      await expect(ifcTypeRow).toBeVisible()
+      // Renamed from 'IFC Type' for STEP compatibility; value comes from the
+      // entity's own type field ('IFCBUILDINGELEMENTPROXY'-style), no longer
+      // constructor.name. `first()` because 'Type' is a substring of other
+      // row text the panel may add later.
+      const typeRow = propertiesPanel.locator('tr').filter({hasText: 'Type'}).first()
+      await expect(typeRow).toBeVisible()
 
       await assertPropertyValue(propertiesPanel, 'Express Id', '621')
       await assertPropertyValue(propertiesPanel, 'Name', 'Together')

--- a/src/Components/Properties/itemProperties.jsx
+++ b/src/Components/Properties/itemProperties.jsx
@@ -70,15 +70,23 @@ function entityTypeName(model, ifcProps) {
   if (typeof rawType === 'string' && rawType.length > 0) {
     return rawType
   }
-  if (typeof rawType === 'number' &&
-      typeof model?.ifcManager?.getIfcType === 'function') {
-    try {
-      const name = model.ifcManager.getIfcType(0, rawType)
-      if (typeof name === 'string' && name.length > 0) {
-        return name
+  if (typeof rawType === 'number') {
+    // Two manager shapes exist: ShareIfcManager's `getIfcType(modelID,
+    // typeCode)` and the Conway-direct shim, which lacks it but exposes
+    // the compat surface's `properties.getIfcType(typeCode)` directly.
+    const lookups = [
+      () => model?.ifcManager?.getIfcType?.(0, rawType),
+      () => model?.ifcManager?.ifcAPI?.properties?.getIfcType?.(rawType),
+    ]
+    for (const lookup of lookups) {
+      try {
+        const name = lookup()
+        if (typeof name === 'string' && name.length > 0) {
+          return name
+        }
+      } catch {
+        // Try the next shape, then the constructor heuristic.
       }
-    } catch {
-      // Fall through to the constructor heuristic.
     }
   }
   const ctorName = ifcProps?.constructor?.name

--- a/src/Components/Properties/itemProperties.jsx
+++ b/src/Components/Properties/itemProperties.jsx
@@ -20,10 +20,9 @@ import {stoi} from '../../utils/strings'
 export async function createPropertyTable(model, ifcProps, isPset = false, serial = 0) {
   const ROWS = []
   let rowKey = 0
-  if (ifcProps.constructor &&
-      ifcProps.constructor.name &&
-      ifcProps.constructor.name !== 'IfcPropertySet') {
-    ROWS.push(<Row d1={'IFC Type'} d2={ifcProps.constructor.name} key={`type-${serial}`}/>)
+  const typeName = entityTypeName(model, ifcProps)
+  if (!isPset && typeName !== null && typeName !== 'IfcPropertySet') {
+    ROWS.push(<Row d1={'Type'} d2={typeName} key={`type-${serial}`}/>)
   }
   for (const key in ifcProps) {
     if (isPset && (key === 'expressID' || key === 'Name')) {
@@ -43,6 +42,50 @@ export async function createPropertyTable(model, ifcProps, isPset = false, seria
       <tbody>{ROWS}</tbody>
     </table>
   )
+}
+
+
+/**
+ * Display name for the entity's schema type, or null when no usable name
+ * can be derived (the row is omitted rather than showing a junk value).
+ *
+ * Resolution order:
+ *   1. `ifcProps.type` as a string — Conway's compat surface returns the
+ *      entity type name directly ('ADVANCED_FACE', 'IFCWALL', …). This is
+ *      the STEP path and the modern Conway-direct IFC path.
+ *   2. Numeric `ifcProps.type` (an IFC type code from `getLine`-shaped
+ *      surfaces) mapped through `model.ifcManager.getIfcType(0, code)`.
+ *   3. `constructor.name` when it looks like a real IFC class (web-ifc
+ *      dev builds return class instances like `IfcWall`). Minified prod
+ *      builds mangle those names ('t') and plain objects give 'Object' —
+ *      neither is a type, so both are rejected rather than displayed,
+ *      which is the long-standing "IFC Type: Object" bug this replaces.
+ *
+ * @param {object} model IFC model (for the numeric type-code lookup)
+ * @param {object} ifcProps the entity
+ * @return {string|null}
+ */
+function entityTypeName(model, ifcProps) {
+  const rawType = ifcProps?.type
+  if (typeof rawType === 'string' && rawType.length > 0) {
+    return rawType
+  }
+  if (typeof rawType === 'number' &&
+      typeof model?.ifcManager?.getIfcType === 'function') {
+    try {
+      const name = model.ifcManager.getIfcType(0, rawType)
+      if (typeof name === 'string' && name.length > 0) {
+        return name
+      }
+    } catch {
+      // Fall through to the constructor heuristic.
+    }
+  }
+  const ctorName = ifcProps?.constructor?.name
+  if (typeof ctorName === 'string' && ctorName.startsWith('Ifc')) {
+    return ctorName
+  }
+  return null
 }
 
 
@@ -111,7 +154,7 @@ async function prettyProps(model, propName, propValue, isPset, serial = 0) {
             await deref(
               propValue, model, serial,
               // TODO(pablo): there's no 4th param in deref
-              async (v, mdl, srl) => await createPropertyTable(mdl, v, srl))
+              async (v, mdl, srl) => await createPropertyTable(mdl, v, false, srl))
           }
           key={serial}
         />

--- a/src/Containers/CadView.jsx
+++ b/src/Containers/CadView.jsx
@@ -22,6 +22,7 @@ import {disablePageReloadApprovalCheck} from '../utils/event'
 import {groupElementsByTypes} from '../utils/ifc'
 import {navWith} from '../utils/navigate'
 import {addProperties} from '../utils/objects'
+import {labelForGeometryId} from '../utils/geometryLabels'
 import {
   findNodeByOccurrencePath,
   occurrencePathKey,
@@ -606,6 +607,9 @@ export default function CadView({
       rootElt.Name = {value: 'Model'}
       rootElt.LongName = {value: 'Model'}
     }
+    // Ids are only unique within one file — transient anonymous-geometry
+    // rows from the previous model must not leak into this tree.
+    useStore.getState().clearTransientTreeNodes()
     setRootElement(rootElt)
     setElementTypesMap(groupElementsByTypes(rootElt))
     // Load-time property reads are done: drop Conway's materialised
@@ -746,6 +750,17 @@ export default function CadView({
           if (solidNode) {
             targetId = solidNode.expressID
             solidExpressId = solidNode.expressID
+          } else if (pickedGeometryId !== null && pathNode &&
+              occurrenceInstanceIds(occurrencePath, false).length > 1) {
+            // Anonymous piece of a multi-piece part (conway#387): no tree
+            // node exists, but (path, geometry id) is a complete identity —
+            // select it as a solid and materialize a transient NavTree row
+            // so highlight/scroll/eye/permalink all work. The >1-instance
+            // guard keeps single-solid parts (as1's nut, the NEMA screws)
+            // on the part-level selection, where the part node IS the piece.
+            targetId = pickedGeometryId
+            solidExpressId = pickedGeometryId
+            materializeTransientNode(occurrencePath, pickedGeometryId)
           }
         }
         selectItemsInScene([targetId], true, instanceIds, occurrencePath, solidExpressId)
@@ -1020,6 +1035,18 @@ export default function CadView({
           node = parentNode
           occurrencePath = parentPathIds
           solidExpressId = targetId
+        } else if (parentNode &&
+            occurrenceInstanceIds(parentPathIds, false, targetId).length > 0) {
+          // Anonymous-geometry permalink (conway#387): the trailing id names
+          // no tree node, but the instance map holds geometry with that id
+          // under the parent path — the piece exists, it just has no in-file
+          // identity beyond its express id. Select it as a solid and
+          // materialize its transient row so the tree shows what the URL
+          // addressed.
+          node = parentNode
+          occurrencePath = parentPathIds
+          solidExpressId = targetId
+          materializeTransientNode(parentPathIds, targetId)
         }
       }
       // Skip re-selecting when this element is already the active
@@ -1089,6 +1116,28 @@ export default function CadView({
     return typeof viewer.getInstanceIdsForOccurrencePath === 'function' ?
       viewer.getInstanceIdsForOccurrencePath(
         0, occurrencePath, {includeDescendants, geometryExpressId}) : []
+  }
+
+
+  /**
+   * Materialize a transient NavTree row for an anonymous geometry piece
+   * (conway#387): resolve its label from Conway's arbitrary-id lookup
+   * ("Face #6321" / "Solid #250", degrading to "Item #id" on older engines)
+   * and add it to the session-only transient-node store, where NavTreePanel
+   * injects it under its parent part's row. Fire-and-forget: the selection
+   * itself never waits on the label, and the store dedups repeat arrivals
+   * (pick then permalink of the same piece).
+   *
+   * @param {Array<number>} occurrencePath the parent part's NAUO path
+   * @param {number} geometryExpressId the piece's own express id
+   */
+  function materializeTransientNode(occurrencePath, geometryExpressId) {
+    const pathKey = occurrencePathKey(occurrencePath)
+    const ifcAPI = viewer?.IFC?.loader?.ifcManager?.ifcAPI
+    labelForGeometryId(ifcAPI, 0, geometryExpressId).then((label) => {
+      useStore.getState().addTransientTreeNodes(
+        pathKey, [{expressID: geometryExpressId, label}])
+    })
   }
 
 

--- a/src/Containers/CadView.jsx
+++ b/src/Containers/CadView.jsx
@@ -1133,8 +1133,7 @@ export default function CadView({
    */
   function materializeTransientNode(occurrencePath, geometryExpressId) {
     const pathKey = occurrencePathKey(occurrencePath)
-    const ifcAPI = viewer?.IFC?.loader?.ifcManager?.ifcAPI
-    labelForGeometryId(ifcAPI, 0, geometryExpressId).then((label) => {
+    labelForGeometryId(useStore.getState().model, geometryExpressId).then((label) => {
       useStore.getState().addTransientTreeNodes(
         pathKey, [{expressID: geometryExpressId, label}])
     })

--- a/src/loader/Loader.js
+++ b/src/loader/Loader.js
@@ -1238,6 +1238,46 @@ export function convertToShareModel(model, viewer, {fileName = null} = {}) {
       `(${elementProperties.compressed.byteLength}B compressed; ` +
       'decode on first access)')
   }
+
+  // Cache-hit fallback for anonymous geometry pieces (conway#387). The
+  // element-properties table above only holds entities reachable from
+  // spatial-tree nodes; the ids a below-product pick or permalink names
+  // (faces / solids from `BLDRS_face_ids.geometryExpressIds`) aren't in
+  // it. The face_ids extension carries their identity ({type, name}) in a
+  // small side table — layer it under whatever `getItemProperties` surface
+  // exists so transient-row labels ("Face #6321") and the Properties
+  // panel's Type row resolve without a live parser. The synthesized shape
+  // mirrors Conway's arbitrary-id fallback ({expressID, type, Name}).
+  const geometryItemIdentities = model.userData?.bldrsFaceIds?.geometryItemIdentities
+  if (geometryItemIdentities && typeof geometryItemIdentities === 'object') {
+    const priorGetItemProperties = model.getItemProperties
+    model.getItemProperties = async (expressID) => {
+      let found
+      try {
+        found = typeof priorGetItemProperties === 'function' ?
+          await priorGetItemProperties.call(model, expressID) :
+          undefined
+      } catch {
+        found = undefined
+      }
+      if (found !== undefined && found !== null) {
+        return found
+      }
+      const identity = geometryItemIdentities[expressID]
+      if (!identity) {
+        return found
+      }
+      const IFC_LABEL_TYPE = 1
+      return {
+        expressID,
+        type: identity.type,
+        Name: {type: IFC_LABEL_TYPE, value: identity.name ?? ''},
+      }
+    }
+    glbInfo(
+      'reader: hydrated anonymous-geometry identities from BLDRS_face_ids ' +
+      `(${Object.keys(geometryItemIdentities).length} distinct geometry ids)`)
+  }
   // Only override the manager's stock `getExpressId` for genuinely
   // unstructured models (OBJ / STL / direct .glb upload — no per-vertex
   // expressID attribute on any mesh). When the model came from our IFC→

--- a/src/loader/bldrsFaceIds.js
+++ b/src/loader/bldrsFaceIds.js
@@ -151,8 +151,15 @@ export class BldrsFaceIdsReader {
         parsed.geometryExpressIds.map(
           (id) => (typeof id === 'number' && Number.isFinite(id) ? id : null)) :
         null
+      // Geometry-piece identity table (conway#387): distinct geometry
+      // express id → {type, name} captured at write time, so a cache-hit
+      // load (no live parser) can still label transient NavTree rows
+      // ("Face #6321") and serve the Properties panel's type row for
+      // anonymous pieces. Sanitised to string fields / dropped entries.
+      const geometryItemIdentities = sanitizeGeometryItemIdentities(
+        parsed.geometryItemIdentities)
       gltf.scene.userData.bldrsFaceIds =
-        {perPrimitive: resolved, occurrencePaths, geometryExpressIds}
+        {perPrimitive: resolved, occurrencePaths, geometryExpressIds, geometryItemIdentities}
       const total = resolved.reduce(
         (n, e) => n + (e?.expressIds?.length ?? 0), 0)
       glbInfo(
@@ -335,7 +342,103 @@ export function buildFaceIdsExtensionData(captured) {
     data.geometryExpressIds = captured.geometryExpressIds.map(
       (id) => (typeof id === 'number' && Number.isFinite(id) ? id : null))
   }
+  // Geometry-piece identity table — small (one entry per DISTINCT geometry
+  // id, not per instance) and JSON-native. Only emit when captured.
+  const identities = sanitizeGeometryItemIdentities(captured.geometryItemIdentities)
+  if (identities !== null) {
+    data.geometryItemIdentities = identities
+  }
   return data
+}
+
+
+/**
+ * Sanitize a geometry-identity table to `{[id]: {type?, name?}}` with
+ * string-only fields, or null when nothing valid remains. Shared by the
+ * writer (untrusted only in the sense of shape drift) and the reader
+ * (untrusted cache bytes).
+ *
+ * @param {object|null|undefined} raw candidate table
+ * @return {object|null}
+ */
+export function sanitizeGeometryItemIdentities(raw) {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    return null
+  }
+  const clean = {}
+  let kept = 0
+  for (const key of Object.keys(raw)) {
+    const entry = raw[key]
+    if (!entry || typeof entry !== 'object') {
+      continue
+    }
+    const out = {}
+    if (typeof entry.type === 'string' && entry.type.length > 0) {
+      out.type = entry.type
+    }
+    if (typeof entry.name === 'string' && entry.name.length > 0) {
+      out.name = entry.name
+    }
+    if (out.type !== undefined || out.name !== undefined) {
+      clean[key] = out
+      kept++
+    }
+  }
+  return kept > 0 ? clean : null
+}
+
+
+/**
+ * Resolve each distinct geometry express id to its identity ({type, name})
+ * through the live properties surface, for embedding in the cache artifact.
+ * Runs at GLB-write time — the one moment a live parser is guaranteed —
+ * so cache-hit loads can label anonymous pieces without re-parsing.
+ * Conway ≥1.389 resolves arbitrary ids (`getItemProperties` fallback);
+ * older engines return typeless shapes, which are skipped (the reader
+ * degrades to "Item #<id>" exactly as if the table were absent).
+ *
+ * @param {object} ifcManager IfcManager-like with async
+ *   `getItemProperties(modelID, expressID, recursive)`
+ * @param {number} modelID
+ * @param {Array<number|null>} geometryExpressIds per-instance table
+ *   (`instanceIdToGeometryExpressId`); duplicates and nulls are fine
+ * @return {Promise<object|null>} `{[id]: {type?, name?}}` or null
+ */
+export async function captureGeometryItemIdentities(ifcManager, modelID, geometryExpressIds) {
+  if (typeof ifcManager?.getItemProperties !== 'function' ||
+      !Array.isArray(geometryExpressIds)) {
+    return null
+  }
+  const distinct = new Set()
+  for (const id of geometryExpressIds) {
+    if (typeof id === 'number' && Number.isFinite(id)) {
+      distinct.add(id)
+    }
+  }
+  const identities = {}
+  for (const id of distinct) {
+    let props
+    try {
+      props = await ifcManager.getItemProperties(modelID, id, false)
+    } catch {
+      continue
+    }
+    if (!props || typeof props !== 'object') {
+      continue
+    }
+    const entry = {}
+    if (typeof props.type === 'string' && props.type.length > 0) {
+      entry.type = props.type
+    }
+    const name = props.Name?.value
+    if (typeof name === 'string' && name.length > 0) {
+      entry.name = name
+    }
+    if (entry.type !== undefined || entry.name !== undefined) {
+      identities[id] = entry
+    }
+  }
+  return Object.keys(identities).length > 0 ? identities : null
 }
 
 

--- a/src/loader/bldrsFaceIds.test.js
+++ b/src/loader/bldrsFaceIds.test.js
@@ -5,7 +5,9 @@ import {
   BldrsFaceIdsReader,
   base64ToUint32Array,
   buildFaceIdsExtensionData,
+  captureGeometryItemIdentities,
   capturePerTriangleIds,
+  sanitizeGeometryItemIdentities,
 } from './bldrsFaceIds'
 import {
   injectGlbExtensions,
@@ -277,6 +279,32 @@ describe('loader/bldrsFaceIds', () => {
       expect(gltf.scene.userData.bldrsFaceIds.occurrencePaths).toEqual([[10, 20], [11, 20]])
     })
 
+    it('round-trips the geometry-piece identity table', async () => {
+      const indices = new Uint32Array([0, 1, 2, 3, 4, 5])
+      const expressIdsPerVertex = new Uint32Array([700000, 700000, 700000, 700000, 700000, 700000])
+      const instanceIdsPerVertex = new Uint32Array([0, 0, 0, 1, 1, 1])
+      const glb = makeGlbWithIds({indices, expressIdsPerVertex, instanceIdsPerVertex})
+      const {json, bin} = parseGlb(glb)
+      const captured = capturePerTriangleIds(json, bin)
+      captured.geometryExpressIds = [431, 7859]
+      captured.geometryItemIdentities = {
+        431: {type: 'MANIFOLD_SOLID_BREP', name: 'Body1'},
+        7859: {type: 'ADVANCED_FACE'},
+      }
+      const extensionData = buildFaceIdsExtensionData(captured)
+      const {bytes: withExt} = injectGlbExtensions(glb, [
+        {name: BLDRS_FACE_IDS_EXTENSION_NAME, data: extensionData, compress: true},
+      ])
+
+      const reader = new BldrsFaceIdsReader(parserFromGlb(withExt))
+      const gltf = {scene: {userData: {}}}
+      await reader.afterRoot(gltf)
+      expect(gltf.scene.userData.bldrsFaceIds.geometryItemIdentities).toEqual({
+        431: {type: 'MANIFOLD_SOLID_BREP', name: 'Body1'},
+        7859: {type: 'ADVANCED_FACE'},
+      })
+    })
+
     it('leaves occurrencePaths null when the source carries none (IFC)', async () => {
       const indices = new Uint32Array([0, 1, 2])
       const expressIdsPerVertex = new Uint32Array([42, 42, 42])
@@ -357,6 +385,54 @@ describe('loader/bldrsFaceIds', () => {
       // Base64-encoded JSON should be ~4/3 × raw. Compressed should be
       // smaller than raw (gzip on Base64 still recovers some redundancy).
       expect(compressed.byteLength).toBeLessThan(rawSize * 2)
+    })
+  })
+
+  describe('sanitizeGeometryItemIdentities', () => {
+    it('keeps string fields and drops malformed entries', () => {
+      const clean = sanitizeGeometryItemIdentities({
+        1: {type: 'ADVANCED_FACE', name: 'ok'},
+        2: {type: 42, name: null},
+        3: 'not-an-object',
+        4: {},
+      })
+      expect(clean).toEqual({1: {type: 'ADVANCED_FACE', name: 'ok'}})
+    })
+
+    it('returns null for non-objects and empty tables', () => {
+      expect(sanitizeGeometryItemIdentities(null)).toBeNull()
+      expect(sanitizeGeometryItemIdentities([1, 2])).toBeNull()
+      expect(sanitizeGeometryItemIdentities({})).toBeNull()
+    })
+  })
+
+  describe('captureGeometryItemIdentities', () => {
+    it('resolves distinct ids through the live manager, skipping typeless shapes', async () => {
+      // Conway ≥1.389's arbitrary-id fallback shape for known ids; a bare
+      // {expressID, Name} (unknown id / older engine) contributes nothing.
+      const byId = {
+        431: {expressID: 431, type: 'MANIFOLD_SOLID_BREP', Name: {value: 'Body1'}},
+        7859: {expressID: 7859, type: 'ADVANCED_FACE', Name: {value: ''}},
+        999: {expressID: 999, Name: {value: ''}},
+      }
+      const manager = {getItemProperties: jest.fn(
+        (_modelID, id) => Promise.resolve(byId[id]))}
+      const identities = await captureGeometryItemIdentities(
+        manager, 0, [431, 7859, 7859, null, 999])
+      expect(identities).toEqual({
+        431: {type: 'MANIFOLD_SOLID_BREP', name: 'Body1'},
+        7859: {type: 'ADVANCED_FACE'},
+      })
+      // Duplicates collapse — one lookup per distinct id.
+      expect(manager.getItemProperties).toHaveBeenCalledTimes(3)
+    })
+
+    it('returns null without a manager, without ids, or when lookups all fail', async () => {
+      expect(await captureGeometryItemIdentities(null, 0, [1])).toBeNull()
+      expect(await captureGeometryItemIdentities(
+        {getItemProperties: () => Promise.resolve(null)}, 0, [1])).toBeNull()
+      expect(await captureGeometryItemIdentities(
+        {getItemProperties: () => Promise.reject(new Error('boom'))}, 0, [1])).toBeNull()
     })
   })
 })

--- a/src/loader/glbCacheKey.js
+++ b/src/loader/glbCacheKey.js
@@ -15,6 +15,16 @@
 /**
  * Current Bldrs GLB artifact schema version. Bumped on any backwards-
  * incompatible change to the BLDRS_* extension contract or cache-key shape.
+ * 0.12.0 — extended `BLDRS_face_ids` with a geometry-piece identity table
+ *         (`geometryItemIdentities`: distinct geometry express id →
+ *         {type, name}, resolved through the live parser at write time).
+ *         Cache-hit loads can now label anonymous below-product pieces
+ *         ("Face #6321" transient NavTree rows, Properties-panel Type)
+ *         without re-parsing the STEP — the ids themselves already
+ *         travelled in `geometryExpressIds` (0.11.0), but their identity
+ *         didn't. Older 0.11.0 artifacts read as miss; next miss rewrites
+ *         with the table attached. IFC artifacts are unaffected (no
+ *         geometry-express-id table). See conway#387.
  * 0.11.0 — extended `BLDRS_face_ids` with a global per-instance geometry
  *         (solid) express-id table (`geometryExpressIds`, index = synthetic
  *         instance id), and the spatial tree with Conway's ephemeral solid
@@ -86,7 +96,7 @@
  * 0.2.0 — generalised cache key from GitHub-only (owner/repo/branch) to a
  *         per-source-kind 3-level namespace (ns1/ns2/ns3).
  */
-export const BLDRS_GLB_SCHEMA_VERSION = '0.11.0'
+export const BLDRS_GLB_SCHEMA_VERSION = '0.12.0'
 
 
 /**

--- a/src/loader/glbExport.js
+++ b/src/loader/glbExport.js
@@ -34,6 +34,7 @@ import {
 import {
   BLDRS_FACE_IDS_EXTENSION_NAME,
   buildFaceIdsExtensionData,
+  captureGeometryItemIdentities,
   capturePerTriangleIds,
 } from './bldrsFaceIds'
 import {
@@ -305,6 +306,13 @@ export async function exportAndCacheGlb({model, kindLabel, cacheKeyArgs, ifcMana
       const geometryExpressIds = model?.instanceMap?.instanceIdToGeometryExpressId
       if (Array.isArray(geometryExpressIds)) {
         faceIds.geometryExpressIds = geometryExpressIds
+        // Identity table for those geometry pieces (conway#387): distinct
+        // id → {type, name}, resolved through the live parser we have RIGHT
+        // NOW so a cache-hit load can label transient NavTree rows and the
+        // Properties panel without one. Small: one entry per distinct
+        // geometry id (hundreds on NEMA-class parts), not per instance.
+        faceIds.geometryItemIdentities = await captureGeometryItemIdentities(
+          ifcManager, modelId, geometryExpressIds)
       }
     }
     await yieldToBrowser()

--- a/src/store/NavTreeSlice.js
+++ b/src/store/NavTreeSlice.js
@@ -65,5 +65,31 @@ export default function createNavTreeSlice(set, get) {
     // row highlight/scroll, per-solid hide (H), permalink round-trip.
     selectedSolidExpressId: null,
     setSelectedSolidExpressId: (id) => set(() => ({selectedSolidExpressId: id})),
+
+    // Transient NavTree rows for anonymous below-product geometry
+    // (conway#387): parent occurrence-path key → [{expressID, label}].
+    // Session-only by design — rows materialize from a scene pick, a
+    // permalink, or a "N more…" expansion and are reconstructed on the fly;
+    // they are never persisted to the GLB cache, so a reload only recreates
+    // the one a permalink names. Keyed additively with per-id dedup because
+    // the same piece can arrive from several sources (pick then permalink).
+    transientTreeNodes: {},
+    addTransientTreeNodes: (pathKey, nodes) => set((state) => {
+      const existing = state.transientTreeNodes[pathKey] ?? []
+      const known = new Set(existing.map((node) => node.expressID))
+      const fresh = nodes.filter((node) => !known.has(node.expressID))
+      if (fresh.length === 0) {
+        return {}
+      }
+      return {
+        transientTreeNodes: {
+          ...state.transientTreeNodes,
+          [pathKey]: [...existing, ...fresh],
+        },
+      }
+    }),
+    // New model load: ids are only unique within one file, so stale rows
+    // from the previous model must not leak into the next tree.
+    clearTransientTreeNodes: () => set(() => ({transientTreeNodes: {}})),
   }
 }

--- a/src/store/NavTreeSlice.js
+++ b/src/store/NavTreeSlice.js
@@ -76,15 +76,30 @@ export default function createNavTreeSlice(set, get) {
     transientTreeNodes: {},
     addTransientTreeNodes: (pathKey, nodes) => set((state) => {
       const existing = state.transientTreeNodes[pathKey] ?? []
+      const incomingById = new Map(nodes.map((node) => [node.expressID, node]))
+      let upgraded = false
+      // A row that first arrived without a resolvable identity carries the
+      // degraded "Item #<id>" label; a later arrival with a real label (the
+      // properties surface came up, or a pick followed a permalink) upgrades
+      // it in place — the id, not the label, is the row's identity.
+      const merged = existing.map((node) => {
+        const incoming = incomingById.get(node.expressID)
+        if (incoming && incoming.label !== node.label &&
+            node.label === `Item #${node.expressID}`) {
+          upgraded = true
+          return {...node, label: incoming.label}
+        }
+        return node
+      })
       const known = new Set(existing.map((node) => node.expressID))
       const fresh = nodes.filter((node) => !known.has(node.expressID))
-      if (fresh.length === 0) {
+      if (fresh.length === 0 && !upgraded) {
         return {}
       }
       return {
         transientTreeNodes: {
           ...state.transientTreeNodes,
-          [pathKey]: [...existing, ...fresh],
+          [pathKey]: [...merged, ...fresh],
         },
       }
     }),

--- a/src/store/NavTreeSlice.test.js
+++ b/src/store/NavTreeSlice.test.js
@@ -112,6 +112,46 @@ describe('store/NavTreeSlice', () => {
     })
     /* eslint-enable no-magic-numbers */
 
+    describe('transientTreeNodes (conway#387)', () => {
+      const PATH_KEY = '14107'
+      const FACE_ID = 4462
+
+      it('adds, dedups by id, and clears', () => {
+        const store = makeStore()
+        store.getState().addTransientTreeNodes(
+          PATH_KEY, [{expressID: FACE_ID, label: 'Face #4462'}])
+        store.getState().addTransientTreeNodes(
+          PATH_KEY, [{expressID: FACE_ID, label: 'Face #4462'}])
+        expect(store.getState().transientTreeNodes[PATH_KEY]).toEqual(
+          [{expressID: FACE_ID, label: 'Face #4462'}])
+        store.getState().clearTransientTreeNodes()
+        expect(store.getState().transientTreeNodes).toEqual({})
+      })
+
+      it('upgrades a degraded "Item #id" label in place', () => {
+        // A permalink resolved before the properties surface was ready
+        // gets the degraded label; a later pick of the same piece (or a
+        // late label fetch) must replace it, not be dropped by the dedup.
+        const store = makeStore()
+        store.getState().addTransientTreeNodes(
+          PATH_KEY, [{expressID: FACE_ID, label: 'Item #4462'}])
+        store.getState().addTransientTreeNodes(
+          PATH_KEY, [{expressID: FACE_ID, label: 'Face #4462'}])
+        expect(store.getState().transientTreeNodes[PATH_KEY]).toEqual(
+          [{expressID: FACE_ID, label: 'Face #4462'}])
+      })
+
+      it('never downgrades a real label back to "Item #id"', () => {
+        const store = makeStore()
+        store.getState().addTransientTreeNodes(
+          PATH_KEY, [{expressID: FACE_ID, label: 'Face #4462'}])
+        store.getState().addTransientTreeNodes(
+          PATH_KEY, [{expressID: FACE_ID, label: 'Item #4462'}])
+        expect(store.getState().transientTreeNodes[PATH_KEY]).toEqual(
+          [{expressID: FACE_ID, label: 'Face #4462'}])
+      })
+    })
+
     it('selectedInstanceIds is independent of selectedElements', () => {
       // Parent IFC expressID + the synthetic per-instance ID can vary
       // independently — the Conway-direct click sets both, Shift-click

--- a/src/utils/geometryLabels.js
+++ b/src/utils/geometryLabels.js
@@ -1,0 +1,84 @@
+/**
+ * Labels for anonymous below-product STEP geometry (conway#387).
+ *
+ * A picked solid/face that has no NavTree node — geometry below the ephemeral
+ * solid layer — still needs a human-readable row label when it materializes as
+ * a transient node. Conway ≥1.387 resolves any express id to its STEP entity
+ * type name (`getItemProperties` arbitrary-entity fallback); these helpers turn
+ * that into "Face #6321" / "Solid #250", or the item's own name when the file
+ * carries a meaningful one. No tree or persisted state involved — the label is
+ * reconstructed on the fly, which is what keeps transient rows cheap.
+ */
+
+
+/**
+ * STEP entity type name → short display kind. Anything unrecognized (or an
+ * older Conway that doesn't return `type`) degrades to the generic "Item".
+ */
+const KIND_BY_TYPE = {
+  ADVANCED_FACE: 'Face',
+  FACE_SURFACE: 'Face',
+  MANIFOLD_SOLID_BREP: 'Solid',
+  BREP_WITH_VOIDS: 'Solid',
+  FACETED_BREP: 'Solid',
+  SHELL_BASED_SURFACE_MODEL: 'Shell',
+  FACE_BASED_SURFACE_MODEL: 'Shell',
+}
+
+
+/**
+ * Placeholder strings STEP exporters write for "no name".
+ *
+ * @param {string|undefined|null} name
+ * @return {boolean}
+ */
+function isMeaningfulName(name) {
+  return typeof name === 'string' && name.length > 0 &&
+    name !== 'NONE' && name !== 'UNKNOWN'
+}
+
+
+/**
+ * Synthesize the display label for an anonymous geometry item.
+ *
+ * Prefers the item's own in-file name (rare for anonymous geometry, but a
+ * SolidWorks body reached through "N more…" may have one); otherwise
+ * "<Kind> #<expressID>" from the STEP type; otherwise "Item #<expressID>".
+ *
+ * @param {number} expressID the geometry item's express id
+ * @param {object|null} [item] resolved item from
+ *   `ifcAPI.properties.getItemProperties(modelID, expressID)` — may be null
+ *   (lookup failed) or typeless (older Conway)
+ * @return {string}
+ */
+export function geometryItemLabel(expressID, item = null) {
+  const name = item?.Name?.value
+  if (isMeaningfulName(name)) {
+    return name
+  }
+  const kind = KIND_BY_TYPE[item?.type] ?? 'Item'
+  return `${kind} #${expressID}`
+}
+
+
+/**
+ * Resolve + label in one step: fetch the item identity from Conway's
+ * properties surface (feature-detected; an older engine or a lookup failure
+ * degrades to "Item #<expressID>") and synthesize the label.
+ *
+ * @param {object} ifcAPI Conway IfcAPI (needs `properties.getItemProperties`)
+ * @param {number} modelID
+ * @param {number} expressID
+ * @return {Promise<string>}
+ */
+export async function labelForGeometryId(ifcAPI, modelID, expressID) {
+  let item = null
+  try {
+    if (typeof ifcAPI?.properties?.getItemProperties === 'function') {
+      item = await ifcAPI.properties.getItemProperties(modelID, expressID)
+    }
+  } catch {
+    // Label degradation only — the id itself is still the identity.
+  }
+  return geometryItemLabel(expressID, item)
+}

--- a/src/utils/geometryLabels.js
+++ b/src/utils/geometryLabels.js
@@ -62,23 +62,28 @@ export function geometryItemLabel(expressID, item = null) {
 
 
 /**
- * Resolve + label in one step: fetch the item identity from Conway's
- * properties surface (feature-detected; an older engine or a lookup failure
- * degrades to "Item #<expressID>") and synthesize the label.
+ * Resolve + label in one step: fetch the item identity through the model's
+ * uniform one-arg properties surface and synthesize the label.
  *
- * @param {object} ifcAPI Conway IfcAPI (needs `properties.getItemProperties`)
- * @param {number} modelID
+ * `model.getItemProperties(expressID)` is the same surface the Properties
+ * panel uses, so labels resolve wherever it does: live Conway parse
+ * (arbitrary-id fallback, ≥1.389), and cache-hit GLB (the
+ * `BLDRS_element_properties` table plus the face_ids geometry-identity
+ * fallback). An older engine, a missing surface, or a lookup failure
+ * degrades to "Item #<expressID>".
+ *
+ * @param {object} model Share model (needs `getItemProperties(expressID)`)
  * @param {number} expressID
  * @return {Promise<string>}
  */
-export async function labelForGeometryId(ifcAPI, modelID, expressID) {
+export async function labelForGeometryId(model, expressID) {
   let item = null
   try {
-    if (typeof ifcAPI?.properties?.getItemProperties === 'function') {
-      item = await ifcAPI.properties.getItemProperties(modelID, expressID)
+    if (typeof model?.getItemProperties === 'function') {
+      item = await model.getItemProperties(expressID)
     }
   } catch {
     // Label degradation only — the id itself is still the identity.
   }
-  return geometryItemLabel(expressID, item)
+  return geometryItemLabel(expressID, item ?? null)
 }

--- a/src/utils/geometryLabels.test.js
+++ b/src/utils/geometryLabels.test.js
@@ -35,18 +35,29 @@ describe('utils/geometryLabels', () => {
   })
 
   describe('labelForGeometryId', () => {
-    it('resolves through the properties surface', async () => {
-      const ifcAPI = {properties: {getItemProperties: jest.fn().mockResolvedValue(
-        {expressID: NEMA_FACE_ID, type: 'ADVANCED_FACE', Name: {value: 'NONE'}})}}
-      await expect(labelForGeometryId(ifcAPI, 0, NEMA_FACE_ID)).resolves.toBe('Face #29')
-      expect(ifcAPI.properties.getItemProperties).toHaveBeenCalledWith(0, NEMA_FACE_ID)
+    it('resolves through the model\'s uniform properties surface', async () => {
+      // The one-arg `model.getItemProperties(expressID)` contract — live
+      // Conway parse and cache-hit GLB expose the same shape.
+      const model = {getItemProperties: jest.fn().mockResolvedValue(
+        {expressID: NEMA_FACE_ID, type: 'ADVANCED_FACE', Name: {value: 'NONE'}})}
+      await expect(labelForGeometryId(model, NEMA_FACE_ID)).resolves.toBe('Face #29')
+      expect(model.getItemProperties).toHaveBeenCalledWith(NEMA_FACE_ID)
     })
 
-    it('degrades gracefully when the surface is absent or throws', async () => {
-      await expect(labelForGeometryId(null, 0, 5)).resolves.toBe('Item #5')
-      const throwing = {properties: {getItemProperties: jest.fn().mockRejectedValue(
-        new Error('boom'))}}
-      await expect(labelForGeometryId(throwing, 0, 6)).resolves.toBe('Item #6')
+    it('resolves a sync (cache-hit table) surface too', async () => {
+      const model = {getItemProperties: (expressID) =>
+        ({expressID, type: 'MANIFOLD_SOLID_BREP', Name: {value: ''}})}
+      await expect(labelForGeometryId(model, SOLID_ID)).resolves.toBe('Solid #250')
+    })
+
+    it('degrades gracefully when the surface is absent, empty, or throws', async () => {
+      await expect(labelForGeometryId(null, 5)).resolves.toBe('Item #5')
+      const throwing = {getItemProperties: jest.fn().mockRejectedValue(
+        new Error('boom'))}
+      await expect(labelForGeometryId(throwing, 6)).resolves.toBe('Item #6')
+      // A cache-hit table without this id returns undefined.
+      const missing = {getItemProperties: () => undefined}
+      await expect(labelForGeometryId(missing, 7)).resolves.toBe('Item #7')
     })
   })
 })

--- a/src/utils/geometryLabels.test.js
+++ b/src/utils/geometryLabels.test.js
@@ -1,0 +1,52 @@
+import {geometryItemLabel, labelForGeometryId} from './geometryLabels'
+
+
+describe('utils/geometryLabels', () => {
+  const SOLID_ID = 250
+  const FACE_ID = 6321
+  const NEMA_FACE_ID = 29
+  describe('geometryItemLabel', () => {
+    it('prefers a meaningful in-file name over the synthetic label', () => {
+      const item = {type: 'MANIFOLD_SOLID_BREP', Name: {value: 'Boss-Extrude7'}}
+      expect(geometryItemLabel(SOLID_ID, item)).toBe('Boss-Extrude7')
+    })
+
+    it('treats exporter placeholders as unnamed', () => {
+      // SolidWorks writes 'NONE' for anonymous faces — that is not a name.
+      const item = {type: 'ADVANCED_FACE', Name: {value: 'NONE'}}
+      expect(geometryItemLabel(FACE_ID, item)).toBe('Face #6321')
+    })
+
+    it('maps solid and shell types to their display kinds', () => {
+      expect(geometryItemLabel(1, {type: 'BREP_WITH_VOIDS', Name: {value: ''}}))
+        .toBe('Solid #1')
+      expect(geometryItemLabel(2, {type: 'SHELL_BASED_SURFACE_MODEL', Name: {value: ''}}))
+        .toBe('Shell #2')
+    })
+
+    it('degrades to Item for unknown types, null items, and typeless items', () => {
+      // A typeless item is what a pre-1.387 Conway returns; null is a failed
+      // lookup — the express id itself stays the identity either way.
+      expect(geometryItemLabel(7, {type: 'AXIS2_PLACEMENT_3D', Name: {value: ''}}))
+        .toBe('Item #7')
+      expect(geometryItemLabel(8, null)).toBe('Item #8')
+      expect(geometryItemLabel(9, {Name: {value: ''}})).toBe('Item #9')
+    })
+  })
+
+  describe('labelForGeometryId', () => {
+    it('resolves through the properties surface', async () => {
+      const ifcAPI = {properties: {getItemProperties: jest.fn().mockResolvedValue(
+        {expressID: NEMA_FACE_ID, type: 'ADVANCED_FACE', Name: {value: 'NONE'}})}}
+      await expect(labelForGeometryId(ifcAPI, 0, NEMA_FACE_ID)).resolves.toBe('Face #29')
+      expect(ifcAPI.properties.getItemProperties).toHaveBeenCalledWith(0, NEMA_FACE_ID)
+    })
+
+    it('degrades gracefully when the surface is absent or throws', async () => {
+      await expect(labelForGeometryId(null, 0, 5)).resolves.toBe('Item #5')
+      const throwing = {properties: {getItemProperties: jest.fn().mockRejectedValue(
+        new Error('boom'))}}
+      await expect(labelForGeometryId(throwing, 0, 6)).resolves.toBe('Item #6')
+    })
+  })
+})

--- a/src/viewer/ShareViewer.js
+++ b/src/viewer/ShareViewer.js
@@ -1135,6 +1135,54 @@ export class ShareViewer {
 
 
   /**
+   * Enumerate the distinct geometry (solid/face piece) express ids placed
+   * at — or under — a STEP occurrence path, across every child Mesh of the
+   * model. This is the discovery half of anonymous-geometry addressing
+   * (conway#387): the NavTree's "N more…" expansion lists what exists below
+   * a part when the tree itself carries no nodes for it, and each returned
+   * id is permalink-addressable as `[root, ...path, id]`.
+   *
+   * Prefix-inclusive like the instance resolver above (geometry paths can be
+   * SRR-extended below the tree leaf's path). Returns ids in first-seen
+   * (emission) order, deduplicated across meshes and instances; empty when
+   * the model carries no geometry-id table (IFC, pre-0.11.0 caches).
+   *
+   * @param {number} modelID
+   * @param {Array<number>} occurrencePath NAUO express ids, root→leaf
+   * @return {number[]} distinct geometry express ids (empty when none)
+   */
+  getGeometryIdsForOccurrencePath(modelID, occurrencePath) {
+    const model = this._modelById(modelID)
+    if (!model || !Array.isArray(occurrencePath) || occurrencePath.length === 0) {
+      return []
+    }
+    const target = occurrencePathKey(occurrencePath)
+    const descendantPrefix = `${target}/`
+    const seen = new Set()
+    const ids = []
+    model.traverse((obj) => {
+      const byPath = obj.isMesh ? obj.instanceMap?.occurrencePathToInstanceIds : null
+      if (!byPath || typeof obj.instanceMap.getGeometryExpressIdByInstance !== 'function') {
+        return
+      }
+      for (const [key, list] of byPath) {
+        if (key !== target && !key.startsWith(descendantPrefix)) {
+          continue
+        }
+        for (let i = 0; i < list.length; i++) {
+          const geometryExpressId = obj.instanceMap.getGeometryExpressIdByInstance(list[i])
+          if (geometryExpressId !== null && !seen.has(geometryExpressId)) {
+            seen.add(geometryExpressId)
+            ids.push(geometryExpressId)
+          }
+        }
+      }
+    })
+    return ids
+  }
+
+
+  /**
    * Traverse a Conway-direct model, build a subset Mesh from every
    * child Mesh's `instanceMap` via `buildSubset(mesh)`, parent each
    * subset under the corresponding source mesh's parent (so the

--- a/src/viewer/ShareViewer.test.js
+++ b/src/viewer/ShareViewer.test.js
@@ -595,6 +595,30 @@ describe('viewer/ShareViewer getInstanceIdsForOccurrencePath', () => {
       viewer, 0, [10], {includeDescendants: false, geometryExpressId: 424242})).toEqual([])
   })
 
+  it('enumerates distinct geometry ids under a path (getGeometryIdsForOccurrencePath)', () => {
+    // The discovery half of anonymous-geometry addressing (conway#387): a
+    // multibody part's pieces share its (SRR-extended) path; the "N more…"
+    // expansion lists their geometry ids. Duplicated ids across instances
+    // dedup; a sibling part's pieces stay out.
+    const mesh = makeOccurrenceMesh([
+      {parentExpressId: 100, triangleCount: 1, occurrencePath: [10, 66], geometryExpressId: 250},
+      {parentExpressId: 100, triangleCount: 1, occurrencePath: [10, 66], geometryExpressId: 4462},
+      {parentExpressId: 100, triangleCount: 1, occurrencePath: [10, 66], geometryExpressId: 250},
+      {parentExpressId: 101, triangleCount: 1, occurrencePath: [11], geometryExpressId: 9751},
+    ])
+    const viewer = makeResolverViewer(mesh)
+    expect(ShareViewer.prototype.getGeometryIdsForOccurrencePath.call(viewer, 0, [10]))
+      .toEqual([250, 4462])
+    expect(ShareViewer.prototype.getGeometryIdsForOccurrencePath.call(viewer, 0, [11]))
+      .toEqual([9751])
+    // No geometry-id table (IFC / old cache) → empty, callers degrade.
+    const bare = makeOccurrenceMesh([
+      {parentExpressId: 100, triangleCount: 1, occurrencePath: [10]},
+    ])
+    expect(ShareViewer.prototype.getGeometryIdsForOccurrencePath.call(
+      makeResolverViewer(bare), 0, [10])).toEqual([])
+  })
+
   it('is prefix-inclusive: an assembly path lights up every leaf beneath it', () => {
     // Two leaves under assembly-occurrence [10]; a lookup on [10] returns both,
     // a lookup on the exact leaf returns just one.

--- a/yarn.lock
+++ b/yarn.lock
@@ -2473,10 +2473,10 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@bldrs-ai/conway@1.386.1216":
-  version "1.386.1216"
-  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.386.1216.tgz#ae918141c5cc770412b78d97c8c6d3188851fe3b"
-  integrity sha512-5kUNPPCGArASYSCl/CJpz8owZ6KHqcLUe06k4MSP7XgTdR3/ESOhP2iMzKqNUXosEBlMZg2d2kuWY1XivX+lNg==
+"@bldrs-ai/conway@1.389.1221":
+  version "1.389.1221"
+  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.389.1221.tgz#fa74d99cc7dab20bfb9c34c9a05c47c5e1e85443"
+  integrity sha512-fyM/S28eOrF+pJRCcmS1uPoKGLngFUKFCQmBVReH/RvZ8ZetBHZ00vDcG+wZjhc+RziomkWDoqHQ3lB7lalfzw==
   dependencies:
     gl-matrix "3.4.3"
     seedrandom "3.0.5"


### PR DESCRIPTION
## Summary

Implements pablo&#39;s scope decisions on bldrs-ai/conway#387: **every pickable STEP piece is now addressable and navigable, even with no in-file identity** — chained express ids all the way down to faces, synthetic labels in the NavTree only, no persisted state (transient rows reconstructed on the fly), with full eye/scroll affordances and &#34;N more…&#34;.

**What to check on the deploy preview** (NEMA):
`share/v/gh/bldrs-ai/test-models/main/step/grabcad/cnc-router-with-nema23-stepper-motor-1.snapshot.2/NEMA 23 - 76mm.STEP`
- Double-click one of the **wire-assembly pieces** (the colored connector block) — it selects as its own item, a transient row appears under the motor in the NavTree (highlighted, scrolled-to, with a working eye), and the URL becomes `…/[root]/14107/`.
- Copy that URL into a fresh tab — the same piece re-selects and its row rematerializes.
- Arty Z7: pick any of the bare-board&#39;s anonymous pieces — same flow.

## How it works

Identity is the `(occurrencePath, geometryExpressID)` pair that #1594 threaded through the instance map and GLB cache — this PR adds addressing and presentation, no new persisted *state* (the cache gains a derived identity table, see below):

- **Pick**: an anonymous piece of a *multi-piece* part selects as a solid and materializes a session-only transient row under its part. Single-solid parts (as1&#39;s nut, the NEMA screws) keep part-level selection — there the part node *is* the piece.
- **Permalink**: `[root, ...path, geometryId]` gains a third resolution tier — tree node → ephemeral solid child → any geometry id the instance map holds under the parent path.
- **&#34;N more…&#34;**: parts with engine-suppressed solids (`droppedSolids`) get an expansion row; each click materializes the next batch of 250 pieces from the instance map. The count is advisory and retires at zero.
- **Labels**: Conway&#39;s arbitrary-id lookup (conway#389, released as 1.389.1221 and bumped on this branch) gives `Face #6321` / `Solid #250` / in-file body names; older engines degrade to `Item #id`.
- **Markers coherence**: markers stay coordinate-anchored in the URL *hash* while this identity lives in the *path* — the two compose (path = what, hash = where on it).

## Preview-feedback round (cfb961b0)

- **Single injection**: transient rows attach at the part node only — previously every ephemeral solid (sharing the part&#39;s occurrence path) re-injected the same rows.
- **Durable labels**: label resolution moved to the uniform `model.getItemProperties(id)` surface; the GLB cache now carries a geometry-piece identity table (`BLDRS_face_ids.geometryItemIdentities`, distinct id → `{type, name}`, captured while the live parser exists — schema 0.12.0, old artifacts re-capture on next load), and a degraded `Item #id` row label upgrades in place when a better label arrives. Permalinks now reconstitute with the same `Face #id` label a pick shows.
- **Properties panel Type row**: renamed `IFC Type` → `Type` (STEP compatibility) and derived from the entity&#39;s own `type` field instead of `constructor.name` — the long-standing `Object` / minified-`t` display bug.

## Known gaps (by design)

- Root-level parts with empty occurrence paths (DSA2&#39;s single-product monolith) stay unaddressable — there&#39;s no path to anchor the id under. Needs the PDS→node reverse map flagged in `design/new/step-occurrence-selection.md` §Remaining 4.
- The &#34;more&#34; count is advisory when enumeration surfaces face pieces the engine&#39;s solid count never included.
- A transient row attaches at its part, not inside the specific solid the piece belongs to — the instance map doesn&#39;t record piece→solid containment.

## Tests

Transient-row injection/dedup/path-scoped nodeIds, single-injection regression, and more-row emit/retire (`NavTreePanel.test.jsx`), label synthesis incl. placeholder names and engine degradation (`geometryLabels.test.js`), label-upgrade store semantics (`NavTreeSlice.test.js`), identity-table capture/sanitize/GLB round-trip (`bldrsFaceIds.test.js`), prefix-inclusive deduped id enumeration (`ShareViewer.test.js`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PtCiSyHzGiehkDEM7y4GbF

---
_Generated by [Claude Code](https://claude.ai/code/session_01PtCiSyHzGiehkDEM7y4GbF)_