### PR TITLE
Move residency control to the bottom bar, popover opens upward

### DIFF
--- a/src/Components/ElementsControl.jsx
+++ b/src/Components/ElementsControl.jsx
@@ -3,6 +3,7 @@ import {ButtonGroup, Stack} from '@mui/material'
 import useStore from '../store/useStore'
 import {TooltipIconButton} from './Buttons'
 import CutPlaneMenu from './CutPlane/CutPlaneMenu'
+import ResidencyControl from './Residency/ResidencyControl'
 import {
   Close as CloseIcon,
   FilterCenterFocus as FilterCenterFocusIcon,
@@ -61,6 +62,14 @@ export default function ElementsControl({deselectItems}) {
          * (which replaces the model's geometry slot).
          */}
         {!isTempIsolationModeOn && <CutPlaneMenu/>}
+
+        {/*
+         * Residency (demand-model eviction / infill). Grouped with the
+         * cut plane here in the bottom bar — both are "how much of the
+         * model am I looking at" controls. Self-gates: renders nothing
+         * unless the loaded model has batched instances to dial.
+         */}
+        <ResidencyControl/>
 
         {/*
          * Isolate toggle. Visible whenever there's something to

--- a/src/Components/Residency/ResidencyControl.jsx
+++ b/src/Components/Residency/ResidencyControl.jsx
@@ -92,7 +92,8 @@ export default function ResidencyControl() {
         title='Residency'
         icon={<ResidencyIcon className='icon-share'/>}
         onClick={(event) => setAnchorEl(event.currentTarget)}
-        placement='left'
+        placement='top'
+        variant='solid'
         selected={anchorEl !== null || percent < FULL}
         dataTestId='control-button-residency'
       />
@@ -100,8 +101,11 @@ export default function ResidencyControl() {
         open={anchorEl !== null}
         anchorEl={anchorEl}
         onClose={() => setAnchorEl(null)}
-        anchorOrigin={{vertical: 'center', horizontal: 'left'}}
-        transformOrigin={{vertical: 'center', horizontal: 'right'}}
+        // Opens UPWARD from the bottom bar (popover bottom pinned to the
+        // button top). MUI flips/repositions if it would overflow the
+        // viewport, so it stays on-screen on mobile.
+        anchorOrigin={{vertical: 'top', horizontal: 'center'}}
+        transformOrigin={{vertical: 'bottom', horizontal: 'center'}}
       >
         <Stack spacing={1} sx={{p: 2, width: '16em'}}>
           <Typography variant='subtitle2'>Residency: {percent}%</Typography>

--- a/src/Containers/OperationsGroup.jsx
+++ b/src/Containers/OperationsGroup.jsx
@@ -7,7 +7,6 @@ import ImagineControl from '../Components/Imagine/ImagineControl'
 import NotesControl from '../Components/Notes/NotesControl'
 import ProfileControl from '../Components/Profile/ProfileControl'
 import PropertiesControl from '../Components/Properties/PropertiesControl'
-import ResidencyControl from '../Components/Residency/ResidencyControl'
 import ShareControl from '../Components/Share/ShareControl'
 import useStore from '../store/useStore'
 
@@ -58,7 +57,6 @@ export default function OperationsGroup() {
           />
         )}
         {isImagineEnabled && <ImagineControl/>}
-        {(viewer && isModelReady) && <ResidencyControl/>}
         {/* Invisible */}
         <CameraControl/>
       </Stack>


### PR DESCRIPTION
Follow-up to #1617 (residency slider). The eviction/infill control groups more logically with the **cut plane** than with the right-side operations — both are "how much of the model am I looking at" controls.

- Moved `ResidencyControl` from `OperationsGroup` (right side) into `ElementsControl` (the bottom bar's cut-plane group).
- Matched the bottom-group styling: `variant='solid'` button, `placement='top'` tooltip.
- Flipped the popover to open **upward** — `anchorOrigin {top, center}` / `transformOrigin {bottom, center}`, so the panel's bottom pins to the button's top. MUI flips/repositions on viewport overflow, so it stays on-screen on mobile.
- Still self-gating: renders nothing unless the loaded model has batched instances to dial.

The control's `data-testid` is unchanged, so the existing `residencySlider.spec.ts` e2e passes in the new location (verified locally, plus ElementsControl/OperationsGroup/controller unit suites). No visual regression to the right-side operations group (control simply removed from it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S6gTXmrq1GbhqknPqQMRuz

---
_Generated by [Claude Code](https://claude.ai/code/session_01S6gTXmrq1GbhqknPqQMRuz)_