### PR TITLE
Bump @bldrs-ai/conway to 1.436.1311 (romana/DOWA cut geometry + georeferencing jitter)

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@babel/plugin-syntax-import-assertions": "7.18.6",
     "@babel/preset-env": "7.18.10",
     "@babel/preset-react": "7.18.6",
-    "@bldrs-ai/conway": "1.432.1305",
+    "@bldrs-ai/conway": "1.436.1311",
     "@bldrs-ai/ifclib": "5.3.3",
     "@emotion/react": "11.10.0",
     "@emotion/styled": "11.10.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2473,10 +2473,10 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@bldrs-ai/conway@1.432.1305":
-  version "1.432.1305"
-  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.432.1305.tgz#2e55afe3449a9fc2c5730058fd7479dc535eb4e5"
-  integrity sha512-Xnl6uDQQta7Lsgs/umL2f4TBRcyBVGwUdZ9X1JJxwPZfTYnE4hyWH+vQahinwguq5QKdmImTho0Hx+lkjSLCwA==
+"@bldrs-ai/conway@1.436.1311":
+  version "1.436.1311"
+  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.436.1311.tgz#95e32270f59c78d2a14bc22bfe1aa9e5578ab08d"
+  integrity sha512-iABrSJ0Ppxa+e+TnnuFxgG7LWoXEd7U8doVgne//74ypkIZt9DvSD8aYnduJT1+XABEzAUJfDMG/zoNbwY54+A==
   dependencies:
     gl-matrix "3.4.3"
     seedrandom "3.0.5"


### PR DESCRIPTION
Picks up the large-model demand-path fixes from conway **#436** (+ #435, #434), landed in release **1.436.1311**. This is the fix Pablo wanted in for the romana and DOWA models.

### What lands

- **Rel-aggregates master-voids pass in the deferred pump (conway #[436](https://github.com/bldrs-ai/conway/issues/436))** — the actual root cause of the romana/DOWA "janky layout on first load". The classic `StreamAllMeshes` path runs a second pass over `IfcRelAggregates` that re-extracts each related product with the relating assembly's rel-voids as a master override (cutting openings and adding the assembly-placed instance). The deferred geometry pump skipped this pass, so it served **uncut** geometry. The pump now runs `extractRelAggregatesGeometry()` once the product cursor drains, producing byte-identical cut geometry to the classic path. Verified `contentDiff=0` across DOWA (126,687 geometries) and romana (651).

- **float64 coordinate-to-origin ([conway #435](https://github.com/bldrs-ai/conway/pull/435))** — fixes georeferencing jitter during rotation when zoomed in. The `COORDINATE_TO_ORIGIN` recentre no longer quantizes on the float32 gl-matrix grid (~mm at 100km, ~28cm at Swiss LV95), so geometry stays put on every render path for georeferenced models.

- **Quiet IFC/AP214 preview-prefix logging (conway [#434](https://github.com/bldrs-ai/conway/pull/434)/[#435](https://github.com/bldrs-ai/conway/pull/435))** — clears the styled-item error flood (the 1164 "Value in select must be populated" errors on DOWA) from the parse-time preview channel's throwaway prefix extractions.

### Verification

Package contents verified against 1.436.1311: `extractRelAggregatesGeometry` + `demandAggregatesDone_` compiled into the shipped bundle, `coordination_f64.js` present. Loader / viewer / residency / progress suites green (205 tests / 15 suites).

### Supersedes #1620

#1620 bumped to 1.435.1309, which carried only the float64 coordination + quiet-logging fixes — **not** the rel-aggregates cut pass that is the real romana/DOWA root cause. This bump includes everything in one clean release, so #1620 is being closed as superseded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S6gTXmrq1GbhqknPqQMRuz

---
_Generated by [Claude Code](https://claude.ai/code/session_01S6gTXmrq1GbhqknPqQMRuz)_