### PR TITLE
Bump @bldrs-ai/conway 1.434.1300 → 1.432.1305: STEP surface-fidelity release

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@babel/plugin-syntax-import-assertions": "7.18.6",
     "@babel/preset-env": "7.18.10",
     "@babel/preset-react": "7.18.6",
-    "@bldrs-ai/conway": "1.434.1300",
+    "@bldrs-ai/conway": "1.432.1305",
     "@bldrs-ai/ifclib": "5.3.3",
     "@emotion/react": "11.10.0",
     "@emotion/styled": "11.10.0",

--- a/src/viewer/ifc/incrementalBatchedBuilder.js
+++ b/src/viewer/ifc/incrementalBatchedBuilder.js
@@ -28,7 +28,7 @@ const GROWTH = 2
  * model incrementally from the demand pump's delta FlatMesh batches, so
  * there is no monolithic end-of-load build and no preview→model swap.
  *
- * Feed each pump delta to {@link appendBatch}; the builder deduplicates
+ * Feed each pump delta to `appendBatch`; the builder deduplicates
  * geometry by `geometryExpressID` across batches (fetched from Conway
  * once), appends instances into an opaque and/or transparent
  * `THREE.BatchedMesh` (created lazily, grown in place with 2x
@@ -37,7 +37,7 @@ const GROWTH = 2
  * `instanceGeometry`, `instanceColors`).
  *
  * `root` is a stable `Group` — install it in the scene on the first
- * batch and geometry simply appears as it extracts. {@link finalize}
+ * batch and geometry simply appears as it extracts. `finalize`
  * stamps the pick tables, computes bounds + BVHs, and returns
  * `{batches, stats}` in exactly the `flatMeshToBatchedModel` shape, so
  * `buildBatchedConwayModel`'s decoration applies unchanged.

--- a/yarn.lock
+++ b/yarn.lock
@@ -2473,10 +2473,10 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@bldrs-ai/conway@1.434.1300":
-  version "1.434.1300"
-  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.434.1300.tgz#aefac4f2a14ea71c6241300cf90c7b53e98aff5d"
-  integrity sha512-QjFXEiBBvX4tbO3qAk577512JdIGXTe+BL2lFltiT3tE6Z+KmWhLJ6UxnybdVzO5h8kT5PZtqUAkKVmwBcHC+g==
+"@bldrs-ai/conway@1.432.1305":
+  version "1.432.1305"
+  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.432.1305.tgz#2e55afe3449a9fc2c5730058fd7479dc535eb4e5"
+  integrity sha512-Xnl6uDQQta7Lsgs/umL2f4TBRcyBVGwUdZ9X1JJxwPZfTYnE4hyWH+vQahinwguq5QKdmImTho0Hx+lkjSLCwA==
   dependencies:
     gl-matrix "3.4.3"
     seedrandom "3.0.5"


### PR DESCRIPTION
Ships the full STEP surface-fidelity pass for bldrs-ai/test-models#47 (bldrs-ai/conway#432 → conway-geom#150–#154). Note the version: releases are `1.&lt;PR&gt;.&lt;run&gt;`, so `1.432.1305` was published **after** and supersedes `1.434.1300` (the #432 merge includes #434&#39;s changes).

What this picks up, all on the Jetenginestep model and friends:

- **Revolution surfaces** (conway-geom#150/#151): adaptive ring count + CDT-trimmed boundary loops — round shafts and spinner.
- **Linear-extrusion surfaces** (conway#432 + conway-geom#152): extractor builds native profiles from AP214&#39;s bare swept curves; exact developable unwrap — correct compressor drum skins and blades (1,370 faces that previously fell to the flat fallback).
- **Cylindrical + conical surfaces** (conway-geom#153): trimmed (θ, z) unwrap with CDT hole nesting replaces earcut chord projections — smooth blade/join/shaft rings between compressor sections, and the jet drops 4.9M → 3.5M triangles (driver_board 3.7M → 0.4M), so GLBs get lighter across the board.
- **Toroidal surfaces** (conway-geom#154): interior Steiner seeding before CDT — the fuel-manifold tube renders as a round pipe instead of a flat creased ribbon.

Conway CI on #432: no regression failures, two previously-failing ap242 models now pass, visual diff clean across all 24 rendered models.

Also converts two `{@link}` references to method names into plain code spans in `incrementalBatchedBuilder.js` — `jsdoc/no-undefined-types` was failing `eslint --max-warnings 0` on main, blocking any commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J3A79iKimn7UheESvnumj7

---
_Generated by [Claude Code](https://claude.ai/code/session_01J3A79iKimn7UheESvnumj7)_