### PR TITLE
[parked spike — do not merge] #1610 cross-origin isolation headers: MT wasm + break inventory

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -36,18 +36,33 @@
   functions = "netlify/functions"
   framework = "#custom"
 
-# COOP same-origin-allow-popups lets Google Identity Services deliver OAuth
-# tokens via postMessage without nulling window.opener in the cross-origin
-# popup. COEP is intentionally omitted (docs.google.com/picker sends
-# CORP: same-site, which Chrome enforces under any COEP value and blocks the
-# Picker iframe), so crossOriginIsolated is already false here — stricter
-# COOP: same-origin would block GIS OAuth without gaining any isolation. The
-# long-term fix is to load the Picker in a popup window that isn't subject
-# to the parent page's COEP policy (TODO).
+# Cross-origin isolation (issue #1610): COOP same-origin + COEP
+# credentialless makes `crossOriginIsolated` true, which unlocks
+# SharedArrayBuffer and Conway's multithreaded wasm (~2.8x geometry
+# extraction). conway-geom's loader auto-selects the MT build at
+# runtime when isolation is present, and both wasm variants already
+# ship in /static/js — no build changes needed.
+#
+# KNOWN BREAKAGE under these headers, to be fixed in the follow-up
+# phases of #1610 before this merges:
+#  - GIS OAuth popup: COOP same-origin severs window.opener, so
+#    Google's postMessage delivery fails. Fix: our own popup running
+#    the redirect flow into a same-origin /auth callback that relays
+#    the code over BroadcastChannel (channel scope is the origin, not
+#    the browsing-context group, so COOP doesn't sever it).
+#  - Google Drive Picker iframe: docs.google.com sends CORP:
+#    same-site; credentialless COEP loads non-consenting subresources
+#    cookie-less, and a cookie-less Picker session is broken UX. Fix:
+#    host the Picker in our own popup window (popups are not embedded
+#    content, so COEP does not apply to them), relaying the selection
+#    over the same channel.
+# credentialless (vs require-corp) keeps stray cross-origin images/
+# fonts loading (cookie-less) instead of hard-failing them.
 [[headers]]
   for = "/*"
   [headers.values]
-    Cross-Origin-Opener-Policy = "same-origin-allow-popups"
+    Cross-Origin-Opener-Policy = "same-origin"
+    Cross-Origin-Embedder-Policy = "credentialless"
 
 # Override headers for the /subscribe route so that no strict isolation is enforced.
 [[headers]]

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@babel/plugin-syntax-import-assertions": "7.18.6",
     "@babel/preset-env": "7.18.10",
     "@babel/preset-react": "7.18.6",
-    "@bldrs-ai/conway": "1.419.1268",
+    "@bldrs-ai/conway": "1.421.1270",
     "@bldrs-ai/ifclib": "5.3.3",
     "@emotion/react": "11.10.0",
     "@emotion/styled": "11.10.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2473,10 +2473,10 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@bldrs-ai/conway@1.419.1268":
-  version "1.419.1268"
-  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.419.1268.tgz#62164b1f3499a8a15d125dcd8a2ed82e0ef0c291"
-  integrity sha512-uXdbgNX7Giev6gbkz9HYiomOVnSb2WejNdgJesUUDql/XHH+HlZWJW711AGYW+C5LFqXwWsModaBzcKE9f0HUQ==
+"@bldrs-ai/conway@1.421.1270":
+  version "1.421.1270"
+  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.421.1270.tgz#65a3268580934eaf350ee2143c944e88dfa9a05e"
+  integrity sha512-3mxK8ssVYh0+5SzqTkLWDUcGiq9elzG/d7lEngFUAVTZEKhhe3RoCBe9UKMiKx4lB01wO56ig5xZVvuBp7mZlA==
   dependencies:
     gl-matrix "3.4.3"
     seedrandom "3.0.5"


### PR DESCRIPTION
**PARKED** (2026-07-21): the spike completed and refuted its premise — see the measurement thread in bldrs-ai/conway-geom#148 and the reframe in #1610. Browser geometry is ~75% serial JS driver; MT nets zero-to-negative on real machines today (45s vs 31s on PSB). Shipping these headers would regress PSB, so this stays a draft until extraction moves off the main thread and/or the MT tax shrinks — at which point the phases documented below (auth relay over BroadcastChannel, Picker in an owned popup) resume unchanged.

What the spike *proved*: the header flip + conway 1.421.1270 (worker-spawn fix, bldrs-ai/conway#421) gives `crossOriginIsolated === true`, MT wasm selection, and a live pthread worker fleet in a real deploy. The infrastructure works; the payoff doesn't, yet.

---

Phase 1 of #1610 — **deploy-preview reconnaissance only, not for merge**. Two header lines flip the app to full cross-origin isolation (`COOP: same-origin` + `COEP: credentialless`). No build changes needed: conway-geom's loader already auto-selects the MT wasm at runtime when `crossOriginIsolated` is true, and `build-share` already ships both wasm variants to `/static/js`.

## Verification checklist (on this preview)

1. Console: `crossOriginIsolated` → should be `true`; `typeof SharedArrayBuffer` → `"function"`.
2. Load PSB (fresh tab) — network tab should fetch `ConwayGeomWasmWebMT.wasm`.
3. **Expected breakage**: Google sign-in popup (COOP severs `window.opener`); Google Drive Picker iframe (CORP under COEP).

## Fix phases before this merges (tracked in #1610)

- **Auth relay**: our own popup running the redirect flow into a same-origin `/auth` callback page that relays the auth code over `BroadcastChannel` — channel scope is the origin, not the browsing-context group, so COOP's severing doesn't affect it.
- **Picker popup**: host the Picker in our own popup window (popups aren't embedded content — COEP doesn't apply), same relay pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S6gTXmrq1GbhqknPqQMRuz