### PR TITLE
Bump @bldrs-ai/conway to 1.435.1309 (georeferencing jitter + preview log fixes)

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@babel/plugin-syntax-import-assertions": "7.18.6",
     "@babel/preset-env": "7.18.10",
     "@babel/preset-react": "7.18.6",
-    "@bldrs-ai/conway": "1.432.1305",
+    "@bldrs-ai/conway": "1.435.1309",
     "@bldrs-ai/ifclib": "5.3.3",
     "@emotion/react": "11.10.0",
     "@emotion/styled": "11.10.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2473,10 +2473,10 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@bldrs-ai/conway@1.432.1305":
-  version "1.432.1305"
-  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.432.1305.tgz#2e55afe3449a9fc2c5730058fd7479dc535eb4e5"
-  integrity sha512-Xnl6uDQQta7Lsgs/umL2f4TBRcyBVGwUdZ9X1JJxwPZfTYnE4hyWH+vQahinwguq5QKdmImTho0Hx+lkjSLCwA==
+"@bldrs-ai/conway@1.435.1309":
+  version "1.435.1309"
+  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.435.1309.tgz#f79bd854d992f2aabbc724d2f5030ae282059548"
+  integrity sha512-Xt9szr5excz3V4nKE/yyM8CG6EFxYll35LdJNO/eb12tmgCdHzEYHV//VSUfRNNYJjo2gGPV0K2kMhKLyOuMRA==
   dependencies:
     gl-matrix "3.4.3"
     seedrandom "3.0.5"


### PR DESCRIPTION
Superseded by **#1621** (bump to 1.436.1311).

This PR bumped to 1.435.1309, which carried only the float64 coordination + quiet-logging fixes (conway #435). It did **not** include the rel-aggregates master-voids cut pass (conway #436) — which turned out to be the actual root cause of the romana/DOWA "janky layout on first load" (the deferred pump was serving uncut geometry). #1621 folds both releases into one clean bump, so this is closed as superseded.