### PR TITLE
Fix private repos missing from the GitHub file chooser (paginate org repos)

### DIFF
--- a/src/__mocks__/api-handlers-github.ts
+++ b/src/__mocks__/api-handlers-github.ts
@@ -335,10 +335,10 @@ export default function githubApiHandlers(defines: Defines, authed: boolean): Ht
     }),
 
     http.get(`${authed ? GH_BASE_AUTHED : GH_BASE_UNAUTHED}/orgs/bldrs-ai/repos`, () => {
+      // GitHub's `GET /orgs/{org}/repos` returns a bare array (as does the
+      // `/user/repos` handler above) — not a `{data: [...]}` envelope.
       return new Response(
-        JSON.stringify({
-          data: [MOCK_REPOSITORY],
-        }),
+        JSON.stringify([MOCK_REPOSITORY]),
         {
           status: HTTP_OK,
           headers: {'Content-Type': 'application/json'},

--- a/src/net/github/Repositories.js
+++ b/src/net/github/Repositories.js
@@ -3,21 +3,45 @@ import {octokit} from './OctokitExport' // TODO(pablo): don't use directly
 
 
 /**
- * Retrieves repositories associated with an organization
+ * Retrieves repositories associated with an organization.
+ *
+ * Paginates the full org repo list (GitHub caps a page at 100) and asks
+ * for `type: 'all'`, so private repos the authenticated user can see are
+ * included — without pagination only the first page (default 30) came
+ * back, so private / alphabetically-late repos (e.g. `test-models-private`)
+ * silently fell off the list and read as "No match" in the chooser.
  *
  * @param {string} org
  * @param {string} [accessToken]
- * @return {Promise} the list of organization
+ * @return {Promise} the list of organization repositories
  */
 export async function getRepositories(org, accessToken = '') {
   assertDefined(...arguments)
-  const res = await octokit.request('GET /orgs/{org}/repos', {
-    org,
-    headers: {
-      authorization: `Bearer ${accessToken}`,
-    },
-  })
-  return res.data
+  const allRepos = []
+  let page = 1
+  const perPage = 100 // Max value is 100
+
+  for (;;) {
+    const res = await octokit.request('GET /orgs/{org}/repos', {
+      org,
+      // `all` (the authenticated default) returns private repos the token
+      // can access alongside public ones; set explicitly so the intent is
+      // clear and stable if the API default ever changes.
+      type: 'all',
+      per_page: perPage,
+      page: page,
+      headers: {
+        authorization: `Bearer ${accessToken}`,
+      },
+    })
+    allRepos.push(...res.data)
+    if (res.data.length < perPage) {
+      // A short page means we've reached the last one.
+      break
+    }
+    page++
+  }
+  return allRepos
 }
 
 

--- a/src/net/github/Repositories.test.js
+++ b/src/net/github/Repositories.test.js
@@ -6,7 +6,9 @@ describe('net/github/Repositories', () => {
   describe('getRepositories', () => {
     it('successfully get repositories', async () => {
       const res = await getRepositories('bldrs-ai')
-      expect(res.data).toEqual([MOCK_REPOSITORY])
+      // getRepositories returns the paginated array of repos directly
+      // (GitHub's org-repos endpoint returns a bare array).
+      expect(res).toEqual([MOCK_REPOSITORY])
     })
   })
 })


### PR DESCRIPTION
## Why

Opening a private model by stable GitHub URL was impossible from the chooser: typing e.g. `test-models-private` under `@bldrs-ai` returned **"No match"** even when OAuth'd with access.

## Cause

`getRepositories` (the org path) requested `GET /orgs/{org}/repos` with **no pagination**, so only the first page (GitHub's default 30) came back. On an org with many repos, private / alphabetically-late repos silently fell off the list. The sibling `getUserRepositories` already paginates; the org path didn't.

## Fix

- **`src/net/github/Repositories.js`** — paginate the org repo list (`per_page: 100`, loop until a short page), mirroring `getUserRepositories`, and pass `type: 'all'` explicitly (the authenticated default) so private repos the token can see are included.
- **`src/__mocks__/api-handlers-github.ts`** — the mock for `/orgs/{org}/repos` returned a `{data: [...]}` envelope, but GitHub (and the sibling `/user/repos` handler) returns a **bare array**. The old code returned that wrapper and the test compensated by asserting `res.data`; the paginated code spreads the array as production delivers it. Mock now returns a bare array to match reality.
- **`src/net/github/Repositories.test.js`** — assert the returned array directly.

No production consumer changes: real GitHub always returned a bare array, so `getRepositories`' callers (`GitHubFileBrowser`, `SaveModelControl`, both `Object.keys(repos).map(...)`) are unaffected — only the mock was wrong-shaped.

> Note: the GitHub-dependent suites can't run in the dev sandbox (MSW isn't intercepting there — requests hit real GitHub and 401), so CI is the gate; lint is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S6gTXmrq1GbhqknPqQMRuz

---
_Generated by [Claude Code](https://claude.ai/code/session_01S6gTXmrq1GbhqknPqQMRuz)_