### PR TITLE
Fix negative load-report stage durations (engine/Share clock-base mix)

### DIFF
--- a/src/loader/loadProgress.js
+++ b/src/loader/loadProgress.js
@@ -115,6 +115,13 @@ class LoadProgressReporter {
     this.stallTimer = null
     this.stallReported = false
     this.startTime = Date.now()
+    // Engine events carry their own elapsedMs measured from the ENGINE's
+    // clock (conway's tracker starts at OpenModel), not from load start.
+    // This offset rebases them onto the load clock — set once at the first
+    // engine-stamped event — so stage boundaries between Share-stamped
+    // legacy strings and engine events never go backwards (the
+    // "Parsing model geometry: -1.6s" negative-duration line).
+    this.engineElapsedBase = null
     this.ended = false
     // Distinct console warning/error text → occurrence count, captured via
     // the console tee below and appended after the Total line (issue #301
@@ -230,9 +237,22 @@ class LoadProgressReporter {
     // Share-side stages (download/convert/legacy strings) don't carry
     // engine timings — stamp wall clock + heap so every stage line has its
     // owned deltas (the normalized form's format-independent core).
+    // Engine-stamped events are rebased onto the load clock (see
+    // engineElapsedBase above): engine-to-engine deltas are preserved
+    // exactly, and the boundary against Share-stamped stages stays
+    // monotonic.
+    let elapsedMs
+    if (event.elapsedMs === undefined) {
+      elapsedMs = Date.now() - this.startTime
+    } else {
+      if (this.engineElapsedBase === null) {
+        this.engineElapsedBase = (Date.now() - this.startTime) - event.elapsedMs
+      }
+      elapsedMs = event.elapsedMs + this.engineElapsedBase
+    }
     event = {
       ...event,
-      elapsedMs: event.elapsedMs ?? (Date.now() - this.startTime),
+      elapsedMs,
       memoryMb: event.memoryMb ?? usedHeapMb(),
     }
 

--- a/src/loader/loadProgress.test.js
+++ b/src/loader/loadProgress.test.js
@@ -91,6 +91,41 @@ describe('loadProgress', () => {
       expect(useStore.getState().currentLoadLine).toMatch(/^Geometry/)
     })
 
+    it('rebases engine elapsedMs so legacy→engine stage boundaries never go negative', () => {
+      // Regression: engine events carry elapsedMs from the ENGINE clock
+      // (conway's tracker starts at OpenModel), while legacy strings are
+      // stamped from load start. Closing a legacy stage with a raw engine
+      // timestamp produced "Parsing model geometry: -1.6s" whenever the
+      // pre-parse stages (download, read) took longer than the engine's
+      // first-event offset.
+      beginLoadProgress({fileInfo: 'index.ifc'})
+      // 5s of Share-side wall clock passes before the engine starts
+      // (download + read stages under fake timers).
+      const shareSideStagesMs = 5000
+      reportLoadProgress('Preparing file download...')
+      jest.advanceTimersByTime(shareSideStagesMs)
+      reportLoadProgress('Parsing model geometry...')
+      // Engine's first event: 10ms on ITS clock — far behind Share's.
+      reportLoadProgress({phase: 'dataParse', completed: 0, total: 100, elapsedMs: 10})
+      reportLoadProgress({phase: 'geometry', completed: 0, total: 100, elapsedMs: 250})
+      const frozen = reportLines()
+      // Every closed stage line carries a non-negative duration (the legacy
+      // "Parsing model geometry" line closes at 0.000s, not -4.99s).
+      const durations = frozen
+        .map((line) => / (-?[\d.]+)s/.exec(line))
+        .filter((match) => match !== null)
+        .map((match) => Number(match[1]))
+      expect(durations.length).toBeGreaterThan(0)
+      for (const duration of durations) {
+        expect(duration).toBeGreaterThanOrEqual(0)
+      }
+      expect(frozen.some((line) => /^Parsing model geometry: 0\.000s/.test(line))).toBe(true)
+      // Engine-to-engine deltas are preserved exactly: the Parsing stage
+      // (frozen mid-flight, so it keeps its bar) closes at the geometry
+      // event, 250-10 = 240ms on the engine clock.
+      expect(frozen.some((line) => /^Parsing \[.*0\.240s/.test(line))).toBe(true)
+    })
+
     it('normalizes legacy strings into stages with stamped deltas', () => {
       beginLoadProgress({fileInfo: 'model.fbx'})
       reportLoadProgress('Downloading model data...')


### PR DESCRIPTION
## What

Fixes the `Parsing model geometry: -1.614s` line visible in every real load report (surfaced during the #1609 PSB smoke test, but pre-existing — it reproduces on `main` with the classic open too).

**Cause**: stage boundaries subtract `elapsedMs` values from two different clocks. Share-side stages (download, read, legacy strings) are stamped from **load start**; conway's structured events carry the **engine tracker's** elapsedMs (zero at `OpenModel`). Closing the legacy "Parsing model geometry" stage with a raw engine timestamp goes negative whenever download+read take longer than the engine's first-event offset — i.e. always.

**Fix**: rebase engine-stamped events onto the load clock via an offset captured at the first engine event. Engine-to-engine deltas (the `Parsing:`/`Geometry:` timings) are preserved exactly; the legacy→engine boundary becomes monotonic.

## Tests

New regression test drives the exact failing sequence under fake timers (5s of Share-side stages, then engine events at 10ms/250ms on the engine clock) and asserts every closed stage duration is ≥ 0 and the engine-delta stage timing is preserved to the millisecond (`0.240s`). Full loadProgress suite 19/19; Loader suites green.

Independent of #1609 — can land before or after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S6gTXmrq1GbhqknPqQMRuz

---
_Generated by [Claude Code](https://claude.ai/code/session_01S6gTXmrq1GbhqknPqQMRuz)_