### PR TITLE
Bump @bldrs-ai/conway 1.389.1221 → 1.385.1233 (toroidal fix + GLB export fixes)

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@babel/plugin-syntax-import-assertions": "7.18.6",
     "@babel/preset-env": "7.18.10",
     "@babel/preset-react": "7.18.6",
-    "@bldrs-ai/conway": "1.389.1221",
+    "@bldrs-ai/conway": "1.385.1233",
     "@bldrs-ai/ifclib": "5.3.3",
     "@emotion/react": "11.10.0",
     "@emotion/styled": "11.10.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2473,10 +2473,10 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@bldrs-ai/conway@1.389.1221":
-  version "1.389.1221"
-  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.389.1221.tgz#fa74d99cc7dab20bfb9c34c9a05c47c5e1e85443"
-  integrity sha512-fyM/S28eOrF+pJRCcmS1uPoKGLngFUKFCQmBVReH/RvZ8ZetBHZ00vDcG+wZjhc+RziomkWDoqHQ3lB7lalfzw==
+"@bldrs-ai/conway@1.385.1233":
+  version "1.385.1233"
+  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.385.1233.tgz#cf18e5eea83ee06e53253073709cbb841bcbf75a"
+  integrity sha512-i+iZ4v4hgTegu09KnbrnuZ65pqPDnsezL9ARPIYehP4RoprBCQ8MWKWAHm5JvkZnDSLjtkvMvMCpVIcR1T6CMw==
   dependencies:
     gl-matrix "3.4.3"
     seedrandom "3.0.5"


### PR DESCRIPTION
## Summary

Bumps `@bldrs-ai/conway` to 1.385.1233 (build 1233 — the newest main publish; the middle digit tracks the merged PR number, so it reads lower than 1.389 but supersedes it), picking up bldrs-ai/conway#385 / bldrs-ai/conway-geom#146:

- **Topology-aware toroidal surface triangulation** (fixes bldrs-ai/test-models#47): jet-engine shaft fillets restored, spurious shaft geometry removed, `nist_ftc_11` washer hole correct. Toroidal faces are classified by boundary winding/coverage and unwrapped into an injective 2D domain instead of the dual-hemisphere fold whose thresholds dropped or filled faces.
- **GLB export fixes**: chunk rebase offsets are now written back as node translations (chunked exports assemble correctly and are stable across builds), and accessor bounds skip non-finite values (no more truncated GLBs for models with degenerate geometry).

## Validation

Verified on the conway PR's regression + visual-diff runs: CDT exceptions down 130 → 94 with no new failures, all jet part placements identical to the previous release with no triangle losses, and before/after renders reviewed for every digest-changed model. The published 1.385.1233 wasm was checked to contain the new code paths before this bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J3A79iKimn7UheESvnumj7

---
_Generated by [Claude Code](https://claude.ai/code/session_01J3A79iKimn7UheESvnumj7)_