### PR TITLE
Add ?feature=disableGlb escape hatch to force the live Conway render

### DIFF
--- a/src/FeatureFlags.js
+++ b/src/FeatureFlags.js
@@ -86,6 +86,16 @@ export const flags = [
   // A/Bs the same build); flipping this to true is the prod-wide kill
   // switch.
   {name: 'disableStreamOpen', isActive: false},
+  // Off-flag escape hatch for the OPFS GLB cache pipeline (default-on
+  // `glb`). `?feature=disableGlb` skips the pre-parse cache lookup AND
+  // the post-parse export, so the model is always parsed fresh through
+  // Conway and rendered from the live geometry — never a cached GLB.
+  // Needed to A/B the demand/batched render path against the cached GLB
+  // on the same model (a GLB cache hit bypasses Conway entirely, so
+  // `disableStreamOpen` alone has no effect on a cached load), and to
+  // work models whose GLB was baked by an older build. Same inverted
+  // semantics as `disableStreamOpen` (`?feature=` can only turn flags on).
+  {name: 'disableGlb', isActive: false},
   // Demand/tiled rendering (design/new/demand-tiled-rendering.md,
   // #1613): cache-miss IFC/STEP parses open with DEFER_GEOMETRY and
   // pump Conway's ExtractGeometryBatch — parse-time preview + the

--- a/src/loader/Loader.js
+++ b/src/loader/Loader.js
@@ -177,7 +177,10 @@ export async function load(
   // Set when we swap the IFC source with a cached GLB. Drives post-parse
   // diagnostics so the user can see what the GLTF parser produced.
   let cameFromGlbCache = false
-  const wantGlb = isFeatureEnabled('glb') && isIfc
+  // `?feature=disableGlb` forces the live Conway render (skips the OPFS
+  // GLB cache lookup + post-parse export), so a cached GLB never masks
+  // the live geometry — the A/B escape hatch for the batched render path.
+  const wantGlb = isFeatureEnabled('glb') && isIfc && !isFeatureEnabled('disableGlb')
   if (wantGlb) {
     glbVerbose('feature enabled')
   }


### PR DESCRIPTION
## Why

The OPFS GLB cache (default-on `glb`) checks for a cached GLB **before parsing** and, on a hit, swaps to the cached GLB and renders it directly — **Conway is never invoked**. Because OPFS persists across sessions, a model loaded once keeps rendering from its cached GLB. So:

- `?feature=disableStreamOpen` (which only selects Conway's *open* path) has **no effect** on a cached load, and
- there's no way to A/B the live demand/batched render against the cached GLB on the same model.

This blocks investigating the large-model rotation jitter (388_4 / romana / DOWA): those are drag-and-drop → OPFS models, so they're served from a cached GLB baked by whatever build first loaded them, and no existing flag forces the live render.

## What

`?feature=disableGlb` (inverted semantics, same pattern as `disableStreamOpen`) gates `wantGlb`, skipping **both** the pre-parse cache lookup and the post-parse export, so the model is always parsed fresh through Conway and rendered from the live geometry — never a cached GLB.

- `src/FeatureFlags.js` — new off-flag `disableGlb` (`isActive: false`).
- `src/loader/Loader.js` — `wantGlb = glb && isIfc && !disableGlb` (the export context is only set inside the `wantGlb` block, so this disables lookup **and** export).

## Use

- `?feature=disableGlb` → always live render (works on the OPFS hash-path URL too).
- Combine with `?feature=disableStreamOpen` → live render via Conway's **classic/merged** path, for a full A/B of merged vs batched on the same model.

Diagnostic/escape-hatch flag; harmless when off (default). Lets us isolate whether the jitter lives in the baked GLB or the live render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S6gTXmrq1GbhqknPqQMRuz

---
_Generated by [Claude Code](https://claude.ai/code/session_01S6gTXmrq1GbhqknPqQMRuz)_