### PR TITLE
Demand/tiled rendering: progressive geometry, parse-time preview, incremental assembly, camera follow

### DIFF
--- a/design/new/demand-tiled-rendering.md
+++ b/design/new/demand-tiled-rendering.md
@@ -140,18 +140,95 @@ tweened, stops forever on user input.
 
 ### B — Budgeted residency + eviction (the memory endgame)
 
-Wire the full pump→queue→tile-pool→extractor composition. Renderer
-holds BatchedMesh instances only for resident products; eviction
-removes instances and releases tiles (refcounted shared assets make
-mapped-item sharing safe). Priority = camera (frustum + screen-space
-extent) once bounds exist — bounds come from first extraction and are
-cached; pre-first-extraction ordering falls back to file order +
-storey/spatial heuristics. Budget defaults device-sized, overridable.
+Sequenced plan as of the v1.431 field milestone (PSB 77s = 47.9s
+parse + 27.1s assemble; Arty 14.5s). Each step is a separate PR round.
 
-Exit gate: PSB interactive under a ~1.5GB geometry budget; walkthrough
-keeps a stable frame rate while the resident set turns over; no leaks
-across evict/re-extract cycles (pool accounting invariants already
-tested conway-side).
+**B1 — incremental durable assembly (dissolve the 27s assemble
+stage).** Today the demand pump streams render-only preview meshes,
+and the durable model is STILL built monolithically at the end
+(merged BufferGeometry by default, BatchedMesh behind the flag) and
+swapped in. B1 makes the BatchedMesh itself the durable object,
+assembled incrementally during the pump: each delta batch appends
+geometries + instances (capacity reserved with a growth factor —
+BatchedMesh reallocation copies), picking decoration (expressID ↔
+instance ranges) accumulates per batch, opaque/transparent split as
+today. The preview group and the end-of-load build/swap disappear on
+this path; end-of-load work shrinks to nav/spatial wiring + stats.
+The merged path stays as the non-demand fallback. Expected: PSB
+Total ≈ parse + ~0, from 77s to ~50s.
+
+**B2 — residency slider + eviction (the feature, not just the
+policy).** User-accessible control: a glasses icon in OperationsGroup
+opens a popup with a residency slider (100% = whole model resident …
+0% = fully evicted) and a priority-metric selector for eviction
+ordering:
+  a. screen occupancy — projected bounds area, frustum-weighted;
+  b. memory limit — slider maps to a byte budget vs the full model;
+  c. distance from selection — when a part is selected, priority is
+     inverse distance from its bounds.
+Architecture: a ResidencyController scores products with the selected
+metric, keeps the top set that fits the slider's target, and applies
+deltas — evict removes BatchedMesh instances and releases tiles
+(refcounted shared assets keep mapped-item sharing safe), re-infill
+re-extracts through the demand queue (conway tile-pool machinery,
+Phase B InstanceAssetSource). Smoothness rules: rescore throttled
+(~150ms), bounded churn per frame, hysteresis band so the boundary
+doesn't flap. The slider doubles as the instrumentation surface for
+choosing a DEFAULT eviction policy later — dialing it by hand on real
+models is how the intuition gets built.
+
+Exit gate: PSB interactive under a ~1.5GB geometry budget; slider
+drag from 100→10→100 re-infills smoothly with a stable frame rate;
+no leaks across evict/re-extract cycles (pool accounting invariants
+already tested conway-side).
+
+### Parallelism plan (consistent with the #1612 spike findings)
+
+The isolation spike (Share #1612, parked) proved the COOP/COEP + MT
+wasm infrastructure works and refuted the payoff: browser geometry is
+~75% serial JS driver, so MT wasm nets zero-to-negative on real
+machines (PSB 45s MT vs 31s ST) while carrying the MT tax and the
+auth/Picker breakage. The plan that is consistent with that data
+parallelizes the DRIVER, not the inner loops, and needs no headers:
+
+**P1 — props worker (first use of the transfer plane).** The GLB
+props capture + spatial tree + export currently waits for the whole
+load, then runs on idle. Instead: at parse end ("indexReady"), ship
+the serialized columnar index (M4 sidecar machinery) plus the source
+bytes (transfer or OPFS handle) to a worker running its own ST wasm.
+The worker opens a properties-only model (no geometry; windowed
+OPFS-backed BufferProvider keeps residency at a fraction of main) and
+produces the BLDRS props/tree payloads while the MAIN thread is still
+extracting geometry — the props latency disappears into the pump
+window, and the idle cores (M2: 4P+4E far from saturated) do real
+work. Main merges the payloads at writer time.
+
+**P2 — geometry worker sharding (the 30s push).** Generalize the same
+transfer plane: K workers, each with its own ST wasm + model open
+from the shared index sidecar, each extracting a SHARD of the demand
+unit list and posting transferable geometry payloads (the
+PreviewMeshPayload/tile shape) back to the main thread's incremental
+BatchedMesh assembly (B1). This parallelizes the serial JS driver
+itself — the thing the spike showed MT wasm cannot touch — with no
+SAB, no COOP/COEP, no MT tax, no auth/Picker phases. Memory cost of
+K model opens is bounded by the windowed provider + names-only trees.
+
+**P3 — revisit MT wasm** only if P2 profiling shows in-wasm parallel
+sections dominating again, or worker sharding hits a wall SAB would
+fix. The parked #1612 phases (auth relay over BroadcastChannel,
+Picker popup) resume unchanged in that case.
+
+### Load session → observer plane
+
+ProgressiveLoadSession (the format-neutral state machine) grows an
+observer registration: the session emits lifecycle events — opened,
+indexReady(sidecar), previewMesh, meshBatch, assembling, modelReady,
+finished/aborted — and the current preview+camera-follow behavior
+becomes the first observer (render infill). The props worker (P1) is
+the second (kicks its worker on indexReady). Geometry sharding (P2)
+rides the same events. This is the generalization that lets every
+latency-hiding consumer start AS SOON as its inputs exist instead of
+at load end.
 
 ### C — Tiles as truth + GPU picking (Phase C flip)
 

--- a/design/new/demand-tiled-rendering.md
+++ b/design/new/demand-tiled-rendering.md
@@ -1,0 +1,100 @@
+# Demand/tiled rendering — budgeted, progressive geometry for PSB-class models
+
+Consumer-side plan for conway epic
+[conway#390](https://github.com/bldrs-ai/conway/issues/390)'s demand
+plane. Status and motivation: the streamed columnar open shipped
+(default-on, #1609), and the browser-MT spike
+([#1610](https://github.com/bldrs-ai/Share/issues/1610),
+[conway-geom#148](https://github.com/bldrs-ai/conway-geom/issues/148))
+established that load-time whole-model extraction cannot be
+meaningfully accelerated in the browser — ~75% of it is serial JS
+driver. This milestone therefore **deletes** it: extract on demand,
+under an explicit byte budget, rendering what the user is looking at.
+
+## Where a PSB load's 52.6s goes today (clean tab, prod)
+
+| phase | time | heap | this milestone's effect |
+|---|---|---|---|
+| download prep + read | ~3.9s | +1.7GB | untouched (OPFS-from-birth milestone) |
+| streamed parse | 13.4s | +376MB | untouched (already shipped) |
+| whole-model extraction | 31.1s | +627MB | **deleted** — demand batches instead |
+| merged-geometry build | 7.9s | +1.5GB | **deleted** — incremental BatchedMesh adds |
+
+Target: first pixels ≈ parse + first demand batch (~15s class on PSB),
+full interactivity while geometry streams in, geometry residency
+bounded by budget instead of model size.
+
+## Conway machinery this consumes (all merged, tested end-to-end)
+
+- Per-product demand extraction seam: `prepareDemandExtraction()` +
+  `extractProductGeometryByLocalID()` (`@bldrs-ai/conway`, Phase B2).
+- `DemandGeometryQueue` (priority + byte budget) over `GeometryTiles`;
+  `GeometryTilePool` (refcounted shared assets over the wasm TilePool);
+  `IfcTileAssetExtractor` (representation-item closure attribution);
+  `DemandResidencyPump` (async source-residency admission) — the
+  `@bldrs-ai/conway/demand` plane.
+
+## Slices
+
+### A — Progressive extraction + incremental scene (perceived-latency win)
+
+No eviction yet; same total work, radically better time-to-pixels, and
+it de-risks incremental scene mutation.
+
+1. **Conway shim**: a deferred open — `OpenModelStreamed(data,
+   {DEFER_GEOMETRY: true})`-style — that parses and registers the model
+   *without* extraction, plus a batch surface:
+   `ExtractGeometryBatch(modelID, batchSize) → {extracted, remaining}`
+   driving the B2 seam cooperatively, and an incremental
+   `StreamNewMeshes(modelID, cb)` that yields only meshes produced
+   since the last call (the existing scene-walk capture, watermarked).
+2. **Share loader**: when the `demandGeometry` flag is on and the GLB
+   cache misses, open deferred; render loop pulls batches (file order
+   initially), converts through the existing
+   FlatMesh→BatchedMesh/merged path *incrementally*, repaints between
+   batches; spatial tree and properties work from batch one (they never
+   depended on geometry).
+3. **Picking option A** (decided earlier): CPU position+index retained,
+   normals/UVs nulled on upload where the batched path allows.
+4. GLB cache write happens at completion, unchanged. Flag default OFF
+   until preview burn-in (this changes UX semantics — geometry pops in;
+   the names-first skeleton is the designed mitigation).
+
+Exit gate: PSB first-pixels < 20s in a preview; final scene
+mesh-parity with the classic path (same product set, same triangle
+counts); all flows green with the flag off.
+
+### B — Budgeted residency + eviction (the memory endgame)
+
+Wire the full pump→queue→tile-pool→extractor composition. Renderer
+holds BatchedMesh instances only for resident products; eviction
+removes instances and releases tiles (refcounted shared assets make
+mapped-item sharing safe). Priority = camera (frustum + screen-space
+extent) once bounds exist — bounds come from first extraction and are
+cached; pre-first-extraction ordering falls back to file order +
+storey/spatial heuristics. Budget defaults device-sized, overridable.
+
+Exit gate: PSB interactive under a ~1.5GB geometry budget; walkthrough
+keeps a stable frame rate while the resident set turns over; no leaks
+across evict/re-extract cycles (pool accounting invariants already
+tested conway-side).
+
+### C — Tiles as truth + GPU picking (Phase C flip)
+
+Uploads served from wasm tile payloads (`readGeometryTilePayload`),
+CPU-side canonical meshes dropped, picking moves to the GPU ID-buffer
+(option B). Removes the last O(model) CPU geometry copies.
+
+## Flags & rollout
+
+`demandGeometry` (default off) gates A; sub-flags per slice as they
+land. The classic whole-model path remains the fallback until C is
+burned in, mirroring the `disableStreamOpen` rollout pattern.
+
+## Cross-references
+
+- conway epic: conway#390 (status addendum in
+  `design/new/streaming-federated-loader.md`)
+- Browser-MT spike data: #1610, conway-geom#148, parked #1612
+- Cooperative native open (needed by OPFS-from-birth, not by slice A):
+  conway#420

--- a/design/new/demand-tiled-rendering.md
+++ b/design/new/demand-tiled-rendering.md
@@ -64,6 +64,33 @@ Exit gate: PSB first-pixels < 20s in a preview; final scene
 mesh-parity with the classic path (same product set, same triangle
 counts); all flows green with the flag off.
 
+### A2 — Parse-time preview channel (first pixels in the first seconds)
+
+Slice A's first pixels still wait for the parse (~13s on PSB). A2
+moves them into the parse itself. Durable extraction mid-parse is
+structurally impossible for typical IFC — relationship records
+(rel-voids, rel-materials, styled items) extend to ~92–97% of file
+depth (measured on Schependomlaan), so a prefix extraction can miss
+openings and materials. Conway therefore emits **throwaway preview
+payloads** (`Loadersettings.ON_PREVIEW_MESH`): prefix snapshots of the
+live columnar index, extracted through disposable prefix models under
+a per-tick time budget, geometry copied out of the wasm heap
+(self-contained, byte/product-capped), coordination frame pinned so
+preview and durable placements coincide. The durable pump re-extracts
+everything after the parse and replaces the preview — final parity
+untouched by construction.
+
+Share side: `parseIfcWithConway(..., onPreviewMesh)` threads the
+callback into the deferred open; `payloadToPreviewMesh` builds pooled
+render-only meshes (geometry cached by geometryExpressID for mapped
+sharing) into the same preview group the slice-A batches use.
+Preview meshes for products the durable batches later re-emit overlap
+identically until the swap — invisible, and gone with the group.
+
+Measured (node, Schependomlaan 49MB): first payload 583ms into a
+1199ms parse. On PSB-class parses this is first pixels at ~1–2s of
+parse instead of ~13s.
+
 ### B — Budgeted residency + eviction (the memory endgame)
 
 Wire the full pump→queue→tile-pool→extractor composition. Renderer

--- a/design/new/demand-tiled-rendering.md
+++ b/design/new/demand-tiled-rendering.md
@@ -91,6 +91,19 @@ Measured (node, Schependomlaan 49MB): first payload 583ms into a
 1199ms parse. On PSB-class parses this is first pixels at ~1–2s of
 parse instead of ~13s.
 
+### STEP parity (shipped alongside A2)
+
+The whole demand surface is schema-parametric as of conway 1.428:
+AP214/AP203/AP242 get the streamed columnar open, the deferred pump
+(assembly-tree units — one per part, so single-root assemblies like
+Arty stream progressively; conway maps the consumer batch size onto
+part granularity), and the parse-time preview channel via a
+per-schema adapter. The loader needed zero changes — the demand
+branch feature-detects the same pump either way. STEP loads are
+geometry-dominated (Arty: 0.8s parse / 11.5s extraction), so the
+pump is the visible win there; the preview channel is future-proofing
+for large STEP parses.
+
 ### B — Budgeted residency + eviction (the memory endgame)
 
 Wire the full pump→queue→tile-pool→extractor composition. Renderer

--- a/design/new/demand-tiled-rendering.md
+++ b/design/new/demand-tiled-rendering.md
@@ -104,6 +104,40 @@ geometry-dominated (Arty: 0.8s parse / 11.5s extraction), so the
 pump is the visible win there; the preview channel is future-proofing
 for large STEP parses.
 
+Three follow-up fixes (conway #431) made the STEP preview channel
+actually live — it was silently dead and could corrupt the durable
+open: (1) `ColumnarIndexSink` snapshots now CLONE retained complex
+(multi-mapping) entries, because models stamp lazy vtable/buffer
+state onto them in place and AP214's transforms are complex
+instances — a throwaway prefix model was poisoning the durable model
+(Arty pump: 49 → 0 meshes); IFC was immune only because IFC files
+have no complex instances. (2) AP214 `prepareDemandExtraction`
+contains per-record getter throws, so a truncated prefix yields
+partial units instead of aborting (one dangling record used to kill
+the channel on tick #1). (3) `retryEmptyUnits` adapter semantics:
+AP214's unit list is fixed at the file head while geometry arrives
+throughout the file, so the channel re-runs units that captured
+nothing against each richer prefix generation instead of consuming
+the list once before any geometry exists.
+
+### Progressive-load session (format-neutral instrumentation)
+
+`src/viewer/ProgressiveLoadSession.js` — a small state machine
+(idle → previewing → assembling → finished/aborted) that owns
+everything the user sees/reads while a model loads, shared by IFC and
+STEP (both route through `ShareIfcLoader.parse`): demand-preview
+group lifecycle, the camera follow, and progress/summary reporting.
+Format loaders only convert their streams (preview payloads, pump
+batches) to meshes and trigger it.
+
+The camera follow is a STRICT fit: the session keeps a running union
+box of everything shown, and refits only when new geometry lands
+outside the currently framed sphere (overflow-triggered,
+event-driven, min 250ms apart growing to 1s) — so existing geometry
+is never pushed offscreen between timer beats, and contained infill
+causes no camera churn at all. First fit instant, follow-ups
+tweened, stops forever on user input.
+
 ### B — Budgeted residency + eviction (the memory endgame)
 
 Wire the full pump→queue→tile-pool→extractor composition. Renderer

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@babel/plugin-syntax-import-assertions": "7.18.6",
     "@babel/preset-env": "7.18.10",
     "@babel/preset-react": "7.18.6",
-    "@bldrs-ai/conway": "1.419.1268",
+    "@bldrs-ai/conway": "1.422.1273",
     "@bldrs-ai/ifclib": "5.3.3",
     "@emotion/react": "11.10.0",
     "@emotion/styled": "11.10.0",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@babel/plugin-syntax-import-assertions": "7.18.6",
     "@babel/preset-env": "7.18.10",
     "@babel/preset-react": "7.18.6",
-    "@bldrs-ai/conway": "1.423.1278",
+    "@bldrs-ai/conway": "1.425.1281",
     "@bldrs-ai/ifclib": "5.3.3",
     "@emotion/react": "11.10.0",
     "@emotion/styled": "11.10.0",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@babel/plugin-syntax-import-assertions": "7.18.6",
     "@babel/preset-env": "7.18.10",
     "@babel/preset-react": "7.18.6",
-    "@bldrs-ai/conway": "1.430.1294",
+    "@bldrs-ai/conway": "1.431.1296",
     "@bldrs-ai/ifclib": "5.3.3",
     "@emotion/react": "11.10.0",
     "@emotion/styled": "11.10.0",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@babel/plugin-syntax-import-assertions": "7.18.6",
     "@babel/preset-env": "7.18.10",
     "@babel/preset-react": "7.18.6",
-    "@bldrs-ai/conway": "1.429.1291",
+    "@bldrs-ai/conway": "1.430.1294",
     "@bldrs-ai/ifclib": "5.3.3",
     "@emotion/react": "11.10.0",
     "@emotion/styled": "11.10.0",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@babel/plugin-syntax-import-assertions": "7.18.6",
     "@babel/preset-env": "7.18.10",
     "@babel/preset-react": "7.18.6",
-    "@bldrs-ai/conway": "1.431.1296",
+    "@bldrs-ai/conway": "1.434.1300",
     "@bldrs-ai/ifclib": "5.3.3",
     "@emotion/react": "11.10.0",
     "@emotion/styled": "11.10.0",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@babel/plugin-syntax-import-assertions": "7.18.6",
     "@babel/preset-env": "7.18.10",
     "@babel/preset-react": "7.18.6",
-    "@bldrs-ai/conway": "1.422.1273",
+    "@bldrs-ai/conway": "1.423.1278",
     "@bldrs-ai/ifclib": "5.3.3",
     "@emotion/react": "11.10.0",
     "@emotion/styled": "11.10.0",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@babel/plugin-syntax-import-assertions": "7.18.6",
     "@babel/preset-env": "7.18.10",
     "@babel/preset-react": "7.18.6",
-    "@bldrs-ai/conway": "1.425.1281",
+    "@bldrs-ai/conway": "1.426.1283",
     "@bldrs-ai/ifclib": "5.3.3",
     "@emotion/react": "11.10.0",
     "@emotion/styled": "11.10.0",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@babel/plugin-syntax-import-assertions": "7.18.6",
     "@babel/preset-env": "7.18.10",
     "@babel/preset-react": "7.18.6",
-    "@bldrs-ai/conway": "1.426.1283",
+    "@bldrs-ai/conway": "1.428.1289",
     "@bldrs-ai/ifclib": "5.3.3",
     "@emotion/react": "11.10.0",
     "@emotion/styled": "11.10.0",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@babel/plugin-syntax-import-assertions": "7.18.6",
     "@babel/preset-env": "7.18.10",
     "@babel/preset-react": "7.18.6",
-    "@bldrs-ai/conway": "1.428.1289",
+    "@bldrs-ai/conway": "1.429.1291",
     "@bldrs-ai/ifclib": "5.3.3",
     "@emotion/react": "11.10.0",
     "@emotion/styled": "11.10.0",

--- a/src/Containers/CadView.jsx
+++ b/src/Containers/CadView.jsx
@@ -687,14 +687,13 @@ export default function CadView({
       // viewer-replacement work, so it wins the modifier slot. Models
       // without an instanceMap (today's wit-three path, GLB cache hit)
       // keep the legacy Shift behavior unchanged.
-      // BatchedMesh render path (`?feature=batchedMesh`): the raycast sets
-      // `batchId` (the per-instance id); resolve it to the parent IFC
-      // product through the tables `buildBatchedConwayModel` attached.
-      // Selection highlights every occurrence of that product (parent-level
-      // subset, via the model's `createSubset`). Per-occurrence narrowing
-      // would need `instancePicking`, which the batched model doesn't carry
-      // yet — so we pass no instanceIds (avoids a no-op `setInstanceSelection`
-      // + its warn). See design/new/viewer-replacement.md §3b.iv.
+      // BatchedMesh render path (`?feature=batchedMesh` / demandGeometry):
+      // the raycast sets `batchId` (the per-instance id); resolve it to the
+      // parent IFC product, its global occurrence id (the batched "instance
+      // id" `setInstanceSelection` narrows the recolor with), and its STEP
+      // occurrence path / solid geometry id through the per-batch tables
+      // `assembleBatchedModel` attached — the same per-instance pick the
+      // merged path resolves through `mesh.instanceMap`.
       if (mesh.isBatchedMesh && mesh.instanceParents) {
         const batchId = picked.batchId
         if (batchId === undefined || batchId < 0) {
@@ -704,7 +703,19 @@ export default function CadView({
         if (parentExpressId === undefined || !viewer.isolator.canBePickedInScene(parentExpressId)) {
           return
         }
-        selectItemsInScene([parentExpressId], true, [])
+        const instanceId = mesh.instanceOccurrenceIds?.[batchId]
+        if (instanceId === undefined) {
+          // Undecorated batch (no occurrence table): parent-level only.
+          selectItemsInScene([parentExpressId], true, [])
+          return
+        }
+        selectFromInstancePick({
+          parentExpressId,
+          instanceId,
+          rawOccurrencePath: mesh.instanceOccurrencePaths?.[batchId] ?? null,
+          pickedGeometryId: mesh.instanceGeometryIds?.[batchId] ?? null,
+          isShiftKeyDown: event.shiftKey,
+        })
         return
       }
       if (mesh.instanceMap) {
@@ -720,69 +731,13 @@ export default function CadView({
         if (!viewer.isolator.canBePickedInScene(parentExpressId)) {
           return
         }
-        // Route through selectItemsInScene (the single selection
-        // funnel) so a scene pick gets the same treatment as every
-        // other source: store update + element-path permalink in the
-        // URL. Previously this set the store directly and skipped the
-        // funnel, so scene selections never produced a shareable
-        // permalink. The parent expressID is always the "selection" so
-        // the properties panel / nav tree / search respond normally;
-        // `instanceIds` only narrows what the OutlineEffect draws.
-        // Shift = the whole IFC element (every instance) → no
-        // per-instance restriction; no-shift = just this PlacedGeometry.
-        const instanceIds = event.shiftKey ? [] : [instanceId]
-        // STEP: the picked instance's occurrence path so the NavTree highlights
-        // the one occurrence, not every reuse of the part type. Null on shift
-        // (whole element) and for IFC / single-occurrence parts.
-        //
-        // The geometry path can be deeper than any tree node's — Conway
-        // appends a segment per child shape_representation level, and an
-        // SRR-attached brep (Alibre exports) adds a non-NAUO id below the
-        // leaf — so trim to the deepest tree-known prefix or the NavTree's
-        // exact-key matches (row highlight, scroll) find nothing. The store
-        // is read imperatively: this handler is installed once from
-        // `onModel`, before that render's `rootElement` is set.
-        const rawOccurrencePath = event.shiftKey ? null :
-          (mesh.instanceMap.getOccurrencePathByInstance?.(instanceId) ?? null)
-        const rootEltForPick = useStore.getState().rootElement
-        const occurrencePath = rawOccurrencePath ?
-          trimToTreeOccurrencePath(
-            rawOccurrencePath,
-            occurrencePathKeySetForTree(rootEltForPick)) :
-          null
-        // Ephemeral solid resolution: when the tree surfaces the picked
-        // body as a `type:'solid'` child of the node at this path (Conway's
-        // multibody solid layer), select THAT node — its express id is the
-        // picked instance's PlacedGeometry.geometryExpressID — so the
-        // NavTree highlights the one body, not the whole part. Falls back
-        // to the part-level selection when the tree has no matching solid
-        // (single-solid parts, suppressed anonymous dumps, old caches).
-        let targetId = parentExpressId
-        let solidExpressId = null
-        if (occurrencePath) {
-          const pickedGeometryId =
-            mesh.instanceMap.getGeometryExpressIdByInstance?.(instanceId) ?? null
-          const pathNode = pickedGeometryId !== null ?
-            findNodeByOccurrencePath(rootEltForPick, occurrencePath) : null
-          const solidNode = pathNode?.children?.find?.(
-            (child) => child.ephemeral === true && child.expressID === pickedGeometryId)
-          if (solidNode) {
-            targetId = solidNode.expressID
-            solidExpressId = solidNode.expressID
-          } else if (pickedGeometryId !== null && pathNode &&
-              occurrenceInstanceIds(occurrencePath, false).length > 1) {
-            // Anonymous piece of a multi-piece part (conway#387): no tree
-            // node exists, but (path, geometry id) is a complete identity —
-            // select it as a solid and materialize a transient NavTree row
-            // so highlight/scroll/eye/permalink all work. The >1-instance
-            // guard keeps single-solid parts (as1's nut, the NEMA screws)
-            // on the part-level selection, where the part node IS the piece.
-            targetId = pickedGeometryId
-            solidExpressId = pickedGeometryId
-            materializeTransientNode(occurrencePath, pickedGeometryId)
-          }
-        }
-        selectItemsInScene([targetId], true, instanceIds, occurrencePath, solidExpressId)
+        selectFromInstancePick({
+          parentExpressId,
+          instanceId,
+          rawOccurrencePath: mesh.instanceMap.getOccurrencePathByInstance?.(instanceId) ?? null,
+          pickedGeometryId: mesh.instanceMap.getGeometryExpressIdByInstance?.(instanceId) ?? null,
+          isShiftKeyDown: event.shiftKey,
+        })
         return
       }
       // Non-instance branch: elementSelection funnels through
@@ -805,6 +760,82 @@ export default function CadView({
     } catch (e) {
       console.error(e)
     }
+  }
+
+
+  /**
+   * Shared tail of the per-instance scene-pick funnel — used by both the
+   * merged (`mesh.instanceMap`) and batched (per-batch tables) double-click
+   * branches so the two can't drift on the selection contract.
+   *
+   * Routes through selectItemsInScene (the single selection funnel) so a
+   * scene pick gets the same treatment as every other source: store update
+   * + element-path permalink in the URL. The parent expressID is always the
+   * "selection" so the properties panel / nav tree / search respond
+   * normally; `instanceIds` only narrows what the scene highlight draws.
+   * Shift = the whole IFC element (every instance) → no per-instance
+   * restriction; no-shift = just this PlacedGeometry.
+   *
+   * STEP: the picked instance's occurrence path makes the NavTree highlight
+   * the one occurrence, not every reuse of the part type (null on shift and
+   * for IFC / single-occurrence parts). The geometry path can be deeper
+   * than any tree node's — Conway appends a segment per child
+   * shape_representation level, and an SRR-attached brep (Alibre exports)
+   * adds a non-NAUO id below the leaf — so trim to the deepest tree-known
+   * prefix or the NavTree's exact-key matches (row highlight, scroll) find
+   * nothing. The store is read imperatively: the click handler is installed
+   * once from `onModel`, before that render's `rootElement` is set.
+   *
+   * Ephemeral solid resolution: when the tree surfaces the picked body as a
+   * `type:'solid'` child of the node at this path (Conway's multibody solid
+   * layer), select THAT node — its express id is the picked instance's
+   * `PlacedGeometry.geometryExpressID` — so the NavTree highlights the one
+   * body, not the whole part. Falls back to the part-level selection when
+   * the tree has no matching solid (single-solid parts, suppressed
+   * anonymous dumps, old caches).
+   *
+   * @param {object} pick
+   * @param {number} pick.parentExpressId the geometry-owner product id
+   * @param {number} pick.instanceId synthetic per-instance id (IfcInstanceMap
+   *   id on the merged path; global occurrence id on the batched path)
+   * @param {Array<number>|null} pick.rawOccurrencePath untrimmed STEP path
+   * @param {number|null} pick.pickedGeometryId the instance's own geometry
+   *   (solid) express id
+   * @param {boolean} pick.isShiftKeyDown
+   */
+  function selectFromInstancePick({
+    parentExpressId, instanceId, rawOccurrencePath, pickedGeometryId, isShiftKeyDown,
+  }) {
+    const instanceIds = isShiftKeyDown ? [] : [instanceId]
+    const rawPath = isShiftKeyDown ? null : rawOccurrencePath
+    const rootEltForPick = useStore.getState().rootElement
+    const occurrencePath = rawPath ?
+      trimToTreeOccurrencePath(rawPath, occurrencePathKeySetForTree(rootEltForPick)) :
+      null
+    let targetId = parentExpressId
+    let solidExpressId = null
+    if (occurrencePath) {
+      const pathNode = pickedGeometryId !== null ?
+        findNodeByOccurrencePath(rootEltForPick, occurrencePath) : null
+      const solidNode = pathNode?.children?.find?.(
+        (child) => child.ephemeral === true && child.expressID === pickedGeometryId)
+      if (solidNode) {
+        targetId = solidNode.expressID
+        solidExpressId = solidNode.expressID
+      } else if (pickedGeometryId !== null && pathNode &&
+          occurrenceInstanceIds(occurrencePath, false).length > 1) {
+        // Anonymous piece of a multi-piece part (conway#387): no tree
+        // node exists, but (path, geometry id) is a complete identity —
+        // select it as a solid and materialize a transient NavTree row
+        // so highlight/scroll/eye/permalink all work. The >1-instance
+        // guard keeps single-solid parts (as1's nut, the NEMA screws)
+        // on the part-level selection, where the part node IS the piece.
+        targetId = pickedGeometryId
+        solidExpressId = pickedGeometryId
+        materializeTransientNode(occurrencePath, pickedGeometryId)
+      }
+    }
+    selectItemsInScene([targetId], true, instanceIds, occurrencePath, solidExpressId)
   }
 
 

--- a/src/FeatureFlags.js
+++ b/src/FeatureFlags.js
@@ -90,9 +90,10 @@ export const flags = [
   // #1613): cache-miss IFC parses open with DEFER_GEOMETRY and pump
   // Conway's ExtractGeometryBatch, so meshes stream into the scene in
   // file-order batches instead of one 30s+ whole-model extraction.
-  // Off by default while the incremental render path burns in on
-  // previews; flip on via `?feature=demandGeometry`.
-  {name: 'demandGeometry', isActive: false},
+  // TEMPORARILY default-on ON THIS BRANCH for preview burn-in (DnD
+  // loads can't carry `?feature=` params) — flip back to false before
+  // merging to main.
+  {name: 'demandGeometry', isActive: true},
   // BatchedMesh render path: render the Conway-direct geometry as a
   // THREE.BatchedMesh (one geometry per shared shape + per-instance
   // transforms) instead of the merged BufferGeometry — the ~60% vertex-

--- a/src/FeatureFlags.js
+++ b/src/FeatureFlags.js
@@ -86,13 +86,13 @@ export const flags = [
   // A/Bs the same build); flipping this to true is the prod-wide kill
   // switch.
   {name: 'disableStreamOpen', isActive: false},
-  // Demand/tiled rendering slice A (design/new/demand-tiled-rendering.md,
-  // #1613): cache-miss IFC parses open with DEFER_GEOMETRY and pump
-  // Conway's ExtractGeometryBatch, so meshes stream into the scene in
-  // file-order batches instead of one 30s+ whole-model extraction.
-  // TEMPORARILY default-on ON THIS BRANCH for preview burn-in (DnD
-  // loads can't carry `?feature=` params) — flip back to false before
-  // merging to main.
+  // Demand/tiled rendering (design/new/demand-tiled-rendering.md,
+  // #1613): cache-miss IFC/STEP parses open with DEFER_GEOMETRY and
+  // pump Conway's ExtractGeometryBatch — parse-time preview + the
+  // durable model assembling incrementally on screen instead of one
+  // 30s+ whole-model extraction. Default ON (shipped with the
+  // milestone: PSB 77s -> 57s); `?feature=disableStreamOpen` remains
+  // the classic-path escape hatch and this flag the demand kill switch.
   {name: 'demandGeometry', isActive: true},
   // BatchedMesh render path: render the Conway-direct geometry as a
   // THREE.BatchedMesh (one geometry per shared shape + per-instance

--- a/src/FeatureFlags.js
+++ b/src/FeatureFlags.js
@@ -86,6 +86,13 @@ export const flags = [
   // A/Bs the same build); flipping this to true is the prod-wide kill
   // switch.
   {name: 'disableStreamOpen', isActive: false},
+  // Demand/tiled rendering slice A (design/new/demand-tiled-rendering.md,
+  // #1613): cache-miss IFC parses open with DEFER_GEOMETRY and pump
+  // Conway's ExtractGeometryBatch, so meshes stream into the scene in
+  // file-order batches instead of one 30s+ whole-model extraction.
+  // Off by default while the incremental render path burns in on
+  // previews; flip on via `?feature=demandGeometry`.
+  {name: 'demandGeometry', isActive: false},
   // BatchedMesh render path: render the Conway-direct geometry as a
   // THREE.BatchedMesh (one geometry per shared shape + per-instance
   // transforms) instead of the merged BufferGeometry — the ~60% vertex-

--- a/src/loader/Loader.js
+++ b/src/loader/Loader.js
@@ -159,7 +159,6 @@ export async function load(
   }
 
   // Find loader can do a head download for content typecheck, but full download is delayed
-  onProgress(`Determining file type...`)
   // GLB skip path below may swap these to the GLB loader tuple.
   let [loader, isLoaderAsync, isFormatText, isIfc, fixupCb] = await findLoader(path, viewer)
   debug().log(
@@ -341,7 +340,7 @@ export async function load(
         glbExportContext = {kindLabel, cacheKeyArgs, sourceFile: file}
       }
 
-      onProgress('Reading model data...')
+      onProgress('Buffering model bytes...')
       modelData = await file.arrayBuffer()
       if (isFormatText) {
         onProgress('Decoding model data...')

--- a/src/loader/Loader.js
+++ b/src/loader/Loader.js
@@ -788,6 +788,23 @@ export async function load(
         // (no writer is scheduled) — nothing to spill. Fail-soft: any
         // guard failure keeps the resident buffer (pre-spill behavior).
         spillModelSource(viewer?.IFC?.loader?.ifcManager?.ifcAPI, 0, glbExportContext.sourceFile)
+        // Same safe point, wasm-side twin of the source spill: the
+        // scene is built and the GLB written, so nothing reads conway's
+        // native geometry again — free it (per-model) so repeated loads
+        // in one tab reuse the wasm pages instead of stacking whole
+        // model scenes until the tab crashes. Feature-detected;
+        // burn-in gated with the demand path.
+        try {
+          const releaseAPI = viewer?.IFC?.loader?.ifcManager?.ifcAPI
+          if (isFeatureEnabled('demandGeometry') &&
+              typeof releaseAPI?.ReleaseModelGeometry === 'function') {
+            // eslint-disable-next-line new-cap
+            const released = releaseAPI.ReleaseModelGeometry(0)
+            glbVerbose('writer: native geometry released =', released)
+          }
+        } catch (e) {
+          glbVerbose('writer: native geometry release failed (kept):', e)
+        }
       })
     }
     scheduleIdleWork(runWriter)

--- a/src/loader/Loader.test.js
+++ b/src/loader/Loader.test.js
@@ -393,27 +393,22 @@ describe('Loader', () => {
 
         // Verify progress messages are called in correct order
         const progressCalls = onProgress.mock.calls.map((call) => call[0])
-        expect(progressCalls).toContain('Determining file type...')
         expect(progressCalls).toContain('Preparing file download...')
-        expect(progressCalls).toContain('Reading model data...')
+        expect(progressCalls).toContain('Buffering model bytes...')
         // Slice 5b: "Configuring loader..." (the applyWebIfcConfig
         // progress beat from the old wit-three parse path) is gone —
         // Conway-direct parse settings ride on OpenModel directly.
         // The new "Building model..." beat captures the post-parse
         // assembly step (buildConwayIfcModel + decorate).
-        expect(progressCalls).toContain('Parsing model geometry...')
-        expect(progressCalls).toContain('Building model...')
-        expect(progressCalls).toContain('Setting up coordinate system...')
-        expect(progressCalls).toContain('Fitting model to frame...')
-        expect(progressCalls).toContain('Gathering model statistics...')
-        expect(progressCalls).toContain('Model loaded successfully!')
+        expect(progressCalls).toContain('Opening model...')
+        expect(progressCalls).toContain('Assembling render mesh...')
 
         // Ensure onProgress was called multiple times.
         // Count: Determining file type, Preparing file download,
         // Reading model data, Parsing model geometry, Building model,
         // Setting up coordinate system, Fitting model to frame,
         // Gathering model statistics, Model loaded successfully.
-        const EXPECTED_PROGRESS_BEATS = 9
+        const EXPECTED_PROGRESS_BEATS = 4
         expect(onProgress).toHaveBeenCalledTimes(EXPECTED_PROGRESS_BEATS)
       } finally {
         restoreArrayBuffer()
@@ -432,23 +427,18 @@ describe('Loader', () => {
         await load(testPathToUrl(testPath), mockViewer, onProgress, true, setOpfsFile, '')
 
         const progressCalls = onProgress.mock.calls.map((call) => call[0])
-        expect(progressCalls).toContain('Determining file type...')
         expect(progressCalls).toContain('Preparing file download...')
-        expect(progressCalls).toContain('Reading model data...')
+        expect(progressCalls).toContain('Buffering model bytes...')
         // Slice 5b: "Configuring loader..." (the applyWebIfcConfig
         // progress beat from the old wit-three parse path) is gone —
         // Conway-direct parse settings ride on OpenModel directly.
         // The new "Building model..." beat captures the post-parse
         // assembly step (buildConwayIfcModel + decorate).
-        expect(progressCalls).toContain('Parsing model geometry...')
-        expect(progressCalls).toContain('Building model...')
-        expect(progressCalls).toContain('Setting up coordinate system...')
-        expect(progressCalls).toContain('Fitting model to frame...')
-        expect(progressCalls).toContain('Gathering model statistics...')
-        expect(progressCalls).toContain('Model loaded successfully!')
+        expect(progressCalls).toContain('Opening model...')
+        expect(progressCalls).toContain('Assembling render mesh...')
 
         // Verify that progress was called multiple times for IFC-type loading
-        const MIN_PROGRESS_BEATS = 9
+        const MIN_PROGRESS_BEATS = 4
         expect(onProgress.mock.calls.length).toBeGreaterThanOrEqual(MIN_PROGRESS_BEATS)
       } finally {
         restoreArrayBuffer()
@@ -465,15 +455,14 @@ describe('Loader', () => {
         await load(testPathToUrl('obj/Bunny.obj'), mockViewer, onProgress, true, setOpfsFile, '')
 
         const progressCalls = onProgress.mock.calls.map((call) => call[0])
-        expect(progressCalls).toContain('Determining file type...')
         expect(progressCalls).toContain('Preparing file download...')
-        expect(progressCalls).toContain('Reading model data...')
+        expect(progressCalls).toContain('Buffering model bytes...')
         expect(progressCalls).toContain('Decoding model data...')
         expect(progressCalls).toContain('Processing model data...')
         expect(progressCalls).toContain('Applying model fixups...')
         expect(progressCalls).toContain('Converting model format...')
 
-        expect(onProgress).toHaveBeenCalledTimes(7)
+        expect(onProgress).toHaveBeenCalledTimes(6)
       } finally {
         restoreArrayBuffer()
       }
@@ -489,16 +478,15 @@ describe('Loader', () => {
         await load(testPathToUrl('stl/cube.stl'), mockViewer, onProgress, true, setOpfsFile, '')
 
         const progressCalls = onProgress.mock.calls.map((call) => call[0])
-        expect(progressCalls).toContain('Determining file type...')
         expect(progressCalls).toContain('Preparing file download...')
-        expect(progressCalls).toContain('Reading model data...')
+        expect(progressCalls).toContain('Buffering model bytes...')
         // Should NOT contain 'Decoding model data...' for binary files
         expect(progressCalls).not.toContain('Decoding model data...')
         expect(progressCalls).toContain('Processing model data...')
         expect(progressCalls).toContain('Applying model fixups...')
         expect(progressCalls).toContain('Converting model format...')
 
-        expect(onProgress).toHaveBeenCalledTimes(6)
+        expect(onProgress).toHaveBeenCalledTimes(5)
       } finally {
         restoreArrayBuffer()
       }
@@ -526,7 +514,7 @@ describe('Loader', () => {
 
           // Mock the internal loader call
           if (progressCallback) {
-            progressCallback('Parsing model geometry...')
+            progressCallback('Opening model...')
           }
 
           // Simulate Conway calling back with progress
@@ -536,10 +524,10 @@ describe('Loader', () => {
 
           // Mock the rest of the IFC loading process
           if (progressCallback) {
-            progressCallback('Setting up coordinate system...')
+            progressCallback('Assembling render mesh...')
             progressCallback('Fitting model to frame...')
             progressCallback('Gathering model statistics...')
-            progressCallback('Model loaded successfully!')
+            progressCallback('Assembling render mesh...')
           }
 
           return mockModel
@@ -553,12 +541,12 @@ describe('Loader', () => {
 
       // Verify that all expected progress messages were called
       expect(onProgress).toHaveBeenCalledWith('Configuring loader...')
-      expect(onProgress).toHaveBeenCalledWith('Parsing model geometry...')
+      expect(onProgress).toHaveBeenCalledWith('Opening model...')
       expect(onProgress).toHaveBeenCalledWith('Test progress from Conway')
-      expect(onProgress).toHaveBeenCalledWith('Setting up coordinate system...')
+      expect(onProgress).toHaveBeenCalledWith('Assembling render mesh...')
       expect(onProgress).toHaveBeenCalledWith('Fitting model to frame...')
       expect(onProgress).toHaveBeenCalledWith('Gathering model statistics...')
-      expect(onProgress).toHaveBeenCalledWith('Model loaded successfully!')
+      expect(onProgress).toHaveBeenCalledWith('Assembling render mesh...')
 
       // Verify total number of progress calls
       expect(onProgress).toHaveBeenCalledTimes(7)

--- a/src/loader/loadProgress.js
+++ b/src/loader/loadProgress.js
@@ -373,7 +373,11 @@ class LoadProgressReporter {
     if (closedLine !== undefined) {
       this.addReportLine(closedLine)
     }
-    this.addReportLine(this.log.totalLine())
+    // Model stats ride the Total line (products/triangles/units etc. —
+    // set by the loader via setLoadSummary) instead of their own
+    // stage lines.
+    const total = this.log.totalLine()
+    this.addReportLine(this.summary ? `${total} | ${this.summary}` : total)
 
     // Warnings & errors captured from the console during the load, appended
     // after Total (issue #301 preview feedback #4). Restore the console
@@ -520,6 +524,20 @@ export function attachLoadFailureContext() {
     } catch (e) {
       debug().log('loadProgress#attachLoadFailureContext: ', e)
     }
+  }
+}
+
+
+/**
+ * Attach a one-line model summary (products, triangles, units, ...) to the
+ * in-flight load report — appended to the Total line at finish. No-op when
+ * no load is being reported.
+ *
+ * @param {string} text the summary segment
+ */
+export function setLoadSummary(text) {
+  if (activeReporter && !activeReporter.ended) {
+    activeReporter.summary = text
   }
 }
 

--- a/src/viewer/ProgressiveLoadSession.js
+++ b/src/viewer/ProgressiveLoadSession.js
@@ -1,0 +1,424 @@
+import {Box3, Group, MathUtils, Sphere, Vector3} from 'three'
+import {setLoadSummary} from '../loader/loadProgress'
+import debug, {WARN} from '../utils/debug'
+
+
+/** Session lifecycle states (see class doc). */
+export const SessionState = Object.freeze({
+  IDLE: 'idle',
+  PREVIEWING: 'previewing',
+  ASSEMBLING: 'assembling',
+  FINISHED: 'finished',
+  ABORTED: 'aborted',
+})
+
+
+/** Bounding-sphere margin applied when framing the preview. */
+const FRAMING_MARGIN = 1.5
+/** Minimum gap between two follow refits (also the starting cadence). */
+const CAMERA_FOLLOW_MIN_MS = 250
+/** The cadence cap the exponential growth converges to. */
+const CAMERA_FOLLOW_MAX_MS = 1000
+/** Per-refit cadence growth factor. */
+const CAMERA_FOLLOW_GROWTH = 1.5
+const HALF = 0.5
+const FAR_PLANE_SLACK = 4
+/** Box corner count for the sphere-containment test. */
+const BOX_CORNERS = 8
+
+
+/**
+ * Format-neutral progressive-load session — the single owner of the
+ * "what the user sees and reads while a model loads" instrumentation,
+ * shared by every schema the conway loader speaks (IFC and STEP today).
+ * The format loaders convert their stream (parse-time preview payloads,
+ * durable pump batches) into three.js meshes and TRIGGER this session;
+ * the session owns:
+ *
+ *  - the demand-preview group's scene lifecycle (install on first mesh,
+ *    dispose + remove at finish/abort),
+ *  - the camera follow: a STRICT fit of everything shown so far. A
+ *    running union box tracks the preview's true extents, and a refit
+ *    fires when (and only when) new geometry lands OUTSIDE the volume
+ *    the camera currently frames — so existing geometry is never pushed
+ *    offscreen between timer beats. The first fit is instant; follow-up
+ *    fits tween on a cadence that grows 250ms → 1s; the follow stops
+ *    forever the moment the user takes the camera.
+ *  - progress reporting: stage labels pass through to the load
+ *    reporter, and the model summary lands on the report's Total line.
+ *
+ * States: idle → previewing (first mesh) → assembling (final build
+ * running, follow still live) → finished (preview swapped out) or
+ * aborted (load failed; same teardown, error stays with the caller).
+ */
+export default class ProgressiveLoadSession {
+  /**
+   * @param {object} args
+   * @param {object|null} args.scene three.js scene for the preview
+   *   group; null disables the preview/fitting side entirely (reporting
+   *   still works).
+   * @param {Function} [args.getControls] () => camera-controls instance
+   *   (resolved lazily — controls may not exist at construction).
+   * @param {Function} [args.getCamera] () => perspective camera.
+   * @param {Function} [args.onProgress] stage-label reporter.
+   */
+  constructor({scene = null, getControls, getCamera, onProgress}) {
+    this.state = SessionState.IDLE
+    this.scene = scene
+    this.getControls = getControls ?? (() => null)
+    this.getCamera = getCamera ?? (() => null)
+    this.onProgress = onProgress ?? null
+    this.previewGroup = scene !== null ? new Group() : null
+    this.previewInstalled = false
+    // Camera follow state.
+    this.followStopped = false
+    this.followTimer = null
+    this.followedControls = null
+    this.followDelayMs = CAMERA_FOLLOW_MIN_MS
+    this.lastFitMs = 0
+    this.unionBox = new Box3()
+    this.fittedSphere = null
+    this.overflowPending = false
+    this.onControlStart = () => this.stopFollow_()
+  }
+
+
+  /**
+   * Report a load stage label to the progress reporter.
+   *
+   * @param {string} label
+   */
+  report(label) {
+    if (this.onProgress) {
+      this.onProgress(label)
+    }
+  }
+
+
+  /**
+   * Put the model summary onto the report's Total line.
+   *
+   * @param {Array<string>} parts e.g. ['vertices=12', 'units=m']
+   */
+  setSummary(parts) {
+    try {
+      if (parts.length > 0) {
+        setLoadSummary(parts.join(' '))
+      }
+    } catch (e) {
+      debug(WARN).warn('load summary skipped:', e)
+    }
+  }
+
+
+  /**
+   * Add one preview mesh (matrix already stamped by the caller). First
+   * mesh installs the group and frames it instantly; later meshes refit
+   * only when they extend outside the currently framed volume. Never
+   * throws — a preview failure must not break the load.
+   *
+   * @param {object} mesh three.js Mesh
+   */
+  addPreviewMesh(mesh) {
+    if (this.previewGroup === null || this.state === SessionState.FINISHED ||
+        this.state === SessionState.ABORTED) {
+      return
+    }
+    try {
+      this.previewGroup.add(mesh)
+      if (!this.previewInstalled) {
+        this.previewInstalled = true
+        this.scene.add(this.previewGroup)
+      }
+      if (this.state === SessionState.IDLE) {
+        this.state = SessionState.PREVIEWING
+      }
+      this.growUnion_(mesh)
+      if (this.fittedSphere === null) {
+        this.startFollow_()
+      } else {
+        this.maybeRefit_()
+      }
+    } catch (e) {
+      debug(WARN).warn('preview mesh skipped:', e)
+    }
+  }
+
+
+  /**
+   * Stamp the preview group's model-level transform (the deferred-open
+   * coordination contract makes this identity in practice, but the
+   * batch path stamps it for exactness — mirroring the final build).
+   * Rebuilds the union box under the new transform and refits.
+   *
+   * @param {Array<number>} matrixArr 16-element column-major matrix
+   */
+  stampCoordination(matrixArr) {
+    const group = this.previewGroup
+    if (group === null || !group.matrix || typeof group.matrix.fromArray !== 'function') {
+      return
+    }
+    try {
+      group.matrix.fromArray(matrixArr)
+      group.matrixAutoUpdate = false
+      this.rebuildUnion_()
+      this.overflowPending = true
+      this.maybeRefit_()
+    } catch (e) {
+      debug(WARN).warn('preview coordination stamp failed:', e)
+    }
+  }
+
+
+  /** Final model build begins — label only; the follow keeps running. */
+  beginAssembly() {
+    if (this.state === SessionState.PREVIEWING || this.state === SessionState.IDLE) {
+      this.state = SessionState.ASSEMBLING
+    }
+    this.report('Assembling render mesh...')
+  }
+
+
+  /**
+   * The final model is (about to be) installed: stop the camera follow
+   * and swap the preview out, disposing per-mesh geometry/materials so
+   * the preview leaves no residue.
+   */
+  finish() {
+    this.stopFollow_()
+    this.teardownPreview_()
+    this.state = SessionState.FINISHED
+  }
+
+
+  /** The load failed: same teardown as finish, terminal state aborted. */
+  abort() {
+    this.stopFollow_()
+    this.teardownPreview_()
+    this.state = SessionState.ABORTED
+  }
+
+
+  /**
+   * Grow the union box by one mesh's world bounds and flag an overflow
+   * when it escapes the currently framed sphere.
+   *
+   * @param {object} mesh
+   */
+  growUnion_(mesh) {
+    const box = this.meshWorldBox_(mesh)
+    if (box === null) {
+      return
+    }
+    this.unionBox.union(box)
+    if (this.fittedSphere !== null && !this.sphereContainsBox_(this.fittedSphere, box)) {
+      this.overflowPending = true
+    }
+  }
+
+
+  /**
+   * Recompute the union box from scratch (group transform changed).
+   */
+  rebuildUnion_() {
+    this.unionBox.makeEmpty()
+    if (this.previewGroup === null) {
+      return
+    }
+    for (const child of this.previewGroup.children) {
+      const box = this.meshWorldBox_(child)
+      if (box !== null) {
+        this.unionBox.union(box)
+      }
+    }
+  }
+
+
+  /**
+   * A mesh's bounds in scene space (its own matrix composed with the
+   * preview group's stamped transform).
+   *
+   * @param {object} mesh
+   * @return {Box3|null}
+   */
+  meshWorldBox_(mesh) {
+    const geometry = mesh.geometry
+    if (!geometry || typeof geometry.computeBoundingBox !== 'function') {
+      return null
+    }
+    if (geometry.boundingBox === null || geometry.boundingBox === undefined) {
+      geometry.computeBoundingBox()
+    }
+    const bounds = geometry.boundingBox
+    if (!bounds || bounds.isEmpty()) {
+      return null
+    }
+    const box = bounds.clone()
+    if (mesh.matrix) {
+      box.applyMatrix4(mesh.matrix)
+    }
+    if (this.previewGroup !== null && this.previewGroup.matrixAutoUpdate === false) {
+      box.applyMatrix4(this.previewGroup.matrix)
+    }
+    return box
+  }
+
+
+  /**
+   * Does the fitted sphere contain the whole box?
+   *
+   * @param {Sphere} sphere
+   * @param {Box3} box
+   * @return {boolean}
+   */
+  sphereContainsBox_(sphere, box) {
+    const corner = new Vector3()
+    for (let index = 0; index < BOX_CORNERS; ++index) {
+      corner.set(
+        (index & 1) === 0 ? box.min.x : box.max.x,
+        (index & 2) === 0 ? box.min.y : box.max.y,
+        (index & 4) === 0 ? box.min.z : box.max.z)
+      /* eslint-enable no-bitwise */
+      if (!sphere.containsPoint(corner)) {
+        return false
+      }
+    }
+    return true
+  }
+
+
+  /** Start the follow: instant first fit + the timer backstop chain. */
+  startFollow_() {
+    if (this.followStopped || this.followTimer !== null) {
+      return
+    }
+    try {
+      this.followedControls = this.getControls() ?? null
+      this.followedControls?.addEventListener?.('controlstart', this.onControlStart)
+    } catch {
+      this.followedControls = null
+    }
+    try {
+      this.fitUnionToFrame_(false)
+    } catch (e) {
+      debug(WARN).warn('camera follow initial fit failed:', e)
+    }
+    this.followDelayMs = CAMERA_FOLLOW_MIN_MS
+    this.followTimer = setTimeout(() => this.followTick_(), this.followDelayMs)
+  }
+
+
+  /**
+   * Event-driven refit: called from the geometry events themselves (the
+   * load pipeline's scheduler-priority yields starve setTimeout, so the
+   * timer alone fires rarely). Refits only on overflow — a strict fit of
+   * the union is a visual no-op while new geometry stays inside the
+   * framed volume.
+   */
+  maybeRefit_() {
+    if (this.followStopped || !this.overflowPending || this.fittedSphere === null) {
+      return
+    }
+    const now = Date.now()
+    if (now - this.lastFitMs < this.followDelayMs) {
+      return
+    }
+    try {
+      this.fitUnionToFrame_(true)
+    } catch (e) {
+      debug(WARN).warn('camera follow refit failed:', e)
+    }
+  }
+
+
+  /** Timer backstop for overflows that landed inside the refit gap. */
+  followTick_() {
+    this.followTimer = null
+    if (this.followStopped) {
+      return
+    }
+    if (this.overflowPending) {
+      try {
+        this.fitUnionToFrame_(true)
+      } catch (e) {
+        debug(WARN).warn('camera follow refit failed:', e)
+      }
+    }
+    this.followTimer = setTimeout(() => this.followTick_(), this.followDelayMs)
+  }
+
+
+  /**
+   * Strictly frame the union of everything shown so far: fit the
+   * camera to the union box's bounding sphere (with margin), pushing
+   * the far plane out monotonically so successive refits never pop the
+   * projection.
+   *
+   * @param {boolean} withTransition tween the move (false = instant)
+   */
+  fitUnionToFrame_(withTransition) {
+    const controls = this.getControls()
+    const camera = this.getCamera()
+    if (!controls || !camera || this.unionBox.isEmpty()) {
+      return
+    }
+    const sphere = new Sphere()
+    this.unionBox.getBoundingSphere(sphere)
+    if (!(sphere.radius > 0) || !Number.isFinite(sphere.radius)) {
+      return
+    }
+    sphere.radius *= FRAMING_MARGIN
+    const vFov = MathUtils.degToRad(camera.fov)
+    const hFov = Math.atan(Math.tan(vFov * HALF) * camera.aspect) * 2
+    const limitingFov = camera.aspect > 1 ? vFov : hFov
+    const fitDistance = sphere.radius / Math.sin(limitingFov * HALF)
+    const wantFar = (fitDistance + sphere.radius) * FAR_PLANE_SLACK
+    if (camera.far < wantFar) {
+      camera.far = wantFar
+      camera.updateProjectionMatrix()
+    }
+    controls.fitToSphere(sphere, withTransition)
+    this.fittedSphere = sphere
+    this.overflowPending = false
+    this.lastFitMs = Date.now()
+    this.followDelayMs =
+      Math.min(this.followDelayMs * CAMERA_FOLLOW_GROWTH, CAMERA_FOLLOW_MAX_MS)
+  }
+
+
+  /** Stop the camera follow forever (user input, finish, or error). */
+  stopFollow_() {
+    this.followStopped = true
+    if (this.followTimer !== null) {
+      clearTimeout(this.followTimer)
+      this.followTimer = null
+    }
+    try {
+      this.followedControls?.removeEventListener?.('controlstart', this.onControlStart)
+    } catch {
+      // best-effort
+    }
+    this.followedControls = null
+  }
+
+
+  /** Remove the preview group and dispose its meshes' GPU resources. */
+  teardownPreview_() {
+    if (this.previewGroup === null || !this.previewInstalled) {
+      return
+    }
+    try {
+      this.scene.remove(this.previewGroup)
+      for (const child of this.previewGroup.children) {
+        child.geometry?.dispose?.()
+        const materials = Array.isArray(child.material) ? child.material : [child.material]
+        for (const material of materials) {
+          material?.dispose?.()
+        }
+      }
+    } catch (e) {
+      debug(WARN).warn('demand preview teardown failed:', e)
+    }
+    this.previewInstalled = false
+  }
+}

--- a/src/viewer/ProgressiveLoadSession.js
+++ b/src/viewer/ProgressiveLoadSession.js
@@ -22,7 +22,10 @@ const CAMERA_FOLLOW_MAX_MS = 1000
 /** Per-refit cadence growth factor. */
 const CAMERA_FOLLOW_GROWTH = 1.5
 const HALF = 0.5
-const FAR_PLANE_SLACK = 4
+/** Far plane must clear the whole zoom-out range plus the model. */
+const FAR_PLANE_SLACK = 1.5
+/** Zoom-out headroom over the fit distance (mirrors fitModelToFrame). */
+const MAX_DISTANCE_HEADROOM = 10
 /** Box corner count for the sphere-containment test. */
 const BOX_CORNERS = 8
 
@@ -372,7 +375,20 @@ export default class ProgressiveLoadSession {
     const hFov = Math.atan(Math.tan(vFov * HALF) * camera.aspect) * 2
     const limitingFov = camera.aspect > 1 ? vFov : hFov
     const fitDistance = sphere.radius / Math.sin(limitingFov * HALF)
-    const wantFar = (fitDistance + sphere.radius) * FAR_PLANE_SLACK
+    // camera-controls clamps every dolly to [minDistance, maxDistance],
+    // and the activation default is maxDistance = 300 scene units — on
+    // any model whose fit distance exceeds that, fitToSphere silently
+    // parks the camera at the clamp and the model overflows the window.
+    // Scale the zoom-out range with the growing union exactly like the
+    // final fitModelToFrame does (10x headroom), only ever outward —
+    // the union is monotonic, so the range never needs to shrink
+    // mid-follow and the final fit re-derives it anyway.
+    const wantMaxDistance = fitDistance * MAX_DISTANCE_HEADROOM
+    if (typeof controls.maxDistance === 'number' &&
+        controls.maxDistance < wantMaxDistance) {
+      controls.maxDistance = wantMaxDistance
+    }
+    const wantFar = (wantMaxDistance + sphere.radius) * FAR_PLANE_SLACK
     if (camera.far < wantFar) {
       camera.far = wantFar
       camera.updateProjectionMatrix()

--- a/src/viewer/ProgressiveLoadSession.js
+++ b/src/viewer/ProgressiveLoadSession.js
@@ -149,6 +149,38 @@ export default class ProgressiveLoadSession {
 
 
   /**
+   * Track world-space bounds for geometry the caller renders OUTSIDE
+   * the preview group (slice B1: the incremental durable batches).
+   * Same strict-fit semantics as addPreviewMesh — grow the union,
+   * refit on overflow — without the group membership.
+   *
+   * @param {Box3} box world-space bounds of the appended geometry
+   */
+  notifyBounds(box) {
+    if (this.state === SessionState.FINISHED || this.state === SessionState.ABORTED ||
+        !box || box.isEmpty()) {
+      return
+    }
+    try {
+      this.unionBox.union(box)
+      if (this.state === SessionState.IDLE) {
+        this.state = SessionState.PREVIEWING
+      }
+      if (this.fittedSphere !== null && !this.sphereContainsBox_(this.fittedSphere, box)) {
+        this.overflowPending = true
+      }
+      if (this.fittedSphere === null) {
+        this.startFollow_()
+      } else {
+        this.maybeRefit_()
+      }
+    } catch (e) {
+      debug(WARN).warn('bounds notify skipped:', e)
+    }
+  }
+
+
+  /**
    * Stamp the preview group's model-level transform (the deferred-open
    * coordination contract makes this identity in practice, but the
    * batch path stamps it for exactness — mirroring the final build).

--- a/src/viewer/ProgressiveLoadSession.test.js
+++ b/src/viewer/ProgressiveLoadSession.test.js
@@ -10,6 +10,11 @@ function makeControls() {
   return {
     fits: [],
     listeners: {},
+    // The activation defaults (orbit-control.js#activateOrbitControls):
+    // fitToSphere dollies are CLAMPED to maxDistance, so the session
+    // must grow it with the model or big models overflow the window.
+    minDistance: 1,
+    maxDistance: 300,
     fitToSphere(sphere, withTransition) {
       this.fits.push({center: sphere.center.clone(), radius: sphere.radius, withTransition})
     },
@@ -135,6 +140,22 @@ describe('ProgressiveLoadSession', () => {
     bare.addPreviewMesh(cubeAt(0))
     bare.finish()
     expect(bare.state).toBe(SessionState.FINISHED)
+  })
+
+  it('grows the dolly clamp past the activation default for big models', () => {
+    // A model whose fit distance far exceeds maxDistance = 300: without
+    // growing the clamp, camera-controls parks the dolly at 300 and the
+    // model overflows the window (PSB / Arty symptom).
+    session.addPreviewMesh(cubeAt(0, 2000))
+    expect(controls.fits).toHaveLength(1)
+    expect(controls.maxDistance).toBeGreaterThan(controls.fits[0].radius)
+    expect(camera.far).toBeGreaterThan(controls.maxDistance)
+    // Growth is monotonic: a smaller later fit never shrinks the range.
+    const grown = controls.maxDistance
+    session.lastFitMs = Date.now() - 10000
+    session.overflowPending = true
+    session.maybeRefit_()
+    expect(controls.maxDistance).toBe(grown)
   })
 
   it('stampCoordination re-frames the union under the group transform', () => {

--- a/src/viewer/ProgressiveLoadSession.test.js
+++ b/src/viewer/ProgressiveLoadSession.test.js
@@ -1,0 +1,149 @@
+import {BoxGeometry, Matrix4, Mesh, MeshBasicMaterial, Scene} from 'three'
+import ProgressiveLoadSession, {SessionState} from './ProgressiveLoadSession'
+
+
+/* eslint-disable no-magic-numbers */
+
+
+/** @return {object} A camera-controls stand-in recording fit calls. */
+function makeControls() {
+  return {
+    fits: [],
+    listeners: {},
+    fitToSphere(sphere, withTransition) {
+      this.fits.push({center: sphere.center.clone(), radius: sphere.radius, withTransition})
+    },
+    addEventListener(name, fn) {
+      this.listeners[name] = fn
+    },
+    removeEventListener(name) {
+      delete this.listeners[name]
+    },
+  }
+}
+
+
+/** @return {object} A perspective-camera stand-in. */
+function makeCamera() {
+  return {
+    fov: 45,
+    aspect: 1.5,
+    far: 100,
+    updateProjectionMatrix() {/* no-op */},
+  }
+}
+
+
+/**
+ * @param {number} x mesh center x
+ * @param {number} [size] cube edge length
+ * @return {Mesh} A unit-ish cube mesh at (x, 0, 0).
+ */
+function cubeAt(x, size = 1) {
+  const mesh = new Mesh(new BoxGeometry(size, size, size), new MeshBasicMaterial())
+  mesh.matrixAutoUpdate = false
+  mesh.matrix = new Matrix4().makeTranslation(x, 0, 0)
+  return mesh
+}
+
+
+describe('ProgressiveLoadSession', () => {
+  let scene
+  let controls
+  let camera
+  let session
+
+  beforeEach(() => {
+    scene = new Scene()
+    controls = makeControls()
+    camera = makeCamera()
+    session = new ProgressiveLoadSession({
+      scene,
+      getControls: () => controls,
+      getCamera: () => camera,
+      onProgress: jest.fn(),
+    })
+  })
+
+  afterEach(() => {
+    session.finish()
+  })
+
+  it('walks idle → previewing → assembling → finished', () => {
+    expect(session.state).toBe(SessionState.IDLE)
+    session.addPreviewMesh(cubeAt(0))
+    expect(session.state).toBe(SessionState.PREVIEWING)
+    session.beginAssembly()
+    expect(session.state).toBe(SessionState.ASSEMBLING)
+    expect(session.onProgress).toHaveBeenCalledWith('Assembling render mesh...')
+    session.finish()
+    expect(session.state).toBe(SessionState.FINISHED)
+    expect(scene.children).toHaveLength(0)
+  })
+
+  it('installs the preview group on first mesh and fits instantly', () => {
+    session.addPreviewMesh(cubeAt(0))
+    expect(scene.children).toContain(session.previewGroup)
+    expect(controls.fits).toHaveLength(1)
+    expect(controls.fits[0].withTransition).toBe(false)
+  })
+
+  it('strictly frames the union: an escaping mesh triggers a tweened refit', () => {
+    session.addPreviewMesh(cubeAt(0))
+    expect(controls.fits).toHaveLength(1)
+    // Make the refit gate pass immediately.
+    session.lastFitMs = Date.now() - 10000
+    // Far outside the first fitted sphere.
+    session.addPreviewMesh(cubeAt(100))
+    expect(controls.fits).toHaveLength(2)
+    expect(controls.fits[1].withTransition).toBe(true)
+    // The refit's sphere covers BOTH meshes — center between them,
+    // radius spanning the whole union.
+    const fit = controls.fits[1]
+    expect(fit.center.x).toBeCloseTo(50, 0)
+    expect(fit.radius).toBeGreaterThan(50)
+  })
+
+  it('does not refit while new geometry stays inside the framed volume', () => {
+    session.addPreviewMesh(cubeAt(0))
+    session.lastFitMs = Date.now() - 10000
+    // Well inside the margined sphere of the first fit.
+    session.addPreviewMesh(cubeAt(0.1))
+    expect(controls.fits).toHaveLength(1)
+  })
+
+  it('stops following forever when the user takes the camera', () => {
+    session.addPreviewMesh(cubeAt(0))
+    controls.listeners['controlstart']()
+    session.lastFitMs = Date.now() - 10000
+    session.addPreviewMesh(cubeAt(100))
+    expect(controls.fits).toHaveLength(1)
+  })
+
+  it('abort tears the preview down and lands in aborted', () => {
+    session.addPreviewMesh(cubeAt(0))
+    session.abort()
+    expect(session.state).toBe(SessionState.ABORTED)
+    expect(scene.children).toHaveLength(0)
+  })
+
+  it('a scene-less session reports but never previews', () => {
+    const bare = new ProgressiveLoadSession({onProgress: jest.fn()})
+    bare.report('Opening model...')
+    expect(bare.onProgress).toHaveBeenCalledWith('Opening model...')
+    expect(bare.previewGroup).toBeNull()
+    bare.addPreviewMesh(cubeAt(0))
+    bare.finish()
+    expect(bare.state).toBe(SessionState.FINISHED)
+  })
+
+  it('stampCoordination re-frames the union under the group transform', () => {
+    session.addPreviewMesh(cubeAt(0))
+    session.lastFitMs = Date.now() - 10000
+    const shift = new Matrix4().makeTranslation(500, 0, 0)
+    session.stampCoordination(shift.toArray())
+    expect(controls.fits.length).toBeGreaterThanOrEqual(2)
+    const fit = controls.fits[controls.fits.length - 1]
+    expect(fit.center.x).toBeCloseTo(500, 0)
+  })
+})

--- a/src/viewer/ShareViewer.js
+++ b/src/viewer/ShareViewer.js
@@ -38,6 +38,7 @@ import {occurrencePathKey} from '../utils/occurrencePaths'
 import {modelHasCapability} from './ShareModel'
 import {isFeatureEnabled} from '../FeatureFlags'
 import {
+  applyBatchedInstanceSelection,
   applyBatchedPreselection,
   applyBatchedSelection,
   clearBatchedPreselection,
@@ -944,7 +945,9 @@ export class ShareViewer {
         // (setColorAt) rather than overlay a coplanar subset Mesh — see
         // batchedHighlight.js for why the overlay approach can't render
         // reliably on a BatchedMesh. Selection covers every occurrence of
-        // each requested product (per-occurrence narrowing is a follow-up).
+        // each requested product; a follow-on `setInstanceSelection` call
+        // (the click handler / NavTree occurrence funnel) narrows the
+        // recolor to one occurrence via `applyBatchedInstanceSelection`.
         const selMat = this.selector.getSelectionMaterial()
         applyBatchedSelection(model, toBeSelected, selMat?.color)
       } else if (modelHasCapability(model, 'ifcSubsets')) {
@@ -1011,6 +1014,21 @@ export class ShareViewer {
    */
   setInstanceSelection(modelID, instanceIds) {
     const model = this._modelById(modelID)
+    if (modelHasCapability(model, 'batchedPicking')) {
+      // BatchedMesh render path: narrow the selection recolor to just the
+      // named occurrences (global `instanceOccurrenceIds`). Replaces the
+      // parent-level recolor `setSelection` painted, restoring the other
+      // instances of the product to their original colours — the recolor
+      // counterpart of the merged path's one-instance subset.
+      if (!Array.isArray(instanceIds) || instanceIds.length === 0) {
+        // Same "no per-instance highlight" contract as below: leave the
+        // parent-level selection recolor alone.
+        return
+      }
+      const selMat = this.selector.getSelectionMaterial()
+      applyBatchedInstanceSelection(model, instanceIds, selMat?.color)
+      return
+    }
     if (!modelHasCapability(model, 'instancePicking')) {
       debug().warn('setInstanceSelection: model lacks instancePicking capability')
       return
@@ -1086,6 +1104,38 @@ export class ShareViewer {
     const collect = (matchDescendants) => {
       const ids = []
       model.traverse((obj) => {
+        // BatchedMesh render path: the reverse index maps path keys to
+        // batchIds (stamped by `assembleBatchedModel`); resolve each to its
+        // global occurrence id — the "instance id" the batched pick tables
+        // and `setInstanceSelection` speak. The geometry filter goes through
+        // the per-batch `instanceGeometryIds` table.
+        if (obj.isBatchedMesh && obj.occurrencePathToBatchIds) {
+          const byBatchPath = obj.occurrencePathToBatchIds
+          const occurrenceIds = obj.instanceOccurrenceIds
+          const geometryIds = obj.instanceGeometryIds
+          const pushBatchIds = (list) => {
+            for (let i = 0; i < list.length; i++) {
+              const batchId = list[i]
+              if (geometryExpressId === null ||
+                  (geometryIds && geometryIds[batchId] === geometryExpressId)) {
+                ids.push(occurrenceIds[batchId])
+              }
+            }
+          }
+          if (!matchDescendants) {
+            const exact = byBatchPath.get(target)
+            if (exact) {
+              pushBatchIds(exact)
+            }
+            return
+          }
+          for (const [key, list] of byBatchPath) {
+            if (key === target || key.startsWith(descendantPrefix)) {
+              pushBatchIds(list)
+            }
+          }
+          return
+        }
         const byPath = obj.isMesh ? obj.instanceMap?.occurrencePathToInstanceIds : null
         if (!byPath) {
           return
@@ -1161,6 +1211,28 @@ export class ShareViewer {
     const seen = new Set()
     const ids = []
     model.traverse((obj) => {
+      // BatchedMesh render path: geometry (solid) ids live in the per-batch
+      // `instanceGeometryIds` table, keyed through the same reverse
+      // path→batchIds index the instance resolver uses.
+      if (obj.isBatchedMesh && obj.occurrencePathToBatchIds) {
+        const geometryIds = obj.instanceGeometryIds
+        if (!geometryIds) {
+          return
+        }
+        for (const [key, list] of obj.occurrencePathToBatchIds) {
+          if (key !== target && !key.startsWith(descendantPrefix)) {
+            continue
+          }
+          for (let i = 0; i < list.length; i++) {
+            const geometryExpressId = geometryIds[list[i]]
+            if (geometryExpressId !== undefined && !seen.has(geometryExpressId)) {
+              seen.add(geometryExpressId)
+              ids.push(geometryExpressId)
+            }
+          }
+        }
+        return
+      }
       const byPath = obj.isMesh ? obj.instanceMap?.occurrencePathToInstanceIds : null
       if (!byPath || typeof obj.instanceMap.getGeometryExpressIdByInstance !== 'function') {
         return

--- a/src/viewer/ifc/ShareIfcLoader.js
+++ b/src/viewer/ifc/ShareIfcLoader.js
@@ -23,6 +23,7 @@ import {buildConwayIfcModel} from './buildConwayIfcModel'
 import {decorateConwayDirectIfcModel, parseIfcWithConway} from './conwayDirectIfcLoader'
 import {flatMeshToBufferGeometry} from './flatMeshToBufferGeometry'
 import {flatMeshToInstancedModel} from './flatMeshToInstancedModel'
+import {payloadToPreviewMesh} from './parsePreviewMesh'
 import {isOutOfMemoryError} from '../../utils/oom'
 import {isFeatureEnabled} from '../../FeatureFlags'
 import {runIfcItemsMapParityCheck} from './ifcItemsMapParity'
@@ -172,6 +173,39 @@ export default class ShareIfcLoader {
       const demandPreview = scene !== null && isFeatureEnabled('demandGeometry') ?
         new Group() : null
       let previewInstalled = false
+
+      // Slice A2 (parse-time preview channel): conway emits
+      // self-contained preview payloads WHILE THE PARSE RUNS — preview
+      // quality (openings/materials can be missing), replaced wholesale
+      // by the durable batches below. Same group, same frame (payload
+      // transforms carry the pinned coordination), best-effort like
+      // every other preview step.
+      const previewGeometryCache = new Map()
+      const previewMaterialCache = new Map()
+      let parsePreviewCount = 0
+      const PARSE_PREVIEW_REFIT_EVERY = 256
+      const onPreviewMesh = demandPreview === null ? undefined : (payload) => {
+        try {
+          const mesh = payloadToPreviewMesh(payload, previewGeometryCache, previewMaterialCache)
+          if (mesh === null) {
+            return
+          }
+          demandPreview.add(mesh)
+          if (!previewInstalled) {
+            previewInstalled = true
+            scene.add(demandPreview)
+          }
+          // Frame the very first geometry immediately, then refit
+          // occasionally as the preview grows (the first durable batch
+          // refits again).
+          if (++parsePreviewCount === 1 || parsePreviewCount % PARSE_PREVIEW_REFIT_EVERY === 0) {
+            ifc.context.fitToFrame()
+          }
+        } catch (e) {
+          debug(WARN).warn('parse preview mesh skipped:', e)
+        }
+      }
+
       const onMeshBatch = demandPreview === null ? undefined : (batch, batchModelID) => {
         try {
           const assembled = flatMeshToBufferGeometry(batch, ifcAPI, batchModelID)
@@ -201,7 +235,7 @@ export default class ShareIfcLoader {
       }
 
       const {modelID, captured} =
-        await parseIfcWithConway(buffer, ifcAPI, undefined, onProgress, onMeshBatch)
+        await parseIfcWithConway(buffer, ifcAPI, undefined, onProgress, onMeshBatch, onPreviewMesh)
 
       if (onProgress) {
         onProgress('Building model...')

--- a/src/viewer/ifc/ShareIfcLoader.js
+++ b/src/viewer/ifc/ShareIfcLoader.js
@@ -17,9 +17,11 @@
 // those were fields on the fork's IFCManager because parse was
 // attached to it. Now we own the loader so we hold direct refs.
 
+import {Group, Mesh} from 'three'
 import {buildBatchedConwayModel} from './buildBatchedConwayModel'
 import {buildConwayIfcModel} from './buildConwayIfcModel'
 import {decorateConwayDirectIfcModel, parseIfcWithConway} from './conwayDirectIfcLoader'
+import {flatMeshToBufferGeometry} from './flatMeshToBufferGeometry'
 import {flatMeshToInstancedModel} from './flatMeshToInstancedModel'
 import {isOutOfMemoryError} from '../../utils/oom'
 import {isFeatureEnabled} from '../../FeatureFlags'
@@ -157,13 +159,53 @@ export default class ShareIfcLoader {
       // model...' carries real per-phase counts (headerParse / dataParse /
       // geometry — conway #301). Engines without the extension just keep
       // the coarse strings.
-      const {modelID, captured} = await parseIfcWithConway(buffer, ifcAPI, undefined, onProgress)
+      const scene = typeof ifc.context?.getScene === 'function' ?
+        ifc.context.getScene() : null
+
+      // Demand/tiled rendering slice A (#1613): while the batch pump
+      // runs, stream each batch into a render-only preview group so
+      // first pixels arrive right after the parse. The final model is
+      // then built exactly as before (full picking/decoration) and the
+      // preview is swapped out — identical end state, progressive
+      // arrival. Every preview step is best-effort: a preview failure
+      // must never break the load (mirrors the batchedMesh guard).
+      const demandPreview = scene !== null && isFeatureEnabled('demandGeometry') ?
+        new Group() : null
+      let previewInstalled = false
+      const onMeshBatch = demandPreview === null ? undefined : (batch, batchModelID) => {
+        try {
+          const assembled = flatMeshToBufferGeometry(batch, ifcAPI, batchModelID)
+          demandPreview.add(new Mesh(assembled.geometry, assembled.materials))
+          if (!previewInstalled) {
+            previewInstalled = true
+            scene.add(demandPreview)
+            // Placed transforms are already coordinated; stamp the
+            // model-level coordination like the final build does, then
+            // frame the first batch so the user sees geometry
+            // immediately. Async + best-effort by design.
+            // eslint-disable-next-line new-cap
+            Promise.resolve(ifcAPI.GetCoordinationMatrix(batchModelID))
+              .then((matrixArr) => {
+                if (demandPreview.matrix &&
+                    typeof demandPreview.matrix.fromArray === 'function') {
+                  demandPreview.matrix.fromArray(matrixArr)
+                  demandPreview.matrixAutoUpdate = false
+                }
+                ifc.context.fitToFrame()
+              })
+              .catch((e) => debug(WARN).warn('demand preview coordination failed:', e))
+          }
+        } catch (e) {
+          debug(WARN).warn('demand preview batch skipped:', e)
+        }
+      }
+
+      const {modelID, captured} =
+        await parseIfcWithConway(buffer, ifcAPI, undefined, onProgress, onMeshBatch)
 
       if (onProgress) {
         onProgress('Building model...')
       }
-      const scene = typeof ifc.context?.getScene === 'function' ?
-        ifc.context.getScene() : null
 
       // BatchedMesh render path (`?feature=batchedMesh`, §3b.iv): render the
       // deduped geometry as a THREE.BatchedMesh. Falls back to the merged
@@ -184,6 +226,23 @@ export default class ShareIfcLoader {
         ifcModel = merged.mesh
         buildStats = merged.stats
         decorateConwayDirectIfcModel(ifcModel, ifcAPI, modelID, {scene})
+      }
+
+      // Swap the preview out before the real model installs — dispose
+      // per-batch geometry/materials so the preview leaves no residue.
+      if (demandPreview !== null && previewInstalled) {
+        try {
+          scene.remove(demandPreview)
+          for (const child of demandPreview.children) {
+            child.geometry?.dispose?.()
+            const materials = Array.isArray(child.material) ? child.material : [child.material]
+            for (const material of materials) {
+              material?.dispose?.()
+            }
+          }
+        } catch (e) {
+          debug(WARN).warn('demand preview teardown failed:', e)
+        }
       }
 
       ifc.addIfcModel(ifcModel)

--- a/src/viewer/ifc/ShareIfcLoader.js
+++ b/src/viewer/ifc/ShareIfcLoader.js
@@ -17,7 +17,7 @@
 // those were fields on the fork's IFCManager because parse was
 // attached to it. Now we own the loader so we hold direct refs.
 
-import {Group, Mesh} from 'three'
+import {Box3, Group, MathUtils, Mesh, Sphere} from 'three'
 import {buildBatchedConwayModel} from './buildBatchedConwayModel'
 import {buildConwayIfcModel} from './buildConwayIfcModel'
 import {decorateConwayDirectIfcModel, parseIfcWithConway} from './conwayDirectIfcLoader'
@@ -150,23 +150,32 @@ export default class ShareIfcLoader {
     if (ifc.context.items.ifcModels.length !== 0) {
       throw new Error('Model cannot be loaded.  A model is already present')
     }
-    // Camera follow: fitToFrame already tweens (camera-controls
-    // fitToSphere with a transition), but a payload-count refit
-    // cadence let growing geometry drift offscreen between refits on
-    // sparse-payload stretches (PSB). Follow time-based instead —
-    // once per second while new geometry arrived — and stop forever
-    // the moment the user takes the camera (never fight input) or
-    // the load finishes.
-    const CAMERA_FOLLOW_MS = 1000
+    // Camera follow for the demand preview. Does NOT go through
+    // ifc.context.fitToFrame(): that frames scene.children[last]
+    // (#1561), which is only accidentally the preview group — when it
+    // isn't, every "fit" targets something else (geometry grows
+    // offscreen and the camera never visibly moves). The follower
+    // frames the preview group EXPLICITLY with camera-controls
+    // fitToSphere: the first fit is instant (get eyes on the first
+    // geometry immediately), later fits tween, and the cadence grows
+    // exponentially from 250ms to 1s so the early burst tracks tightly
+    // without churning all load long. Stops forever the moment the
+    // user takes the camera (never fight input) or the load finishes.
+    const CAMERA_FOLLOW_MIN_MS = 250
+    const CAMERA_FOLLOW_MAX_MS = 1000
+    const CAMERA_FOLLOW_GROWTH = 1.5
+    const FRAMING_MARGIN = 1.5
+    let cameraFollowTarget = null
     let previewGeometryDirty = false
     let cameraFollowStopped = false
-    let cameraFollowInterval = null
+    let cameraFollowTimer = null
+    let cameraFollowDelayMs = CAMERA_FOLLOW_MIN_MS
     let followedControls = null
     const stopCameraFollow = () => {
       cameraFollowStopped = true
-      if (cameraFollowInterval !== null) {
-        clearInterval(cameraFollowInterval)
-        cameraFollowInterval = null
+      if (cameraFollowTimer !== null) {
+        clearTimeout(cameraFollowTimer)
+        cameraFollowTimer = null
       }
       try {
         followedControls?.removeEventListener?.('controlstart', stopCameraFollow)
@@ -175,27 +184,74 @@ export default class ShareIfcLoader {
       }
       followedControls = null
     }
-    const startCameraFollow = () => {
-      if (cameraFollowStopped || cameraFollowInterval !== null) {
+    const fitPreviewToFrame = (withTransition) => {
+      const controls = ifc.context?.ifcCamera?.cameraControls
+      const camera = ifc.context?.ifcCamera?.perspectiveCamera
+      if (!controls || !camera || cameraFollowTarget === null) {
         return
       }
+      const box = new Box3().setFromObject(cameraFollowTarget)
+      if (box.isEmpty()) {
+        return
+      }
+      const sphere = new Sphere()
+      box.getBoundingSphere(sphere)
+      if (!(sphere.radius > 0) || !Number.isFinite(sphere.radius)) {
+        return
+      }
+      sphere.radius *= FRAMING_MARGIN
+      // Keep the whole zoom range inside the frustum as the model
+      // grows, but only push the planes OUT (monotonic) so successive
+      // refits never pop the projection.
+      const HALF = 0.5
+      const vFov = MathUtils.degToRad(camera.fov)
+      const hFov = Math.atan(Math.tan(vFov * HALF) * camera.aspect) * 2
+      const limitingFov = camera.aspect > 1 ? vFov : hFov
+      const fitDistance = sphere.radius / Math.sin(limitingFov * HALF)
+      const wantFar = (fitDistance + sphere.radius) * 4
+      if (camera.far < wantFar) {
+        camera.far = wantFar
+        camera.updateProjectionMatrix()
+      }
+      controls.fitToSphere(sphere, withTransition)
+    }
+    const followTick = () => {
+      cameraFollowTimer = null
+      if (cameraFollowStopped) {
+        return
+      }
+      if (previewGeometryDirty) {
+        previewGeometryDirty = false
+        try {
+          fitPreviewToFrame(true)
+        } catch (e) {
+          debug(WARN).warn('camera follow refit failed:', e)
+        }
+      }
+      cameraFollowDelayMs =
+        Math.min(cameraFollowDelayMs * CAMERA_FOLLOW_GROWTH, CAMERA_FOLLOW_MAX_MS)
+      cameraFollowTimer = setTimeout(followTick, cameraFollowDelayMs)
+    }
+    const startCameraFollow = (target) => {
+      if (cameraFollowStopped || cameraFollowTimer !== null) {
+        return
+      }
+      cameraFollowTarget = target
       try {
         followedControls = ifc.context?.ifcCamera?.cameraControls ?? null
         followedControls?.addEventListener?.('controlstart', stopCameraFollow)
       } catch {
         followedControls = null
       }
-      cameraFollowInterval = setInterval(() => {
-        if (!previewGeometryDirty) {
-          return
-        }
-        previewGeometryDirty = false
-        try {
-          ifc.context.fitToFrame()
-        } catch (e) {
-          debug(WARN).warn('camera follow refit failed:', e)
-        }
-      }, CAMERA_FOLLOW_MS)
+      // Immediate first frame (no tween — get eyes on it), then the
+      // exponentially growing tweened follow-ups.
+      try {
+        fitPreviewToFrame(false)
+      } catch (e) {
+        debug(WARN).warn('camera follow initial fit failed:', e)
+      }
+      cameraFollowDelayMs = CAMERA_FOLLOW_MIN_MS
+      cameraFollowTimer = setTimeout(followTick, cameraFollowDelayMs)
     }
 
     try {
@@ -244,11 +300,11 @@ export default class ShareIfcLoader {
             previewInstalled = true
             scene.add(demandPreview)
           }
-          // Frame the very first geometry immediately, then let the
-          // follower keep it in frame as the preview grows.
+          // Frame the very first geometry immediately (inside
+          // startCameraFollow), then let the follower keep it framed
+          // as the preview grows.
           if (++parsePreviewCount === 1) {
-            ifc.context.fitToFrame()
-            startCameraFollow()
+            startCameraFollow(demandPreview)
           }
         } catch (e) {
           debug(WARN).warn('parse preview mesh skipped:', e)
@@ -275,8 +331,7 @@ export default class ShareIfcLoader {
                   demandPreview.matrix.fromArray(matrixArr)
                   demandPreview.matrixAutoUpdate = false
                 }
-                ifc.context.fitToFrame()
-                startCameraFollow()
+                startCameraFollow(demandPreview)
               })
               .catch((e) => debug(WARN).warn('demand preview coordination failed:', e))
           }

--- a/src/viewer/ifc/ShareIfcLoader.js
+++ b/src/viewer/ifc/ShareIfcLoader.js
@@ -17,7 +17,7 @@
 // those were fields on the fork's IFCManager because parse was
 // attached to it. Now we own the loader so we hold direct refs.
 
-import {Box3, Group, MathUtils, Mesh, Sphere} from 'three'
+import {Mesh} from 'three'
 import {buildBatchedConwayModel} from './buildBatchedConwayModel'
 import {buildConwayIfcModel} from './buildConwayIfcModel'
 import {decorateConwayDirectIfcModel, parseIfcWithConway} from './conwayDirectIfcLoader'
@@ -27,9 +27,9 @@ import {payloadToPreviewMesh} from './parsePreviewMesh'
 import {isOutOfMemoryError} from '../../utils/oom'
 import {isFeatureEnabled} from '../../FeatureFlags'
 import {runIfcItemsMapParityCheck} from './ifcItemsMapParity'
+import ProgressiveLoadSession from '../ProgressiveLoadSession'
 import ShareIfcManager from './ShareIfcManager'
 import debug, {DEBUG, WARN, isLogEnabled} from '../../utils/debug'
-import {setLoadSummary} from '../../loader/loadProgress'
 
 
 /**
@@ -151,214 +151,64 @@ export default class ShareIfcLoader {
     if (ifc.context.items.ifcModels.length !== 0) {
       throw new Error('Model cannot be loaded.  A model is already present')
     }
-    // Camera follow for the demand preview. Does NOT go through
-    // ifc.context.fitToFrame(): that frames scene.children[last]
-    // (#1561), which is only accidentally the preview group — when it
-    // isn't, every "fit" targets something else (geometry grows
-    // offscreen and the camera never visibly moves). The follower
-    // frames the preview group EXPLICITLY with camera-controls
-    // fitToSphere: the first fit is instant (get eyes on the first
-    // geometry immediately), later fits tween, and the cadence grows
-    // exponentially from 250ms to 1s so the early burst tracks tightly
-    // without churning all load long. Stops forever the moment the
-    // user takes the camera (never fight input) or the load finishes.
-    const CAMERA_FOLLOW_MIN_MS = 250
-    const CAMERA_FOLLOW_MAX_MS = 1000
-    const CAMERA_FOLLOW_GROWTH = 1.5
-    const FRAMING_MARGIN = 1.5
-    let cameraFollowTarget = null
-    let previewGeometryDirty = false
-    let cameraFollowStopped = false
-    let cameraFollowTimer = null
-    let cameraFollowDelayMs = CAMERA_FOLLOW_MIN_MS
-    let followedControls = null
-    const stopCameraFollow = () => {
-      cameraFollowStopped = true
-      if (cameraFollowTimer !== null) {
-        clearTimeout(cameraFollowTimer)
-        cameraFollowTimer = null
-      }
-      try {
-        followedControls?.removeEventListener?.('controlstart', stopCameraFollow)
-      } catch {
-        // best-effort
-      }
-      followedControls = null
-    }
-    const fitPreviewToFrame = (withTransition) => {
-      const controls = ifc.context?.ifcCamera?.cameraControls
-      const camera = ifc.context?.ifcCamera?.perspectiveCamera
-      if (!controls || !camera || cameraFollowTarget === null) {
-        return
-      }
-      const box = new Box3().setFromObject(cameraFollowTarget)
-      if (box.isEmpty()) {
-        return
-      }
-      const sphere = new Sphere()
-      box.getBoundingSphere(sphere)
-      if (!(sphere.radius > 0) || !Number.isFinite(sphere.radius)) {
-        return
-      }
-      sphere.radius *= FRAMING_MARGIN
-      // Keep the whole zoom range inside the frustum as the model
-      // grows, but only push the planes OUT (monotonic) so successive
-      // refits never pop the projection.
-      const HALF = 0.5
-      const vFov = MathUtils.degToRad(camera.fov)
-      const hFov = Math.atan(Math.tan(vFov * HALF) * camera.aspect) * 2
-      const limitingFov = camera.aspect > 1 ? vFov : hFov
-      const fitDistance = sphere.radius / Math.sin(limitingFov * HALF)
-      const wantFar = (fitDistance + sphere.radius) * 4
-      if (camera.far < wantFar) {
-        camera.far = wantFar
-        camera.updateProjectionMatrix()
-      }
-      controls.fitToSphere(sphere, withTransition)
-    }
-    let lastFollowFitMs = 0
-    const maybeFollowRefit = () => {
-      if (cameraFollowStopped || !previewGeometryDirty) {
-        return
-      }
-      const now = Date.now()
-      if (now - lastFollowFitMs < cameraFollowDelayMs) {
-        return
-      }
-      lastFollowFitMs = now
-      cameraFollowDelayMs =
-        Math.min(cameraFollowDelayMs * CAMERA_FOLLOW_GROWTH, CAMERA_FOLLOW_MAX_MS)
-      previewGeometryDirty = false
-      try {
-        fitPreviewToFrame(true)
-      } catch (e) {
-        debug(WARN).warn('camera follow refit failed:', e)
-      }
-    }
-    const followTick = () => {
-      cameraFollowTimer = null
-      if (cameraFollowStopped) {
-        return
-      }
-      if (previewGeometryDirty) {
-        previewGeometryDirty = false
-        try {
-          fitPreviewToFrame(true)
-        } catch (e) {
-          debug(WARN).warn('camera follow refit failed:', e)
-        }
-      }
-      cameraFollowDelayMs =
-        Math.min(cameraFollowDelayMs * CAMERA_FOLLOW_GROWTH, CAMERA_FOLLOW_MAX_MS)
-      cameraFollowTimer = setTimeout(followTick, cameraFollowDelayMs)
-    }
-    const startCameraFollow = (target) => {
-      if (cameraFollowStopped || cameraFollowTimer !== null) {
-        return
-      }
-      cameraFollowTarget = target
-      try {
-        followedControls = ifc.context?.ifcCamera?.cameraControls ?? null
-        followedControls?.addEventListener?.('controlstart', stopCameraFollow)
-      } catch {
-        followedControls = null
-      }
-      // Immediate first frame (no tween — get eyes on it), then the
-      // exponentially growing tweened follow-ups.
-      try {
-        fitPreviewToFrame(false)
-      } catch (e) {
-        debug(WARN).warn('camera follow initial fit failed:', e)
-      }
-      cameraFollowDelayMs = CAMERA_FOLLOW_MIN_MS
-      cameraFollowTimer = setTimeout(followTick, cameraFollowDelayMs)
-    }
+    // The progressive-load session owns the format-neutral load
+    // instrumentation — demand-preview lifecycle, strict-fit camera
+    // follow, and progress/summary reporting. IFC and STEP both route
+    // through this parse, so both trigger the same session; format
+    // knowledge stays below (payload/batch → mesh conversion).
+    const scene = typeof ifc.context?.getScene === 'function' ?
+      ifc.context.getScene() : null
+    const session = new ProgressiveLoadSession({
+      scene: scene !== null && isFeatureEnabled('demandGeometry') ? scene : null,
+      getControls: () => ifc.context?.ifcCamera?.cameraControls,
+      getCamera: () => ifc.context?.ifcCamera?.perspectiveCamera,
+      onProgress,
+    })
 
     try {
-      if (onProgress) {
-        onProgress('Opening model...')
-      }
+      session.report('Opening model...')
       const ifcAPI = this.ifcManager.ifcAPI
       // onProgress is threaded into conway's ON_PROGRESS extension so the
       // opaque gap between 'Parsing model geometry...' and 'Building
       // model...' carries real per-phase counts (headerParse / dataParse /
       // geometry — conway #301). Engines without the extension just keep
       // the coarse strings.
-      const scene = typeof ifc.context?.getScene === 'function' ?
-        ifc.context.getScene() : null
-
-      // Demand/tiled rendering slice A (#1613): while the batch pump
-      // runs, stream each batch into a render-only preview group so
-      // first pixels arrive right after the parse. The final model is
-      // then built exactly as before (full picking/decoration) and the
-      // preview is swapped out — identical end state, progressive
-      // arrival. Every preview step is best-effort: a preview failure
-      // must never break the load (mirrors the batchedMesh guard).
-      const demandPreview = scene !== null && isFeatureEnabled('demandGeometry') ?
-        new Group() : null
-      let previewInstalled = false
-
-      // Slice A2 (parse-time preview channel): conway emits
-      // self-contained preview payloads WHILE THE PARSE RUNS — preview
-      // quality (openings/materials can be missing), replaced wholesale
-      // by the durable batches below. Same group, same frame (payload
-      // transforms carry the pinned coordination), best-effort like
-      // every other preview step.
+      //
+      // Demand/tiled rendering (#1613): the parse-time preview payloads
+      // (slice A2) and the durable pump batches (slice A) both stream
+      // into the session's preview group — format-specific here is only
+      // the conversion to meshes; lifecycle, fitting, and reporting are
+      // the session's. Every preview step is best-effort: a preview
+      // failure must never break the load.
+      const usePreview = session.previewGroup !== null
       const previewGeometryCache = new Map()
       const previewMaterialCache = new Map()
-      let parsePreviewCount = 0
 
-      const onPreviewMesh = demandPreview === null ? undefined : (payload) => {
+      const onPreviewMesh = !usePreview ? undefined : (payload) => {
         try {
           const mesh = payloadToPreviewMesh(payload, previewGeometryCache, previewMaterialCache)
-          if (mesh === null) {
-            return
-          }
-          demandPreview.add(mesh)
-          previewGeometryDirty = true
-          if (!previewInstalled) {
-            previewInstalled = true
-            scene.add(demandPreview)
-          }
-          // Frame the very first geometry immediately (inside
-          // startCameraFollow), then let the follower keep it framed
-          // as the preview grows. Refits ride the geometry events
-          // themselves: the load pipeline's scheduler-priority yields
-          // starve setTimeout in browsers, so the timer alone fired
-          // rarely (one refit at the very end).
-          if (++parsePreviewCount === 1) {
-            startCameraFollow(demandPreview)
-          } else {
-            maybeFollowRefit()
+          if (mesh !== null) {
+            session.addPreviewMesh(mesh)
           }
         } catch (e) {
           debug(WARN).warn('parse preview mesh skipped:', e)
         }
       }
 
-      const onMeshBatch = demandPreview === null ? undefined : (batch, batchModelID) => {
+      let firstBatch = true
+      const onMeshBatch = !usePreview ? undefined : (batch, batchModelID) => {
         try {
           const assembled = flatMeshToBufferGeometry(batch, ifcAPI, batchModelID)
-          demandPreview.add(new Mesh(assembled.geometry, assembled.materials))
-          previewGeometryDirty = true
-          maybeFollowRefit()
-          if (!previewInstalled) {
-            previewInstalled = true
-            scene.add(demandPreview)
+          session.addPreviewMesh(new Mesh(assembled.geometry, assembled.materials))
+          if (firstBatch) {
+            firstBatch = false
             // Placed transforms are already coordinated; stamp the
-            // model-level coordination like the final build does, then
-            // frame the first batch so the user sees geometry
-            // immediately. Async + best-effort by design.
+            // model-level coordination like the final build does
+            // (identity on the deferred path by contract). Async +
+            // best-effort by design.
             // eslint-disable-next-line new-cap
             Promise.resolve(ifcAPI.GetCoordinationMatrix(batchModelID))
-              .then((matrixArr) => {
-                if (demandPreview.matrix &&
-                    typeof demandPreview.matrix.fromArray === 'function') {
-                  demandPreview.matrix.fromArray(matrixArr)
-                  demandPreview.matrixAutoUpdate = false
-                }
-                startCameraFollow(demandPreview)
-              })
+              .then((matrixArr) => session.stampCoordination(matrixArr))
               .catch((e) => debug(WARN).warn('demand preview coordination failed:', e))
           }
         } catch (e) {
@@ -369,9 +219,7 @@ export default class ShareIfcLoader {
       const {modelID, captured} =
         await parseIfcWithConway(buffer, ifcAPI, undefined, onProgress, onMeshBatch, onPreviewMesh)
 
-      if (onProgress) {
-        onProgress('Assembling render mesh...')
-      }
+      session.beginAssembly()
 
       // BatchedMesh render path (`?feature=batchedMesh`, §3b.iv): render the
       // deduped geometry as a THREE.BatchedMesh. Falls back to the merged
@@ -394,24 +242,9 @@ export default class ShareIfcLoader {
         decorateConwayDirectIfcModel(ifcModel, ifcAPI, modelID, {scene})
       }
 
-      stopCameraFollow()
-
-      // Swap the preview out before the real model installs — dispose
-      // per-batch geometry/materials so the preview leaves no residue.
-      if (demandPreview !== null && previewInstalled) {
-        try {
-          scene.remove(demandPreview)
-          for (const child of demandPreview.children) {
-            child.geometry?.dispose?.()
-            const materials = Array.isArray(child.material) ? child.material : [child.material]
-            for (const material of materials) {
-              material?.dispose?.()
-            }
-          }
-        } catch (e) {
-          debug(WARN).warn('demand preview teardown failed:', e)
-        }
-      }
+      // Swap the preview out before the real model installs — the
+      // session stops the camera follow and disposes preview meshes.
+      session.finish()
 
       ifc.addIfcModel(ifcModel)
 
@@ -474,9 +307,7 @@ export default class ShareIfcLoader {
             metresPerUnit === MM ? 'mm' : `${metresPerUnit} m`
           parts.push(`units=${unitLabel}`)
         }
-        if (parts.length > 0) {
-          setLoadSummary(parts.join(' '))
-        }
+        session.setSummary(parts)
       } catch (e) {
         debug(WARN).warn('load summary skipped:', e)
       }
@@ -514,7 +345,7 @@ export default class ShareIfcLoader {
 
       return ifcModel
     } catch (err) {
-      stopCameraFollow()
+      session.abort()
       this.ifcLastError = err
       this._ifc.ifcLastError = err
       // Rethrow OOM so callers can present a tailored UX message.

--- a/src/viewer/ifc/ShareIfcLoader.js
+++ b/src/viewer/ifc/ShareIfcLoader.js
@@ -18,7 +18,8 @@
 // attached to it. Now we own the loader so we hold direct refs.
 
 import {Mesh} from 'three'
-import {buildBatchedConwayModel} from './buildBatchedConwayModel'
+import {assembleBatchedModel, buildBatchedConwayModel} from './buildBatchedConwayModel'
+import {IncrementalBatchedBuilder} from './incrementalBatchedBuilder'
 import {buildConwayIfcModel} from './buildConwayIfcModel'
 import {decorateConwayDirectIfcModel, parseIfcWithConway} from './conwayDirectIfcLoader'
 import {flatMeshToBufferGeometry} from './flatMeshToBufferGeometry'
@@ -165,6 +166,8 @@ export default class ShareIfcLoader {
       onProgress,
     })
 
+    let builder = null
+
     try {
       session.report('Opening model...')
       const ifcAPI = this.ifcManager.ifcAPI
@@ -195,24 +198,28 @@ export default class ShareIfcLoader {
         }
       }
 
-      let firstBatch = true
+      // Slice B1: pump deltas assemble the DURABLE BatchedMesh model
+      // incrementally — the on-screen group IS the final model, so
+      // there is no monolithic end-of-load build and no swap. Falls
+      // back to the render-only preview mesh (and the end-of-load
+      // builds below) on any builder failure.
       const onMeshBatch = !usePreview ? undefined : (batch, batchModelID) => {
         try {
-          const assembled = flatMeshToBufferGeometry(batch, ifcAPI, batchModelID)
-          session.addPreviewMesh(new Mesh(assembled.geometry, assembled.materials))
-          if (firstBatch) {
-            firstBatch = false
-            // Placed transforms are already coordinated; stamp the
-            // model-level coordination like the final build does
-            // (identity on the deferred path by contract). Async +
-            // best-effort by design.
-            // eslint-disable-next-line new-cap
-            Promise.resolve(ifcAPI.GetCoordinationMatrix(batchModelID))
-              .then((matrixArr) => session.stampCoordination(matrixArr))
-              .catch((e) => debug(WARN).warn('demand preview coordination failed:', e))
+          if (builder === null) {
+            builder = new IncrementalBatchedBuilder(ifcAPI, batchModelID, {
+              onBounds: (box) => session.notifyBounds(box),
+            })
+            scene.add(builder.root)
           }
+          builder.appendBatch(batch)
         } catch (e) {
-          debug(WARN).warn('demand preview batch skipped:', e)
+          debug(WARN).warn('incremental batch append failed; preview fallback:', e)
+          try {
+            const assembled = flatMeshToBufferGeometry(batch, ifcAPI, batchModelID)
+            session.addPreviewMesh(new Mesh(assembled.geometry, assembled.materials))
+          } catch (previewError) {
+            debug(WARN).warn('demand preview batch skipped:', previewError)
+          }
         }
       }
 
@@ -221,12 +228,34 @@ export default class ShareIfcLoader {
 
       session.beginAssembly()
 
+      let ifcModel
+      let buildStats
+
+      // Slice B1: the incrementally assembled batches only need
+      // decoration — the group already on screen becomes the durable
+      // model. Fallback on any error: remove the partial group and run
+      // the end-of-load builds below from `captured` as before.
+      if (builder !== null && builder.hasContent()) {
+        try {
+          const incremental = builder.finalize()
+          ifcModel = assembleBatchedModel(
+            incremental.batches, ifcAPI, modelID, {scene, root: builder.root})
+          buildStats = incremental.stats
+        } catch (e) {
+          debug(WARN).warn('incremental assembly failed; end-of-load fallback:', e)
+          try {
+            scene.remove(builder.root)
+          } catch {
+            // best-effort
+          }
+          ifcModel = undefined
+        }
+      }
+
       // BatchedMesh render path (`?feature=batchedMesh`, §3b.iv): render the
       // deduped geometry as a THREE.BatchedMesh. Falls back to the merged
       // path on any construction error so the flag can never break a load.
-      let ifcModel
-      let buildStats
-      if (isFeatureEnabled('batchedMesh')) {
+      if (ifcModel === undefined && isFeatureEnabled('batchedMesh')) {
         try {
           const batched = buildBatchedConwayModel(captured, ifcAPI, modelID, {scene})
           ifcModel = batched.model
@@ -346,6 +375,16 @@ export default class ShareIfcLoader {
       return ifcModel
     } catch (err) {
       session.abort()
+      // A partially assembled incremental group must not survive a
+      // failed load — remove it (its wasm-side twin is released by the
+      // engine's own error paths).
+      try {
+        if (builder !== null && builder.root.parent) {
+          builder.root.parent.remove(builder.root)
+        }
+      } catch {
+        // best-effort
+      }
       this.ifcLastError = err
       this._ifc.ifcLastError = err
       // Rethrow OOM so callers can present a tailored UX message.

--- a/src/viewer/ifc/ShareIfcLoader.js
+++ b/src/viewer/ifc/ShareIfcLoader.js
@@ -29,6 +29,7 @@ import {isFeatureEnabled} from '../../FeatureFlags'
 import {runIfcItemsMapParityCheck} from './ifcItemsMapParity'
 import ShareIfcManager from './ShareIfcManager'
 import debug, {DEBUG, WARN, isLogEnabled} from '../../utils/debug'
+import {setLoadSummary} from '../../loader/loadProgress'
 
 
 /**
@@ -215,6 +216,25 @@ export default class ShareIfcLoader {
       }
       controls.fitToSphere(sphere, withTransition)
     }
+    let lastFollowFitMs = 0
+    const maybeFollowRefit = () => {
+      if (cameraFollowStopped || !previewGeometryDirty) {
+        return
+      }
+      const now = Date.now()
+      if (now - lastFollowFitMs < cameraFollowDelayMs) {
+        return
+      }
+      lastFollowFitMs = now
+      cameraFollowDelayMs =
+        Math.min(cameraFollowDelayMs * CAMERA_FOLLOW_GROWTH, CAMERA_FOLLOW_MAX_MS)
+      previewGeometryDirty = false
+      try {
+        fitPreviewToFrame(true)
+      } catch (e) {
+        debug(WARN).warn('camera follow refit failed:', e)
+      }
+    }
     const followTick = () => {
       cameraFollowTimer = null
       if (cameraFollowStopped) {
@@ -256,7 +276,7 @@ export default class ShareIfcLoader {
 
     try {
       if (onProgress) {
-        onProgress('Parsing model geometry...')
+        onProgress('Opening model...')
       }
       const ifcAPI = this.ifcManager.ifcAPI
       // onProgress is threaded into conway's ON_PROGRESS extension so the
@@ -302,9 +322,14 @@ export default class ShareIfcLoader {
           }
           // Frame the very first geometry immediately (inside
           // startCameraFollow), then let the follower keep it framed
-          // as the preview grows.
+          // as the preview grows. Refits ride the geometry events
+          // themselves: the load pipeline's scheduler-priority yields
+          // starve setTimeout in browsers, so the timer alone fired
+          // rarely (one refit at the very end).
           if (++parsePreviewCount === 1) {
             startCameraFollow(demandPreview)
+          } else {
+            maybeFollowRefit()
           }
         } catch (e) {
           debug(WARN).warn('parse preview mesh skipped:', e)
@@ -316,6 +341,7 @@ export default class ShareIfcLoader {
           const assembled = flatMeshToBufferGeometry(batch, ifcAPI, batchModelID)
           demandPreview.add(new Mesh(assembled.geometry, assembled.materials))
           previewGeometryDirty = true
+          maybeFollowRefit()
           if (!previewInstalled) {
             previewInstalled = true
             scene.add(demandPreview)
@@ -344,7 +370,7 @@ export default class ShareIfcLoader {
         await parseIfcWithConway(buffer, ifcAPI, undefined, onProgress, onMeshBatch, onPreviewMesh)
 
       if (onProgress) {
-        onProgress('Building model...')
+        onProgress('Assembling render mesh...')
       }
 
       // BatchedMesh render path (`?feature=batchedMesh`, §3b.iv): render the
@@ -389,9 +415,6 @@ export default class ShareIfcLoader {
 
       ifc.addIfcModel(ifcModel)
 
-      if (onProgress) {
-        onProgress('Setting up coordinate system...')
-      }
       // eslint-disable-next-line new-cap
       const matrixArr = await ifcAPI.GetCoordinationMatrix(modelID)
       // Apply the coordination matrix to the model directly. Wit-three's
@@ -408,14 +431,8 @@ export default class ShareIfcLoader {
         ifcModel.matrixAutoUpdate = false
       }
 
-      if (onProgress) {
-        onProgress('Fitting model to frame...')
-      }
       ifc.context.fitToFrame()
 
-      if (onProgress) {
-        onProgress('Gathering model statistics...')
-      }
       // `getStatistics` / `getConwayVersion` are Conway-adapter extensions
       // (Logger-backed); stock web-ifc (the USE_WEBIFC_SHIM=false engine)
       // doesn't expose them. The model mesh is already built + added above,
@@ -439,9 +456,31 @@ export default class ShareIfcLoader {
         }
       }
 
-      if (onProgress) {
-        onProgress('Model loaded successfully!')
+      // Model summary onto the report's Total line (replaces the old
+      // per-stage stats/coordinate-system lines): mesh shape from the
+      // build, units from the feature-detected scaling factor
+      // (1 = m, 0.001 = mm).
+      try {
+        const parts = []
+        if (buildStats) {
+          parts.push(`vertices=${buildStats.vertexCount ?? buildStats.totalVerts ?? '?'}`)
+          parts.push(`triangles=${buildStats.triangleCount ?? buildStats.totalTriangles ?? '?'}`)
+        }
+        if (typeof ifcAPI.GetLinearScalingFactor === 'function') {
+          // eslint-disable-next-line new-cap
+          const metresPerUnit = ifcAPI.GetLinearScalingFactor(modelID)
+          const MM = 0.001
+          const unitLabel = metresPerUnit === 1 ? 'm' :
+            metresPerUnit === MM ? 'mm' : `${metresPerUnit} m`
+          parts.push(`units=${unitLabel}`)
+        }
+        if (parts.length > 0) {
+          setLoadSummary(parts.join(' '))
+        }
+      } catch (e) {
+        debug(WARN).warn('load summary skipped:', e)
       }
+
 
       // Parallel-run the new IfcItemsMap populators against the live
       // model and log the diff. Diagnostic only — no behavior change.

--- a/src/viewer/ifc/ShareIfcLoader.js
+++ b/src/viewer/ifc/ShareIfcLoader.js
@@ -150,6 +150,54 @@ export default class ShareIfcLoader {
     if (ifc.context.items.ifcModels.length !== 0) {
       throw new Error('Model cannot be loaded.  A model is already present')
     }
+    // Camera follow: fitToFrame already tweens (camera-controls
+    // fitToSphere with a transition), but a payload-count refit
+    // cadence let growing geometry drift offscreen between refits on
+    // sparse-payload stretches (PSB). Follow time-based instead —
+    // once per second while new geometry arrived — and stop forever
+    // the moment the user takes the camera (never fight input) or
+    // the load finishes.
+    const CAMERA_FOLLOW_MS = 1000
+    let previewGeometryDirty = false
+    let cameraFollowStopped = false
+    let cameraFollowInterval = null
+    let followedControls = null
+    const stopCameraFollow = () => {
+      cameraFollowStopped = true
+      if (cameraFollowInterval !== null) {
+        clearInterval(cameraFollowInterval)
+        cameraFollowInterval = null
+      }
+      try {
+        followedControls?.removeEventListener?.('controlstart', stopCameraFollow)
+      } catch {
+        // best-effort
+      }
+      followedControls = null
+    }
+    const startCameraFollow = () => {
+      if (cameraFollowStopped || cameraFollowInterval !== null) {
+        return
+      }
+      try {
+        followedControls = ifc.context?.ifcCamera?.cameraControls ?? null
+        followedControls?.addEventListener?.('controlstart', stopCameraFollow)
+      } catch {
+        followedControls = null
+      }
+      cameraFollowInterval = setInterval(() => {
+        if (!previewGeometryDirty) {
+          return
+        }
+        previewGeometryDirty = false
+        try {
+          ifc.context.fitToFrame()
+        } catch (e) {
+          debug(WARN).warn('camera follow refit failed:', e)
+        }
+      }, CAMERA_FOLLOW_MS)
+    }
+
     try {
       if (onProgress) {
         onProgress('Parsing model geometry...')
@@ -183,7 +231,7 @@ export default class ShareIfcLoader {
       const previewGeometryCache = new Map()
       const previewMaterialCache = new Map()
       let parsePreviewCount = 0
-      const PARSE_PREVIEW_REFIT_EVERY = 256
+
       const onPreviewMesh = demandPreview === null ? undefined : (payload) => {
         try {
           const mesh = payloadToPreviewMesh(payload, previewGeometryCache, previewMaterialCache)
@@ -191,15 +239,16 @@ export default class ShareIfcLoader {
             return
           }
           demandPreview.add(mesh)
+          previewGeometryDirty = true
           if (!previewInstalled) {
             previewInstalled = true
             scene.add(demandPreview)
           }
-          // Frame the very first geometry immediately, then refit
-          // occasionally as the preview grows (the first durable batch
-          // refits again).
-          if (++parsePreviewCount === 1 || parsePreviewCount % PARSE_PREVIEW_REFIT_EVERY === 0) {
+          // Frame the very first geometry immediately, then let the
+          // follower keep it in frame as the preview grows.
+          if (++parsePreviewCount === 1) {
             ifc.context.fitToFrame()
+            startCameraFollow()
           }
         } catch (e) {
           debug(WARN).warn('parse preview mesh skipped:', e)
@@ -210,6 +259,7 @@ export default class ShareIfcLoader {
         try {
           const assembled = flatMeshToBufferGeometry(batch, ifcAPI, batchModelID)
           demandPreview.add(new Mesh(assembled.geometry, assembled.materials))
+          previewGeometryDirty = true
           if (!previewInstalled) {
             previewInstalled = true
             scene.add(demandPreview)
@@ -226,6 +276,7 @@ export default class ShareIfcLoader {
                   demandPreview.matrixAutoUpdate = false
                 }
                 ifc.context.fitToFrame()
+                startCameraFollow()
               })
               .catch((e) => debug(WARN).warn('demand preview coordination failed:', e))
           }
@@ -261,6 +312,8 @@ export default class ShareIfcLoader {
         buildStats = merged.stats
         decorateConwayDirectIfcModel(ifcModel, ifcAPI, modelID, {scene})
       }
+
+      stopCameraFollow()
 
       // Swap the preview out before the real model installs — dispose
       // per-batch geometry/materials so the preview leaves no residue.
@@ -367,6 +420,7 @@ export default class ShareIfcLoader {
 
       return ifcModel
     } catch (err) {
+      stopCameraFollow()
       this.ifcLastError = err
       this._ifc.ifcLastError = err
       // Rethrow OOM so callers can present a tailored UX message.

--- a/src/viewer/ifc/batchedHighlight.js
+++ b/src/viewer/ifc/batchedHighlight.js
@@ -69,6 +69,36 @@ function highlightState(mesh) {
 
 
 /**
+ * Lazily build + cache the occurrence-id → batchIds index for per-instance
+ * narrowing (`instanceOccurrenceIds` is the global emission-order id the
+ * pick tables and the store's `selectedInstanceIds` speak). Built only when
+ * per-instance selection is actually used, so parent-level-only models pay
+ * nothing. One occurrence id maps to at most one batchId within a mesh, but
+ * the list shape mirrors `parentIndex` so `setLayer` treats both alike.
+ *
+ * @param {object} mesh BatchedMesh carrying `instanceOccurrenceIds`
+ * @param {object} state this mesh's highlight state
+ * @return {Map<number, Array<number>>}
+ */
+function occurrenceIndexOf(mesh, state) {
+  if (!state.occurrenceIndex) {
+    const occurrenceIndex = new Map()
+    const occIds = mesh.instanceOccurrenceIds
+    for (let b = 0; b < occIds.length; b++) {
+      const list = occurrenceIndex.get(occIds[b])
+      if (list) {
+        list.push(b)
+      } else {
+        occurrenceIndex.set(occIds[b], [b])
+      }
+    }
+    state.occurrenceIndex = occurrenceIndex
+  }
+  return state.occurrenceIndex
+}
+
+
+/**
  * Repaint one instance to its current layered colour: preselection wins
  * over selection wins over the instance's original colour. Alpha always
  * comes from the original (keeps a highlighted glass pane translucent).
@@ -93,16 +123,21 @@ function paint(mesh, batchId) {
 
 
 /**
- * Replace a highlight layer with the instances whose parent product is in
- * `expressIds`, repainting everything whose membership changed.
+ * Replace a highlight layer with the matched instances, repainting
+ * everything whose membership changed. `ids` are parent product express ids
+ * by default; with `byOccurrence` they are global occurrence ids
+ * (`instanceOccurrenceIds`) — the per-instance narrowing the no-shift scene
+ * pick and NavTree occurrence selection use.
  *
  * @param {object} model BatchedMesh or Group
- * @param {Array<number>|Set<number>} expressIds parent IFC product ids
+ * @param {Array<number>|Set<number>} matchIds parent IFC product ids, or
+ *   occurrence ids when `byOccurrence`
  * @param {object|null} color `{r,g,b}` (0..1) highlight, or null to clear
  * @param {'sel'|'pre'} layer which layer to set
+ * @param {boolean} [byOccurrence] resolve ids through the occurrence index
  */
-function setLayer(model, expressIds, color, layer) {
-  const ids = expressIds instanceof Set ? expressIds : new Set(expressIds ?? [])
+function setLayer(model, matchIds, color, layer, byOccurrence = false) {
+  const ids = matchIds instanceof Set ? matchIds : new Set(matchIds ?? [])
   const setKey = layer === 'pre' ? 'preSet' : 'selSet'
   const colorKey = layer === 'pre' ? 'preColor' : 'selColor'
   eachBatch(model, (mesh) => {
@@ -112,14 +147,18 @@ function setLayer(model, expressIds, color, layer) {
     if (!mesh.instanceParents || !mesh.instanceColors || typeof mesh.setColorAt !== 'function') {
       return
     }
+    if (byOccurrence && !mesh.instanceOccurrenceIds) {
+      return
+    }
     const state = highlightState(mesh)
     state[colorKey] = color ?? undefined
-    // O(matched): walk the requested products' batchIds via the index, not
+    // O(matched): walk the requested ids' batchIds via the index, not
     // all N instances.
+    const index = byOccurrence ? occurrenceIndexOf(mesh, state) : state.parentIndex
     const next = new Set()
     if (color && ids.size > 0) {
       for (const id of ids) {
-        const list = state.parentIndex.get(id)
+        const list = index.get(id)
         if (list) {
           for (const b of list) {
             next.add(b)
@@ -152,6 +191,24 @@ function setLayer(model, expressIds, color, layer) {
  */
 export function applyBatchedSelection(model, expressIds, color = DEFAULT_HIGHLIGHT) {
   setLayer(model, expressIds, color, 'sel')
+}
+
+
+/**
+ * Narrow the sticky selection highlight to specific occurrences (global
+ * emission-order occurrence ids off `instanceOccurrenceIds`). REPLACES the
+ * selection layer, so calling it after `applyBatchedSelection` (which paints
+ * every instance of the selected product) restores the product's other
+ * instances to their original colours and leaves only the named
+ * occurrence(s) highlighted — the batched counterpart of the merged path's
+ * `setInstanceSelection` one-instance subset.
+ *
+ * @param {object} model BatchedMesh or Group
+ * @param {Array<number>|Set<number>} occurrenceIds global occurrence ids
+ * @param {object} [color] `{r,g,b}` 0..1; defaults to cyan
+ */
+export function applyBatchedInstanceSelection(model, occurrenceIds, color = DEFAULT_HIGHLIGHT) {
+  setLayer(model, occurrenceIds, color, 'sel', true)
 }
 
 

--- a/src/viewer/ifc/batchedSubset.js
+++ b/src/viewer/ifc/batchedSubset.js
@@ -63,6 +63,11 @@ const VEC3 = 3
  * @param {Set<number>} idSet parent IFC product expressIDs to keep
  * @param {object} [opts]
  * @param {object} [opts.material] subset material (defaults to the batch's)
+ * @param {Set<number>} [opts.excludeInstances] global occurrence ids
+ *   (`instanceOccurrenceIds`) to omit even when their parent matches — the
+ *   seam that lets the isolator hide ONE STEP occurrence of a reused part
+ *   while its siblings stay shown (mirrors the merged path's
+ *   `createSubsetMeshByParent` opt of the same name).
  * @return {Mesh|null}
  */
 export function buildBatchedSubsetMesh(mesh, idSet, opts = {}) {
@@ -71,12 +76,18 @@ export function buildBatchedSubsetMesh(mesh, idSet, opts = {}) {
   }
   const parents = mesh.instanceParents
   const geometries = mesh.instanceGeometry
+  const occurrenceIds = mesh.instanceOccurrenceIds
+  const exclude = (opts.excludeInstances && opts.excludeInstances.size > 0 && occurrenceIds) ?
+    opts.excludeInstances : null
   // First pass: which batchIds match, and how big the merged buffers get.
   const selected = []
   let vertexTotal = 0
   let indexTotal = 0
   for (let batchId = 0; batchId < parents.length; batchId++) {
     if (!idSet.has(parents[batchId])) {
+      continue
+    }
+    if (exclude !== null && exclude.has(occurrenceIds[batchId])) {
       continue
     }
     const geom = geometries[batchId]
@@ -230,11 +241,15 @@ export function attachBatchedSubsets(model, fallbackParent, defaults = {}) {
       customID = 'default',
       removePrevious = true,
       material = defaults.material,
+      // Per-occurrence hide (STEP): omit these occurrence ids from the
+      // re-bake — see buildBatchedSubsetMesh. Same opt name as the merged
+      // path's attachInstanceMapSubsets, so IfcIsolator passes it blindly.
+      excludeInstances = undefined,
     } = opts || {}
     if (removePrevious) {
       removeSubset(customID)
     }
-    const meshes = buildBatchedModelSubsets(model, ids ?? [], {material})
+    const meshes = buildBatchedModelSubsets(model, ids ?? [], {material, excludeInstances})
     if (meshes.length === 0) {
       return []
     }

--- a/src/viewer/ifc/buildBatchedConwayModel.js
+++ b/src/viewer/ifc/buildBatchedConwayModel.js
@@ -49,7 +49,28 @@ import {
  */
 export function buildBatchedConwayModel(capturedFlatMeshes, ifcAPI, modelID, opts = {}) {
   const {batches, stats} = flatMeshToBatchedModel(capturedFlatMeshes, ifcAPI, modelID)
+  return {model: assembleBatchedModel(batches, ifcAPI, modelID, opts), stats}
+}
 
+
+/**
+ * Decorate prepared batches into the final batched model — shared by the
+ * one-shot path above and the incremental demand-path builder (slice B1,
+ * `incrementalBatchedBuilder.js`), which assembles the same BatchHandle
+ * shape progressively during the pump and only needs this decoration at
+ * the end.
+ *
+ * @param {Array} batches BatchHandle list (`{mesh, instanceParents, ...}`)
+ * @param {object} ifcAPI Conway-compatible IfcAPI
+ * @param {number} modelID
+ * @param {object} [opts]
+ * @param {object} [opts.scene] subset fallbackParent (see above)
+ * @param {object} [opts.root] existing Group already holding the batch
+ *   meshes (the incremental path's scene-installed root) — used as the
+ *   model object so the on-screen group IS the durable model, no swap.
+ * @return {object} the decorated model
+ */
+export function assembleBatchedModel(batches, ifcAPI, modelID, opts = {}) {
   if (batches.length === 0) {
     // Degenerate (no renderable geometry). Throw so ShareIfcLoader falls
     // back to the merged path rather than adding an empty model.
@@ -78,8 +99,9 @@ export function buildBatchedConwayModel(capturedFlatMeshes, ifcAPI, modelID, opt
   }
 
   // Single batch → the BatchedMesh is the model; two → a Group of them.
-  const model = batches.length === 1 ? batches[0].mesh : new Group()
-  if (model.isGroup) {
+  // The incremental path passes its scene-installed root instead.
+  const model = opts.root ?? (batches.length === 1 ? batches[0].mesh : new Group())
+  if (model.isGroup && opts.root === undefined) {
     for (const batch of batches) {
       model.add(batch.mesh)
     }
@@ -120,5 +142,5 @@ export function buildBatchedConwayModel(capturedFlatMeshes, ifcAPI, modelID, opt
   // STEP/IFC metadata surface is unchanged.
   attachConwayDirectModelMethods(model, ifcAPI, modelID)
 
-  return {model, stats}
+  return model
 }

--- a/src/viewer/ifc/buildBatchedConwayModel.js
+++ b/src/viewer/ifc/buildBatchedConwayModel.js
@@ -5,6 +5,7 @@ import {
   attachConwayDirectModelMethods,
   makeConwayDirectIfcManager,
 } from './conwayDirectIfcLoader'
+import {occurrencePathKey} from '../../utils/occurrencePaths'
 
 
 /**
@@ -32,10 +33,13 @@ import {
  *     (design/new/viewer-replacement.md §3b.iv).
  *
  * Capabilities: `expressIdPicking` + `batchedPicking` (NOT `instancePicking`
- * — per-occurrence narrowing is still a follow-up; a click highlights every
- * occurrence of the picked product). `setInstanceSelection` guards on
- * `instancePicking` and so no-ops safely; the parent-level recolor from
- * `setSelection` stands.
+ * — that flag means "has an IfcInstanceMap"; the batched path carries its
+ * per-occurrence identity in the per-batch tables instead:
+ * `instanceOccurrenceIds` / `instanceOccurrencePaths` / `instanceGeometryIds`
+ * plus the reverse `occurrencePathToBatchIds` index). `setInstanceSelection`
+ * and `getInstanceIdsForOccurrencePath` branch on `batchedPicking` / the
+ * tables directly, so per-occurrence selection highlight and per-occurrence
+ * hide work like the merged path.
  *
  * @param {Array} capturedFlatMeshes FlatMeshes captured during the parse
  * @param {object} ifcAPI Conway-compatible IfcAPI
@@ -50,6 +54,38 @@ import {
 export function buildBatchedConwayModel(capturedFlatMeshes, ifcAPI, modelID, opts = {}) {
   const {batches, stats} = flatMeshToBatchedModel(capturedFlatMeshes, ifcAPI, modelID)
   return {model: assembleBatchedModel(batches, ifcAPI, modelID, opts), stats}
+}
+
+
+/**
+ * Reverse index for the batched NavTree→scene join: occurrence-path key
+ * (`occurrencePathKey`) → the batchIds placed at that exact path. Only
+ * non-empty paths are indexed (an empty root path can't disambiguate
+ * occurrences) — the same rule `instanceMapFromOrderedPlacedRanges` applies
+ * on the merged path. Null in → null out (IFC / no occurrence data).
+ *
+ * @param {Array<Array<number>|null>|null} instanceOccurrencePaths
+ * @return {Map<string, Array<number>>|null}
+ */
+function buildOccurrencePathIndex(instanceOccurrencePaths) {
+  if (!instanceOccurrencePaths) {
+    return null
+  }
+  const byPath = new Map()
+  for (let batchId = 0; batchId < instanceOccurrencePaths.length; batchId++) {
+    const path = instanceOccurrencePaths[batchId]
+    if (!path || path.length === 0) {
+      continue
+    }
+    const key = occurrencePathKey(path)
+    const list = byPath.get(key)
+    if (list) {
+      list.push(batchId)
+    } else {
+      byPath.set(key, [batchId])
+    }
+  }
+  return byPath
 }
 
 
@@ -85,6 +121,15 @@ export function assembleBatchedModel(batches, ifcAPI, modelID, opts = {}) {
     batch.mesh.instanceOccurrenceIds = batch.instanceOccurrenceIds
     batch.mesh.instanceGeometry = batch.instanceGeometry
     batch.mesh.instanceColors = batch.instanceColors
+    // Per-occurrence identity tables (STEP): solid geometry ids + NAUO
+    // occurrence paths, plus the reverse path→batchIds index ShareViewer's
+    // `getInstanceIdsForOccurrencePath` reads (the NavTree→scene join).
+    // `?? null` keeps older BatchHandle shapes (tests, external callers)
+    // working — consumers treat a missing table as "no occurrence data".
+    batch.mesh.instanceGeometryIds = batch.instanceGeometryIds ?? null
+    batch.mesh.instanceOccurrencePaths = batch.instanceOccurrencePaths ?? null
+    batch.mesh.occurrencePathToBatchIds =
+      buildOccurrencePathIndex(batch.mesh.instanceOccurrencePaths)
     batch.mesh.computeBoundingBox?.()
     batch.mesh.computeBoundingSphere?.()
     // Per-geometry BVH for the batch. `ShareIfc` patches

--- a/src/viewer/ifc/conwayDirectIfcLoader.js
+++ b/src/viewer/ifc/conwayDirectIfcLoader.js
@@ -84,9 +84,13 @@ import {instanceMapFromGeometry} from './IfcInstanceMap'
  *   ProgressEvents ({phase, completed, total?, unit, elapsedMs}) during
  *   the parse — a conway `Loadersettings.ON_PROGRESS` extension (#301);
  *   silently ignored by engines that predate it (real web-ifc, old pins).
+ * @param {Function} [onMeshBatch] demand/tiled slice A: receives each
+ *   extracted batch's FlatMesh[] as it lands (only on the
+ *   `demandGeometry` deferred path) so callers can render progressively;
+ *   `captured` still accumulates everything for one-shot consumers.
  * @return {Promise<{modelID: number, captured: Array}>}
  */
-export async function parseIfcWithConway(buffer, ifcAPI, settings = undefined, onProgress = undefined) {
+export async function parseIfcWithConway(buffer, ifcAPI, settings = undefined, onProgress = undefined, onMeshBatch = undefined) {
   if (!ifcAPI || typeof ifcAPI.OpenModel !== 'function') {
     throw new Error('parseIfcWithConway: ifcAPI.OpenModel is unavailable')
   }
@@ -116,6 +120,44 @@ export async function parseIfcWithConway(buffer, ifcAPI, settings = undefined, o
       ON_MODEL_INFO: (info) => onProgress({modelInfo: info}),
     }
   }
+  // Demand/tiled rendering slice A (`demandGeometry` flag, #1613):
+  // deferred open + batch pump. The open returns in parse time; meshes
+  // then stream in file-order batches through `onMeshBatch` (and
+  // accumulate into `captured` for the classic one-shot consumers),
+  // yielding to the event loop between batches so the scene can render
+  // progressively. Feature-detected; engines without the pump fall
+  // through to the classic selection below.
+  if (isFeatureEnabled('demandGeometry') &&
+      !isFeatureEnabled('disableStreamOpen') &&
+      typeof ifcAPI.OpenModelStreamed === 'function' &&
+      typeof ifcAPI.ExtractGeometryBatch === 'function') {
+    // eslint-disable-next-line new-cap
+    const modelID = await ifcAPI.OpenModelStreamed(
+      data, {...openSettings, DEFER_GEOMETRY: true})
+    if (typeof modelID !== 'number' || modelID < 0) {
+      throw new Error(`parseIfcWithConway: OpenModel returned ${modelID}`)
+    }
+    const captured = []
+    for (;;) {
+      const batch = []
+      // eslint-disable-next-line new-cap
+      const {extracted, remaining} = ifcAPI.ExtractGeometryBatch(
+        modelID, DEMAND_EXTRACT_BATCH_SIZE, (flatMesh) => batch.push(flatMesh))
+      if (batch.length > 0) {
+        captured.push(...batch)
+        if (onMeshBatch) {
+          onMeshBatch(batch)
+        }
+      }
+      if (remaining === 0 && extracted === 0) {
+        break
+      }
+      // Yield so the renderer paints between batches.
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    }
+    return {modelID, captured}
+  }
+
   // Open-path selection, most preferred first:
   //   1. OpenModelStreamed (conway #390, default): streamed columnar
   //      parse — no per-record object phase, the dominant JS-heap cost
@@ -152,6 +194,12 @@ export async function parseIfcWithConway(buffer, ifcAPI, settings = undefined, o
   })
   return {modelID, captured}
 }
+
+
+// Products extracted per demand batch: large enough that per-batch
+// capture/render overhead amortizes, small enough that first pixels
+// arrive within a couple of seconds of parse completing.
+const DEMAND_EXTRACT_BATCH_SIZE = 64
 
 
 // web-ifc numeric log levels (conway's SetLogLevel shim uses the same

--- a/src/viewer/ifc/conwayDirectIfcLoader.js
+++ b/src/viewer/ifc/conwayDirectIfcLoader.js
@@ -89,9 +89,16 @@ import {instanceMapFromGeometry} from './IfcInstanceMap'
  *   on the `demandGeometry` deferred path) so callers can render
  *   progressively;
  *   `captured` still accumulates everything for one-shot consumers.
+ * @param {Function} [onPreviewMesh] demand/tiled slice A2: receives
+ *   conway PreviewMeshPayloads WHILE THE PARSE RUNS (self-contained
+ *   copied geometry, preview quality — openings/materials can be
+ *   missing; replaced wholesale by the durable batches). Only on the
+ *   `demandGeometry` deferred path with engines that support
+ *   ON_PREVIEW_MESH; silently ignored otherwise.
  * @return {Promise<{modelID: number, captured: Array}>}
  */
-export async function parseIfcWithConway(buffer, ifcAPI, settings = undefined, onProgress = undefined, onMeshBatch = undefined) {
+export async function parseIfcWithConway(
+  buffer, ifcAPI, settings = undefined, onProgress = undefined, onMeshBatch = undefined, onPreviewMesh = undefined) {
   if (!ifcAPI || typeof ifcAPI.OpenModel !== 'function') {
     throw new Error('parseIfcWithConway: ifcAPI.OpenModel is unavailable')
   }
@@ -132,9 +139,16 @@ export async function parseIfcWithConway(buffer, ifcAPI, settings = undefined, o
       !isFeatureEnabled('disableStreamOpen') &&
       typeof ifcAPI.OpenModelStreamed === 'function' &&
       typeof ifcAPI.ExtractGeometryBatch === 'function') {
+    const deferSettings = {...openSettings, DEFER_GEOMETRY: true}
+    if (onPreviewMesh) {
+      // Slice A2 (parse-time preview channel): conway emits preview
+      // payloads between the parse's cooperative yields. Passing the
+      // callback to an engine without the channel is harmless (unknown
+      // settings are ignored), so no feature detection is needed here.
+      deferSettings.ON_PREVIEW_MESH = onPreviewMesh
+    }
     // eslint-disable-next-line new-cap
-    const modelID = await ifcAPI.OpenModelStreamed(
-      data, {...openSettings, DEFER_GEOMETRY: true})
+    const modelID = await ifcAPI.OpenModelStreamed(data, deferSettings)
     if (typeof modelID !== 'number' || modelID < 0) {
       throw new Error(`parseIfcWithConway: OpenModel returned ${modelID}`)
     }

--- a/src/viewer/ifc/conwayDirectIfcLoader.js
+++ b/src/viewer/ifc/conwayDirectIfcLoader.js
@@ -84,9 +84,10 @@ import {instanceMapFromGeometry} from './IfcInstanceMap'
  *   ProgressEvents ({phase, completed, total?, unit, elapsedMs}) during
  *   the parse — a conway `Loadersettings.ON_PROGRESS` extension (#301);
  *   silently ignored by engines that predate it (real web-ifc, old pins).
- * @param {Function} [onMeshBatch] demand/tiled slice A: receives each
- *   extracted batch's FlatMesh[] as it lands (only on the
- *   `demandGeometry` deferred path) so callers can render progressively;
+ * @param {Function} [onMeshBatch] demand/tiled slice A: receives
+ *   `(flatMeshes, modelID)` for each extracted batch as it lands (only
+ *   on the `demandGeometry` deferred path) so callers can render
+ *   progressively;
  *   `captured` still accumulates everything for one-shot consumers.
  * @return {Promise<{modelID: number, captured: Array}>}
  */
@@ -146,7 +147,7 @@ export async function parseIfcWithConway(buffer, ifcAPI, settings = undefined, o
       if (batch.length > 0) {
         captured.push(...batch)
         if (onMeshBatch) {
-          onMeshBatch(batch)
+          onMeshBatch(batch, modelID)
         }
       }
       if (remaining === 0 && extracted === 0) {

--- a/src/viewer/ifc/conwayDirectIfcLoader.js
+++ b/src/viewer/ifc/conwayDirectIfcLoader.js
@@ -168,7 +168,7 @@ export async function parseIfcWithConway(
         break
       }
       // Yield so the renderer paints between batches.
-      await new Promise((resolve) => setTimeout(resolve, 0))
+      await yieldToEventLoop()
     }
     return {modelID, captured}
   }
@@ -215,6 +215,34 @@ export async function parseIfcWithConway(
 // capture/render overhead amortizes, small enough that first pixels
 // arrive within a couple of seconds of parse completing.
 const DEMAND_EXTRACT_BATCH_SIZE = 64
+
+
+/**
+ * Yield to the event loop without background-tab timer throttling:
+ * backgrounded tabs clamp setTimeout to >=1s, collapsing the pump to a
+ * ~5% duty cycle. scheduler.yield() (and a MessageChannel fallback)
+ * post ordinary tasks, which are not clamped, so loads keep their CPU
+ * when the tab is backgrounded.
+ *
+ * @return {Promise<void>} resolves on the next event-loop task
+ */
+function yieldToEventLoop() {
+  if (typeof globalThis.scheduler?.yield === 'function') {
+    return globalThis.scheduler.yield()
+  }
+  if (typeof globalThis.MessageChannel === 'function') {
+    return new Promise((resolve) => {
+      const channel = new MessageChannel()
+      channel.port1.onmessage = () => {
+        channel.port1.close()
+        resolve()
+      }
+      channel.port2.postMessage(null)
+    })
+  }
+  // Non-browser environments (tests); throttling doesn't apply there.
+  return new Promise((resolve) => setTimeout(resolve, 0))
+}
 
 
 // web-ifc numeric log levels (conway's SetLogLevel shim uses the same

--- a/src/viewer/ifc/conwayDirectIfcLoader.js
+++ b/src/viewer/ifc/conwayDirectIfcLoader.js
@@ -170,6 +170,20 @@ export async function parseIfcWithConway(
       // Yield so the renderer paints between batches.
       await yieldToEventLoop()
     }
+    if (captured.length === 0) {
+      // The deferred columnar open is IFC-only: for STEP input (and any
+      // streamed-parse failure) conway falls back internally to a
+      // classic, fully-extracted open where the batch pump is a no-op —
+      // the model is fine, it just has nothing to pump. Serve the
+      // one-shot capture instead of returning an empty scene.
+      // No onMeshBatch here: extraction is already complete, so a
+      // preview would just double the geometry conversion right before
+      // the final build renders the same thing.
+      // eslint-disable-next-line new-cap
+      ifcAPI.StreamAllMeshes(modelID, (flatMesh) => {
+        captured.push(flatMesh)
+      })
+    }
     return {modelID, captured}
   }
 

--- a/src/viewer/ifc/conwayDirectIfcLoader.test.js
+++ b/src/viewer/ifc/conwayDirectIfcLoader.test.js
@@ -212,11 +212,14 @@ describe('viewer/ifc/conwayDirectIfcLoader', () => {
         expect(ifcAPI.ExtractGeometryBatch).not.toHaveBeenCalled()
       })
 
-      it('demandGeometry ships default-off in FeatureFlags', () => {
+      it('demandGeometry flag exists (temporarily default-on for branch burn-in)', () => {
+        // Default-off is the mainline contract; this branch flips it on so
+        // DnD loads (which can't carry ?feature=) exercise the demand path.
+        // Restore the isActive=false assertion before merging to main.
         const {flags} = jest.requireActual('../../FeatureFlags')
         const flag = flags.find((f) => f.name === 'demandGeometry')
         expect(flag).toBeDefined()
-        expect(flag.isActive).toBe(false)
+        expect(flag.isActive).toBe(true)
       })
 
       it('threads onPreviewMesh into the deferred open as ON_PREVIEW_MESH (slice A2)', async () => {

--- a/src/viewer/ifc/conwayDirectIfcLoader.test.js
+++ b/src/viewer/ifc/conwayDirectIfcLoader.test.js
@@ -218,6 +218,25 @@ describe('viewer/ifc/conwayDirectIfcLoader', () => {
         expect(flag).toBeDefined()
         expect(flag.isActive).toBe(false)
       })
+
+      it('threads onPreviewMesh into the deferred open as ON_PREVIEW_MESH (slice A2)', async () => {
+        mockIsFeatureEnabled.mockImplementation((name) => name === 'demandGeometry')
+        const ifcAPI = makeDemandAPI(10)
+        const onPreviewMesh = jest.fn()
+        await parseIfcWithConway(
+          new ArrayBuffer(4), ifcAPI, undefined, undefined, undefined, onPreviewMesh)
+        const [, settings] = ifcAPI.OpenModelStreamed.mock.calls[0]
+        expect(settings.DEFER_GEOMETRY).toBe(true)
+        expect(settings.ON_PREVIEW_MESH).toBe(onPreviewMesh)
+      })
+
+      it('omits ON_PREVIEW_MESH when no preview callback is given', async () => {
+        mockIsFeatureEnabled.mockImplementation((name) => name === 'demandGeometry')
+        const ifcAPI = makeDemandAPI(10)
+        await parseIfcWithConway(new ArrayBuffer(4), ifcAPI)
+        const [, settings] = ifcAPI.OpenModelStreamed.mock.calls[0]
+        expect(settings.ON_PREVIEW_MESH).toBeUndefined()
+      })
     })
 
     describe('open-path selection (disableStreamOpen flag)', () => {

--- a/src/viewer/ifc/conwayDirectIfcLoader.test.js
+++ b/src/viewer/ifc/conwayDirectIfcLoader.test.js
@@ -222,6 +222,28 @@ describe('viewer/ifc/conwayDirectIfcLoader', () => {
         expect(flag.isActive).toBe(true)
       })
 
+      it('serves the one-shot capture when the pump no-ops (STEP / classic fallback)', async () => {
+        // The deferred columnar open is IFC-only: STEP input falls back
+        // internally to a classic fully-extracted open whose pump returns
+        // {0,0} immediately. The loader must serve StreamAllMeshes then,
+        // not an empty scene.
+        mockIsFeatureEnabled.mockImplementation((name) => name === 'demandGeometry')
+        const ifcAPI = makeDemandAPI(10)
+        ifcAPI.ExtractGeometryBatch = jest.fn(() => ({extracted: 0, remaining: 0}))
+        ifcAPI.StreamAllMeshes = jest.fn((modelID, cb) => {
+          for (let i = 0; i < 5; i++) {
+            cb({expressID: 2000 + i, geometries: {size: () => 1}})
+          }
+        })
+        const batches = []
+        const result = await parseIfcWithConway(
+          new ArrayBuffer(4), ifcAPI, undefined, undefined, (batch) => batches.push(batch.length))
+        expect(result.captured).toHaveLength(5)
+        expect(ifcAPI.StreamAllMeshes).toHaveBeenCalledTimes(1)
+        // No preview batches for an already-complete extraction.
+        expect(batches).toEqual([])
+      })
+
       it('threads onPreviewMesh into the deferred open as ON_PREVIEW_MESH (slice A2)', async () => {
         mockIsFeatureEnabled.mockImplementation((name) => name === 'demandGeometry')
         const ifcAPI = makeDemandAPI(10)

--- a/src/viewer/ifc/conwayDirectIfcLoader.test.js
+++ b/src/viewer/ifc/conwayDirectIfcLoader.test.js
@@ -137,6 +137,89 @@ describe('viewer/ifc/conwayDirectIfcLoader', () => {
       expect(ifcAPI.OpenModel.mock.calls[0][1]).toBe(settings)
     })
 
+    describe('demandGeometry deferred open + batch pump (slice A)', () => {
+      beforeEach(() => mockIsFeatureEnabled.mockReset())
+      afterAll(() => mockIsFeatureEnabled.mockReset())
+
+      /**
+       * @param {number} products total products the fake engine holds
+       * @return {object} IfcAPI stub with the deferred pump surface
+       */
+      function makeDemandAPI(products) {
+        let cursor = 0
+        return {
+          wasmModule: {},
+          OpenModelStreamed: jest.fn(() => Promise.resolve(5)),
+          OpenModelAsync: jest.fn(() => Promise.resolve(8)),
+          OpenModel: jest.fn(() => 9),
+          StreamAllMeshes: jest.fn(),
+          ExtractGeometryBatch: jest.fn((modelID, batchSize, cb) => {
+            const take = Math.min(batchSize, products - cursor)
+            for (let i = 0; i < take; i++) {
+              cb({expressID: 1000 + cursor + i, geometries: {size: () => 1}})
+            }
+            cursor += take
+            return {extracted: take, remaining: products - cursor}
+          }),
+        }
+      }
+
+      it('opens deferred and pumps batches to completion', async () => {
+        mockIsFeatureEnabled.mockImplementation((name) => name === 'demandGeometry')
+        const ifcAPI = makeDemandAPI(150)
+        const batches = []
+        const result = await parseIfcWithConway(
+          new ArrayBuffer(4), ifcAPI, undefined, undefined, (batch) => batches.push(batch.length))
+        expect(result.modelID).toBe(5)
+        // Deferred settings rode the open.
+        const [, settings] = ifcAPI.OpenModelStreamed.mock.calls[0]
+        expect(settings.DEFER_GEOMETRY).toBe(true)
+        // 150 products in batches of 64 → 3 extraction rounds; all
+        // meshes accumulate AND stream incrementally.
+        expect(result.captured).toHaveLength(150)
+        expect(batches).toEqual([64, 64, 22])
+        // The one-shot capture path is not used on this branch.
+        expect(ifcAPI.StreamAllMeshes).not.toHaveBeenCalled()
+      })
+
+      it('falls through to the classic selection when the engine lacks the pump', async () => {
+        mockIsFeatureEnabled.mockImplementation((name) => name === 'demandGeometry')
+        const ifcAPI = makeDemandAPI(10)
+        delete ifcAPI.ExtractGeometryBatch
+        const result = await parseIfcWithConway(new ArrayBuffer(4), ifcAPI)
+        // Classic streamed open (no defer), one-shot capture.
+        expect(result.modelID).toBe(5)
+        const [, settings] = ifcAPI.OpenModelStreamed.mock.calls[0]
+        expect(settings?.DEFER_GEOMETRY).toBeUndefined()
+        expect(ifcAPI.StreamAllMeshes).toHaveBeenCalledTimes(1)
+      })
+
+      it('stays on the classic path when the flag is off', async () => {
+        mockIsFeatureEnabled.mockImplementation(() => false)
+        const ifcAPI = makeDemandAPI(10)
+        await parseIfcWithConway(new ArrayBuffer(4), ifcAPI)
+        expect(ifcAPI.ExtractGeometryBatch).not.toHaveBeenCalled()
+        expect(ifcAPI.StreamAllMeshes).toHaveBeenCalledTimes(1)
+      })
+
+      it('disableStreamOpen also disables the demand path', async () => {
+        mockIsFeatureEnabled.mockImplementation(
+          (name) => name === 'demandGeometry' || name === 'disableStreamOpen')
+        const ifcAPI = makeDemandAPI(10)
+        const result = await parseIfcWithConway(new ArrayBuffer(4), ifcAPI)
+        // Full classic fallback: OpenModelAsync, not the deferred open.
+        expect(result.modelID).toBe(8)
+        expect(ifcAPI.ExtractGeometryBatch).not.toHaveBeenCalled()
+      })
+
+      it('demandGeometry ships default-off in FeatureFlags', () => {
+        const {flags} = jest.requireActual('../../FeatureFlags')
+        const flag = flags.find((f) => f.name === 'demandGeometry')
+        expect(flag).toBeDefined()
+        expect(flag.isActive).toBe(false)
+      })
+    })
+
     describe('open-path selection (disableStreamOpen flag)', () => {
       // Share's jest config doesn't clearMocks, so a per-test
       // implementation would otherwise leak into later tests — reset to

--- a/src/viewer/ifc/flatMeshToBatchedModel.js
+++ b/src/viewer/ifc/flatMeshToBatchedModel.js
@@ -48,19 +48,19 @@ import {makeSurfaceMaterial} from '../lookMaterial'
 
 
 /** Fallback colour used when a PlacedGeometry has no `.color` field. */
-const DEFAULT_COLOR = {x: 0.8, y: 0.8, z: 0.8, w: 1}
+export const DEFAULT_COLOR = {x: 0.8, y: 0.8, z: 0.8, w: 1}
 
 /** Interleaved vertex stride from Conway: `[px, py, pz, nx, ny, nz]`. */
-const VERT_STRIDE = 6
+export const VERT_STRIDE = 6
 
 /** Floats per position / normal vector. */
 const VEC3 = 3
 
 /** Indices per triangle. */
-const INDICES_PER_TRIANGLE = 3
+export const INDICES_PER_TRIANGLE = 3
 
 /** An instance is transparent (own blended batch) when alpha is below this. */
-const OPAQUE_ALPHA = 1
+export const OPAQUE_ALPHA = 1
 
 
 /**
@@ -104,7 +104,7 @@ const OPAQUE_ALPHA = 1
  * @param {number} vertCount vertices
  * @return {BufferGeometry}
  */
-function localGeometry(rawVerts, rawIndices, vertCount) {
+export function localGeometry(rawVerts, rawIndices, vertCount) {
   const positions = new Float32Array(vertCount * VEC3)
   const normals = new Float32Array(vertCount * VEC3)
   for (let v = 0; v < vertCount; v++) {

--- a/src/viewer/ifc/flatMeshToBatchedModel.js
+++ b/src/viewer/ifc/flatMeshToBatchedModel.js
@@ -73,6 +73,15 @@ export const OPAQUE_ALPHA = 1
  *   expressID`.
  * @property {Uint32Array} instanceOccurrenceIds `batchId → synthetic 0-based
  *   occurrence id` (global emission order across both batches).
+ * @property {Uint32Array} instanceGeometryIds `batchId → the placement's
+ *   geometryExpressID` (the solid's own id for STEP). Lets per-solid
+ *   selection narrow a multibody part's shared occurrence path to one body,
+ *   mirroring the merged path's `getGeometryExpressIdByInstance`.
+ * @property {Array<Array<number>|null>|null} instanceOccurrencePaths
+ *   `batchId → STEP occurrence path` (NAUO express ids, root→leaf) off
+ *   `PlacedGeometry.occurrencePath`. Null (whole table) for IFC / engines
+ *   that don't emit paths, so nothing downstream pays; per-entry null when
+ *   a single placement has no path.
  * @property {Array<BufferGeometry>} instanceGeometry `batchId → the shared
  *   local-space shape geometry` this instance was added from. Retained so
  *   `batchedSubset` can re-bake a selection/isolation subset (the packed
@@ -203,7 +212,18 @@ function collectGroups(flatMeshes, api, modelID) {
         totals.indexCount += indexSize
       }
       const color = placed.color ?? DEFAULT_COLOR
-      group.placements.push({matrix: placed.flatTransformation, color, parentExpressId, occurrenceId})
+      group.placements.push({
+        matrix: placed.flatTransformation,
+        color,
+        parentExpressId,
+        occurrenceId,
+        // Per-occurrence identity (STEP): the NAUO path disambiguates a
+        // reused part's placements; the geometry id names the solid. Both
+        // ride into the per-batch pick tables so the batched path can
+        // narrow selection / hide to one occurrence like the merged path.
+        occurrencePath: placed.occurrencePath ?? null,
+        geometryExpressId: geomExpressID,
+      })
       occurrenceId++
       totals.placements++
       if (color.w < OPAQUE_ALPHA) {
@@ -253,6 +273,9 @@ function buildBatch(groups, transparent) {
   const mesh = new BatchedMesh(instanceCount, vertexCount, indexCount, material)
   const instanceParents = new Uint32Array(instanceCount)
   const instanceOccurrenceIds = new Uint32Array(instanceCount)
+  const instanceGeometryIds = new Uint32Array(instanceCount)
+  const instanceOccurrencePaths = new Array(instanceCount)
+  let hasOccurrencePaths = false
   const instanceGeometry = new Array(instanceCount)
   const instanceColors = new Array(instanceCount)
   const matrix = new Matrix4()
@@ -268,6 +291,11 @@ function buildBatch(groups, transparent) {
         placement.color.x, placement.color.y, placement.color.z, placement.color.w))
       instanceParents[batchId] = placement.parentExpressId
       instanceOccurrenceIds[batchId] = placement.occurrenceId
+      instanceGeometryIds[batchId] = placement.geometryExpressId
+      instanceOccurrencePaths[batchId] = placement.occurrencePath
+      if (placement.occurrencePath) {
+        hasOccurrencePaths = true
+      }
       instanceGeometry[batchId] = group.geometry
       instanceColors[batchId] = placement.color
     }
@@ -275,6 +303,10 @@ function buildBatch(groups, transparent) {
   return {
     mesh, material, transparent,
     instanceParents, instanceOccurrenceIds, instanceGeometry, instanceColors,
+    instanceGeometryIds,
+    // Null (not an all-null array) for IFC so consumers can cheaply skip
+    // occurrence lookups — mirrors the merged path's IfcInstanceMap.
+    instanceOccurrencePaths: hasOccurrencePaths ? instanceOccurrencePaths : null,
   }
 }
 

--- a/src/viewer/ifc/incrementalBatchedBuilder.js
+++ b/src/viewer/ifc/incrementalBatchedBuilder.js
@@ -1,0 +1,336 @@
+import {BatchedMesh, Box3, DoubleSide, Group, Matrix4, Vector4} from 'three'
+import {forEachVectorItem} from './conwayVector'
+import {makeSurfaceMaterial} from '../lookMaterial'
+import {
+  DEFAULT_COLOR,
+  INDICES_PER_TRIANGLE,
+  OPAQUE_ALPHA,
+  VERT_STRIDE,
+  localGeometry,
+} from './flatMeshToBatchedModel'
+
+
+/* eslint-disable no-magic-numbers */
+/**
+ * Initial per-batch capacities; each grows 2x in place when exceeded
+ * (three r167+ BatchedMesh.setInstanceCount / setGeometrySize).
+ */
+const INITIAL_INSTANCES = 1024
+const INITIAL_VERTICES = 1 << 18
+const INITIAL_INDICES = 1 << 19
+const GROWTH = 2
+/* eslint-enable no-magic-numbers */
+
+
+/**
+ * IncrementalBatchedBuilder — slice B1 of
+ * design/new/demand-tiled-rendering.md: assemble the DURABLE BatchedMesh
+ * model incrementally from the demand pump's delta FlatMesh batches, so
+ * there is no monolithic end-of-load build and no preview→model swap.
+ *
+ * Feed each pump delta to {@link appendBatch}; the builder deduplicates
+ * geometry by `geometryExpressID` across batches (fetched from Conway
+ * once), appends instances into an opaque and/or transparent
+ * `THREE.BatchedMesh` (created lazily, grown in place with 2x
+ * amortization), and accumulates the per-instance pick tables the
+ * batched consumers read (`instanceParents`, `instanceOccurrenceIds`,
+ * `instanceGeometry`, `instanceColors`).
+ *
+ * `root` is a stable `Group` — install it in the scene on the first
+ * batch and geometry simply appears as it extracts. {@link finalize}
+ * stamps the pick tables, computes bounds + BVHs, and returns
+ * `{batches, stats}` in exactly the `flatMeshToBatchedModel` shape, so
+ * `buildBatchedConwayModel`'s decoration applies unchanged.
+ *
+ * Instance/table layout matches the one-shot builder given the same
+ * stream: emission-order `occurrenceId`s, opaque/transparent split by
+ * placement alpha, per-placement skip semantics.
+ */
+export class IncrementalBatchedBuilder {
+  /**
+   * @param {object} api Conway-compatible IfcAPI (`GetGeometry`,
+   *   `GetVertexArray`, `GetIndexArray`).
+   * @param {number} modelID
+   * @param {object} [opts]
+   * @param {Function} [opts.onBounds] called with a world-space `Box3`
+   *   for every appended instance (drives the camera follow).
+   * @param {number} [opts.initialInstances] test hook: initial capacity.
+   * @param {number} [opts.initialVertices] test hook: initial capacity.
+   * @param {number} [opts.initialIndices] test hook: initial capacity.
+   */
+  constructor(api, modelID, opts = {}) {
+    this.api = api
+    this.modelID = modelID
+    this.onBounds = opts.onBounds ?? null
+    this.initialInstances = opts.initialInstances ?? INITIAL_INSTANCES
+    this.initialVertices = opts.initialVertices ?? INITIAL_VERTICES
+    this.initialIndices = opts.initialIndices ?? INITIAL_INDICES
+    this.root = new Group()
+    // geometryExpressID → {geometry, vertCount, indexCount, box,
+    // idByBatch: Map(batchState → geometryId)} — geometry fetched from
+    // Conway exactly once per model.
+    this.geometryCache = new Map()
+    this.badGeometry = new Set()
+    // Lazily created per transparency: see ensureBatch_.
+    this.opaque = null
+    this.transparent = null
+    this.occurrenceId = 0
+    this.totals = {
+      placements: 0, transparentPlacements: 0, vertexCount: 0, indexCount: 0,
+      skippedFlatMeshes: 0, skippedPlacedGeometries: 0,
+    }
+    this.scratchMatrix = new Matrix4()
+    this.scratchRgba = new Vector4()
+    this.scratchBox = new Box3()
+  }
+
+
+  /** @return {boolean} True once any instance has been appended. */
+  hasContent() {
+    return this.totals.placements > 0
+  }
+
+
+  /**
+   * Append one pump delta (a FlatMesh vector or array). Never throws
+   * on per-record problems — mirrors the one-shot builder's skip
+   * accounting.
+   *
+   * @param {object|Array} flatMeshes delta FlatMesh source
+   */
+  appendBatch(flatMeshes) {
+    forEachVectorItem(flatMeshes, (flatMesh) => {
+      const parentExpressId = flatMesh?.expressID
+      const placedVec = flatMesh?.geometries
+      if (parentExpressId === undefined || !placedVec) {
+        this.totals.skippedFlatMeshes++
+        return
+      }
+      forEachVectorItem(placedVec, (placed) => {
+        this.appendPlacement_(parentExpressId, placed)
+      })
+    })
+  }
+
+
+  /**
+   * Stamp typed pick tables, compute bounds, and hand back the batches
+   * + stats in the `flatMeshToBatchedModel` return shape.
+   *
+   * @return {{batches: Array, stats: object}}
+   */
+  finalize() {
+    const batches = []
+    for (const state of [this.opaque, this.transparent]) {
+      if (state === null || state.cursor === 0) {
+        continue
+      }
+      state.mesh.instanceParents = Uint32Array.from(state.instanceParents)
+      state.mesh.instanceOccurrenceIds = Uint32Array.from(state.instanceOccurrenceIds)
+      state.mesh.instanceGeometry = state.instanceGeometry.slice()
+      state.mesh.instanceColors = state.instanceColors.slice()
+      batches.push({
+        mesh: state.mesh,
+        material: state.material,
+        transparent: state.transparentFlag,
+        instanceParents: state.mesh.instanceParents,
+        instanceOccurrenceIds: state.mesh.instanceOccurrenceIds,
+        instanceGeometry: state.mesh.instanceGeometry,
+        instanceColors: state.mesh.instanceColors,
+      })
+    }
+    const parents = new Set()
+    for (const batch of batches) {
+      for (const parent of batch.instanceParents) {
+        parents.add(parent)
+      }
+    }
+    return {
+      batches,
+      stats: {
+        uniqueGeometryCount: this.geometryCache.size,
+        instanceCount: this.totals.placements,
+        vertexCount: this.totals.vertexCount,
+        triangleCount: (this.totals.indexCount / INDICES_PER_TRIANGLE) | 0,
+        parentCount: parents.size,
+        materialCount: batches.length,
+        transparentInstanceCount: this.totals.transparentPlacements,
+        skippedFlatMeshes: this.totals.skippedFlatMeshes,
+        skippedPlacedGeometries: this.totals.skippedPlacedGeometries,
+      },
+    }
+  }
+
+
+  /**
+   * Resolve (or reject) one placement and append its instance.
+   *
+   * @param {number} parentExpressId
+   * @param {object} placed Conway PlacedGeometry
+   */
+  appendPlacement_(parentExpressId, placed) {
+    const geomExpressID = placed?.geometryExpressID
+    if (geomExpressID === undefined) {
+      this.totals.skippedPlacedGeometries++
+      return
+    }
+    const entry = this.resolveGeometry_(geomExpressID)
+    if (entry === null) {
+      this.totals.skippedPlacedGeometries++
+      return
+    }
+    const color = placed.color ?? DEFAULT_COLOR
+    const isTransparent = color.w < OPAQUE_ALPHA
+    const state = this.ensureBatch_(isTransparent)
+    this.ensureCapacity_(state, entry)
+
+    let geometryId = entry.idByBatch.get(state)
+    if (geometryId === undefined) {
+      geometryId = state.mesh.addGeometry(entry.geometry)
+      entry.idByBatch.set(state, geometryId)
+    }
+    const batchId = state.mesh.addInstance(geometryId)
+    const matrix = this.scratchMatrix.fromArray(placed.flatTransformation)
+    state.mesh.setMatrixAt(batchId, matrix)
+    state.mesh.setColorAt(batchId, this.scratchRgba.set(color.x, color.y, color.z, color.w))
+    state.instanceParents.push(parentExpressId)
+    state.instanceOccurrenceIds.push(this.occurrenceId)
+    state.instanceGeometry.push(entry.geometry)
+    state.instanceColors.push(color)
+    state.cursor++
+    this.occurrenceId++
+    this.totals.placements++
+    if (isTransparent) {
+      this.totals.transparentPlacements++
+    }
+    if (this.onBounds !== null) {
+      try {
+        this.onBounds(this.scratchBox.copy(entry.box).applyMatrix4(matrix))
+      } catch {
+        // Camera follow is best-effort — never break the append.
+      }
+    }
+  }
+
+
+  /**
+   * Fetch-and-cache one geometry from Conway (once per model), or null
+   * for known-bad/degenerate shapes.
+   *
+   * @param {number} geomExpressID
+   * @return {object|null} cache entry
+   */
+  resolveGeometry_(geomExpressID) {
+    const cached = this.geometryCache.get(geomExpressID)
+    if (cached !== undefined) {
+      return cached
+    }
+    if (this.badGeometry.has(geomExpressID)) {
+      return null
+    }
+    // eslint-disable-next-line new-cap
+    const geom = this.api.GetGeometry(this.modelID, geomExpressID)
+    if (!geom) {
+      this.badGeometry.add(geomExpressID)
+      return null
+    }
+    // eslint-disable-next-line new-cap
+    const indexSize = geom.GetIndexDataSize()
+    // eslint-disable-next-line new-cap
+    const vertSize = geom.GetVertexDataSize()
+    if (indexSize === 0 || vertSize === 0 || vertSize % VERT_STRIDE !== 0) {
+      this.badGeometry.add(geomExpressID)
+      return null
+    }
+    const vertCount = (vertSize / VERT_STRIDE) | 0
+    // eslint-disable-next-line new-cap
+    const rawVerts = this.api.GetVertexArray(geom.GetVertexData(), vertCount * VERT_STRIDE)
+    // eslint-disable-next-line new-cap
+    const rawIndices = this.api.GetIndexArray(geom.GetIndexData(), indexSize)
+    const geometry = localGeometry(rawVerts, rawIndices, vertCount)
+    geometry.computeBoundingBox()
+    const entry = {
+      geometry,
+      vertCount,
+      indexCount: indexSize,
+      box: geometry.boundingBox,
+      idByBatch: new Map(),
+    }
+    this.geometryCache.set(geomExpressID, entry)
+    this.totals.vertexCount += vertCount
+    this.totals.indexCount += indexSize
+    return entry
+  }
+
+
+  /**
+   * Get (or lazily create + parent) the batch state for a transparency.
+   *
+   * @param {boolean} transparent
+   * @return {object} batch state
+   */
+  ensureBatch_(transparent) {
+    const key = transparent ? 'transparent' : 'opaque'
+    if (this[key] !== null) {
+      return this[key]
+    }
+    const material = makeSurfaceMaterial({side: DoubleSide})
+    if (transparent) {
+      material.transparent = true
+      material.depthWrite = false
+    }
+    const mesh = new BatchedMesh(
+      this.initialInstances, this.initialVertices, this.initialIndices, material)
+    const state = {
+      mesh,
+      material,
+      transparentFlag: transparent,
+      cursor: 0,
+      maxInstances: this.initialInstances,
+      maxVertices: this.initialVertices,
+      maxIndices: this.initialIndices,
+      usedVertices: 0,
+      usedIndices: 0,
+      instanceParents: [],
+      instanceOccurrenceIds: [],
+      instanceGeometry: [],
+      instanceColors: [],
+    }
+    this[key] = state
+    this.root.add(mesh)
+    return state
+  }
+
+
+  /**
+   * Grow the batch in place (2x amortized) so the next instance — and,
+   * when the geometry is new to this batch, its vertex/index ranges —
+   * fit. three's setInstanceCount/setGeometrySize copy the underlying
+   * buffers; growth doubles so total copy work stays linear.
+   *
+   * @param {object} state batch state
+   * @param {object} entry geometry cache entry
+   */
+  ensureCapacity_(state, entry) {
+    if (state.cursor + 1 > state.maxInstances) {
+      state.maxInstances = Math.max(state.maxInstances * GROWTH, state.cursor + 1)
+      state.mesh.setInstanceCount(state.maxInstances)
+    }
+    if (entry.idByBatch.has(state)) {
+      return
+    }
+    const needVertices = state.usedVertices + entry.vertCount
+    const needIndices = state.usedIndices + entry.indexCount
+    if (needVertices > state.maxVertices || needIndices > state.maxIndices) {
+      while (state.maxVertices < needVertices) {
+        state.maxVertices *= GROWTH
+      }
+      while (state.maxIndices < needIndices) {
+        state.maxIndices *= GROWTH
+      }
+      state.mesh.setGeometrySize(state.maxVertices, state.maxIndices)
+    }
+    state.usedVertices = needVertices
+    state.usedIndices = needIndices
+  }
+}

--- a/src/viewer/ifc/incrementalBatchedBuilder.js
+++ b/src/viewer/ifc/incrementalBatchedBuilder.js
@@ -127,6 +127,12 @@ export class IncrementalBatchedBuilder {
       }
       state.mesh.instanceParents = Uint32Array.from(state.instanceParents)
       state.mesh.instanceOccurrenceIds = Uint32Array.from(state.instanceOccurrenceIds)
+      state.mesh.instanceGeometryIds = Uint32Array.from(state.instanceGeometryIds)
+      // Null (not an all-null array) for IFC — matches the one-shot
+      // builder so consumers can cheaply skip occurrence lookups.
+      state.mesh.instanceOccurrencePaths =
+        state.instanceOccurrencePaths.some((p) => p !== null) ?
+          state.instanceOccurrencePaths.slice() : null
       state.mesh.instanceGeometry = state.instanceGeometry.slice()
       state.mesh.instanceColors = state.instanceColors.slice()
       batches.push({
@@ -135,6 +141,8 @@ export class IncrementalBatchedBuilder {
         transparent: state.transparentFlag,
         instanceParents: state.mesh.instanceParents,
         instanceOccurrenceIds: state.mesh.instanceOccurrenceIds,
+        instanceGeometryIds: state.mesh.instanceGeometryIds,
+        instanceOccurrencePaths: state.mesh.instanceOccurrencePaths,
         instanceGeometry: state.mesh.instanceGeometry,
         instanceColors: state.mesh.instanceColors,
       })
@@ -195,6 +203,10 @@ export class IncrementalBatchedBuilder {
     state.mesh.setColorAt(batchId, this.scratchRgba.set(color.x, color.y, color.z, color.w))
     state.instanceParents.push(parentExpressId)
     state.instanceOccurrenceIds.push(this.occurrenceId)
+    // Per-occurrence identity (STEP): NAUO path + solid geometry id, so
+    // the batched consumers can narrow selection / hide to one occurrence.
+    state.instanceGeometryIds.push(geomExpressID)
+    state.instanceOccurrencePaths.push(placed.occurrencePath ?? null)
     state.instanceGeometry.push(entry.geometry)
     state.instanceColors.push(color)
     state.cursor++
@@ -293,6 +305,8 @@ export class IncrementalBatchedBuilder {
       usedIndices: 0,
       instanceParents: [],
       instanceOccurrenceIds: [],
+      instanceGeometryIds: [],
+      instanceOccurrencePaths: [],
       instanceGeometry: [],
       instanceColors: [],
     }

--- a/src/viewer/ifc/incrementalBatchedBuilder.test.js
+++ b/src/viewer/ifc/incrementalBatchedBuilder.test.js
@@ -1,0 +1,130 @@
+
+import {BatchedMesh} from 'three'
+import {IncrementalBatchedBuilder} from './incrementalBatchedBuilder'
+import {flatMeshToBatchedModel} from './flatMeshToBatchedModel'
+
+
+const IDENTITY_MAT = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]
+const OPAQUE = {x: 0.8, y: 0.8, z: 0.8, w: 1}
+const GLASS = {x: 0.6, y: 0.8, z: 1, w: 0.4}
+
+
+/** @return {Float32Array} single-triangle interleaved verts (p+n). */
+function unitTriangleVerts() {
+  return new Float32Array([
+    0, 0, 0, 0, 0, 1,
+    1, 0, 0, 0, 0, 1,
+    0, 1, 0, 0, 0, 1,
+  ])
+}
+
+
+/**
+ * @param {object} byGeomExpressId geomExpressID → {vertexData, indexData}
+ * @return {object} mock Conway IfcAPI
+ */
+function makeApi(byGeomExpressId) {
+  return {
+    GetGeometry(_modelID, geomExpressID) {
+      const g = byGeomExpressId[geomExpressID]
+      if (!g) {
+        return null
+      }
+      return {
+        GetVertexData: () => geomExpressID,
+        GetIndexData: () => geomExpressID,
+        GetVertexDataSize: () => g.vertexData.length,
+        GetIndexDataSize: () => g.indexData.length,
+      }
+    },
+    GetVertexArray(ptr) {
+      return byGeomExpressId[ptr].vertexData
+    },
+    GetIndexArray(ptr) {
+      return byGeomExpressId[ptr].indexData
+    },
+  }
+}
+
+
+/**
+ * @param {number} expressID parent product id
+ * @param {Array} placements [{geomExpressID, color}]
+ * @return {object} FlatMesh-shaped object
+ */
+function flatMesh(expressID, placements) {
+  return {
+    expressID,
+    geometries: placements.map(({geomExpressID, color}) => ({
+      geometryExpressID: geomExpressID,
+      flatTransformation: IDENTITY_MAT,
+      color,
+    })),
+  }
+}
+
+
+describe('IncrementalBatchedBuilder', () => {
+  const shapes = {
+    999: {vertexData: unitTriangleVerts(), indexData: new Uint32Array([0, 1, 2])},
+    888: {vertexData: unitTriangleVerts(), indexData: new Uint32Array([0, 1, 2])},
+  }
+
+  it('matches the one-shot builder across split appends', () => {
+    const stream = [
+      flatMesh(1, [{geomExpressID: 999, color: OPAQUE}]),
+      flatMesh(2, [{geomExpressID: 999, color: OPAQUE}, {geomExpressID: 888, color: GLASS}]),
+      flatMesh(3, [{geomExpressID: 888, color: OPAQUE}]),
+    ]
+    const oneShot = flatMeshToBatchedModel(stream, makeApi(shapes), 0)
+
+    const builder = new IncrementalBatchedBuilder(makeApi(shapes), 0)
+    builder.appendBatch([stream[0]])
+    builder.appendBatch([stream[1], stream[2]])
+    const incremental = builder.finalize()
+
+    expect(incremental.stats).toEqual(oneShot.stats)
+    expect(incremental.batches).toHaveLength(oneShot.batches.length)
+    for (let where = 0; where < incremental.batches.length; where++) {
+      const a = incremental.batches[where]
+      const b = oneShot.batches[where]
+      expect(a.transparent).toBe(b.transparent)
+      expect(Array.from(a.instanceParents)).toEqual(Array.from(b.instanceParents))
+      expect(Array.from(a.instanceOccurrenceIds)).toEqual(Array.from(b.instanceOccurrenceIds))
+      expect(a.mesh).toBeInstanceOf(BatchedMesh)
+    }
+  })
+
+  it('grows capacity in place across small initial limits', () => {
+    const builder = new IncrementalBatchedBuilder(makeApi(shapes), 0, {
+      initialInstances: 1, initialVertices: 3, initialIndices: 3,
+    })
+    for (let product = 1; product <= 5; product++) {
+      builder.appendBatch([flatMesh(product, [
+        {geomExpressID: 999, color: OPAQUE},
+        {geomExpressID: 888, color: OPAQUE},
+      ])])
+    }
+    const {batches, stats} = builder.finalize()
+    expect(stats.instanceCount).toBe(10)
+    expect(stats.uniqueGeometryCount).toBe(2)
+    expect(batches).toHaveLength(1)
+    expect(batches[0].instanceParents).toHaveLength(10)
+  })
+
+  it('reports bounds per appended instance and skips bad geometry', () => {
+    const boxes = []
+    const builder = new IncrementalBatchedBuilder(makeApi(shapes), 0, {
+      onBounds: (box) => boxes.push(box.clone()),
+    })
+    builder.appendBatch([
+      flatMesh(1, [{geomExpressID: 999, color: OPAQUE}]),
+      flatMesh(2, [{geomExpressID: 12345, color: OPAQUE}]),
+    ])
+    expect(boxes).toHaveLength(1)
+    expect(boxes[0].max.x).toBeCloseTo(1)
+    const {stats} = builder.finalize()
+    expect(stats.skippedPlacedGeometries).toBe(1)
+    expect(builder.hasContent()).toBe(true)
+  })
+})

--- a/src/viewer/ifc/parsePreviewMesh.js
+++ b/src/viewer/ifc/parsePreviewMesh.js
@@ -1,0 +1,61 @@
+import {
+  BufferAttribute,
+  BufferGeometry,
+  DoubleSide,
+  InterleavedBuffer,
+  InterleavedBufferAttribute,
+  Mesh,
+} from 'three'
+import {makeSurfaceColor, makeSurfaceMaterial} from '../lookMaterial'
+
+
+/**
+ * Demand/tiled rendering slice A2 (#1613): build a render-only THREE.Mesh
+ * from a conway PreviewMeshPayload — the parse-time preview channel's
+ * self-contained emission (geometry already copied out of the wasm heap,
+ * interleaved [px,py,pz,nx,ny,nz], transform premultiplied with the
+ * pinned coordination frame).
+ *
+ * Payloads for shared (mapped) geometry omit `vertexData`/`indexData`
+ * after the first emission; `geometryCache` (keyed by geometryExpressID)
+ * resolves those to the earlier BufferGeometry — so callers must reuse
+ * one cache per load. Materials are pooled by rgba in `materialCache`.
+ * Preview meshes are disposable by design: the durable batches (and the
+ * final build) replace them wholesale.
+ *
+ * @param {object} payload conway PreviewMeshPayload
+ * @param {Map<number, object>} geometryCache geometryExpressID → BufferGeometry
+ * @param {Map<string, object>} materialCache rgba key → Material
+ * @return {object|null} a matrix-stamped Mesh, or null when the payload
+ *   references geometry this load has not seen (nothing to render)
+ */
+export function payloadToPreviewMesh(payload, geometryCache, materialCache) {
+  let geometry = geometryCache.get(payload.geometryExpressID)
+  if (geometry === undefined) {
+    if (payload.vertexData === undefined || payload.indexData === undefined) {
+      return null
+    }
+    geometry = new BufferGeometry()
+    const floatsPerVertex = 6
+    const interleaved = new InterleavedBuffer(payload.vertexData, floatsPerVertex)
+    geometry.setAttribute('position', new InterleavedBufferAttribute(interleaved, 3, 0))
+    geometry.setAttribute('normal', new InterleavedBufferAttribute(interleaved, 3, 3))
+    geometry.setIndex(new BufferAttribute(payload.indexData, 1))
+    geometryCache.set(payload.geometryExpressID, geometry)
+  }
+  const {x, y, z, w} = payload.color
+  const materialKey = `${x},${y},${z},${w}`
+  let material = materialCache.get(materialKey)
+  if (material === undefined) {
+    material = makeSurfaceMaterial({color: makeSurfaceColor(x, y, z), side: DoubleSide})
+    if (w !== 1) {
+      material.transparent = true
+      material.opacity = w
+    }
+    materialCache.set(materialKey, material)
+  }
+  const mesh = new Mesh(geometry, material)
+  mesh.matrixAutoUpdate = false
+  mesh.matrix.fromArray(payload.flatTransformation)
+  return mesh
+}

--- a/src/viewer/ifc/parsePreviewMesh.test.js
+++ b/src/viewer/ifc/parsePreviewMesh.test.js
@@ -1,0 +1,68 @@
+/* eslint-disable no-magic-numbers */
+import {payloadToPreviewMesh} from './parsePreviewMesh'
+
+
+describe('viewer/ifc/parsePreviewMesh', () => {
+  /**
+   * @param {object} [overrides] payload field overrides
+   * @return {object} a minimal carrier payload (one triangle)
+   */
+  function makePayload(overrides = {}) {
+    return {
+      expressID: 42,
+      geometryExpressID: 7,
+      color: {x: 0.5, y: 0.25, z: 0.125, w: 1},
+      flatTransformation: [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 10, 20, 30, 1],
+      vertexData: new Float32Array([
+        0, 0, 0, 0, 0, 1,
+        1, 0, 0, 0, 0, 1,
+        0, 1, 0, 0, 0, 1,
+      ]),
+      indexData: new Uint32Array([0, 1, 2]),
+      ...overrides,
+    }
+  }
+
+  it('builds a matrix-stamped mesh from a carrier payload', () => {
+    const geometryCache = new Map()
+    const materialCache = new Map()
+    const mesh = payloadToPreviewMesh(makePayload(), geometryCache, materialCache)
+    expect(mesh).not.toBeNull()
+    expect(mesh.matrixAutoUpdate).toBe(false)
+    expect(mesh.matrix.elements[12]).toBe(10)
+    expect(mesh.matrix.elements[13]).toBe(20)
+    expect(mesh.matrix.elements[14]).toBe(30)
+    expect(mesh.geometry.getAttribute('position').count).toBe(3)
+    expect(mesh.geometry.getIndex().count).toBe(3)
+    expect(geometryCache.size).toBe(1)
+    expect(materialCache.size).toBe(1)
+  })
+
+  it('resolves data-less payloads through the geometry cache (mapped sharing)', () => {
+    const geometryCache = new Map()
+    const materialCache = new Map()
+    const first = payloadToPreviewMesh(makePayload(), geometryCache, materialCache)
+    const second = payloadToPreviewMesh(
+      makePayload({expressID: 43, vertexData: undefined, indexData: undefined}),
+      geometryCache, materialCache)
+    expect(second).not.toBeNull()
+    expect(second.geometry).toBe(first.geometry)
+    expect(second.material).toBe(first.material)
+    expect(geometryCache.size).toBe(1)
+    expect(materialCache.size).toBe(1)
+  })
+
+  it('returns null for a data-less payload with no cached geometry', () => {
+    const mesh = payloadToPreviewMesh(
+      makePayload({vertexData: undefined, indexData: undefined}), new Map(), new Map())
+    expect(mesh).toBeNull()
+  })
+
+  it('marks translucent colors transparent', () => {
+    const materialCache = new Map()
+    const mesh = payloadToPreviewMesh(
+      makePayload({color: {x: 0.2, y: 0.4, z: 0.6, w: 0.5}}), new Map(), materialCache)
+    expect(mesh.material.transparent).toBe(true)
+    expect(mesh.material.opacity).toBe(0.5)
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -2473,10 +2473,10 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@bldrs-ai/conway@1.425.1281":
-  version "1.425.1281"
-  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.425.1281.tgz#2d586f9f232dc2ecdff3c41512da1119b45cb7f6"
-  integrity sha512-6xYvrjDGxbSfGYKlOIYhBoC50DIPvfx+igjbpC80E66PEk0cbVhKrdMADZkhROtge5i5yP5Nmwl2UxeANgyYKg==
+"@bldrs-ai/conway@1.426.1283":
+  version "1.426.1283"
+  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.426.1283.tgz#36af322de2cbe511e29557c99e74ab9f7e7c6459"
+  integrity sha512-SyniJQ3gmmkQ/KbVbuZneOiAoJFFd23oQAG3RLrbTFKnSqxodx+DdALdEXtSLp797K6kXKfjAsnnH+rmcGRTbg==
   dependencies:
     gl-matrix "3.4.3"
     seedrandom "3.0.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2473,10 +2473,10 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@bldrs-ai/conway@1.431.1296":
-  version "1.431.1296"
-  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.431.1296.tgz#117f071f287e14869f117b950685227f2526b8e1"
-  integrity sha512-uk7C+8lfDFwsZr+SfVW+Y0RqfHzdsxro9Jlh3x1H7/DOwDi57H+DXmISW0g0vg6ZLn5vapNFpk08rgi9KvhVKQ==
+"@bldrs-ai/conway@1.434.1300":
+  version "1.434.1300"
+  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.434.1300.tgz#aefac4f2a14ea71c6241300cf90c7b53e98aff5d"
+  integrity sha512-QjFXEiBBvX4tbO3qAk577512JdIGXTe+BL2lFltiT3tE6Z+KmWhLJ6UxnybdVzO5h8kT5PZtqUAkKVmwBcHC+g==
   dependencies:
     gl-matrix "3.4.3"
     seedrandom "3.0.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2473,10 +2473,10 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@bldrs-ai/conway@1.430.1294":
-  version "1.430.1294"
-  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.430.1294.tgz#ce5f59a0b7152bcf5c42bcf7db932b988a98095a"
-  integrity sha512-dvsP1GYtrbzie4vw1G9Ewmv9HVsVmzL+lZ19klrYnrsLHKeHUffqTQbF4m8qN6E5DF2W781bBNmy2Ae+mlQHLw==
+"@bldrs-ai/conway@1.431.1296":
+  version "1.431.1296"
+  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.431.1296.tgz#117f071f287e14869f117b950685227f2526b8e1"
+  integrity sha512-uk7C+8lfDFwsZr+SfVW+Y0RqfHzdsxro9Jlh3x1H7/DOwDi57H+DXmISW0g0vg6ZLn5vapNFpk08rgi9KvhVKQ==
   dependencies:
     gl-matrix "3.4.3"
     seedrandom "3.0.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2473,10 +2473,10 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@bldrs-ai/conway@1.426.1283":
-  version "1.426.1283"
-  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.426.1283.tgz#36af322de2cbe511e29557c99e74ab9f7e7c6459"
-  integrity sha512-SyniJQ3gmmkQ/KbVbuZneOiAoJFFd23oQAG3RLrbTFKnSqxodx+DdALdEXtSLp797K6kXKfjAsnnH+rmcGRTbg==
+"@bldrs-ai/conway@1.428.1289":
+  version "1.428.1289"
+  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.428.1289.tgz#c741fe1ae1e73bf2607c92b0dd605b260f339316"
+  integrity sha512-ZoaSHtsiXSM3y5XPPw++hbB8dGxUk/2GodnbeYBfUfs4JR6UOwi+PsoxLTrQ4llScwTbaIi/9hLrbOl0ILnneA==
   dependencies:
     gl-matrix "3.4.3"
     seedrandom "3.0.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2473,10 +2473,10 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@bldrs-ai/conway@1.419.1268":
-  version "1.419.1268"
-  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.419.1268.tgz#62164b1f3499a8a15d125dcd8a2ed82e0ef0c291"
-  integrity sha512-uXdbgNX7Giev6gbkz9HYiomOVnSb2WejNdgJesUUDql/XHH+HlZWJW711AGYW+C5LFqXwWsModaBzcKE9f0HUQ==
+"@bldrs-ai/conway@1.422.1273":
+  version "1.422.1273"
+  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.422.1273.tgz#a69caf9f752ec73e0819b02c4578b9e0fbf23713"
+  integrity sha512-FOsFzf3wpjdNPLYM3X/JClkiUxssALQzIGQIys/ndH5wKv3rMEv8af3zNCXb7QcX5XJET7Z0mDNs4HG97Qtc8w==
   dependencies:
     gl-matrix "3.4.3"
     seedrandom "3.0.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2473,10 +2473,10 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@bldrs-ai/conway@1.429.1291":
-  version "1.429.1291"
-  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.429.1291.tgz#24fcd7f9769fd6132bbe059734375d4bc1d748f3"
-  integrity sha512-7XwB/taawgDFxO5KKzkGG8J7SGjHfunD1rNY5P9iolJvvFQZWr2Z3sWmPB29kgliPSARS7jEbigIXaY+vNGrqA==
+"@bldrs-ai/conway@1.430.1294":
+  version "1.430.1294"
+  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.430.1294.tgz#ce5f59a0b7152bcf5c42bcf7db932b988a98095a"
+  integrity sha512-dvsP1GYtrbzie4vw1G9Ewmv9HVsVmzL+lZ19klrYnrsLHKeHUffqTQbF4m8qN6E5DF2W781bBNmy2Ae+mlQHLw==
   dependencies:
     gl-matrix "3.4.3"
     seedrandom "3.0.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2473,10 +2473,10 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@bldrs-ai/conway@1.423.1278":
-  version "1.423.1278"
-  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.423.1278.tgz#a18a1ae0f054066adfece4fd2537ef7f9fdb690f"
-  integrity sha512-MgMST8/sWg2p9yD9T9bRA34A9vSufCSBPgnv2FIDUHupT7ZENiDmqkjY2UFgNG1oWOPeHMwo63aU2VqcHgkchw==
+"@bldrs-ai/conway@1.425.1281":
+  version "1.425.1281"
+  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.425.1281.tgz#2d586f9f232dc2ecdff3c41512da1119b45cb7f6"
+  integrity sha512-6xYvrjDGxbSfGYKlOIYhBoC50DIPvfx+igjbpC80E66PEk0cbVhKrdMADZkhROtge5i5yP5Nmwl2UxeANgyYKg==
   dependencies:
     gl-matrix "3.4.3"
     seedrandom "3.0.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2473,10 +2473,10 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@bldrs-ai/conway@1.422.1273":
-  version "1.422.1273"
-  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.422.1273.tgz#a69caf9f752ec73e0819b02c4578b9e0fbf23713"
-  integrity sha512-FOsFzf3wpjdNPLYM3X/JClkiUxssALQzIGQIys/ndH5wKv3rMEv8af3zNCXb7QcX5XJET7Z0mDNs4HG97Qtc8w==
+"@bldrs-ai/conway@1.423.1278":
+  version "1.423.1278"
+  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.423.1278.tgz#a18a1ae0f054066adfece4fd2537ef7f9fdb690f"
+  integrity sha512-MgMST8/sWg2p9yD9T9bRA34A9vSufCSBPgnv2FIDUHupT7ZENiDmqkjY2UFgNG1oWOPeHMwo63aU2VqcHgkchw==
   dependencies:
     gl-matrix "3.4.3"
     seedrandom "3.0.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2473,10 +2473,10 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@bldrs-ai/conway@1.428.1289":
-  version "1.428.1289"
-  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.428.1289.tgz#c741fe1ae1e73bf2607c92b0dd605b260f339316"
-  integrity sha512-ZoaSHtsiXSM3y5XPPw++hbB8dGxUk/2GodnbeYBfUfs4JR6UOwi+PsoxLTrQ4llScwTbaIi/9hLrbOl0ILnneA==
+"@bldrs-ai/conway@1.429.1291":
+  version "1.429.1291"
+  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.429.1291.tgz#24fcd7f9769fd6132bbe059734375d4bc1d748f3"
+  integrity sha512-7XwB/taawgDFxO5KKzkGG8J7SGjHfunD1rNY5P9iolJvvFQZWr2Z3sWmPB29kgliPSARS7jEbigIXaY+vNGrqA==
   dependencies:
     gl-matrix "3.4.3"
     seedrandom "3.0.5"


### PR DESCRIPTION
Milestone PR for #1613 (design doc: `design/new/demand-tiled-rendering.md` in this diff). Measured on PSB.ifc (860MB): **77s → 57s total**, with first geometry on screen during the parse and the end-of-load assemble stage collapsed from 27s to 3.5s. Arty STEP streams progressively with a clean report.

## What's here

- **`demandGeometry` flag + loader branch** (`parseIfcWithConway`): deferred columnar open (`DEFER_GEOMETRY`) → `ExtractGeometryBatch` pump (64 products/round, throttle-proof yields via `scheduler.yield`/MessageChannel) → `onMeshBatch`/`onPreviewMesh` hooks. Fully feature-detected; old engines, flag-off, and `disableStreamOpen` fall through to the classic path. STEP fallback serves `StreamAllMeshes` when the pump has nothing.
- **Parse-time preview** (`parsePreviewMesh.js`): conway's preview channel payloads render during the parse — interleaved buffers, geometry cached by `geometryExpressID`, materials pooled by rgba.
- **`ProgressiveLoadSession`** (`src/viewer/ProgressiveLoadSession.js`): format-neutral load state machine (idle → previewing → assembling → finished/aborted) shared by IFC and STEP — owns the preview group lifecycle, the strict-fit camera follow (running union box, overflow-triggered refits, dolly-clamp growth so big models never overflow the window, stop-on-user-input), and progress/summary reporting (`setLoadSummary` onto the report's Total line, with units via `GetLinearScalingFactor`).
- **B1 — incremental durable assembly** (`incrementalBatchedBuilder.js`): pump deltas assemble the durable BatchedMesh model directly — geometry deduped across batches, instances appended into opaque/transparent batches grown in place (2× amortized), pick tables accumulated per batch. The on-screen group IS the final model (decoration shared with the one-shot path via `assembleBatchedModel`); no monolithic build, no preview→model swap. Builder failure falls back to the previous path.
- **Native geometry release**: `ReleaseModelGeometry` after the GLB write (with the source spill), so repeated loads reuse wasm pages.
- **conway 1.434.1300**: deferred open + pump + preview channel (schema-parametric, STEP parity), coordination identity contract, float-mirror freeze, snapshot complex-entry cloning, quiet preview-prefix logging.

## Tests

Full suite green (216 suites / 1976 tests): pump parity + fallthroughs, preview payload conversion, session state machine + strict-fit/overflow/dolly-clamp behavior, incremental-vs-one-shot builder parity + in-place growth, load report format.

## Pre-merge note

`demandGeometry` is default-ON from branch burn-in (`src/FeatureFlags.js` comment says "flip back before merging") — decide at submit: keep on to ship the demand path, or flip off for `?feature=` opt-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S6gTXmrq1GbhqknPqQMRuz