### PR TITLE
Block-indexed container for element properties (schema 0.13.0)

### DIFF
--- a/design/new/lazy-properties-memory.md
+++ b/design/new/lazy-properties-memory.md
@@ -115,6 +115,32 @@ suspicion. What's robust:
 - **Neither step moves the 448 MB / ~150–200 s geometry write** — that's
   identical across prod/#1588/#1589 and is the compression track (below).
 
+### Step 3.5 — reader-side block-indexed properties container (GLB schema 0.13.0)
+
+The streaming writer (#1589) fixed the *write* side but the reader
+still inflated the whole payload as ONE string (`pako.ungzip(...,
+{to: 'string'})`) and `JSON.parse`d it into one object graph. Two
+failures: V8 caps a single string at ~512MiB, so a PSB-class model's
+properties died in pako's string join (`RangeError: Invalid string
+length` — observed in the field 2026-07) with the panel silently
+empty; and even under the cap, the parse materialised a multi-GB
+graph for a panel that reads one element at a time.
+
+Replaced the wire format with a block-indexed container ("BPRI"
+magic): gzipped header (id→block index + pset table) + independently
+gzipped ~1MB record blocks. The reader decodes the header on first
+access and one block per record miss (16-block LRU) — every string
+and object graph on the read path is bounded by the block size. Both
+capture paths emit the same container (the streaming sweep feeds
+blocks incrementally; the slow BFS encodes its map), so
+`injectGlbExtensions` always gets `precompressed` bytes.
+
+**No legacy read path** (deliberate — the extension was unannounced):
+the 0.13.0 cache-key bump makes old local artifacts read as a miss
+and rewrite; an old-format payload arriving as a shared GLB *file*
+raises a "Clear Local Cache" alert instead of decoding. See
+`bldrsElementProperties.js` header comment for the byte layout.
+
 > **Merge-order note (why it mattered):** #1588 and #1589 are independent
 > branches, but #1588 alone keeps the *eager* capture and rode the OOM;
 > #1589 has the fix. #1588's `ReleaseEntityCache` releases are also no-ops

--- a/src/loader/GlbWriter.worker.js
+++ b/src/loader/GlbWriter.worker.js
@@ -4,9 +4,9 @@
 // parse write.
 //
 // What this worker handles (post-GLTFExporter, post-compression):
-//   - JSON.stringify on the per-extension payload (heavy on
-//     `BLDRS_element_properties` — multi-MB nested objects on big
-//     IFCs)
+//   - JSON.stringify on the per-extension payload (multi-MB nested
+//     objects on big IFCs; `BLDRS_element_properties` arrives as
+//     precompressed container bytes and skips this)
 //   - pako.gzip on the resulting bytes (CPU-bound)
 //   - injectGlbExtensions byte-splice (sync but fast once stringify
 //     + gzip are done)
@@ -39,7 +39,7 @@
 //     mode: 'draco' | 'meshopt' | null,
 //     extensions: [
 //       {name: 'BLDRS_spatial_tree',      data: object|null, compress: true},
-//       {name: 'BLDRS_element_properties', data: object|null, compress: true},
+//       {name: 'BLDRS_element_properties', precompressed: Uint8Array|undefined},
 //       {name: 'BLDRS_face_ids',          data: object|null, compress: true},
 //     ],
 //     sceneExtras: {                  // optional small string-keyed

--- a/src/loader/Loader.convertToShareModel.test.js
+++ b/src/loader/Loader.convertToShareModel.test.js
@@ -7,6 +7,7 @@
 
 import {BufferAttribute, BufferGeometry, Mesh, Scene} from 'three'
 import {__sanitizeCachedTitleForTest, convertToShareModel} from './Loader'
+import {encodeElementProperties, makeElementPropertiesPayload} from './bldrsElementProperties'
 import {decorateShareModel, inferModelCapabilities} from '../viewer/ShareModel'
 import {attachElementSubsets} from '../viewer/three/elementSubsets'
 
@@ -271,27 +272,27 @@ describe('Loader/convertToShareModel — Phase 2b.2 capability + subset wiring',
 
   it('cache-hit BLDRS_element_properties hydrates getItemProperties and getPropertySets', () => {
     // Mirrors what `BldrsElementPropertiesReader#afterRoot` parks: a
-    // `{compressed, decode}` lazy payload. The hydration block in
-    // convertToShareModel attaches closures that read the maps for
-    // entity / pset lookups via the payload's `decode()` (which caches
-    // internally — see makeLazyPayload). Each closure call hits
-    // `decode()` but the gzip / JSON.parse work happens once.
-    const decoded = {
-      itemProperties: {
-        100: {expressID: 100, Name: {type: 1, value: 'Wall A'}},
-        500: {expressID: 500, Name: {type: 1, value: 'Pset_WallCommon'}, HasProperties: []},
-      },
-      propertySets: {100: [500]},
+    // `{compressed, getRecord, getPsetIds}` lazy per-entity payload.
+    // The hydration block in convertToShareModel attaches closures
+    // that delegate lookups to the payload's accessors (which decode
+    // the header index + record blocks lazily — see
+    // makeElementPropertiesPayload).
+    const records = {
+      100: {expressID: 100, Name: {type: 1, value: 'Wall A'}},
+      500: {expressID: 500, Name: {type: 1, value: 'Pset_WallCommon'}, HasProperties: []},
     }
-    // Realistic mock: decode() returns the same object every time
-    // (proves the closures use the cached payload, not re-parse).
+    const psetIndex = {100: [500]}
     const mesh = new Mesh(new BufferGeometry())
-    let decodeReturns = 0
+    let accessorCalls = 0
     mesh.userData.bldrsElementProperties = {
       compressed: new Uint8Array([0]),
-      decode() {
-        decodeReturns++
-        return decoded
+      getRecord(id) {
+        accessorCalls++
+        return records[id]
+      },
+      getPsetIds(id) {
+        accessorCalls++
+        return psetIndex[id] ?? []
       },
     }
     convertToShareModel(mesh, makeViewerStub())
@@ -299,12 +300,8 @@ describe('Loader/convertToShareModel — Phase 2b.2 capability + subset wiring',
     expect(typeof mesh.getItemProperties).toBe('function')
     expect(typeof mesh.getPropertySets).toBe('function')
     // No decode happens at hydration time — closures defer the work.
-    expect(decodeReturns).toBe(0)
+    expect(accessorCalls).toBe(0)
 
-    // Each closure invocation calls decode() but the real
-    // makeLazyPayload caches internally so the actual decompress +
-    // parse happens once. Our mock returns the same object reference
-    // each time; that's what we assert.
     const wall = mesh.getItemProperties(100)
     expect(wall.Name.value).toBe('Wall A')
     const pset = mesh.getItemProperties(500)
@@ -314,22 +311,16 @@ describe('Loader/convertToShareModel — Phase 2b.2 capability + subset wiring',
     // matching the Properties.jsx consumer contract.
     const psets = mesh.getPropertySets(100)
     expect(psets).toHaveLength(1)
-    expect(psets[0]).toEqual(decoded.itemProperties[500])
-
-    // Caching invariant: every decode() call returned the same object
-    // ref (i.e. the closures consume the payload's cached form rather
-    // than asking for a fresh parse). That's what makes the lazy
-    // wrapper a one-shot decompress instead of one-per-lookup.
-    expect(decodeReturns).toBeGreaterThan(0)
+    expect(psets[0]).toEqual(records[500])
+    expect(accessorCalls).toBeGreaterThan(0)
   })
 
   it('cache-hit Properties: getPropertySets returns [] for a product with no psets', () => {
-    const decoded = {itemProperties: {100: {expressID: 100}}, propertySets: {}}
+    // Real payload over real container bytes — pins the
+    // encode → lazy-read integration on the consumer surface.
     const mesh = new Mesh(new BufferGeometry())
-    mesh.userData.bldrsElementProperties = {
-      compressed: new Uint8Array([0]),
-      decode: () => decoded,
-    }
+    mesh.userData.bldrsElementProperties = makeElementPropertiesPayload(
+      encodeElementProperties({100: {expressID: 100}}, {}))
     convertToShareModel(mesh, makeViewerStub())
     expect(mesh.getPropertySets(100)).toEqual([])
     // Also for an expressID that isn't in the index at all.
@@ -343,10 +334,8 @@ describe('Loader/convertToShareModel — Phase 2b.2 capability + subset wiring',
     // undefined lets the consumer's null-guard kick in. Critical: no
     // throw on lookup miss.
     const mesh = new Mesh(new BufferGeometry())
-    mesh.userData.bldrsElementProperties = {
-      compressed: new Uint8Array([0]),
-      decode: () => ({itemProperties: {1: {x: 1}}, propertySets: {}}),
-    }
+    mesh.userData.bldrsElementProperties = makeElementPropertiesPayload(
+      encodeElementProperties({1: {x: 1}}, {}))
     convertToShareModel(mesh, makeViewerStub())
     expect(mesh.getItemProperties(1)).toEqual({x: 1})
     expect(mesh.getItemProperties(9999)).toBeUndefined()

--- a/src/loader/Loader.js
+++ b/src/loader/Loader.js
@@ -1214,17 +1214,20 @@ export function convertToShareModel(model, viewer, {fileName = null} = {}) {
   }
 
   // Cache-hit hydration for BLDRS_element_properties. The reader
-  // plugin parked a lazy-decode payload on
-  // `model.userData.bldrsElementProperties` (compressed bytes + a
-  // `decode()` closure). Promote it to `model.getItemProperties(id)`
-  // and `model.getPropertySets(id)` so the Properties panel
-  // (`Components/Properties/Properties.jsx`,
+  // plugin parked a lazy per-entity payload on
+  // `model.userData.bldrsElementProperties` (block-indexed container
+  // bytes + `getRecord`/`getPsetIds` accessors). Promote it to
+  // `model.getItemProperties(id)` and `model.getPropertySets(id)` so
+  // the Properties panel (`Components/Properties/Properties.jsx`,
   // `Components/Properties/itemProperties.jsx`) renders on cache-hit
   // without touching the (shared, parser-stateless) `ifcManager`.
   //
-  // First call to either method triggers the lazy `decode()` (one-shot
-  // pako.ungzip + JSON.parse, then cached). A load that never opens
-  // the Properties panel pays nothing.
+  // First call to either method decodes the payload's header index;
+  // each record block inflates only when one of its entities is
+  // requested (LRU-cached). A load that never opens the Properties
+  // panel pays nothing, and no call ever materialises the whole
+  // closure — which is what keeps >512MiB-JSON models (over V8's max
+  // string length) working at all. See `bldrsElementProperties.js`.
   //
   // Signature note: the closures take one arg (expressID), matching
   // `web-ifc-three.IFCModel.getItemProperties(id)` / `getPropertySets(id)`
@@ -1237,19 +1240,11 @@ export function convertToShareModel(model, viewer, {fileName = null} = {}) {
   // from the propertySets index, matching the existing consumer
   // expectation in Properties.jsx#createPsetsList.
   const elementProperties = model.userData?.bldrsElementProperties
-  if (elementProperties && typeof elementProperties.decode === 'function') {
-    model.getItemProperties = (expressID) => {
-      const data = elementProperties.decode()
-      return data.itemProperties[expressID]
-    }
+  if (elementProperties && typeof elementProperties.getRecord === 'function') {
+    model.getItemProperties = (expressID) => elementProperties.getRecord(expressID)
     model.getPropertySets = (expressID) => {
-      const data = elementProperties.decode()
-      const psetIds = data.propertySets[expressID]
-      if (!Array.isArray(psetIds) || psetIds.length === 0) {
-        return []
-      }
-      return psetIds
-        .map((pid) => data.itemProperties[pid])
+      return elementProperties.getPsetIds(expressID)
+        .map((pid) => elementProperties.getRecord(pid))
         .filter((p) => p !== null && p !== undefined)
     }
     glbVerbose(

--- a/src/loader/bldrsElementProperties.js
+++ b/src/loader/bldrsElementProperties.js
@@ -14,30 +14,61 @@
 // `design/new/viewer-replacement.md` §3b.iii default-on gating and
 // `design/new/glb-model-sharing.md` §"Extension catalogue".
 //
-// Wire shape (compressed JSON in a glTF bufferView):
+// Wire shape (binary container in a glTF bufferView) — the
+// **block-indexed** format, schema 0.13.0+:
+//
+//   [0..3]   magic  "BPRI" (Bldrs PRoperties Indexed)
+//   [4..7]   u32 LE container format version (currently 1)
+//   [8..11]  u32 LE byteLength of the gzipped header JSON
+//   [12..)   gzipped header JSON
+//   [then]   concatenated per-block gzip members
+//
+// Header JSON:
 //
 //   {
-//     itemProperties: { [expressID]: { ...shallow IFC entity data } },
-//     propertySets:   { [productExpressID]: [psetExpressID, ...] },
+//     blocks:       [[byteOffset, byteLength], ...],  // into the block
+//                                                     // region (starts
+//                                                     // right after the
+//                                                     // header bytes)
+//     blockIds:     [[expressID, ...], ...],          // ids per block,
+//                                                     // same order
+//     propertySets: { [productExpressID]: [psetExpressID, ...] },
 //   }
 //
-// `itemProperties` is the full closure of entities reachable via
-// references from spatial-tree elements (products, their properties,
-// referenced types, owner histories, etc.). `propertySets` is the
-// product→psetIds index — the consumer side rebuilds the full pset
-// array per product by indexing back into `itemProperties`.
+// Each block decompresses to a standalone JSON object
+// `{"<expressID>": {...shallow IFC entity data}, ...}` of about
+// BLOCK_TARGET_CHARS uncompressed. The union of all blocks is the
+// `itemProperties` closure: every entity reachable via references
+// from spatial-tree elements (products, their properties, referenced
+// types, owner histories, etc.). `propertySets` is the product→psetIds
+// index — the consumer rebuilds the pset array per product by
+// fetching each pset id as a record.
 //
-// Why split into two tables instead of inlining psets per product:
+// Why blocks + an index instead of one gzipped JSON document (the
+// pre-0.13.0 format): decompressing a monolithic payload needs the
+// whole JSON as ONE JS string, and V8 caps strings at ~512MiB —
+// PSB-class models exceed that and the old reader died in pako's
+// string join (`RangeError: Invalid string length`) before
+// `JSON.parse` even ran. Worse, even under the cap the parse
+// materialised the full multi-GB object graph for a panel that shows
+// one element at a time. The indexed format keeps reads bounded: one
+// ~1MB block inflates + parses per miss, LRU-cached. There is no
+// legacy-format read path — an old payload raises a "clear your
+// local cache" alert instead (the cache-key schema bump already
+// makes locally cached old artifacts read as a miss; the alert
+// covers GLBs that arrive as files).
+//
+// Why split psets into an id index instead of inlining per product:
 // psets are shared across many products in typical IFCs (one
 // `Pset_WallCommon` referenced by every wall). Deduplicating
 // via shared IDs keeps the artifact 3-5× smaller than inlining.
 //
-// Reader is **lazy** — the `afterRoot` hook stores the compressed
-// bytes and a decode closure on `userData.bldrsElementProperties`.
-// First call to `model.getItemProperties` / `model.getPropertySets`
-// triggers a one-shot decompress + JSON.parse, cached for subsequent
-// calls. Avoids paying the parse cost on a load that never opens
-// the Properties panel.
+// Reader is **lazy** — the `afterRoot` hook stores the container
+// bytes and per-entity accessors on `userData.bldrsElementProperties`.
+// The header (index + pset table) decodes on the first
+// `model.getItemProperties` / `model.getPropertySets` call; record
+// blocks decode on demand. A load that never opens the Properties
+// panel pays nothing.
 //
 // TODO(viewer-replacement Phase 5+): same untrusted-input concern as
 // `bldrsSpatialTree.js`. Today the writer is in-browser and trusted;
@@ -50,11 +81,199 @@
 // as a product in `itemProperties`).
 import * as pako from 'pako'
 import {IFCRELDEFINESBYPROPERTIES} from 'web-ifc'
+import useStore from '../store/useStore'
 import {yieldToBrowser} from '../utils/scheduling'
 import {glbInfo, glbVerbose} from './glbLog'
 
 
 export const BLDRS_ELEMENT_PROPERTIES_EXTENSION_NAME = 'BLDRS_element_properties'
+
+// Container magic "BPRI" as a LE u32 (bytes 0x42 0x50 0x52 0x49 on
+// disk). Distinct from the gzip magic (0x1f 0x8b) that opened every
+// pre-0.13.0 payload — the reader tells the two formats apart by
+// these leading bytes alone.
+const CONTAINER_MAGIC = 0x49525042
+const CONTAINER_VERSION = 1
+// magic u32 + version u32 + headerByteLength u32.
+const CONTAINER_HEADER_BYTES = 12
+const GZIP_MAGIC_0 = 0x1f
+const GZIP_MAGIC_1 = 0x8b
+
+// Target uncompressed JSON chars per record block. Bounds every
+// reader-side string/parse to ~this size regardless of model scale
+// (the whole point of the format — see the header comment), while
+// keeping the block count low enough that the header's per-block
+// index stays trivial (a PSB-class ~800MB closure is ~800 blocks).
+// Also the writer-side flush threshold: records concatenate into a
+// small string buffer until a block fills — per-record gzip calls
+// would pay setup overhead millions of times; one giant join would
+// recreate the whole-payload-resident problem the streaming writer
+// exists to avoid.
+const BLOCK_TARGET_CHARS = 1048576 // 1 MiB
+
+// Decoded (inflated + parsed) blocks the reader keeps hot, LRU.
+// Properties-panel access patterns hop between a product's block and
+// the blocks holding its psets / owner history / material refs —
+// a handful of ~1MB blocks covers that working set.
+const BLOCK_CACHE_MAX = 16
+
+
+/**
+ * Incremental writer for the block-indexed container. Both capture
+ * paths feed it: the streaming sweep adds records as it walks the
+ * parsed model (never holding the closure as one object graph), the
+ * slow BFS path adds them from its materialised map. Memory held is
+ * O(compressed blocks + id lists + one uncompressed block).
+ */
+export class ElementPropertiesContainerWriter {
+  /**
+   * @param {number} [blockTargetChars] uncompressed chars per block —
+   *   tests pass a small value to force multi-block containers
+   */
+  constructor(blockTargetChars = BLOCK_TARGET_CHARS) {
+    this.blockTargetChars = blockTargetChars
+    this.gzippedBlocks = []
+    this.blockIds = []
+    this.curParts = []
+    this.curIds = []
+    this.curChars = 0
+    this.recordCount = 0
+  }
+
+  /**
+   * Append one entity record to the container.
+   *
+   * @param {number} expressID
+   * @param {object} props shallow IFC entity data (JSON-serialisable)
+   */
+  addRecord(expressID, props) {
+    const rec = `"${expressID}":${JSON.stringify(props)}`
+    this.curParts.push(rec)
+    this.curIds.push(expressID)
+    this.curChars += rec.length
+    this.recordCount++
+    if (this.curChars >= this.blockTargetChars) {
+      this.flushBlock()
+    }
+  }
+
+  /** Gzip the pending records into a finished block. */
+  flushBlock() {
+    if (this.curIds.length === 0) {
+      return
+    }
+    this.gzippedBlocks.push(pako.gzip(`{${this.curParts.join(',')}}`))
+    this.blockIds.push(this.curIds)
+    this.curParts = []
+    this.curIds = []
+    this.curChars = 0
+  }
+
+  /**
+   * Flush and assemble the final container bytes.
+   *
+   * @param {object} [propertySets] product→psetIds index
+   * @return {Uint8Array}
+   */
+  finish(propertySets) {
+    this.flushBlock()
+    const blocks = []
+    let offset = 0
+    for (const block of this.gzippedBlocks) {
+      blocks.push([offset, block.byteLength])
+      offset += block.byteLength
+    }
+    const header = {blocks, blockIds: this.blockIds, propertySets: propertySets ?? {}}
+    const headerGz = pako.gzip(JSON.stringify(header))
+    const out = new Uint8Array(CONTAINER_HEADER_BYTES + headerGz.byteLength + offset)
+    const dv = new DataView(out.buffer)
+    dv.setUint32(0, CONTAINER_MAGIC, true)
+    dv.setUint32(4, CONTAINER_VERSION, true)
+    dv.setUint32(8, headerGz.byteLength, true)
+    out.set(headerGz, CONTAINER_HEADER_BYTES)
+    let p = CONTAINER_HEADER_BYTES + headerGz.byteLength
+    for (const block of this.gzippedBlocks) {
+      out.set(block, p)
+      p += block.byteLength
+    }
+    return out
+  }
+}
+
+
+/**
+ * Encode a fully-materialised `{itemProperties, propertySets}` pair
+ * into container bytes. Used by the slow capture path (whose BFS
+ * already holds the closure as one object) and by tests.
+ *
+ * @param {object} itemProperties expressID → record
+ * @param {object} propertySets productID → psetIds
+ * @param {number} [blockTargetChars]
+ * @return {Uint8Array}
+ */
+export function encodeElementProperties(itemProperties, propertySets, blockTargetChars = BLOCK_TARGET_CHARS) {
+  const writer = new ElementPropertiesContainerWriter(blockTargetChars)
+  for (const id of Object.keys(itemProperties)) {
+    writer.addRecord(Number(id), itemProperties[id])
+  }
+  return writer.finish(propertySets)
+}
+
+
+/**
+ * Parse a container's fixed preamble + gzipped header. Throws on
+ * anything malformed — callers translate to their own degrade path.
+ *
+ * @param {Uint8Array} bytes
+ * @return {{header: object, blocksStart: number}} `blocksStart` is
+ *   the byte offset of the block region within `bytes`
+ */
+function parseContainerHeader(bytes) {
+  if (!(bytes instanceof Uint8Array) || bytes.byteLength < CONTAINER_HEADER_BYTES) {
+    throw new Error('container too short')
+  }
+  const dv = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength)
+  if (dv.getUint32(0, true) !== CONTAINER_MAGIC) {
+    throw new Error('bad container magic')
+  }
+  const version = dv.getUint32(4, true)
+  if (version !== CONTAINER_VERSION) {
+    throw new Error(`unsupported container version ${version}`)
+  }
+  const headerLen = dv.getUint32(8, true)
+  const blocksStart = CONTAINER_HEADER_BYTES + headerLen
+  if (blocksStart > bytes.byteLength) {
+    throw new Error(`header length ${headerLen} exceeds container ${bytes.byteLength}`)
+  }
+  const header = JSON.parse(pako.ungzip(bytes.subarray(CONTAINER_HEADER_BYTES, blocksStart), {to: 'string'}))
+  if (!header || typeof header !== 'object' ||
+      !Array.isArray(header.blocks) || !Array.isArray(header.blockIds) ||
+      header.blocks.length !== header.blockIds.length ||
+      !header.propertySets || typeof header.propertySets !== 'object') {
+    throw new Error('malformed container header')
+  }
+  return {header, blocksStart}
+}
+
+
+/**
+ * Decode an entire container back to the materialised
+ * `{itemProperties, propertySets}` pair. Test/tooling helper — the
+ * runtime read path stays per-block (`makeElementPropertiesPayload`)
+ * precisely so it never has to do this.
+ *
+ * @param {Uint8Array} bytes container bytes
+ * @return {object} `{itemProperties, propertySets}`
+ */
+export function decodeElementProperties(bytes) {
+  const {header, blocksStart} = parseContainerHeader(bytes)
+  const itemProperties = {}
+  for (const [offset, byteLength] of header.blocks) {
+    const blockBytes = bytes.subarray(blocksStart + offset, blocksStart + offset + byteLength)
+    Object.assign(itemProperties, JSON.parse(pako.ungzip(blockBytes, {to: 'string'})))
+  }
+  return {itemProperties, propertySets: header.propertySets}
+}
 
 // Cooperative-yield interval for the fast-path entity walk + the
 // reachability BFS. The fast path iterates every parsed IFC entity
@@ -194,20 +413,17 @@ function collectSpatialTreeIds(root) {
  * BFS for environments that don't expose the adapter internals
  * (tests, non-Conway loaders).
  *
- * Both paths produce the same decoded wire JSON (same entity set,
+ * Both paths produce the same decoded record set (same entities,
  * same pset index) so the cached artifact is equivalent regardless
  * of which path ran. The streaming path is ~100× faster on large
  * IFCs (no Promise per entity) AND fixed-memory: peak retained heap
  * is O(reachable ids + one record) instead of O(all parsed records).
  *
- * Return shape is a discriminated union:
- *   - `{compressedBytes: Uint8Array}` — streaming path; already the
- *     gzipped wire JSON, ready to embed as a bufferView payload
- *     (pass to `injectGlbExtensions` as `precompressed`).
- *   - `{itemProperties, propertySets}` — slow path; the decoded wire
- *     object, compressed later by the inject step (`compress: true`).
- *   - `null` — no manager available (non-IFC sources, cache-hit GLB
- *     with no live parser).
+ * Returns `{compressedBytes: Uint8Array}` — the block-indexed
+ * container (see the header comment), ready to embed as a bufferView
+ * payload (pass to `injectGlbExtensions` as `precompressed`) — or
+ * `null` when no manager is available (non-IFC sources, cache-hit
+ * GLB with no live parser).
  *
  * @param {object|null|undefined} ifcManager IfcManager-like.
  * @param {number} modelID
@@ -224,17 +440,13 @@ export async function captureBldrsElementProperties(ifcManager, modelID, spatial
   if (compressedBytes !== null) {
     return {compressedBytes}
   }
-  return await captureBldrsElementPropertiesSlow(ifcManager, modelID, spatialTree)
+  const slow = await captureBldrsElementPropertiesSlow(ifcManager, modelID, spatialTree)
+  if (slow === null) {
+    return null
+  }
+  return {compressedBytes: encodeElementProperties(slow.itemProperties, slow.propertySets)}
 }
 
-
-// Text-buffer flush threshold for the streaming deflate. Records are
-// concatenated into a small string buffer and pushed into pako's
-// streaming Deflate in ~64KB slabs — per-record push calls would pay
-// deflate-call overhead millions of times; one giant join would
-// recreate the whole-payload-resident problem the streaming path
-// exists to avoid.
-const STREAM_FLUSH_CHARS = 65536
 
 // NOTE (bench, SKYLARK 7.8M entities, conway 1.372-1.374): an earlier
 // revision also released conway's entity cache every 200k getLines
@@ -252,8 +464,9 @@ const STREAM_FLUSH_CHARS = 65536
 /**
  * Streaming sync-bulk capture path. Reaches into the Conway adapter's
  * internal `IfcApiProxyIfc` to get the upstream Conway `IfcStepModel`
- * and walks it synchronously, gzipping the wire JSON incrementally —
- * the full property closure is NEVER resident as one JS object graph.
+ * and walks it synchronously, gzipping records into container blocks
+ * incrementally — the full property closure is NEVER resident as one
+ * JS object graph.
  * Peak retained memory is O(reachable ids + pset index + one record +
  * compressed output) instead of the old fast path's O(every parsed
  * record) (~GBs on 100MB-class IFCs before the reachability filter
@@ -295,7 +508,7 @@ const STREAM_FLUSH_CHARS = 65536
  *     `ifcAPI.getPassthrough`, non-Conway IFC backends)
  *   - the proxy's internal `model` field isn't where we expect
  *   - the iteration yields zero entities (parser state empty)
- *   - the streaming deflate reports an error
+ *   - assembling the container throws (gzip failure)
  *
  * Coupling notes: this reaches `ifcAPI.getPassthrough(modelID)` and
  * then `proxy.model[0]` (the IfcStepModel) — both are stable on
@@ -305,9 +518,9 @@ const STREAM_FLUSH_CHARS = 65536
  *
  * @param {object} ifcManager IfcManager-like with `.ifcAPI`.
  * @param {number} modelID
- * @return {Promise<Uint8Array|null>} gzipped wire JSON (the exact
- *   bytes a reader `pako.ungzip` + `JSON.parse` expects) or `null`
- *   when the streaming path is unavailable.
+ * @return {Promise<Uint8Array|null>} block-indexed container bytes
+ *   (what `makeElementPropertiesPayload` reads) or `null` when the
+ *   streaming path is unavailable.
  */
 async function captureBldrsElementPropertiesStreaming(ifcManager, modelID) {
   const ifcAPI = ifcManager.ifcAPI
@@ -341,33 +554,12 @@ async function captureBldrsElementPropertiesStreaming(ifcManager, modelID) {
   }
 
   const startMs = Date.now()
-  const deflator = new pako.Deflate({gzip: true})
-  let textBuf = []
-  let textLen = 0
-  const flushText = () => {
-    if (textLen > 0) {
-      deflator.push(textBuf.join(''), false)
-      textBuf = []
-      textLen = 0
-    }
-  }
-  const pushText = (chunk) => {
-    textBuf.push(chunk)
-    textLen += chunk.length
-    if (textLen >= STREAM_FLUSH_CHARS) {
-      flushText()
-    }
-  }
-  let emittedCount = 0
+  // Records land in the container writer in BFS discovery order (not
+  // ascending-integer) — block assignment is arbitrary anyway; the
+  // reader looks entries up through the header's id→block index.
+  const writer = new ElementPropertiesContainerWriter()
   const emitRecord = (id, props) => {
-    // Same wire JSON as `JSON.stringify({itemProperties: {...}})`
-    // would produce for this entry — numeric-string key, record value.
-    // Key ORDER differs from the legacy one-shot stringify (BFS
-    // discovery order vs ascending-integer), which is byte-different
-    // but decode-identical: the reader JSON.parses into a plain object
-    // and every consumer looks entries up by id.
-    pushText(`${emittedCount === 0 ? '' : ','}"${id}":${JSON.stringify(props)}`)
-    emittedCount++
+    writer.addRecord(id, props)
   }
 
   // `visited` = "serialized or queued for serialization" — every id
@@ -388,8 +580,6 @@ async function captureBldrsElementPropertiesStreaming(ifcManager, modelID) {
   const hadMemoization = stepModel.elementMemoization
   stepModel.elementMemoization = false
   try {
-    pushText('{"itemProperties":{')
-
     /**
      * Sweep-1 record body, shared by the roots-only and full-scan
      * enumerations below: decode one record via sync `getLine`, feed
@@ -563,25 +753,26 @@ async function captureBldrsElementPropertiesStreaming(ifcManager, modelID) {
       }
     }
 
-    pushText(`},"propertySets":${JSON.stringify(propertySets)}}`)
-    flushText()
-    deflator.push('', true)
-    if (deflator.err) {
+    let containerBytes
+    try {
+      containerBytes = writer.finish(propertySets)
+    } catch (e) {
       glbInfo(
-        `${BLDRS_ELEMENT_PROPERTIES_EXTENSION_NAME}: streaming deflate error ` +
-        `${deflator.err} (${deflator.msg}); falling back to slow path`)
+        `${BLDRS_ELEMENT_PROPERTIES_EXTENSION_NAME}: container finish failed ` +
+        `(${e}); falling back to slow path`)
       return null
     }
 
     glbInfo(
-      `${BLDRS_ELEMENT_PROPERTIES_EXTENSION_NAME}: streamed ${emittedCount} ` +
+      `${BLDRS_ELEMENT_PROPERTIES_EXTENSION_NAME}: streamed ${writer.recordCount} ` +
       `reachable-from-IfcRoot entities (of ${iterCount} scanned, ` +
       `${rootExpressIDs ? 'roots-only' : 'full'} scan; ` +
       `${psetRelCount} IfcRelDefinesByProperties → ` +
       `${Object.keys(propertySets).length} products with psets) into ` +
-      `${deflator.result.byteLength}B gzip in ${Date.now() - startMs}ms`)
+      `${containerBytes.byteLength}B container ` +
+      `(${writer.gzippedBlocks.length} blocks) in ${Date.now() - startMs}ms`)
 
-    return deflator.result
+    return containerBytes
   } finally {
     stepModel.elementMemoization = hadMemoization
     // Drop the descriptors the sweep materialised; they rematerialise
@@ -718,18 +909,26 @@ async function captureBldrsElementPropertiesSlow(ifcManager, modelID, spatialTre
 
 /**
  * GLTFLoader plugin that registers the BLDRS_element_properties
- * extension. Stores the compressed bytes + a `decode()` closure on
- * `gltf.scene.userData.bldrsElementProperties`; the actual
- * `pako.ungzip` + `JSON.parse` runs only on the first
- * `model.getItemProperties` / `model.getPropertySets` call (the
- * Properties panel may never open).
+ * extension. Stores the container bytes + per-entity accessors
+ * (`getRecord` / `getPsetIds`) on
+ * `gltf.scene.userData.bldrsElementProperties`; the header index
+ * decodes on the first access and record blocks decode on demand
+ * (the Properties panel may never open).
+ *
+ * A payload in the pre-0.13.0 monolithic-gzip format is NOT decoded
+ * — there is deliberately no legacy read path. It raises a
+ * "clear your local cache" alert instead and attaches nothing, so
+ * the panel degrades the same as a GLB without the extension.
+ * Locally cached old artifacts never reach here (the schema-version
+ * bump in `glbCacheKey.js` makes them read as a cache miss); this
+ * covers old GLBs arriving as files.
  *
  * Register at GLTFLoader construction:
  *   loader.register((parser) => new BldrsElementPropertiesReader(parser))
  *
- * The userData payload shape is intentionally not the decoded tree
- * — `Loader.js#convertToShareModel` reads `.decode()` lazily when it
- * hydrates `model.getItemProperties`.
+ * The userData payload shape is intentionally not the decoded tables
+ * — `Loader.js#convertToShareModel` wires `model.getItemProperties`
+ * through the lazy accessors.
  */
 export class BldrsElementPropertiesReader {
   /**
@@ -773,9 +972,24 @@ export class BldrsElementPropertiesReader {
       const arrayBuffer = await this.parser.getDependency('buffer', bufferIndex)
       // Hold a Uint8Array view (not a copy) over the parsed BIN
       // chunk. Cheap: no allocation, no decompression. The first
-      // `decode()` call below pays the full cost.
+      // accessor call below pays the decode cost.
       const compressed = new Uint8Array(arrayBuffer, byteOffset, byteLength)
-      const payload = makeLazyPayload(compressed, this.name)
+      // Pre-0.13.0 payloads were one monolithic gzip (leading bytes
+      // 0x1f 0x8b) — a format the reader deliberately no longer
+      // decodes (see class comment). Alert instead of attaching so
+      // the Properties panel's silence is explained and actionable.
+      if (compressed.byteLength >= 2 &&
+          compressed[0] === GZIP_MAGIC_0 && compressed[1] === GZIP_MAGIC_1) {
+        glbInfo(
+          `${this.name}: payload is the pre-0.13.0 monolithic gzip format; ` +
+          'not decoding — alerting to clear cache')
+        useStore.getState().setAlert(
+          'This model was cached in an older format that this version of Share ' +
+          'no longer reads, so element properties are unavailable. ' +
+          'Clear the local cache (Profile menu → Clear Local Cache) and reload the model to rebuild it.')
+        return gltf
+      }
+      const payload = makeElementPropertiesPayload(compressed, this.name)
       if (gltf.scene) {
         gltf.scene.userData.bldrsElementProperties = payload
       } else {
@@ -790,59 +1004,116 @@ export class BldrsElementPropertiesReader {
 
 
 /**
- * Build a lazy-decode payload object that holds the compressed bytes
- * and decodes on first `decode()` call. Cached after first decode.
- * Exposed so `Loader.js#convertToShareModel` can construct the same
- * shape directly for testing or for non-GLTFLoader code paths.
+ * Build a lazy per-entity payload over container bytes. Exposed so
+ * `Loader.js#convertToShareModel` consumers and tests can construct
+ * the same shape directly for non-GLTFLoader code paths.
  *
- * Validation on decode is shape-only: must JSON-parse to an object
- * with `itemProperties` (record) and optional `propertySets` (record).
- * A failed validation logs and yields an empty-but-well-shaped payload
- * — consumers degrade to "no props" rather than crash.
+ * The header (id→block index + pset table) decodes on the first
+ * accessor call; each record block inflates + parses only when one
+ * of its entities is requested, then rides a small LRU. Nothing here
+ * ever materialises the whole closure — the strings and object
+ * graphs in play are bounded by BLOCK_TARGET_CHARS per block, which
+ * is what makes arbitrarily large models decodable at all (V8 caps
+ * a single string at ~512MiB; see the header comment).
  *
- * @param {Uint8Array} compressed gzipped JSON bytes
+ * Any decode failure (bad magic, truncated bytes, corrupt block)
+ * logs and degrades to "no record found" — consumers show "no props"
+ * rather than crash.
+ *
+ * @param {Uint8Array} compressed container bytes
  * @param {string} [tag] log-prefix tag (e.g. extension name)
- * @return {object} `{compressed, decode(): {itemProperties, propertySets}}`
+ * @return {object} `{compressed, getRecord(expressID), getPsetIds(expressID)}`
  */
-export function makeLazyPayload(compressed, tag = BLDRS_ELEMENT_PROPERTIES_EXTENSION_NAME) {
-  let cached = null
+export function makeElementPropertiesPayload(compressed, tag = BLDRS_ELEMENT_PROPERTIES_EXTENSION_NAME) {
+  let header = null
+  let blocksStart = 0
+  let idToBlock = null
+  let headerFailed = false
+  // blockIndex → parsed record object. Insertion-ordered Map as LRU:
+  // a hit re-inserts, eviction takes the oldest key.
+  const blockCache = new Map()
+
+  const ensureHeader = () => {
+    if (header !== null || headerFailed) {
+      return
+    }
+    try {
+      const parsed = parseContainerHeader(compressed)
+      header = parsed.header
+      blocksStart = parsed.blocksStart
+      idToBlock = new Map()
+      header.blockIds.forEach((ids, blockIndex) => {
+        for (const id of ids) {
+          idToBlock.set(id, blockIndex)
+        }
+      })
+      // One-shot per cache hit — visible by default so user-reported
+      // "panel is empty" issues can be triaged from the console
+      // without flipping a feature flag. The entity/pset counts are
+      // the most useful diagnostic: a count of 0 means the writer
+      // captured nothing (likely no spatial tree on the source IFC);
+      // a non-zero count with empty panel points at consumer wiring.
+      glbInfo(
+        `${tag}: decoded payload index (${compressed.byteLength}B container, ` +
+        `${header.blocks.length} blocks, ` +
+        `${idToBlock.size} entities, ` +
+        `${Object.keys(header.propertySets).length} products with psets)`)
+    } catch (e) {
+      glbInfo(`${tag}: decode failed:`, e)
+      headerFailed = true
+    }
+  }
+
+  const getBlock = (blockIndex) => {
+    const cached = blockCache.get(blockIndex)
+    if (cached !== undefined) {
+      blockCache.delete(blockIndex)
+      blockCache.set(blockIndex, cached)
+      return cached
+    }
+    let records
+    try {
+      const [offset, byteLength] = header.blocks[blockIndex]
+      const blockBytes = compressed.subarray(blocksStart + offset, blocksStart + offset + byteLength)
+      records = JSON.parse(pako.ungzip(blockBytes, {to: 'string'}))
+    } catch (e) {
+      glbInfo(`${tag}: block ${blockIndex} decode failed:`, e)
+      // Cache the failure as an empty block so a corrupt block logs
+      // once instead of re-inflating on every access to its entities.
+      records = {}
+    }
+    blockCache.set(blockIndex, records)
+    if (blockCache.size > BLOCK_CACHE_MAX) {
+      blockCache.delete(blockCache.keys().next().value)
+    }
+    return records
+  }
+
   return {
     compressed,
-    decode() {
-      if (cached !== null) {
-        return cached
+    /**
+     * @param {number} expressID
+     * @return {object|undefined} the entity record, undefined if absent
+     */
+    getRecord(expressID) {
+      ensureHeader()
+      if (header === null) {
+        return undefined
       }
-      try {
-        const text = pako.ungzip(compressed, {to: 'string'})
-        const parsed = JSON.parse(text)
-        if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
-          glbInfo(`${tag}: decoded payload is not an object; using empty`)
-          cached = {itemProperties: {}, propertySets: {}}
-          return cached
-        }
-        cached = {
-          itemProperties: (parsed.itemProperties && typeof parsed.itemProperties === 'object' && !Array.isArray(parsed.itemProperties)) ?
-            parsed.itemProperties : {},
-          propertySets: (parsed.propertySets && typeof parsed.propertySets === 'object' && !Array.isArray(parsed.propertySets)) ?
-            parsed.propertySets : {},
-        }
-        // One-shot per cache hit — visible by default so user-reported
-        // "panel is empty" issues can be triaged from the console
-        // without flipping a feature flag. The entity/pset counts are
-        // the most useful diagnostic: a count of 0 means the writer
-        // captured nothing (likely no spatial tree on the source IFC);
-        // a non-zero count with empty panel points at consumer wiring.
-        glbInfo(
-          `${tag}: decoded payload (${compressed.byteLength}B compressed → ` +
-          `${text.length}B JSON, ` +
-          `${Object.keys(cached.itemProperties).length} entities, ` +
-          `${Object.keys(cached.propertySets).length} products with psets)`)
-        return cached
-      } catch (e) {
-        glbInfo(`${tag}: decode failed:`, e)
-        cached = {itemProperties: {}, propertySets: {}}
-        return cached
+      const blockIndex = idToBlock.get(Number(expressID))
+      if (blockIndex === undefined) {
+        return undefined
       }
+      return getBlock(blockIndex)[expressID]
+    },
+    /**
+     * @param {number} expressID product id
+     * @return {Array<number>} pset expressIDs, [] if none
+     */
+    getPsetIds(expressID) {
+      ensureHeader()
+      const psetIds = header?.propertySets?.[expressID]
+      return Array.isArray(psetIds) ? psetIds : []
     },
   }
 }

--- a/src/loader/bldrsElementProperties.test.js
+++ b/src/loader/bldrsElementProperties.test.js
@@ -1,10 +1,13 @@
 /* eslint-disable no-magic-numbers */
-import * as pako from 'pako'
+import useStore from '../store/useStore'
 import {
   BLDRS_ELEMENT_PROPERTIES_EXTENSION_NAME,
   BldrsElementPropertiesReader,
+  ElementPropertiesContainerWriter,
   captureBldrsElementProperties,
-  makeLazyPayload,
+  decodeElementProperties,
+  encodeElementProperties,
+  makeElementPropertiesPayload,
 } from './bldrsElementProperties'
 import {
   injectGlbExtensions,
@@ -14,31 +17,32 @@ import {
 
 
 describe('loader/bldrsElementProperties', () => {
+  /**
+   * Decode a capture result (both paths return the block-indexed
+   * container as `{compressedBytes}`) back to the materialised
+   * tables so assertions can run on content. Asserts the result
+   * shape on the way through.
+   *
+   * @param {object} result `{compressedBytes: Uint8Array}`
+   * @return {object} `{itemProperties, propertySets}`
+   */
+  function decodeCaptured(result) {
+    expect(result).not.toBeNull()
+    expect(result.compressedBytes).toBeInstanceOf(Uint8Array)
+    return decodeElementProperties(result.compressedBytes)
+  }
+
   describe('captureBldrsElementProperties — streaming path via Conway adapter', () => {
     // The streaming path reaches into `ifcAPI.getPassthrough(modelID)`
     // and iterates the upstream Conway `IfcStepModel` synchronously,
     // calling `proxy.getLine(expressID)` per entity to convert raw
     // STEP-tape data to the wit-three-shape object consumers expect.
-    // Records are gzipped into the wire JSON incrementally (never all
-    // resident at once), so the capture returns `{compressedBytes}` —
-    // tests decode it back to assert on content. Pset extraction
+    // Records are gzipped into container blocks incrementally (never
+    // all resident at once), so the capture returns `{compressedBytes}`
+    // — tests decode it back to assert on content. Pset extraction
     // happens inline — `IfcRelDefinesByProperties` entities
     // encountered during the walk build the product→psetIds index in
     // one pass. No spatial tree needed.
-
-    /**
-     * Decode a streaming-path capture result back to the wire object
-     * so assertions can run on content. Asserts the discriminated-
-     * union shape on the way through.
-     *
-     * @param {object} result `{compressedBytes: Uint8Array}`
-     * @return {object} `{itemProperties, propertySets}`
-     */
-    function decodeCaptured(result) {
-      expect(result).not.toBeNull()
-      expect(result.compressedBytes).toBeInstanceOf(Uint8Array)
-      return JSON.parse(pako.ungzip(result.compressedBytes, {to: 'string'}))
-    }
 
     /**
      * Build a fake ifcManager that mimics the adapter surface:
@@ -400,8 +404,7 @@ describe('loader/bldrsElementProperties', () => {
         getPropertySets: () => Promise.resolve([]),
       }
       const tree = {expressID: 1, type: 'IFCPROJECT', children: []}
-      const captured = await captureBldrsElementProperties(mgr, 0, tree)
-      expect(captured).not.toBeNull()
+      const captured = decodeCaptured(await captureBldrsElementProperties(mgr, 0, tree))
       expect(captured.itemProperties[1]).toBeDefined()
     })
 
@@ -555,8 +558,7 @@ describe('loader/bldrsElementProperties', () => {
         })),
         getPropertySets: jest.fn(() => Promise.resolve([])),
       }
-      const captured = await captureBldrsElementProperties(mgr, 0, tree)
-      expect(captured).not.toBeNull()
+      const captured = decodeCaptured(await captureBldrsElementProperties(mgr, 0, tree))
       expect(Object.keys(captured.itemProperties).sort()).toEqual(['1', '2', '3'])
       expect(captured.itemProperties[1]).toEqual({
         expressID: 1, Name: {type: 1, value: 'Entity 1'},
@@ -589,7 +591,7 @@ describe('loader/bldrsElementProperties', () => {
         }),
         getPropertySets: jest.fn(() => Promise.resolve([])),
       }
-      const captured = await captureBldrsElementProperties(mgr, 0, tree)
+      const captured = decodeCaptured(await captureBldrsElementProperties(mgr, 0, tree))
       expect(captured.itemProperties[1]).toBeDefined()
       expect(captured.itemProperties[2]).toBeUndefined() // skipped
       expect(captured.itemProperties[3]).toBeDefined()
@@ -612,7 +614,7 @@ describe('loader/bldrsElementProperties', () => {
         getItemProperties: jest.fn((mid, id) => Promise.resolve(entities[id])),
         getPropertySets: jest.fn(() => Promise.resolve([])),
       }
-      const captured = await captureBldrsElementProperties(mgr, 0, tree)
+      const captured = decodeCaptured(await captureBldrsElementProperties(mgr, 0, tree))
       expect(Object.keys(captured.itemProperties).sort()).toEqual(['1', '100', '200', '300'])
     })
 
@@ -641,7 +643,7 @@ describe('loader/bldrsElementProperties', () => {
         getItemProperties: jest.fn((mid, id) => Promise.resolve(entities[id])),
         getPropertySets: jest.fn(() => Promise.resolve([])),
       }
-      const captured = await captureBldrsElementProperties(mgr, 0, tree)
+      const captured = decodeCaptured(await captureBldrsElementProperties(mgr, 0, tree))
       expect(Object.keys(captured.itemProperties).sort())
         .toEqual(['1', '10', '11', '12'])
     })
@@ -658,7 +660,7 @@ describe('loader/bldrsElementProperties', () => {
         getItemProperties: jest.fn((mid, id) => Promise.resolve(entities[id])),
         getPropertySets: jest.fn(() => Promise.resolve([])),
       }
-      const captured = await captureBldrsElementProperties(mgr, 0, tree)
+      const captured = decodeCaptured(await captureBldrsElementProperties(mgr, 0, tree))
       expect(Object.keys(captured.itemProperties).sort()).toEqual(['1', '2', '3'])
       // Each entity fetched exactly once despite the cycle.
       expect(mgr.getItemProperties).toHaveBeenCalledTimes(3)
@@ -680,7 +682,7 @@ describe('loader/bldrsElementProperties', () => {
         getItemProperties: jest.fn((mid, id) => Promise.resolve(entities[id])),
         getPropertySets: jest.fn(() => Promise.resolve([])),
       }
-      const captured = await captureBldrsElementProperties(mgr, 0, tree)
+      const captured = decodeCaptured(await captureBldrsElementProperties(mgr, 0, tree))
       expect(Object.keys(captured.itemProperties)).toEqual(['1'])
       // Only the seed was fetched — no chasing of {type:1} or {type:2}.
       expect(mgr.getItemProperties).toHaveBeenCalledTimes(1)
@@ -700,7 +702,7 @@ describe('loader/bldrsElementProperties', () => {
         getItemProperties: jest.fn((mid, id) => Promise.resolve({expressID: id})),
         getPropertySets: jest.fn((mid, id) => Promise.resolve(id === 100 ? psets : [])),
       }
-      const captured = await captureBldrsElementProperties(mgr, 0, tree)
+      const captured = decodeCaptured(await captureBldrsElementProperties(mgr, 0, tree))
       expect(captured.propertySets[100]).toEqual([500, 501])
       // psets themselves are entities → in itemProperties.
       expect(captured.itemProperties[500]).toBeDefined()
@@ -713,7 +715,7 @@ describe('loader/bldrsElementProperties', () => {
         getItemProperties: jest.fn(() => Promise.resolve({})),
         getPropertySets: jest.fn(() => Promise.resolve([])),
       }
-      const captured = await captureBldrsElementProperties(mgr, 0, tree)
+      const captured = decodeCaptured(await captureBldrsElementProperties(mgr, 0, tree))
       expect(captured.propertySets).toEqual({})
     })
 
@@ -730,7 +732,7 @@ describe('loader/bldrsElementProperties', () => {
           return Promise.resolve([])
         }),
       }
-      const captured = await captureBldrsElementProperties(mgr, 0, tree)
+      const captured = decodeCaptured(await captureBldrsElementProperties(mgr, 0, tree))
       // Item properties for both still captured; pset index just lacks 2.
       expect(captured.itemProperties[1]).toBeDefined()
       expect(captured.itemProperties[2]).toBeDefined()
@@ -738,52 +740,62 @@ describe('loader/bldrsElementProperties', () => {
     })
   })
 
-  describe('makeLazyPayload — lazy decode', () => {
-    /**
-     * @param {object} obj data to wrap
-     * @return {Uint8Array} gzipped JSON bytes
-     */
-    function compressed(obj) {
-      return pako.gzip(new TextEncoder().encode(JSON.stringify(obj)))
-    }
-
+  describe('makeElementPropertiesPayload — lazy indexed decode', () => {
     it('does not decode at construction', () => {
-      // The compressed input is intentionally invalid; constructor must
+      // The container input is intentionally invalid; constructor must
       // not touch it (proof that decode is truly lazy).
       const badBytes = new Uint8Array([0x42, 0x4c, 0x44, 0x52])
-      const payload = makeLazyPayload(badBytes)
+      const payload = makeElementPropertiesPayload(badBytes)
       expect(payload.compressed).toBe(badBytes)
       // No throw, no work done.
     })
 
-    it('decodes on first call and caches the result', () => {
-      const bytes = compressed({itemProperties: {1: {x: 1}}, propertySets: {1: [10]}})
-      const payload = makeLazyPayload(bytes)
-      const a = payload.decode()
-      const b = payload.decode()
-      expect(a).toBe(b) // same object reference — cached
-      expect(a.itemProperties[1]).toEqual({x: 1})
-      expect(a.propertySets[1]).toEqual([10])
+    it('returns records and pset ids from an encoded container', () => {
+      const bytes = encodeElementProperties({1: {x: 1}, 2: {y: 2}}, {1: [10]})
+      const payload = makeElementPropertiesPayload(bytes)
+      expect(payload.getRecord(1)).toEqual({x: 1})
+      expect(payload.getRecord(2)).toEqual({y: 2})
+      expect(payload.getRecord(999)).toBeUndefined()
+      expect(payload.getPsetIds(1)).toEqual([10])
+      expect(payload.getPsetIds(2)).toEqual([])
     })
 
-    it('returns empty-shape payload on a malformed compressed blob', () => {
-      const payload = makeLazyPayload(new Uint8Array([0xff, 0xff, 0xff, 0xff]))
-      const decoded = payload.decode()
-      expect(decoded).toEqual({itemProperties: {}, propertySets: {}})
+    it('degrades to no-records on a malformed container', () => {
+      const payload = makeElementPropertiesPayload(new Uint8Array([0xff, 0xff, 0xff, 0xff]))
+      expect(payload.getRecord(1)).toBeUndefined()
+      expect(payload.getPsetIds(1)).toEqual([])
     })
 
-    it('returns empty-shape payload on a non-object JSON payload', () => {
-      const bytes = compressed([1, 2, 3])
-      const payload = makeLazyPayload(bytes)
-      expect(payload.decode()).toEqual({itemProperties: {}, propertySets: {}})
+    it('reads records back across many blocks (and through LRU eviction)', () => {
+      // A tiny block target forces one block per record — 50 blocks is
+      // well past the reader's LRU capacity, so the sequential reads
+      // below also exercise eviction + re-inflate of cold blocks.
+      const writer = new ElementPropertiesContainerWriter(8)
+      const records = {}
+      for (let id = 1; id <= 50; id++) {
+        records[id] = {Name: {type: 1, value: `Entity ${id}`}}
+        writer.addRecord(id, records[id])
+      }
+      const bytes = writer.finish({7: [8]})
+      const payload = makeElementPropertiesPayload(bytes)
+      for (let id = 1; id <= 50; id++) {
+        expect(payload.getRecord(id)).toEqual(records[id])
+      }
+      // Revisit an early (long-evicted) block.
+      expect(payload.getRecord(1)).toEqual(records[1])
+      expect(payload.getPsetIds(7)).toEqual([8])
+      // The materialising test helper agrees with the lazy reader.
+      const decoded = decodeElementProperties(bytes)
+      expect(decoded.itemProperties).toEqual(records)
+      expect(decoded.propertySets).toEqual({7: [8]})
     })
 
-    it('isolates missing fields — keeps the ones that ARE valid objects', () => {
-      // Only itemProperties present, no propertySets.
-      const bytes = compressed({itemProperties: {99: {a: 1}}})
-      const decoded = makeLazyPayload(bytes).decode()
-      expect(decoded.itemProperties[99]).toEqual({a: 1})
-      expect(decoded.propertySets).toEqual({})
+    it('round-trips an empty capture', () => {
+      const bytes = encodeElementProperties({}, {})
+      const payload = makeElementPropertiesPayload(bytes)
+      expect(payload.getRecord(1)).toBeUndefined()
+      expect(payload.getPsetIds(1)).toEqual([])
+      expect(decodeElementProperties(bytes)).toEqual({itemProperties: {}, propertySets: {}})
     })
   })
 
@@ -807,15 +819,14 @@ describe('loader/bldrsElementProperties', () => {
     }
 
     it('parks a lazy payload on gltf.scene.userData', async () => {
-      const data = {
-        itemProperties: {1: {Name: {type: 1, value: 'X'}}},
-        propertySets: {1: [2]},
-      }
+      const container = encodeElementProperties(
+        {1: {Name: {type: 1, value: 'X'}}},
+        {1: [2]})
       const baseGlb = serializeGlb(
         {asset: {version: '2.0'}, buffers: [{byteLength: 4}]},
         new Uint8Array(4))
       const {bytes: withExt} = injectGlbExtensions(baseGlb, [
-        {name: BLDRS_ELEMENT_PROPERTIES_EXTENSION_NAME, data, compress: true},
+        {name: BLDRS_ELEMENT_PROPERTIES_EXTENSION_NAME, precompressed: container},
       ])
       const reader = new BldrsElementPropertiesReader(parserFromGlb(withExt))
       const gltf = {scene: {userData: {}}}
@@ -823,10 +834,33 @@ describe('loader/bldrsElementProperties', () => {
       const payload = gltf.scene.userData.bldrsElementProperties
       expect(payload).toBeDefined()
       expect(payload.compressed).toBeInstanceOf(Uint8Array)
-      expect(typeof payload.decode).toBe('function')
+      expect(typeof payload.getRecord).toBe('function')
       // Decode now and assert content.
-      expect(payload.decode().itemProperties[1]).toEqual({Name: {type: 1, value: 'X'}})
-      expect(payload.decode().propertySets[1]).toEqual([2])
+      expect(payload.getRecord(1)).toEqual({Name: {type: 1, value: 'X'}})
+      expect(payload.getPsetIds(1)).toEqual([2])
+    })
+
+    it('alerts and attaches nothing for a pre-0.13.0 monolithic-gzip payload', async () => {
+      // The old wire format was one gzip of the whole
+      // `{itemProperties, propertySets}` JSON — exactly what the
+      // inject step's `{data, compress: true}` path produces, so use
+      // it to build the legacy fixture. The reader must refuse it
+      // (no legacy decode path exists), leave userData untouched, and
+      // raise the clear-cache alert.
+      useStore.getState().setAlert(null)
+      const legacy = {itemProperties: {1: {x: 1}}, propertySets: {}}
+      const baseGlb = serializeGlb(
+        {asset: {version: '2.0'}, buffers: [{byteLength: 4}]},
+        new Uint8Array(4))
+      const {bytes: withExt} = injectGlbExtensions(baseGlb, [
+        {name: BLDRS_ELEMENT_PROPERTIES_EXTENSION_NAME, data: legacy, compress: true},
+      ])
+      const reader = new BldrsElementPropertiesReader(parserFromGlb(withExt))
+      const gltf = {scene: {userData: {}}}
+      await expect(reader.afterRoot(gltf)).resolves.toBe(gltf)
+      expect(gltf.scene.userData.bldrsElementProperties).toBeUndefined()
+      expect(useStore.getState().alert).toMatch(/Clear Local Cache/)
+      useStore.getState().setAlert(null)
     })
 
     it('is a no-op when the GLB has no extension', async () => {
@@ -862,7 +896,7 @@ describe('loader/bldrsElementProperties', () => {
         {asset: {version: '2.0'}, buffers: [{byteLength: 4}]},
         new Uint8Array(4))
       const {bytes: withExt} = injectGlbExtensions(baseGlb, [
-        {name: BLDRS_ELEMENT_PROPERTIES_EXTENSION_NAME, data: {itemProperties: {}}, compress: true},
+        {name: BLDRS_ELEMENT_PROPERTIES_EXTENSION_NAME, precompressed: encodeElementProperties({}, {})},
       ])
       const reader = new BldrsElementPropertiesReader(parserFromGlb(withExt))
       const gltf = {/* no .scene */}
@@ -873,10 +907,10 @@ describe('loader/bldrsElementProperties', () => {
   describe('end-to-end: capture → inject → reader → decode', () => {
     it('streams an adapter capture through precompressed inject + reader decode', async () => {
       // The streaming writer's full production pipeline: adapter
-      // capture emits gzipped wire bytes → injectGlbExtensions embeds
-      // them verbatim as `precompressed` → the reader's single decode
-      // branch (ungzip + JSON.parse) recovers the same tables the
-      // legacy object-capture path produced.
+      // capture emits block-indexed container bytes →
+      // injectGlbExtensions embeds them verbatim as `precompressed` →
+      // the reader's lazy per-entity accessors recover the same
+      // records the capture serialised.
       const entities = {
         100: {
           expressID: 100, type: 3124254112,
@@ -920,11 +954,14 @@ describe('loader/bldrsElementProperties', () => {
       })
       const gltf = {scene: {userData: {}}}
       await reader.afterRoot(gltf)
-      const decoded = gltf.scene.userData.bldrsElementProperties.decode()
+      const payload = gltf.scene.userData.bldrsElementProperties
 
+      expect(payload.getRecord(100)).toEqual(entities[100])
+      expect(payload.getRecord(500)).toEqual(entities[500])
+      expect(payload.getPsetIds(100)).toEqual([500])
+      // Full-set check via the materialising helper on the same bytes.
+      const decoded = decodeElementProperties(payload.compressed)
       expect(Object.keys(decoded.itemProperties).sort()).toEqual(['100', '500', '999'])
-      expect(decoded.itemProperties[100]).toEqual(entities[100])
-      expect(decoded.itemProperties[500]).toEqual(entities[500])
       expect(decoded.propertySets).toEqual({100: [500]})
     })
 
@@ -945,7 +982,8 @@ describe('loader/bldrsElementProperties', () => {
         getPropertySets: (mid, id) => Promise.resolve(id === 100 ? [entities[500]] : []),
       }
 
-      const captured = await captureBldrsElementProperties(mgr, 0, tree)
+      const capturedResult = await captureBldrsElementProperties(mgr, 0, tree)
+      const captured = decodeCaptured(capturedResult)
       expect(captured.itemProperties[100]).toBeDefined()
       expect(captured.itemProperties[999]).toBeDefined() // followed via BFS
       expect(captured.itemProperties[500]).toBeDefined() // captured via psets
@@ -955,7 +993,7 @@ describe('loader/bldrsElementProperties', () => {
         {asset: {version: '2.0'}, buffers: [{byteLength: 4}]},
         new Uint8Array(4))
       const {bytes: withExt} = injectGlbExtensions(baseGlb, [
-        {name: BLDRS_ELEMENT_PROPERTIES_EXTENSION_NAME, data: captured, compress: true},
+        {name: BLDRS_ELEMENT_PROPERTIES_EXTENSION_NAME, precompressed: capturedResult.compressedBytes},
       ])
 
       // Now read back.
@@ -967,7 +1005,7 @@ describe('loader/bldrsElementProperties', () => {
       })
       const gltf = {scene: {userData: {}}}
       await reader.afterRoot(gltf)
-      const decoded = gltf.scene.userData.bldrsElementProperties.decode()
+      const decoded = decodeElementProperties(gltf.scene.userData.bldrsElementProperties.compressed)
 
       expect(decoded.itemProperties).toEqual(captured.itemProperties)
       expect(decoded.propertySets).toEqual(captured.propertySets)
@@ -1020,7 +1058,8 @@ describe('loader/bldrsElementProperties', () => {
         getPropertySets: () => Promise.resolve([]),
       }
 
-      const captured = await captureBldrsElementProperties(mgr, 0, tree)
+      const capturedResult = await captureBldrsElementProperties(mgr, 0, tree)
+      const captured = decodeCaptured(capturedResult)
       // BFS reaches entities via OwnerHistory's `OwningUser` /
       // `OwningApplication` refs — those field names aren't in
       // `GEOMETRIC_FIELD_NAMES`. But `ObjectPlacement` (→559) and
@@ -1035,12 +1074,12 @@ describe('loader/bldrsElementProperties', () => {
       expect(captured.itemProperties[559]).toBeUndefined()
       expect(captured.itemProperties[611]).toBeUndefined()
 
-      // Round-trip through compress + inject + parse + decode.
+      // Round-trip through inject + parse + lazy read.
       const baseGlb = serializeGlb(
         {asset: {version: '2.0'}, buffers: [{byteLength: 4}]},
         new Uint8Array(4))
       const {bytes: withExt} = injectGlbExtensions(baseGlb, [
-        {name: BLDRS_ELEMENT_PROPERTIES_EXTENSION_NAME, data: captured, compress: true},
+        {name: BLDRS_ELEMENT_PROPERTIES_EXTENSION_NAME, precompressed: capturedResult.compressedBytes},
       ])
       const {json, bin} = parseGlb(withExt)
       const buffer = bin.buffer.slice(bin.byteOffset, bin.byteOffset + bin.byteLength)
@@ -1050,22 +1089,22 @@ describe('loader/bldrsElementProperties', () => {
       })
       const gltf = {scene: {userData: {}}}
       await reader.afterRoot(gltf)
-      const decoded = gltf.scene.userData.bldrsElementProperties.decode()
+      const payload = gltf.scene.userData.bldrsElementProperties
 
       // Byte-for-byte (key-for-key) preservation of the IFC site shape,
       // including null-valued fields, numeric `type` discriminant, and
       // every typed-primitive / reference. This is the contract that
       // `@bldrs-ai/ifclib`'s `deref` builds the Properties panel on.
-      const decodedSite = decoded.itemProperties[621]
+      const decodedSite = payload.getRecord(621)
       expect(decodedSite).toEqual(ifcSiteEntity)
       expect(decodedSite.GlobalId).toEqual({type: 1, value: '02uD5Qe8H3mek2PYnMWHk1'})
       expect(decodedSite.OwnerHistory).toEqual({type: 5, value: 28})
       expect(decodedSite.Description).toBeNull()
       expect(decodedSite.PredefinedType).toEqual({type: 3, value: 'NOTDEFINED'})
 
-      // Following the OwnerHistory ref via the same decoded map must
+      // Following the OwnerHistory ref via the same payload must
       // resolve — that's the deref chain the Properties panel walks.
-      const referenced = decoded.itemProperties[decodedSite.OwnerHistory.value]
+      const referenced = payload.getRecord(decodedSite.OwnerHistory.value)
       expect(referenced).toEqual(ownerHistory)
     })
   })

--- a/src/loader/glbCacheKey.js
+++ b/src/loader/glbCacheKey.js
@@ -15,6 +15,20 @@
 /**
  * Current Bldrs GLB artifact schema version. Bumped on any backwards-
  * incompatible change to the BLDRS_* extension contract or cache-key shape.
+ * 0.13.0 — replaced `BLDRS_element_properties`' monolithic gzipped-JSON
+ *         payload with a block-indexed binary container ("BPRI" magic:
+ *         gzipped header carrying an id→block index + the pset table,
+ *         followed by independently gzipped ~1MB record blocks). The
+ *         old format required inflating the whole payload into ONE JS
+ *         string — V8 caps strings at ~512MiB, so PSB-class models
+ *         died in pako's string join (`RangeError: Invalid string
+ *         length`) and even smaller models materialised the full
+ *         object graph for a panel that reads one element at a time.
+ *         The reader now decodes the header index on first access and
+ *         one block per record miss (LRU-cached). NO legacy read
+ *         path: older 0.12.0 artifacts read as miss and rewrite; an
+ *         old-format payload arriving as a shared GLB file raises a
+ *         "clear local cache" alert instead of decoding.
  * 0.12.0 — extended `BLDRS_face_ids` with a geometry-piece identity table
  *         (`geometryItemIdentities`: distinct geometry express id →
  *         {type, name}, resolved through the live parser at write time).
@@ -96,7 +110,7 @@
  * 0.2.0 — generalised cache key from GitHub-only (owner/repo/branch) to a
  *         per-source-kind 3-level namespace (ns1/ns2/ns3).
  */
-export const BLDRS_GLB_SCHEMA_VERSION = '0.12.0'
+export const BLDRS_GLB_SCHEMA_VERSION = '0.13.0'
 
 
 /**

--- a/src/loader/glbExport.js
+++ b/src/loader/glbExport.js
@@ -359,28 +359,24 @@ export async function exportAndCacheGlb({model, kindLabel, cacheKeyArgs, ifcMana
     // eliminates that block — the main thread only pays the
     // structured-clone cost across postMessage (~50ms on a
     // Schependomlaan payload, scales sublinearly with size).
-    // (The element-properties payload usually arrives already gzipped
-    // from the streaming capture — see below — so for it the worker
-    // only splices bytes; the stringify+gzip offload still applies to
-    // its slow-path object form and to the other extensions.)
+    // (The element-properties payload always arrives as already-
+    // compressed container bytes from the capture — see below — so
+    // for it the worker only splices bytes; the stringify+gzip
+    // offload applies to the other extensions.)
     //
     // The fallback path runs everything inline (no worker) — used
     // when the worker fails to construct (Safari edge cases,
     // module-worker support detection failure). Same result either
     // way; the only observable difference is main-thread freeze
     // duration.
-    // The element-properties capture is a discriminated union: the
-    // streaming path (Conway adapter available) hands back already-
-    // gzipped wire bytes — pass them through as `precompressed` so
-    // neither this thread nor the worker re-materialises the payload;
-    // the slow path hands back the decoded object, compressed by the
-    // inject step as before.
-    const elementPropertiesExt = elementProperties?.compressedBytes instanceof Uint8Array ?
-      {name: BLDRS_ELEMENT_PROPERTIES_EXTENSION_NAME, precompressed: elementProperties.compressedBytes} :
-      {name: BLDRS_ELEMENT_PROPERTIES_EXTENSION_NAME, data: elementProperties, compress: true}
+    // The element-properties capture (both streaming and slow paths)
+    // hands back the block-indexed container bytes — pass them
+    // through as `precompressed` so neither this thread nor the
+    // worker re-materialises the payload. Nullish when no capture ran
+    // (non-IFC source); the inject filter drops the entry.
     const extensionsForInject = [
       {name: BLDRS_SPATIAL_TREE_EXTENSION_NAME, data: spatialTree, compress: true},
-      elementPropertiesExt,
+      {name: BLDRS_ELEMENT_PROPERTIES_EXTENSION_NAME, precompressed: elementProperties?.compressedBytes},
       {name: BLDRS_FACE_IDS_EXTENSION_NAME, data: faceIdsData, compress: true},
     ]
     // Scene-level metadata that rides along in the same inject pass

--- a/src/viewer/ShareModel.test.js
+++ b/src/viewer/ShareModel.test.js
@@ -224,14 +224,16 @@ describe('viewer/ShareModel', () => {
 
     it('promotes typedProperties when userData carries a BLDRS_element_properties payload', () => {
       // Mirrors what `BldrsElementPropertiesReader#afterRoot` parks: a
-      // `{compressed, decode}` lazy-decode object on userData.
-      // `Loader.js#convertToShareModel` hangs `getItemProperties` /
-      // `getPropertySets` off it. Capability flip is independent of
-      // the consumer wiring — presence of the payload is the signal.
+      // `{compressed, getRecord, getPsetIds}` lazy per-entity payload
+      // on userData. `Loader.js#convertToShareModel` hangs
+      // `getItemProperties` / `getPropertySets` off it. Capability
+      // flip is independent of the consumer wiring — presence of the
+      // payload is the signal.
       const root = new Group()
       root.userData.bldrsElementProperties = {
         compressed: new Uint8Array([0]),
-        decode: () => ({itemProperties: {}, propertySets: {}}),
+        getRecord: () => undefined,
+        getPsetIds: () => [],
       }
       const caps = inferModelCapabilities(root)
       expect(caps.typedProperties).toBe(true)


### PR DESCRIPTION
## Summary

Replaces the monolithic gzipped-JSON wire format for `BLDRS_element_properties` with a block-indexed binary container. The old format required inflating the entire payload into a single JS string, which V8 caps at ~512MiB — PSB-class models failed with `RangeError: Invalid string length` in pako's string join. The new format keeps reads bounded: one ~1MB block inflates + parses per cache miss, with an LRU cache preventing re-inflation of hot blocks.

## Key Changes

- **Container format ("BPRI" magic):** Fixed 12-byte preamble (magic + version + header length) + gzipped header (id→block index + pset table) + independently gzipped ~1MB record blocks. Distinct from pre-0.13.0 gzip magic (0x1f 0x8b), so the reader tells formats apart by leading bytes alone.

- **Writer-side (`ElementPropertiesContainerWriter`):** Incremental record accumulation into blocks; flushes when reaching `BLOCK_TARGET_CHARS` (1 MiB uncompressed). Both capture paths (streaming sweep + slow BFS) feed it; both emit the same container format.

- **Reader-side (`makeElementPropertiesPayload`):** Lazy header decode on first accessor call; per-block inflate + parse on demand with 16-block LRU. Never materialises the full closure — all strings and object graphs are bounded by block size.

- **Capture paths unified:** Streaming path now returns `{compressedBytes}` (container bytes) instead of raw gzipped JSON; slow path encodes its materialised map via `encodeElementProperties`. Both paths produce equivalent containers.

- **Legacy format handling:** Pre-0.13.0 payloads (gzip magic 0x1f 0x8b) are detected but not decoded. Instead, an alert prompts the user to clear the local cache (the schema-version bump in `glbCacheKey.js` already makes cached old artifacts read as a miss; this covers GLBs arriving as files).

- **Test helpers:** Added `encodeElementProperties` (materialised→container) and `decodeElementProperties` (container→materialised) for test/tooling use; updated test suite to decode captured results before assertion.

## Implementation Details

- **Block target size:** 1 MiB uncompressed balances reader-side string/parse bounds against header index triviality (PSB-class ~800MB closure → ~800 blocks).

- **LRU eviction:** Insertion-ordered Map; a hit re-inserts (moves to end), oldest key evicts when cache exceeds 16 blocks. Properties-panel access patterns (product + its psets/owner history/materials) fit comfortably in the working set.

- **Streaming writer:** Records concatenate into a small string buffer and flush to pako in ~64KB slabs (avoiding per-record gzip overhead and the whole-payload-resident problem the streaming path exists to solve).

- **Lazy decode:** Header (index + pset table) decodes on first `getRecord`/`getPsetIds` call; record blocks decode on demand. A load that never opens the Properties panel pays nothing.

- **Error handling:** Malformed containers (bad magic, truncated bytes, corrupt blocks) log and degrade to "no record found" — consumers show "no props" rather than crash.

See `design/new/lazy-properties-memory.md` §3.5 for memory analysis and format rationale.

https://claude.ai/code/session_01F9WE6GLJ9MVYW3TR53rPQW