### PR TITLE
Handle cache clear for temporary uploaded models

### DIFF
--- a/src/Components/Profile/ProfileControl.jsx
+++ b/src/Components/Profile/ProfileControl.jsx
@@ -35,6 +35,7 @@ import {
   CleaningServicesOutlined as CleaningServicesOutlinedIcon,
 } from '@mui/icons-material'
 import {clearOPFSCache} from '../../OPFS/utils'
+import {reloadAfterCacheClear} from '../../utils/navigate'
 
 
 /**
@@ -47,6 +48,7 @@ export default function ProfileControl() {
   const appMetadata = useStore((state) => state.appMetadata)
   const setAccessToken = useStore((state) => state.setAccessToken)
   const viewer = useStore((state) => state.viewer)
+  const appPrefix = useStore((state) => state.appPrefix)
   // The §6e Neutral/Flat render toggle only appears when the whole look system
   // is enabled (`?feature=look`); off, there's no look to switch.
   const isLookEnabled = isFeatureEnabled('look')
@@ -359,7 +361,10 @@ export default function ProfileControl() {
               console.error('Clear OPFS cache failed (reloading anyway)', err)
               captureException(err)
             } finally {
-              window.location.reload()
+              // On a temporary (uploaded) model the just-cleared OPFS was the
+              // only copy, so reloading the same URL would error; go to the
+              // home model instead. Normal models just reload from source.
+              reloadAfterCacheClear(appPrefix)
             }
           }}
           data-testid='clear-local-cache'

--- a/src/utils/navigate.js
+++ b/src/utils/navigate.js
@@ -24,6 +24,59 @@ export function navToDefault(navigate, appPrefix) {
 
 
 /**
+ * True when `pathname` addresses a temporary (uploaded) model. These live
+ * under the `/v/new/<uuid>` route and are stored only in OPFS — there is
+ * no remote source to reload them from, so clearing the cache leaves the
+ * URL pointing at a model that no longer exists.
+ *
+ * @param {string} pathname e.g. window.location.pathname
+ * @return {boolean}
+ */
+export function isTempModelPath(pathname) {
+  return typeof pathname === 'string' && pathname.includes('/v/new/')
+}
+
+
+/**
+ * Full path to the home model (`index.ifc`) with the default camera, as a
+ * plain string suitable for a hard `window.location.assign`. Mirrors the
+ * destination `navToDefault` computes for SPA navigation.
+ *
+ * @param {?string} [appPrefix] e.g. '/share'; derived from the current
+ *   install prefix when omitted (matches BaseRoutes' computation).
+ * @return {string}
+ */
+export function homeModelPath(appPrefix) {
+  const prefix = appPrefix ||
+    `${window.location.pathname.startsWith('/Share') ? '/Share' : ''}/share`
+  const cameraHash = `#${HASH_PREFIX_CAMERA}:-133.022,131.828,161.85,-38.078,22.64,-2.314`
+  return `${prefix}/v/p/index.ifc${cameraHash}`
+}
+
+
+/**
+ * Refresh the page after a Clear-Local-Cache reset. A normal model reloads
+ * from its remote source, so a plain page reload is enough. But a temporary
+ * (uploaded) model exists only in the OPFS cache we just cleared — reloading
+ * its `/v/new/<uuid>` URL would parse as a local model that is no longer
+ * present, and the loader would raise a "file not found" error dialog (with
+ * a Reset button). Detect that case and navigate to the home model instead,
+ * so the user gets a fresh session with no error — exactly what hitting
+ * Reset would have produced.
+ *
+ * @param {?string} [appPrefix] e.g. '/share'
+ */
+export function reloadAfterCacheClear(appPrefix) {
+  if (isTempModelPath(window.location.pathname)) {
+    disablePageReloadApprovalCheck()
+    window.location.assign(homeModelPath(appPrefix))
+    return
+  }
+  window.location.reload()
+}
+
+
+/**
  * Helper for calling navigate that will append search query to path,
  * if present, before appending an optional hash.
  *

--- a/src/utils/navigate.js
+++ b/src/utils/navigate.js
@@ -40,7 +40,10 @@ export function isTempModelPath(pathname) {
 /**
  * Full path to the home model (`index.ifc`) with the default camera, as a
  * plain string suitable for a hard `window.location.assign`. Mirrors the
- * destination `navToDefault` computes for SPA navigation.
+ * destination `navToDefault` computes for SPA navigation, including
+ * carrying the current query string forward — feature flags live there
+ * (`?feature=…`, read from `window.location.search` at runtime) and would
+ * otherwise be dropped by the cache-clear redirect.
  *
  * @param {?string} [appPrefix] e.g. '/share'; derived from the current
  *   install prefix when omitted (matches BaseRoutes' computation).
@@ -49,8 +52,9 @@ export function isTempModelPath(pathname) {
 export function homeModelPath(appPrefix) {
   const prefix = appPrefix ||
     `${window.location.pathname.startsWith('/Share') ? '/Share' : ''}/share`
+  const search = window.location.search || ''
   const cameraHash = `#${HASH_PREFIX_CAMERA}:-133.022,131.828,161.85,-38.078,22.64,-2.314`
-  return `${prefix}/v/p/index.ifc${cameraHash}`
+  return `${prefix}/v/p/index.ifc${search}${cameraHash}`
 }
 
 

--- a/src/utils/navigate.test.js
+++ b/src/utils/navigate.test.js
@@ -1,4 +1,4 @@
-import {navigateToModel} from './navigate'
+import {navigateToModel, isTempModelPath, homeModelPath, reloadAfterCacheClear} from './navigate'
 
 
 describe('navigateToModel', () => {
@@ -42,5 +42,85 @@ describe('navigateToModel', () => {
 
   it('throws for invalid target', () => {
     expect(() => navigateToModel(null)).toThrow(/invalid target/)
+  })
+})
+
+
+describe('isTempModelPath', () => {
+  it('is true for uploaded /v/new/ models', () => {
+    expect(isTempModelPath('/share/v/new/AA77535-D1B6-49A9-915B.ifc')).toBe(true)
+    expect(isTempModelPath('/Share/share/v/new/uuid.ifc')).toBe(true)
+  })
+
+  it('is false for hosted, github and other routes', () => {
+    expect(isTempModelPath('/share/v/p/index.ifc')).toBe(false)
+    expect(isTempModelPath('/share/v/gh/org/repo/main/model.ifc')).toBe(false)
+    expect(isTempModelPath('')).toBe(false)
+    expect(isTempModelPath(undefined)).toBe(false)
+  })
+})
+
+
+describe('homeModelPath', () => {
+  let locationGetter
+
+  afterEach(() => {
+    if (locationGetter) {
+      locationGetter.mockRestore()
+      locationGetter = null
+    }
+  })
+
+  it('uses the given appPrefix', () => {
+    expect(homeModelPath('/share')).toBe(
+      '/share/v/p/index.ifc#c:-133.022,131.828,161.85,-38.078,22.64,-2.314')
+  })
+
+  it('derives the install prefix when appPrefix is omitted', () => {
+    locationGetter = jest.spyOn(window, 'location', 'get')
+      .mockReturnValue({pathname: '/Share/share/v/new/uuid.ifc'})
+    expect(homeModelPath()).toBe(
+      '/Share/share/v/p/index.ifc#c:-133.022,131.828,161.85,-38.078,22.64,-2.314')
+  })
+})
+
+
+describe('reloadAfterCacheClear', () => {
+  let assignCalls
+  let reloadCalls
+  let locationGetter
+
+  const mockLocation = (pathname) => {
+    assignCalls = []
+    reloadCalls = 0
+    locationGetter = jest.spyOn(window, 'location', 'get').mockReturnValue({
+      pathname,
+      assign: (url) => assignCalls.push(url),
+      reload: () => {
+        reloadCalls += 1
+      },
+    })
+  }
+
+  afterEach(() => {
+    if (locationGetter) {
+      locationGetter.mockRestore()
+      locationGetter = null
+    }
+  })
+
+  it('navigates to the home model for a temporary model', () => {
+    mockLocation('/share/v/new/uuid.ifc')
+    reloadAfterCacheClear('/share')
+    expect(assignCalls).toEqual([
+      '/share/v/p/index.ifc#c:-133.022,131.828,161.85,-38.078,22.64,-2.314'])
+    expect(reloadCalls).toBe(0)
+  })
+
+  it('reloads in place for a normal model', () => {
+    mockLocation('/share/v/p/index.ifc')
+    reloadAfterCacheClear('/share')
+    expect(assignCalls).toEqual([])
+    expect(reloadCalls).toBe(1)
   })
 })

--- a/src/utils/navigate.test.js
+++ b/src/utils/navigate.test.js
@@ -82,6 +82,13 @@ describe('homeModelPath', () => {
     expect(homeModelPath()).toBe(
       '/Share/share/v/p/index.ifc#c:-133.022,131.828,161.85,-38.078,22.64,-2.314')
   })
+
+  it('carries the current query string forward (feature flags)', () => {
+    locationGetter = jest.spyOn(window, 'location', 'get')
+      .mockReturnValue({pathname: '/share/v/new/uuid.ifc', search: '?feature=bot'})
+    expect(homeModelPath('/share')).toBe(
+      '/share/v/p/index.ifc?feature=bot#c:-133.022,131.828,161.85,-38.078,22.64,-2.314')
+  })
 })
 
 
@@ -90,11 +97,12 @@ describe('reloadAfterCacheClear', () => {
   let reloadCalls
   let locationGetter
 
-  const mockLocation = (pathname) => {
+  const mockLocation = (pathname, search = '') => {
     assignCalls = []
     reloadCalls = 0
     locationGetter = jest.spyOn(window, 'location', 'get').mockReturnValue({
       pathname,
+      search,
       assign: (url) => assignCalls.push(url),
       reload: () => {
         reloadCalls += 1
@@ -114,6 +122,14 @@ describe('reloadAfterCacheClear', () => {
     reloadAfterCacheClear('/share')
     expect(assignCalls).toEqual([
       '/share/v/p/index.ifc#c:-133.022,131.828,161.85,-38.078,22.64,-2.314'])
+    expect(reloadCalls).toBe(0)
+  })
+
+  it('preserves the query string when navigating home', () => {
+    mockLocation('/share/v/new/uuid.ifc', '?feature=bot')
+    reloadAfterCacheClear('/share')
+    expect(assignCalls).toEqual([
+      '/share/v/p/index.ifc?feature=bot#c:-133.022,131.828,161.85,-38.078,22.64,-2.314'])
     expect(reloadCalls).toBe(0)
   })
 


### PR DESCRIPTION
## Summary
When clearing the OPFS cache, temporary (uploaded) models stored under `/v/new/<uuid>` need special handling. Since these models exist only in the cache we just cleared, reloading the same URL would fail with a "file not found" error. This change detects temporary models and navigates to the home model instead, giving users a fresh session without error dialogs.

## Changes
- **`src/utils/navigate.js`**: Added three new utility functions:
  - `isTempModelPath(pathname)` — detects if a URL addresses a temporary uploaded model (contains `/v/new/`)
  - `homeModelPath(appPrefix)` — computes the full path to the home model with default camera, suitable for hard navigation via `window.location.assign`
  - `reloadAfterCacheClear(appPrefix)` — orchestrates the post-cache-clear refresh: navigates to home for temporary models, reloads in place for normal models

- **`src/Components/Profile/ProfileControl.jsx`**: Updated the "Clear Local Cache" button handler to call `reloadAfterCacheClear(appPrefix)` instead of a plain `window.location.reload()`, with explanatory comments on the temporary-model edge case

- **`src/utils/navigate.test.js`**: Added comprehensive test coverage for all three new functions, including:
  - Path detection for `/v/new/` routes (case-insensitive prefix handling)
  - Home path generation with and without explicit `appPrefix`
  - Cache-clear behavior: navigation for temporary models vs. reload for normal models

## Implementation notes
- `homeModelPath` mirrors the camera hash and route structure that `navToDefault` computes for SPA navigation, ensuring consistency
- The `appPrefix` derivation in `homeModelPath` matches `BaseRoutes`' logic for computing the install prefix from `window.location.pathname`
- Tests mock `window.location` to verify both the navigation path and the reload/assign call counts

https://claude.ai/code/session_01AGKapcSycWErDXtCGciXff