### PR TITLE
Open-dialog GitHub browser: filterable/paginated Selector + private-repo opt-in + persistence

### DIFF
--- a/src/Components/Auth/PopupAuth.jsx
+++ b/src/Components/Auth/PopupAuth.jsx
@@ -21,13 +21,18 @@ function PopupAuth() {
     if (params.get('scope')) {
       const scope = params.get('scope')
 
-      // Trigger the Auth0 login redirect
+      // Trigger the Auth0 login redirect. `prompt: 'login'` forces Auth0 to
+      // re-authenticate through the upstream connection so a widened
+      // `connection_scope` (e.g. GitHub `repo`) is actually re-requested and
+      // consented — without it Auth0 can reuse the cached identity/token and
+      // the extra scope is silently dropped (token comes back unchanged).
       loginWithRedirect({
         authorizationParams: {
           redirect_uri: `${window.location.origin}/popup-callback`,
           scope: 'openid profile email offline_access',
           connection: connection,
           connection_scope: scope,
+          prompt: 'login',
           ...(linkToken && {linkToken}), // ← forward it
         },
       })

--- a/src/Components/Open/GitHubFileBrowser.jsx
+++ b/src/Components/Open/GitHubFileBrowser.jsx
@@ -1,6 +1,6 @@
 
-import React, {ReactElement, useEffect, useState} from 'react'
-import {Button, Stack, Typography} from '@mui/material'
+import React, {ReactElement, useEffect, useRef, useState} from 'react'
+import {Button, Stack, Tooltip, Typography} from '@mui/material'
 import {navigateBaseOnModelPath} from '../../utils/location'
 import {navigateToModel} from '../../utils/navigate'
 import {useAuth0} from '../../Auth0/Auth0Proxy'
@@ -13,6 +13,12 @@ import useStore from '../../store/useStore'
 import {addRecentFileEntry, setPendingModelNameUpdate} from '../../connections/persistence'
 import Selector from './Selector'
 import SelectorSeparator from './SelectorSeparator'
+
+
+/** localStorage key for remembering the GitHub browser's last selections. */
+const GH_BROWSER_STATE_KEY = 'bldrs.openDialog.github'
+/** subscriptionStatus values that carry (or will carry) Pro entitlements. */
+const PRO_STATUSES = ['sharePro', 'shareProPendingReauth']
 
 
 /**
@@ -64,6 +70,16 @@ export default function GitHubFileBrowser({
   const [filesArr, setFilesArr] = useState([''])
   const [branchesArr, setBranchesArr] = useState([''])
   const [selectedBranchName, setSelectedBranchName] = useState('')
+  // True once the current org's repo list is known to include a private
+  // repo — i.e. the token already carries the `repo` scope, so the
+  // "Enable private repos" opt-in is hidden.
+  const [hasPrivateRepos, setHasPrivateRepos] = useState(false)
+  const appMetadata = useStore((state) => state.appMetadata)
+  const isProUser = PRO_STATUSES.includes(appMetadata?.subscriptionStatus)
+  // Restore-once + refetch-on-token-change bookkeeping (see effects below).
+  const restoredRef = useRef(false)
+  const pendingRestoreRef = useRef(null)
+  const prevTokenRef = useRef(accessToken)
   const orgNamesArrWithAt = orgNamesArr.map((name) => `@${name}`)
   const orgName = resolveValue(selectedOrgName, orgNamesArr)
   const repoName = resolveValue(selectedRepoName, repoNamesArr)
@@ -105,6 +121,9 @@ export default function GitHubFileBrowser({
     }
     const repoNames = Object.keys(repos).map((key) => repos[key].name)
     setRepoNamesArr(repoNames)
+    // A private repo in the list means the token already has `repo` scope;
+    // otherwise GitHub filtered private repos out and the opt-in should show.
+    setHasPrivateRepos(Object.values(repos).some((repo) => repo?.private))
     setCurrentPath('')
     setFoldersArr([''])
     setSelectedFolderName('')
@@ -160,6 +179,112 @@ export default function GitHubFileBrowser({
   const selectBranch = (branchOrIndex) => {
     setSelectedBranchName(branchOrIndex)
   }
+
+  // --- Private-repo opt-in (A) -------------------------------------------
+  // Explicit, Pro-gated action to grant the GitHub `repo` scope. OAuth
+  // scopes are global (not per-org): this grants read access to private
+  // repos across ALL of the user's orgs, labelled as such. Non-Pro users
+  // route to subscribe. On success popup-callback flips localStorage
+  // `refreshAuth`, ProfileControl refreshes the token, and the effect below
+  // refetches the current org so newly-visible private repos appear.
+  const awaitingGrantRef = useRef(false)
+  const enablePrivateRepos = () => {
+    if (isProUser) {
+      awaitingGrantRef.current = true
+      window.open('/popup-auth?scope=repo&connection=github', 'authPopup', 'width=600,height=600')
+    } else {
+      window.open('/subscribe/', '_blank', 'noopener')
+    }
+  }
+
+  // Refetch the selected org's repos after a private-repo grant lands (the
+  // token changes). Gated on `awaitingGrantRef` so the routine background
+  // token refresh (BaseRoutes fresh-claims) never wipes a live selection.
+  useEffect(() => {
+    if (prevTokenRef.current !== accessToken) {
+      prevTokenRef.current = accessToken
+      if (awaitingGrantRef.current && accessToken && selectedOrgName !== '') {
+        awaitingGrantRef.current = false
+        selectOrg(selectedOrgName)
+      }
+    }
+    // Runs only on a token change, by design.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [accessToken])
+
+  // --- Dialog state persistence ------------------------------------------
+  // Persist the resolved selections so the dialog reopens where it left off
+  // (across sessions, localStorage). Skips the empty initial render so a
+  // good saved state is not clobbered before the restore below runs.
+  useEffect(() => {
+    if (!orgName) {
+      return
+    }
+    try {
+      localStorage.setItem(GH_BROWSER_STATE_KEY, JSON.stringify({
+        org: orgName, repo: repoName || '', branch: branchName || '',
+      }))
+    } catch {
+      // localStorage can throw (quota / private mode); persistence is best-effort.
+    }
+  }, [orgName, repoName, branchName])
+
+  // Restore once, after the org list loads: reselect the saved org, then let
+  // the repo + branch restores below chain as each list arrives. Every step
+  // is best-effort — anything no longer present is silently skipped.
+  useEffect(() => {
+    if (restoredRef.current || orgNamesArr.length === 0 || orgNamesArr[0] === '') {
+      return
+    }
+    restoredRef.current = true
+    let saved = null
+    try {
+      saved = JSON.parse(localStorage.getItem(GH_BROWSER_STATE_KEY) || 'null')
+    } catch {
+      saved = null
+    }
+    if (!saved || !saved.org) {
+      return
+    }
+    const orgIdx = orgNamesArr.indexOf(saved.org)
+    if (orgIdx < 0) {
+      return
+    }
+    pendingRestoreRef.current = {repo: saved.repo, branch: saved.branch}
+    selectOrg(orgIdx)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [orgNamesArr])
+
+  // Restore the saved repo once its org's repo list has loaded.
+  useEffect(() => {
+    const pending = pendingRestoreRef.current
+    if (!pending || !pending.repo || repoNamesArr.length === 0 || repoNamesArr[0] === '') {
+      return
+    }
+    const repoIdx = repoNamesArr.indexOf(pending.repo)
+    if (repoIdx < 0) {
+      pendingRestoreRef.current = null
+      return
+    }
+    // Keep the branch for the next stage; drop the repo so this runs once.
+    pendingRestoreRef.current = {branch: pending.branch}
+    selectRepo(repoIdx)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [repoNamesArr])
+
+  // Restore the saved branch once the repo's branch list has loaded.
+  useEffect(() => {
+    const pending = pendingRestoreRef.current
+    if (!pending || pending.repo || !pending.branch ||
+        branchesArr.length === 0 || branchesArr[0] === '') {
+      return
+    }
+    pendingRestoreRef.current = null
+    const branchIdx = branchesArr.indexOf(pending.branch)
+    if (branchIdx >= 0) {
+      selectBranch(branchIdx)
+    }
+  }, [branchesArr])
 
   const validateOrg = async (name) => {
     if (!name.trim()) {
@@ -242,6 +367,24 @@ export default function GitHubFileBrowser({
           validate={validateRepo}
           data-testid='openRepository'
         />
+        {selectedOrgName !== '' && !hasPrivateRepos && (
+          <Tooltip
+            title={isProUser ?
+              'Grants Share read access to your private repositories across all your GitHub organizations.' :
+              'Browsing private repositories is a Pro feature.'}
+            placement='top'
+          >
+            <Button
+              onClick={enablePrivateRepos}
+              size='small'
+              variant='text'
+              sx={{textTransform: 'none', alignSelf: 'flex-start', mt: -0.75, mb: 0.5}}
+              data-testid='enable-private-repos'
+            >
+              {isProUser ? 'Enable private repos' : 'Private repos (Pro)'}
+            </Button>
+          </Tooltip>
+        )}
         <Selector
           label='Branch'
           list={branchesArr}

--- a/src/Components/Open/GitHubFileBrowser.jsx
+++ b/src/Components/Open/GitHubFileBrowser.jsx
@@ -183,6 +183,39 @@ export default function GitHubFileBrowser({
     setSelectedBranchName(branchOrIndex)
   }
 
+  // --- Cascading clear ---------------------------------------------------
+  // Clearing a field (× on its dropdown) resets it and every field below it
+  // to its default state — one click back to whatever level you want.
+  const resetFolderAndFile = () => {
+    setSelectedFolderName('')
+    setCurrentPath('')
+    setFoldersArr([''])
+    setFilesArr([''])
+    setSelectedFileIndex('')
+  }
+  const clearBranch = () => {
+    setSelectedBranchName('')
+    resetFolderAndFile()
+  }
+  const clearRepo = () => {
+    setSelectedRepoName('')
+    setBranchesArr([''])
+    setSelectedBranchName('')
+    resetFolderAndFile()
+  }
+  const clearOrg = () => {
+    setSelectedOrgName('')
+    setRepoNamesArr([''])
+    setSelectedRepoName('')
+    setHasPrivateRepos(false)
+    setBranchesArr([''])
+    setSelectedBranchName('')
+    resetFolderAndFile()
+  }
+  const clearFile = () => {
+    setSelectedFileIndex('')
+  }
+
   // --- Private-repo opt-in (A) -------------------------------------------
   // Explicit, Pro-gated action to grant the GitHub `repo` scope. OAuth
   // scopes are global (not per-org): this grants read access to private
@@ -192,6 +225,10 @@ export default function GitHubFileBrowser({
   // refetches the current org so newly-visible private repos appear.
   const awaitingGrantRef = useRef(false)
   const enablePrivateRepos = () => {
+    // Guard against a second popup while one grant is already in flight.
+    if (grantPending) {
+      return
+    }
     if (isProUser) {
       awaitingGrantRef.current = true
       setGrantPending(true)
@@ -200,6 +237,18 @@ export default function GitHubFileBrowser({
       window.open('/subscribe/', '_blank', 'noopener')
     }
   }
+
+  // Reset the pending flag when the popup closes (main window regains focus),
+  // so a cancelled grant doesn't leave the checkbox stuck checked. A
+  // successful grant hides the whole affordance via `hasPrivateRepos` anyway.
+  useEffect(() => {
+    if (!grantPending) {
+      return undefined
+    }
+    const onFocus = () => setGrantPending(false)
+    window.addEventListener('focus', onFocus)
+    return () => window.removeEventListener('focus', onFocus)
+  }, [grantPending])
 
   // Refetch the selected org's repos after a private-repo grant lands (the
   // token changes). Gated on `awaitingGrantRef` so the routine background
@@ -362,6 +411,7 @@ export default function GitHubFileBrowser({
           selected={selectedOrgName}
           setSelected={selectOrg}
           validate={validateOrg}
+          onClear={clearOrg}
           data-testid='openOrganization'
         />
         <Selector
@@ -370,6 +420,7 @@ export default function GitHubFileBrowser({
           selected={selectedRepoName}
           setSelected={selectRepo}
           validate={validateRepo}
+          onClear={clearRepo}
           data-testid='openRepository'
         />
         {selectedOrgName !== '' && !hasPrivateRepos && (
@@ -380,6 +431,7 @@ export default function GitHubFileBrowser({
                 <Checkbox
                   size='small'
                   checked={grantPending}
+                  disabled={grantPending}
                   onChange={enablePrivateRepos}
                   sx={{py: 0, pl: 0, pr: 1}}
                   data-testid='enable-private-repos'
@@ -404,6 +456,7 @@ export default function GitHubFileBrowser({
           selected={selectedBranchName}
           setSelected={selectBranch}
           validate={validateBranch}
+          onClear={clearBranch}
           data-testid='openBranch'
         />
         <SelectorSeparator
@@ -420,6 +473,7 @@ export default function GitHubFileBrowser({
           list={filesArr}
           selected={selectedFileIndex}
           setSelected={setSelectedFileIndex}
+          onClear={clearFile}
           data-testid='openFile'
         />
       </Stack>

--- a/src/Components/Open/GitHubFileBrowser.jsx
+++ b/src/Components/Open/GitHubFileBrowser.jsx
@@ -423,7 +423,7 @@ export default function GitHubFileBrowser({
           onClear={clearRepo}
           data-testid='openRepository'
         />
-        {selectedOrgName !== '' && !hasPrivateRepos && (
+        {selectedOrgName !== '' && repoNamesArr.length > 0 && repoNamesArr[0] !== '' && !hasPrivateRepos && (
           <Stack sx={{alignSelf: 'flex-start', width: '100%', px: 0.5, py: 0.5, mb: 0.5}}>
             <FormControlLabel
               sx={{ml: 0, mr: 0}}

--- a/src/Components/Open/GitHubFileBrowser.jsx
+++ b/src/Components/Open/GitHubFileBrowser.jsx
@@ -161,7 +161,10 @@ export default function GitHubFileBrowser({
     if (selectedFolderName_ === '[Parent Directory]') {
       const pathSegments = currentPath.split('/').filter(Boolean)
       pathSegments.pop()
-      newPath = pathSegments.join('/')
+      // Keep the same leading-'/' shape drilling-down produces (e.g. '/step'),
+      // not a bare 'step' — otherwise the path is malformed for the next
+      // fetch / for navigateToFile and the picker gets stuck.
+      newPath = pathSegments.length > 0 ? `/${pathSegments.join('/')}` : ''
     } else {
       newPath = selectedFolderName_ === '/' ? '' : `${currentPath}/${selectedFolderName_}`.replace('//', '/')
     }
@@ -181,6 +184,22 @@ export default function GitHubFileBrowser({
 
   const selectBranch = (branchOrIndex) => {
     setSelectedBranchName(branchOrIndex)
+  }
+
+  // Jump straight to a folder path (used by restore) without walking each
+  // level — fetch its listing and set the path + folder/file options.
+  const restoreFolderPath = async (path) => {
+    try {
+      const {files, directories} = await getFilesAndFolders(repoName, orgName, path, accessToken)
+      const fileNames = files.map((file) => file.name)
+      const directoryNames = directories.map((directory) => directory.name)
+      const navigationOptions = path ? ['[Parent Directory]', ...directoryNames] : [...directoryNames]
+      setCurrentPath(path)
+      setFilesArr(fileNames)
+      setFoldersArr(navigationOptions)
+    } catch {
+      // Best-effort — a path that no longer exists just leaves the root listing.
+    }
   }
 
   // --- Cascading clear ---------------------------------------------------
@@ -267,21 +286,25 @@ export default function GitHubFileBrowser({
   }, [accessToken])
 
   // --- Dialog state persistence ------------------------------------------
-  // Persist the resolved selections so the dialog reopens where it left off
-  // (across sessions, localStorage). Skips the empty initial render so a
-  // good saved state is not clobbered before the restore below runs.
+  // Persist org / repo / branch / folder-path so the dialog reopens where it
+  // left off (across sessions, localStorage). Gated on `restoredRef` — not on
+  // a non-empty org — so it stays quiet until the restore below has run (no
+  // clobbering saved state), but AFTER that it persists every change,
+  // INCLUDING a deliberate clear, so cleared fields stay cleared even if the
+  // dialog is closed without opening a file. The file is intentionally not
+  // persisted (reopen lands in the same folder, ready for a new file).
   useEffect(() => {
-    if (!orgName) {
+    if (!restoredRef.current) {
       return
     }
     try {
       localStorage.setItem(GH_BROWSER_STATE_KEY, JSON.stringify({
-        org: orgName, repo: repoName || '', branch: branchName || '',
+        org: orgName || '', repo: repoName || '', branch: branchName || '', path: currentPath || '',
       }))
     } catch {
       // localStorage can throw (quota / private mode); persistence is best-effort.
     }
-  }, [orgName, repoName, branchName])
+  }, [orgName, repoName, branchName, currentPath])
 
   // Restore once, after the org list loads: reselect the saved org, then let
   // the repo + branch restores below chain as each list arrives. Every step
@@ -304,7 +327,7 @@ export default function GitHubFileBrowser({
     if (orgIdx < 0) {
       return
     }
-    pendingRestoreRef.current = {repo: saved.repo, branch: saved.branch}
+    pendingRestoreRef.current = {repo: saved.repo, branch: saved.branch, path: saved.path}
     selectOrg(orgIdx)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [orgNamesArr])
@@ -320,24 +343,31 @@ export default function GitHubFileBrowser({
       pendingRestoreRef.current = null
       return
     }
-    // Keep the branch for the next stage; drop the repo so this runs once.
-    pendingRestoreRef.current = {branch: pending.branch}
+    // Keep the branch + path for the next stage; drop the repo so this runs once.
+    pendingRestoreRef.current = {branch: pending.branch, path: pending.path}
     selectRepo(repoIdx)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [repoNamesArr])
 
-  // Restore the saved branch once the repo's branch list has loaded.
+  // Restore the saved branch + folder path once the repo's branch list has
+  // loaded (selectRepo has set the root listing). The file is NOT restored.
   useEffect(() => {
     const pending = pendingRestoreRef.current
-    if (!pending || pending.repo || !pending.branch ||
-        branchesArr.length === 0 || branchesArr[0] === '') {
+    if (!pending || pending.repo || branchesArr.length === 0 || branchesArr[0] === '') {
       return
     }
+    const savedPath = pending.path
     pendingRestoreRef.current = null
-    const branchIdx = branchesArr.indexOf(pending.branch)
-    if (branchIdx >= 0) {
-      selectBranch(branchIdx)
+    if (pending.branch) {
+      const branchIdx = branchesArr.indexOf(pending.branch)
+      if (branchIdx >= 0) {
+        selectBranch(branchIdx)
+      }
     }
+    if (savedPath) {
+      restoreFolderPath(savedPath)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [branchesArr])
 
   const validateOrg = async (name) => {

--- a/src/Components/Open/GitHubFileBrowser.jsx
+++ b/src/Components/Open/GitHubFileBrowser.jsx
@@ -34,6 +34,21 @@ function resolveValue(value, list) {
 
 
 /**
+ * Keep only the file names Share can open, matched by supported extension
+ * (case-insensitive, via {@link pathSuffixSupported}). GitHub's contents API
+ * has no server-side extension filter, so this is the enforcement point for
+ * the *listed* files; a name typed into the File field bypasses it on purpose
+ * (see validateFile / navigateToFile).
+ *
+ * @param {Array<{name: string}>} files
+ * @return {Array<string>}
+ */
+function supportedFileNames(files) {
+  return files.map((file) => file.name).filter((name) => pathSuffixSupported(name))
+}
+
+
+/**
  * @property {Function} navigate Callback from CadView to change page url
  * @property {Function} setIsDialogDisplayed callback
  * @property {Function} onCancel Called when user clicks Cancel to go back
@@ -86,7 +101,10 @@ export default function GitHubFileBrowser({
   const orgNamesArrWithAt = orgNamesArr.map((name) => `@${name}`)
   const orgName = resolveValue(selectedOrgName, orgNamesArr)
   const repoName = resolveValue(selectedRepoName, repoNamesArr)
-  const fileName = filesArr[selectedFileIndex]
+  // selectedFileIndex is a list index (number) for a picked file, or the raw
+  // string a user typed in "Enter name..." mode — the latter lets any valid
+  // filename through even when its extension isn't in the listed set.
+  const fileName = typeof selectedFileIndex === 'number' ? filesArr[selectedFileIndex] : selectedFileIndex
   const branchName = resolveValue(selectedBranchName, branchesArr)
 
   // Lazy-fetch the user's GitHub organizations only when this browser is mounted
@@ -144,7 +162,7 @@ export default function GitHubFileBrowser({
     setBranchesArr(branchNames)
     setSelectedBranchName(branchNames.length > 0 ? branchNames.indexOf('main') >= 0 ? branchNames.indexOf('main') : 0 : '')
 
-    const fileNames = files.map((file) => file.name)
+    const fileNames = supportedFileNames(files)
     const directoryNames = directories.map((directory) => directory.name)
 
     setFilesArr(fileNames)
@@ -173,7 +191,7 @@ export default function GitHubFileBrowser({
     setCurrentPath(newPath)
 
     const {files, directories} = await getFilesAndFolders(repoName, orgName, newPath, accessToken)
-    const fileNames = files.map((file) => file.name)
+    const fileNames = supportedFileNames(files)
     const directoryNames = directories.map((directory) => directory.name)
 
     const navigationOptions = newPath ? ['[Parent Directory]', ...directoryNames] : [...directoryNames]
@@ -191,7 +209,7 @@ export default function GitHubFileBrowser({
   const restoreFolderPath = async (path) => {
     try {
       const {files, directories} = await getFilesAndFolders(repoName, orgName, path, accessToken)
-      const fileNames = files.map((file) => file.name)
+      const fileNames = supportedFileNames(files)
       const directoryNames = directories.map((directory) => directory.name)
       const navigationOptions = path ? ['[Parent Directory]', ...directoryNames] : [...directoryNames]
       setCurrentPath(path)
@@ -244,17 +262,15 @@ export default function GitHubFileBrowser({
   // refetches the current org so newly-visible private repos appear.
   const awaitingGrantRef = useRef(false)
   const enablePrivateRepos = () => {
-    // Guard against a second popup while one grant is already in flight.
-    if (grantPending) {
+    // The checkbox is disabled for non-Pro / in-flight / already-granted, so
+    // this only fires for an eligible Pro user — guard defensively anyway, and
+    // never open a second popup while one grant is in flight.
+    if (grantPending || hasPrivateRepos || !isProUser) {
       return
     }
-    if (isProUser) {
-      awaitingGrantRef.current = true
-      setGrantPending(true)
-      window.open('/popup-auth?scope=repo&connection=github', 'authPopup', 'width=600,height=600')
-    } else {
-      window.open('/subscribe/', '_blank', 'noopener')
-    }
+    awaitingGrantRef.current = true
+    setGrantPending(true)
+    window.open('/popup-auth?scope=repo&connection=github', 'authPopup', 'width=600,height=600')
   }
 
   // Reset the pending flag when the popup closes (main window regains focus),
@@ -410,8 +426,14 @@ export default function GitHubFileBrowser({
     }
   }
 
+  // Accept any non-empty file name. Listed files are already extension-filtered;
+  // a typed name is allowed through by design (unsupported/extensionless
+  // included), so the loader — not this dialog — has the final say. (Sync is
+  // fine; Selector awaits the result either way.)
+  const validateFile = (name) => name.trim().length > 0
+
   const navigateToFile = () => {
-    if (pathSuffixSupported(fileName)) {
+    if (fileName && fileName.trim().length > 0) {
       const branch = branchName || 'main'
       const sharePath = navigateBaseOnModelPath(orgName, repoName, branch, `${currentPath}/${fileName}`)
       navigateToModel({pathname: sharePath}, navigate)
@@ -453,15 +475,19 @@ export default function GitHubFileBrowser({
           onClear={clearRepo}
           data-testid='openRepository'
         />
-        {selectedOrgName !== '' && repoNamesArr.length > 0 && repoNamesArr[0] !== '' && !hasPrivateRepos && (
+        {selectedOrgName !== '' && repoNamesArr.length > 0 && repoNamesArr[0] !== '' && (
           <Stack sx={{alignSelf: 'flex-start', width: '100%', px: 0.5, py: 0.5, mb: 0.5}}>
             <FormControlLabel
               sx={{ml: 0, mr: 0}}
               control={
+                // Always shown once an org's repos load, so the capability is
+                // discoverable. Non-Pro users see it greyed-out (disabled) with
+                // a "(Pro only)" label; already-granted tokens show it enabled
+                // (checked) and locked.
                 <Checkbox
                   size='small'
-                  checked={grantPending}
-                  disabled={grantPending}
+                  checked={grantPending || hasPrivateRepos}
+                  disabled={grantPending || hasPrivateRepos || !isProUser}
                   onChange={enablePrivateRepos}
                   sx={{py: 0, pl: 0, pr: 1}}
                   data-testid='enable-private-repos'
@@ -469,14 +495,16 @@ export default function GitHubFileBrowser({
               }
               label={
                 <Typography variant='body2'>
-                  {isProUser ? 'Enable private repos' : 'Enable private repos (Pro)'}
+                  {`Enable private repos${isProUser ? '' : ' (Pro only)'}`}
                 </Typography>
               }
             />
             <Typography variant='caption' sx={{color: 'text.secondary', mt: 0.25}}>
-              {isProUser ?
-                'Grants Share read access to your private repos across all your GitHub orgs.' :
-                'Browsing private repositories is a Pro feature.'}
+              {hasPrivateRepos ?
+                'Private repos are enabled for this account.' :
+                isProUser ?
+                  'Grants Share read access to your private repos across all your GitHub orgs.' :
+                  'Browsing private repositories is a Pro feature.'}
             </Typography>
           </Stack>
         )}
@@ -503,6 +531,7 @@ export default function GitHubFileBrowser({
           list={filesArr}
           selected={selectedFileIndex}
           setSelected={setSelectedFileIndex}
+          validate={validateFile}
           onClear={clearFile}
           data-testid='openFile'
         />

--- a/src/Components/Open/GitHubFileBrowser.jsx
+++ b/src/Components/Open/GitHubFileBrowser.jsx
@@ -1,6 +1,6 @@
 
 import React, {ReactElement, useEffect, useRef, useState} from 'react'
-import {Button, Stack, Tooltip, Typography} from '@mui/material'
+import {Button, Checkbox, FormControlLabel, Stack, Typography} from '@mui/material'
 import {navigateBaseOnModelPath} from '../../utils/location'
 import {navigateToModel} from '../../utils/navigate'
 import {useAuth0} from '../../Auth0/Auth0Proxy'
@@ -74,6 +74,9 @@ export default function GitHubFileBrowser({
   // repo — i.e. the token already carries the `repo` scope, so the
   // "Enable private repos" opt-in is hidden.
   const [hasPrivateRepos, setHasPrivateRepos] = useState(false)
+  // True from the moment the user opts into private repos until the token
+  // refresh + refetch lands — drives the checkbox's transient checked state.
+  const [grantPending, setGrantPending] = useState(false)
   const appMetadata = useStore((state) => state.appMetadata)
   const isProUser = PRO_STATUSES.includes(appMetadata?.subscriptionStatus)
   // Restore-once + refetch-on-token-change bookkeeping (see effects below).
@@ -191,6 +194,7 @@ export default function GitHubFileBrowser({
   const enablePrivateRepos = () => {
     if (isProUser) {
       awaitingGrantRef.current = true
+      setGrantPending(true)
       window.open('/popup-auth?scope=repo&connection=github', 'authPopup', 'width=600,height=600')
     } else {
       window.open('/subscribe/', '_blank', 'noopener')
@@ -205,6 +209,7 @@ export default function GitHubFileBrowser({
       prevTokenRef.current = accessToken
       if (awaitingGrantRef.current && accessToken && selectedOrgName !== '') {
         awaitingGrantRef.current = false
+        setGrantPending(false)
         selectOrg(selectedOrgName)
       }
     }
@@ -368,22 +373,30 @@ export default function GitHubFileBrowser({
           data-testid='openRepository'
         />
         {selectedOrgName !== '' && !hasPrivateRepos && (
-          <Tooltip
-            title={isProUser ?
-              'Grants Share read access to your private repositories across all your GitHub organizations.' :
-              'Browsing private repositories is a Pro feature.'}
-            placement='top'
-          >
-            <Button
-              onClick={enablePrivateRepos}
-              size='small'
-              variant='text'
-              sx={{textTransform: 'none', alignSelf: 'flex-start', mt: -0.75, mb: 0.5}}
-              data-testid='enable-private-repos'
-            >
-              {isProUser ? 'Enable private repos' : 'Private repos (Pro)'}
-            </Button>
-          </Tooltip>
+          <Stack sx={{alignSelf: 'flex-start', width: '100%', px: 0.5, py: 0.5, mb: 0.5}}>
+            <FormControlLabel
+              sx={{ml: 0, mr: 0}}
+              control={
+                <Checkbox
+                  size='small'
+                  checked={grantPending}
+                  onChange={enablePrivateRepos}
+                  sx={{py: 0, pl: 0, pr: 1}}
+                  data-testid='enable-private-repos'
+                />
+              }
+              label={
+                <Typography variant='body2'>
+                  {isProUser ? 'Enable private repos' : 'Enable private repos (Pro)'}
+                </Typography>
+              }
+            />
+            <Typography variant='caption' sx={{color: 'text.secondary', mt: 0.25}}>
+              {isProUser ?
+                'Grants Share read access to your private repos across all your GitHub orgs.' :
+                'Browsing private repositories is a Pro feature.'}
+            </Typography>
+          </Stack>
         )}
         <Selector
           label='Branch'

--- a/src/Components/Open/GitHubFileBrowser.test.jsx
+++ b/src/Components/Open/GitHubFileBrowser.test.jsx
@@ -148,19 +148,22 @@ describe('GitHubFileBrowser', () => {
 
 
   describe('private-repo opt-in', () => {
-    it('shows the Pro-gated opt-in for a free user once public repos load', async () => {
+    it('always shows the opt-in once repos load — greyed with a (Pro only) label for a free user', async () => {
       await renderBrowser()
       await selectOption('openOrganization', '@bldrs-ai')
-      const checkbox = await screen.findByTestId('enable-private-repos')
-      expect(checkbox).toBeInTheDocument()
-      expect(screen.getByText('Enable private repos (Pro)')).toBeInTheDocument()
+      expect(await screen.findByTestId('enable-private-repos')).toBeInTheDocument()
+      expect(screen.getByText('Enable private repos (Pro only)')).toBeInTheDocument()
+      // Free users see it, but disabled (greyed) so they can't act.
+      expect(screen.getByRole('checkbox')).toBeDisabled()
     })
 
-    it('a free user clicking the opt-in is routed to subscribe', async () => {
+    it('a free user cannot trigger a grant — the disabled checkbox opens nothing', async () => {
       await renderBrowser()
       await selectOption('openOrganization', '@bldrs-ai')
-      fireEvent.click(await screen.findByTestId('enable-private-repos'))
-      expect(openSpy).toHaveBeenCalledWith('/subscribe/', '_blank', 'noopener')
+      const checkbox = await screen.findByRole('checkbox')
+      expect(checkbox).toBeDisabled()
+      fireEvent.click(checkbox)
+      expect(openSpy).not.toHaveBeenCalled()
     })
 
     it('a Pro user clicking the opt-in launches the repo-scope grant popup', async () => {
@@ -170,8 +173,9 @@ describe('GitHubFileBrowser', () => {
       await renderBrowser()
       await selectOption('openOrganization', '@bldrs-ai')
       const checkbox = await screen.findByTestId('enable-private-repos')
-      // Pro users see the bare label (no "(Pro)" upsell suffix).
-      expect(screen.queryByText(/\(Pro\)/)).not.toBeInTheDocument()
+      // Pro users see the bare label (no "(Pro only)" suffix) and an enabled box.
+      expect(screen.queryByText(/\(Pro only\)/)).not.toBeInTheDocument()
+      expect(screen.getByRole('checkbox')).not.toBeDisabled()
       fireEvent.click(checkbox)
       expect(openSpy).toHaveBeenCalledWith(
         '/popup-auth?scope=repo&connection=github',
@@ -180,12 +184,62 @@ describe('GitHubFileBrowser', () => {
       )
     })
 
-    it('hides the opt-in when the org already exposes a private repo', async () => {
+    it('shows the opt-in as checked + locked when private repos are already visible', async () => {
       getRepositories.mockResolvedValue([{name: 'secret', private: true}])
       await renderBrowser()
       await selectOption('openOrganization', '@bldrs-ai')
       await waitFor(() => expect(getRepositories).toHaveBeenCalled())
-      expect(screen.queryByTestId('enable-private-repos')).not.toBeInTheDocument()
+      const checkbox = await screen.findByRole('checkbox')
+      expect(checkbox).toBeChecked()
+      expect(checkbox).toBeDisabled()
+      expect(screen.getByText('Private repos are enabled for this account.')).toBeInTheDocument()
+    })
+  })
+
+
+  describe('file listing', () => {
+    it('lists only files whose extension Share supports (case-insensitive)', async () => {
+      getFilesAndFolders.mockResolvedValue({
+        files: [
+          {name: 'window.ifc'},
+          {name: 'part.STP'},
+          {name: 'readme.md'},
+          {name: 'notes.txt'},
+        ],
+        directories: [],
+      })
+      await renderBrowser()
+      await selectOption('openOrganization', '@bldrs-ai')
+      await selectOption('openRepository', 'repoA')
+      await waitFor(() => expect(getBranches).toHaveBeenCalled())
+
+      fireEvent.mouseDown(within(screen.getByTestId('openFile')).getByRole('combobox'))
+      expect(await screen.findByRole('option', {name: 'window.ifc'})).toBeInTheDocument()
+      expect(screen.getByRole('option', {name: 'part.STP'})).toBeInTheDocument()
+      expect(screen.queryByRole('option', {name: 'readme.md'})).not.toBeInTheDocument()
+      expect(screen.queryByRole('option', {name: 'notes.txt'})).not.toBeInTheDocument()
+    })
+
+    it('lets the user type an unsupported filename and open it anyway', async () => {
+      const setIsDialogDisplayed = jest.fn()
+      await renderBrowser({setIsDialogDisplayed})
+      await selectOption('openOrganization', '@bldrs-ai')
+      await selectOption('openRepository', 'repoA')
+      await waitFor(() => expect(getBranches).toHaveBeenCalled())
+
+      // File → "Enter name..." → type an unsupported extension.
+      fireEvent.mouseDown(within(screen.getByTestId('openFile')).getByRole('combobox'))
+      fireEvent.click(await screen.findByRole('option', {name: 'Enter name...'}))
+      const input = within(screen.getByTestId('openFile')).getByRole('textbox')
+      fireEvent.change(input, {target: {value: 'design.skp'}})
+      await screen.findByText('Found')
+      fireEvent.keyDown(input, {key: 'Enter'})
+
+      const openButton = screen.getByTestId('button-openfromgithub')
+      await waitFor(() => expect(openButton).not.toBeDisabled())
+      fireEvent.click(openButton)
+      expect(navigateToModel).toHaveBeenCalled()
+      expect(setIsDialogDisplayed).toHaveBeenCalledWith(false)
     })
   })
 

--- a/src/Components/Open/GitHubFileBrowser.test.jsx
+++ b/src/Components/Open/GitHubFileBrowser.test.jsx
@@ -1,27 +1,244 @@
 import React from 'react'
-import {render, screen} from '@testing-library/react'
+import {act, fireEvent, render, screen, waitFor, within} from '@testing-library/react'
 import {RouteThemeCtx} from '../../Share.fixture'
+import {useAuth0} from '../../Auth0/Auth0Proxy'
+import {getOrganizations} from '../../net/github/Organizations'
+import {getRepositories, getUserRepositories} from '../../net/github/Repositories'
+import {getFilesAndFolders} from '../../net/github/Files'
+import {getBranches} from '../../net/github/Branches'
+import {navigateToModel} from '../../utils/navigate'
+import {addRecentFileEntry, setPendingModelNameUpdate} from '../../connections/persistence'
+import useStore from '../../store/useStore'
 import GitHubFileBrowser from './GitHubFileBrowser'
 
 
-jest.mock('../../net/github/Organizations', () => ({
-  getOrganizations: jest.fn().mockResolvedValue({}),
+// Mock the whole GitHub network layer so these tests never touch the wire —
+// each fn resolves deterministic fixtures we control per-test (private flags,
+// repo lists, etc.). Anything left un-set falls back to the beforeEach values.
+jest.mock('../../Auth0/Auth0Proxy')
+jest.mock('../../net/github/Organizations')
+jest.mock('../../net/github/Repositories')
+jest.mock('../../net/github/Files')
+jest.mock('../../net/github/Branches')
+jest.mock('../../utils/navigate', () => ({navigateToModel: jest.fn()}))
+jest.mock('../../connections/persistence', () => ({
+  addRecentFileEntry: jest.fn(),
+  setPendingModelNameUpdate: jest.fn(),
 }))
 
 
-describe('GitHubFileBrowser', () => {
-  const navigate = jest.fn()
+const GH_BROWSER_STATE_KEY = 'bldrs.openDialog.github'
 
-  it('renders all the UI elements', () => {
-    render(
-      <GitHubFileBrowser navigate={navigate}/>,
-      {wrapper: RouteThemeCtx},
-    )
+
+/**
+ * Open a Selector's dropdown and click the option with the given label.
+ * Retries the open until the (async-loaded) option is present.
+ *
+ * @param {string} testId the Selector root data-testid
+ * @param {string|RegExp} optionName the option's accessible name
+ * @return {Promise<void>}
+ */
+async function selectOption(testId, optionName) {
+  const combo = within(screen.getByTestId(testId)).getByRole('combobox')
+  fireEvent.mouseDown(combo)
+  const option = await screen.findByRole('option', {name: optionName})
+  fireEvent.click(option)
+}
+
+
+/**
+ * Render the browser and wait until the org list has loaded (the effect's
+ * async fetch settled), so subsequent interactions are deterministic.
+ *
+ * @param {object} [props] extra props
+ * @return {Promise<object>} render result
+ */
+async function renderBrowser(props = {}) {
+  const utils = render(
+    <GitHubFileBrowser
+      navigate={jest.fn()}
+      setIsDialogDisplayed={jest.fn()}
+      onCancel={jest.fn()}
+      {...props}
+    />,
+    {wrapper: RouteThemeCtx},
+  )
+  await waitFor(() => expect(getOrganizations).toHaveBeenCalled())
+  // Flush the resolved org promise → setOrgNamesArr re-render.
+  await act(async () => {
+    await Promise.resolve()
+  })
+  return utils
+}
+
+
+describe('GitHubFileBrowser', () => {
+  let openSpy
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    localStorage.clear()
+    useAuth0.mockReturnValue({user: {nickname: 'cypresstester'}})
+    getOrganizations.mockResolvedValue({0: {login: 'bldrs-ai'}})
+    getRepositories.mockResolvedValue([
+      {name: 'repoA', private: false},
+      {name: 'repoB', private: false},
+    ])
+    getUserRepositories.mockResolvedValue([{name: 'userRepo', private: false}])
+    getFilesAndFolders.mockResolvedValue({
+      files: [{name: 'window.ifc'}],
+      directories: [{name: 'sub'}],
+    })
+    getBranches.mockResolvedValue([{name: 'main'}, {name: 'dev'}])
+    openSpy = jest.spyOn(window, 'open').mockImplementation(() => ({}))
+    act(() => {
+      useStore.setState({accessToken: 'test-token', appMetadata: {subscriptionStatus: 'free'}})
+    })
+  })
+
+  afterEach(() => {
+    openSpy.mockRestore()
+  })
+
+
+  it('renders all the UI elements', async () => {
+    await renderBrowser()
     expect(screen.getByText(/Browse files on Github/i)).toBeInTheDocument()
     expect(screen.getByLabelText(/Organization/i)).toBeInTheDocument()
     expect(screen.getByLabelText(/Repository/i)).toBeInTheDocument()
     expect(screen.getByLabelText(/Branch/i)).toBeInTheDocument()
     expect(screen.getByLabelText(/Folder/i)).toBeInTheDocument()
     expect(screen.getByLabelText(/File/i)).toBeInTheDocument()
+  })
+
+
+  describe('happy-path open', () => {
+    it('drives org → repo → file and opens the model', async () => {
+      const setIsDialogDisplayed = jest.fn()
+      const navigate = jest.fn()
+      await renderBrowser({setIsDialogDisplayed, navigate})
+
+      await selectOption('openOrganization', '@bldrs-ai')
+      await waitFor(() => expect(getRepositories).toHaveBeenCalledWith('bldrs-ai', 'test-token'))
+
+      await selectOption('openRepository', 'repoA')
+      await waitFor(() => expect(getBranches).toHaveBeenCalled())
+      // selectRepo fetched the root listing for repoA.
+      expect(getFilesAndFolders).toHaveBeenCalledWith('repoA', 'bldrs-ai', '/', 'test-token')
+
+      await selectOption('openFile', 'window.ifc')
+
+      const openButton = screen.getByTestId('button-openfromgithub')
+      await waitFor(() => expect(openButton).not.toBeDisabled())
+      fireEvent.click(openButton)
+
+      expect(navigateToModel).toHaveBeenCalled()
+      expect(addRecentFileEntry).toHaveBeenCalledWith(expect.objectContaining({name: 'window.ifc', source: 'github'}))
+      expect(setPendingModelNameUpdate).toHaveBeenCalled()
+      expect(setIsDialogDisplayed).toHaveBeenCalledWith(false)
+    })
+
+    it('routes a user-nickname org through getUserRepositories', async () => {
+      await renderBrowser()
+      await selectOption('openOrganization', '@cypresstester')
+      await waitFor(() => expect(getUserRepositories).toHaveBeenCalledWith('test-token', 'cypresstester'))
+      expect(getRepositories).not.toHaveBeenCalled()
+    })
+  })
+
+
+  describe('private-repo opt-in', () => {
+    it('shows the Pro-gated opt-in for a free user once public repos load', async () => {
+      await renderBrowser()
+      await selectOption('openOrganization', '@bldrs-ai')
+      const checkbox = await screen.findByTestId('enable-private-repos')
+      expect(checkbox).toBeInTheDocument()
+      expect(screen.getByText('Enable private repos (Pro)')).toBeInTheDocument()
+    })
+
+    it('a free user clicking the opt-in is routed to subscribe', async () => {
+      await renderBrowser()
+      await selectOption('openOrganization', '@bldrs-ai')
+      fireEvent.click(await screen.findByTestId('enable-private-repos'))
+      expect(openSpy).toHaveBeenCalledWith('/subscribe/', '_blank', 'noopener')
+    })
+
+    it('a Pro user clicking the opt-in launches the repo-scope grant popup', async () => {
+      act(() => {
+        useStore.setState({appMetadata: {subscriptionStatus: 'sharePro'}})
+      })
+      await renderBrowser()
+      await selectOption('openOrganization', '@bldrs-ai')
+      const checkbox = await screen.findByTestId('enable-private-repos')
+      // Pro users see the bare label (no "(Pro)" upsell suffix).
+      expect(screen.queryByText(/\(Pro\)/)).not.toBeInTheDocument()
+      fireEvent.click(checkbox)
+      expect(openSpy).toHaveBeenCalledWith(
+        '/popup-auth?scope=repo&connection=github',
+        'authPopup',
+        expect.any(String),
+      )
+    })
+
+    it('hides the opt-in when the org already exposes a private repo', async () => {
+      getRepositories.mockResolvedValue([{name: 'secret', private: true}])
+      await renderBrowser()
+      await selectOption('openOrganization', '@bldrs-ai')
+      await waitFor(() => expect(getRepositories).toHaveBeenCalled())
+      expect(screen.queryByTestId('enable-private-repos')).not.toBeInTheDocument()
+    })
+  })
+
+
+  describe('cascading clear', () => {
+    it('clearing the org also clears the repo below it', async () => {
+      await renderBrowser()
+      await selectOption('openOrganization', '@bldrs-ai')
+      await selectOption('openRepository', 'repoA')
+      // Both fields now carry a value, so both show a clear ×.
+      expect(await screen.findByTestId('selector-clear-select-repository')).toBeInTheDocument()
+
+      fireEvent.click(screen.getByTestId('selector-clear-select-organization'))
+
+      // Cascade: org and repo are both reset, so neither × remains.
+      await waitFor(() => {
+        expect(screen.queryByTestId('selector-clear-select-organization')).not.toBeInTheDocument()
+      })
+      expect(screen.queryByTestId('selector-clear-select-repository')).not.toBeInTheDocument()
+    })
+  })
+
+
+  describe('dialog-state persistence', () => {
+    it('persists the org + repo selection to localStorage', async () => {
+      await renderBrowser()
+      await selectOption('openOrganization', '@bldrs-ai')
+      await selectOption('openRepository', 'repoA')
+
+      await waitFor(() => {
+        const saved = JSON.parse(localStorage.getItem(GH_BROWSER_STATE_KEY) || '{}')
+        expect(saved.org).toBe('bldrs-ai')
+        expect(saved.repo).toBe('repoA')
+      })
+    })
+
+    it('restores a saved org + repo on mount', async () => {
+      localStorage.setItem(GH_BROWSER_STATE_KEY, JSON.stringify({
+        org: 'bldrs-ai', repo: 'repoA', branch: 'main', path: '',
+      }))
+
+      await renderBrowser()
+
+      // The restore chain reselects the org, then its saved repo.
+      await waitFor(() => expect(getRepositories).toHaveBeenCalledWith('bldrs-ai', 'test-token'))
+      await waitFor(() => expect(getFilesAndFolders).toHaveBeenCalledWith('repoA', 'bldrs-ai', '/', 'test-token'))
+    })
+
+    it('does not restore anything when localStorage is empty', async () => {
+      await renderBrowser()
+      // No org saved → no repo fetch fires on its own.
+      expect(getRepositories).not.toHaveBeenCalled()
+      expect(getUserRepositories).not.toHaveBeenCalled()
+    })
   })
 })

--- a/src/Components/Open/Github.spec.ts
+++ b/src/Components/Open/Github.spec.ts
@@ -122,14 +122,37 @@ describe('Open 100: GitHub Integration', () => {
      * @param optionName - the option's accessible name
      */
     async function pickOption(page: Page, testId: string, optionName: string) {
-      await page.getByTestId(testId).getByRole('combobox').click({force: true})
-      await page.getByRole('option', {name: optionName, exact: true}).click()
+      // force: MUI's Select renders a zero-opacity native <input> over the
+      // combobox, so a normal click fails the actionability hit-test. MUI opens
+      // the menu on mousedown regardless, so a forced click is both safe and
+      // sufficient here (same reason for the other combobox opens below).
+      const combobox = page.getByTestId(testId).getByRole('combobox')
+      await combobox.click({force: true})
+      const option = page.getByRole('option', {name: optionName, exact: true})
+      await option.waitFor({state: 'visible'})
+      await option.click()
+      // Confirm the pick landed on the field itself (position-independent, so
+      // it doesn't race the private-repo opt-in's layout insertion).
+      await expect(combobox).toContainText(optionName)
+    }
+
+    /**
+     * Select the org and wait for its repos (and the opt-in they trigger) to
+     * settle, so later field interactions happen against a stable layout.
+     *
+     * @param page - Playwright page object
+     */
+    async function selectOrgSettled(page: Page) {
+      await pickOption(page, 'openOrganization', '@cypresstester')
+      // The opt-in only renders once the repo list is back — waiting on it
+      // pins the layout before we open the next menu.
+      await expect(page.getByTestId('enable-private-repos')).toBeVisible()
     }
 
     test('selects org → repo → file through the dropdowns', async ({page}) => {
       await openGithubBrowser(page)
 
-      await pickOption(page, 'openOrganization', '@cypresstester')
+      await selectOrgSettled(page)
       await pickOption(page, 'openRepository', 'test-repo')
       await pickOption(page, 'openFile', 'window.ifc')
 
@@ -139,16 +162,23 @@ describe('Open 100: GitHub Integration', () => {
 
     test('filters repositories with the live text input', async ({page}) => {
       await openGithubBrowser(page)
-      await pickOption(page, 'openOrganization', '@cypresstester')
+      await selectOrgSettled(page)
 
       // Switch the Repository field into "Enter name..." text mode and type.
       await page.getByTestId('openRepository').getByRole('combobox').click({force: true})
-      await page.getByRole('option', {name: 'Enter name...', exact: true}).click()
+      const enterName = page.getByRole('option', {name: 'Enter name...', exact: true})
+      await enterName.waitFor({state: 'visible'})
+      await enterName.click()
       await page.getByTestId('openRepository').getByRole('textbox').fill('test')
 
       const matches = page.getByTestId('selector-matches-repository')
       await expect(matches).toBeVisible()
-      await matches.getByText('test-repo', {exact: true}).click()
+      const match = matches.getByText('test-repo', {exact: true})
+      await match.waitFor({state: 'visible'})
+      await match.click()
+      // Confirm the async repo selection registered before opening File —
+      // otherwise the file list hasn't loaded yet and the assertion races it.
+      await expect(page.getByTestId('openRepository').getByRole('combobox')).toContainText('test-repo')
 
       // Selecting the filtered match drives the downstream file listing.
       await page.getByTestId('openFile').getByRole('combobox').click({force: true})
@@ -157,7 +187,7 @@ describe('Open 100: GitHub Integration', () => {
 
     test('clearing the organization cascades to clear the repository', async ({page}) => {
       await openGithubBrowser(page)
-      await pickOption(page, 'openOrganization', '@cypresstester')
+      await selectOrgSettled(page)
       await pickOption(page, 'openRepository', 'test-repo')
 
       // Both fields hold a value → both show a clear ×.

--- a/src/Components/Open/Github.spec.ts
+++ b/src/Components/Open/Github.spec.ts
@@ -1,9 +1,10 @@
-import {expect, test} from '@playwright/test'
+import {Page, expect, test} from '@playwright/test'
 import {
   auth0Login,
   homepageSetup,
   returningUserVisitsHomepageWaitForModel,
   setIsReturningUser,
+  setupAuthenticationIntercepts,
   visitHomepageWaitForModel,
 } from '../../tests/e2e/utils'
 import {setupVirtualPathIntercept, waitForModelReady} from '../../tests/e2e/models'
@@ -85,6 +86,87 @@ describe('Open 100: GitHub Integration', () => {
         await expect(page.getByTestId('dialog-open')).toHaveCount(0)
         await expectScreen(page, 'Github-ui-model-loaded.png')
       })
+    })
+  })
+
+  /**
+   * Exercises the GitHub file browser's Selector UI (PRs #1624 / #1625):
+   * paginated dropdown selection, live text filtering, and the cascading
+   * clear (×). These assert on picker state only and never click Open, so
+   * they steer clear of the model-load flake tracked by #1269. All traffic
+   * (orgs, repos, branches, contents) is served by the MSW handlers.
+   */
+  describe('File browser Selector UI', () => {
+    /**
+     * Log in and reveal the GitHub file browser inside the Open dialog.
+     *
+     * @param page - Playwright page object
+     */
+    async function openGithubBrowser(page: Page) {
+      await homepageSetup(page)
+      await setupAuthenticationIntercepts(page)
+      await returningUserVisitsHomepageWaitForModel(page)
+      await page.goto('/share/v/p/index.ifc', {waitUntil: 'domcontentloaded'})
+      await auth0Login(page)
+      await page.getByTestId('control-button-open').click()
+      await page.getByRole('tab', {name: 'GitHub'}).click()
+      await page.getByTestId('button-browse-github').click()
+      await expect(page.getByTestId('openOrganization')).toBeVisible()
+    }
+
+    /**
+     * Open a Selector's dropdown and click the option with the given name.
+     *
+     * @param page - Playwright page object
+     * @param testId - the Selector root data-testid
+     * @param optionName - the option's accessible name
+     */
+    async function pickOption(page: Page, testId: string, optionName: string) {
+      await page.getByTestId(testId).getByRole('combobox').click({force: true})
+      await page.getByRole('option', {name: optionName, exact: true}).click()
+    }
+
+    test('selects org → repo → file through the dropdowns', async ({page}) => {
+      await openGithubBrowser(page)
+
+      await pickOption(page, 'openOrganization', '@cypresstester')
+      await pickOption(page, 'openRepository', 'test-repo')
+      await pickOption(page, 'openFile', 'window.ifc')
+
+      // File chosen → Open is enabled (we stop here, no model load).
+      await expect(page.getByTestId('button-openfromgithub')).toBeEnabled()
+    })
+
+    test('filters repositories with the live text input', async ({page}) => {
+      await openGithubBrowser(page)
+      await pickOption(page, 'openOrganization', '@cypresstester')
+
+      // Switch the Repository field into "Enter name..." text mode and type.
+      await page.getByTestId('openRepository').getByRole('combobox').click({force: true})
+      await page.getByRole('option', {name: 'Enter name...', exact: true}).click()
+      await page.getByTestId('openRepository').getByRole('textbox').fill('test')
+
+      const matches = page.getByTestId('selector-matches-repository')
+      await expect(matches).toBeVisible()
+      await matches.getByText('test-repo', {exact: true}).click()
+
+      // Selecting the filtered match drives the downstream file listing.
+      await page.getByTestId('openFile').getByRole('combobox').click({force: true})
+      await expect(page.getByRole('option', {name: 'window.ifc', exact: true})).toBeVisible()
+    })
+
+    test('clearing the organization cascades to clear the repository', async ({page}) => {
+      await openGithubBrowser(page)
+      await pickOption(page, 'openOrganization', '@cypresstester')
+      await pickOption(page, 'openRepository', 'test-repo')
+
+      // Both fields hold a value → both show a clear ×.
+      await expect(page.getByTestId('selector-clear-select-repository')).toBeVisible()
+
+      await page.getByTestId('selector-clear-select-organization').click()
+
+      // Cascade wiped the repo selection, so its × is gone.
+      await expect(page.getByTestId('selector-clear-select-repository')).toHaveCount(0)
     })
   })
 })

--- a/src/Components/Open/Selector.jsx
+++ b/src/Components/Open/Selector.jsx
@@ -1,11 +1,20 @@
 import React, {ReactElement, useEffect, useRef, useState} from 'react'
 import {Divider, IconButton, MenuItem, Stack, TextField, Typography} from '@mui/material'
-import {Close as ClearIcon} from '@mui/icons-material'
+import {
+  Close as ClearIcon,
+  KeyboardArrowLeft as PrevIcon,
+  KeyboardArrowRight as NextIcon,
+} from '@mui/icons-material'
 import {disablePageReloadApprovalCheck} from '../../utils/event'
 
 
 const DEBOUNCE_MS = 300
 const OTHER_VALUE = '__other__'
+/** Sentinel option values for the dropdown pager rows. */
+const PREV_VALUE = '__prev__'
+const NEXT_VALUE = '__next__'
+/** Options shown per dropdown page before the prev/next pager appears. */
+const PAGE_SIZE = 10
 
 
 /**
@@ -30,18 +39,39 @@ export default function Selector({
   const [isTextMode, setIsTextMode] = useState(false)
   const [inputText, setInputText] = useState('')
   const [validationStatus, setValidationStatus] = useState('idle')
+  const [page, setPage] = useState(0)
+  const [isOpen, setIsOpen] = useState(false)
+  const pagerClickRef = useRef(false)
   const debounceRef = useRef(null)
   const textInputRef = useRef(null)
 
+  // Reset to the first page whenever the option set changes (e.g. a new
+  // org is picked and the repo list is replaced).
+  useEffect(() => {
+    setPage(0)
+  }, [list])
+
   const handleSelect = (e) => {
-    if (e.target.value === OTHER_VALUE) {
+    const value = e.target.value
+    // Pager rows change the visible page without selecting or closing —
+    // pagerClickRef tells onClose to keep the menu open (see the Select).
+    if (value === PREV_VALUE || value === NEXT_VALUE) {
+      pagerClickRef.current = true
+      const pageCount = Math.max(1, Math.ceil(list.length / PAGE_SIZE))
+      setPage((p) => {
+        const next = value === PREV_VALUE ? p - 1 : p + 1
+        return Math.min(pageCount - 1, Math.max(0, next))
+      })
+      return
+    }
+    if (value === OTHER_VALUE) {
       setIsTextMode(true)
       setInputText('')
       setValidationStatus('idle')
       return
     }
     disablePageReloadApprovalCheck()
-    setSelected(e.target.value)
+    setSelected(value)
   }
 
   const handleTextChange = (e) => {
@@ -161,6 +191,12 @@ export default function Selector({
   }
 
   const isEmpty = list.length === 0
+  const pageCount = Math.max(1, Math.ceil(list.length / PAGE_SIZE))
+  const clampedPage = Math.min(page, pageCount - 1)
+  const pageStart = clampedPage * PAGE_SIZE
+  const pageEnd = Math.min(pageStart + PAGE_SIZE, list.length)
+  const pageItems = list.slice(pageStart, pageEnd)
+  const isPaged = list.length > PAGE_SIZE
 
   return (
     <TextField
@@ -178,7 +214,29 @@ export default function Selector({
       SelectProps={isEmpty ? {
         displayEmpty: true,
         renderValue: () => <span style={{opacity: 1}}>{emptyText}</span>,
-      } : undefined}
+      } : {
+        open: isOpen,
+        onOpen: () => {
+          // Jump to the page holding the current selection so its row is
+          // rendered (keeps the highlight correct, avoids MUI's
+          // out-of-range warning) and paging starts from context.
+          if (typeof selected === 'number' && selected >= 0) {
+            setPage(Math.floor(selected / PAGE_SIZE))
+          }
+          setIsOpen(true)
+        },
+        onClose: () => {
+          // A pager row requested a page change — keep the menu open.
+          if (pagerClickRef.current) {
+            pagerClickRef.current = false
+            return
+          }
+          setIsOpen(false)
+        },
+        // Derive the field label straight from the value so a selection on
+        // any page still shows once the menu closes / repaginates.
+        renderValue: (val) => (typeof val === 'number' ? list[val] : val),
+      }}
       InputLabelProps={isEmpty ? {shrink: true} : undefined}
       {...props}
     >
@@ -193,9 +251,37 @@ export default function Selector({
           </MenuItem>,
           <Divider key='divider'/>,
         ] : []),
-        ...list.map((listMember, i) => (
-          <MenuItem key={i} value={i}><Typography variant='p'>{listMember}</Typography></MenuItem>
-        )),
+        ...(isPaged ? [
+          <MenuItem
+            key='prev'
+            value={PREV_VALUE}
+            disabled={clampedPage === 0}
+            data-testid={`selector-prev-${label.toLowerCase()}`}
+          >
+            <PrevIcon fontSize='small' sx={{mr: 0.5}}/>
+            <Typography variant='caption'>
+              {`Prev · ${pageStart + 1}–${pageEnd} of ${list.length}`}
+            </Typography>
+          </MenuItem>,
+          <MenuItem
+            key='next'
+            value={NEXT_VALUE}
+            disabled={clampedPage >= pageCount - 1}
+            data-testid={`selector-next-${label.toLowerCase()}`}
+          >
+            <NextIcon fontSize='small' sx={{mr: 0.5}}/>
+            <Typography variant='caption'>Next</Typography>
+          </MenuItem>,
+          <Divider key='pager-divider'/>,
+        ] : []),
+        ...pageItems.map((listMember, j) => {
+          const globalIndex = pageStart + j
+          return (
+            <MenuItem key={globalIndex} value={globalIndex}>
+              <Typography variant='p'>{listMember}</Typography>
+            </MenuItem>
+          )
+        }),
       ]}
     </TextField>
   )

--- a/src/Components/Open/Selector.jsx
+++ b/src/Components/Open/Selector.jsx
@@ -24,6 +24,8 @@ const PAGE_SIZE = 10
  * @property {Array} list list of elements to populate select options
  * @property {Function} [validate] Optional async fn (value: string) => boolean. When provided, adds "Other..." option.
  * @property {string} [emptyText] Placeholder shown when list is empty. Default: '<None>'
+ * @property {Function} [onClear] Optional. When provided and a value is selected, shows a
+ *   clear (×) affordance on the dropdown; the parent handles the reset (e.g. cascading clear).
  * @property {string} [data-testid] id for testing
  * @return {ReactElement}
  */
@@ -34,6 +36,7 @@ export default function Selector({
   list,
   validate,
   emptyText = '<None>',
+  onClear,
   ...props
 }) {
   const [isTextMode, setIsTextMode] = useState(false)
@@ -91,7 +94,7 @@ export default function Selector({
     // The live filter below already handles names present in the list, so
     // only fall back to async validation for a typed value that is NOT in
     // the list (e.g. an exact repo the API can resolve but wasn't fetched).
-    const hasListMatch = list.some((item) => String(item).toLowerCase().includes(query))
+    const hasListMatch = list.some((item) => item !== null && item !== undefined && String(item).toLowerCase().includes(query))
     if (hasListMatch || !validate) {
       return
     }
@@ -137,6 +140,16 @@ export default function Selector({
 
   const handleKeyDown = (e) => {
     if (e.key === 'Enter') {
+      // Enter accepts an EXACT (case-insensitive) in-list match — e.g.
+      // "test-models" selects that entry even though it's also a prefix of
+      // "test-models-private". A prefix-only query is left as-is so the user
+      // keeps typing; the API-validate fallback still handles out-of-list names.
+      const typed = inputText.trim().toLowerCase()
+      const exactIdx = list.findIndex((item) => typeof item === 'string' && item.toLowerCase() === typed)
+      if (exactIdx >= 0) {
+        selectMatch(exactIdx)
+        return
+      }
       handleAccept()
     } else if (e.key === 'Escape') {
       handleClear()
@@ -180,7 +193,8 @@ export default function Selector({
     const query = inputText.trim().toLowerCase()
     const matches = list
       .map((item, i) => ({item, i}))
-      .filter(({item}) => item !== '' && (query === '' || String(item).toLowerCase().includes(query)))
+      .filter(({item}) => item !== null && item !== undefined && item !== '' &&
+        (query === '' || String(item).toLowerCase().includes(query)))
     const matchPageCount = Math.max(1, Math.ceil(matches.length / PAGE_SIZE))
     const matchPage = Math.min(page, matchPageCount - 1)
     const matchStart = matchPage * PAGE_SIZE
@@ -321,9 +335,26 @@ export default function Selector({
           setIsOpen(false)
         },
         // Derive the field label straight from the value so a selection on
-        // any page still shows once the menu closes / repaginates.
-        renderValue: (val) => (typeof val === 'number' ? list[val] : val),
+        // any page still shows once the menu closes / repaginates. `?? ''`
+        // keeps a stale/out-of-range index from rendering `undefined`.
+        renderValue: (val) => (typeof val === 'number' ? (list[val] ?? '') : (val ?? '')),
       }}
+      InputProps={(onClear && !isEmpty && selected !== '' && selected !== null && selected !== undefined) ? {
+        endAdornment: (
+          <IconButton
+            aria-label='clear'
+            data-testid={`selector-clear-select-${label.toLowerCase()}`}
+            onMouseDown={(e) => e.stopPropagation()}
+            onClick={(e) => {
+              e.stopPropagation()
+              onClear()
+            }}
+            sx={{mr: 2.5, p: 0.25}}
+          >
+            <ClearIcon fontSize='small'/>
+          </IconButton>
+        ),
+      } : undefined}
       InputLabelProps={isEmpty ? {shrink: true} : undefined}
       {...props}
     >
@@ -363,6 +394,9 @@ export default function Selector({
         ] : []),
         ...pageItems.map((listMember, j) => {
           const globalIndex = pageStart + j
+          if (listMember === null || listMember === undefined) {
+            return null
+          }
           return (
             <MenuItem key={globalIndex} value={globalIndex}>
               <Typography variant='p'>{listMember}</Typography>

--- a/src/Components/Open/Selector.jsx
+++ b/src/Components/Open/Selector.jsx
@@ -68,6 +68,7 @@ export default function Selector({
       setIsTextMode(true)
       setInputText('')
       setValidationStatus('idle')
+      setPage(0)
       return
     }
     disablePageReloadApprovalCheck()
@@ -77,12 +78,21 @@ export default function Selector({
   const handleTextChange = (e) => {
     const value = e.target.value
     setInputText(value)
+    setPage(0)
     setValidationStatus('idle')
 
     if (debounceRef.current) {
       clearTimeout(debounceRef.current)
     }
-    if (!value.trim()) {
+    const query = value.trim().toLowerCase()
+    if (!query) {
+      return
+    }
+    // The live filter below already handles names present in the list, so
+    // only fall back to async validation for a typed value that is NOT in
+    // the list (e.g. an exact repo the API can resolve but wasn't fetched).
+    const hasListMatch = list.some((item) => String(item).toLowerCase().includes(query))
+    if (hasListMatch || !validate) {
       return
     }
     setValidationStatus('checking')
@@ -111,6 +121,18 @@ export default function Selector({
     setIsTextMode(false)
     setInputText('')
     setValidationStatus('idle')
+  }
+
+  // Pick one of the live-filtered matches by its index into the full list.
+  const selectMatch = (index) => {
+    disablePageReloadApprovalCheck()
+    if (debounceRef.current) {
+      clearTimeout(debounceRef.current)
+    }
+    setIsTextMode(false)
+    setInputText('')
+    setValidationStatus('idle')
+    setSelected(index)
   }
 
   const handleKeyDown = (e) => {
@@ -148,9 +170,21 @@ export default function Selector({
       statusColor = 'success.main'
       statusText = 'Found'
     } else if (validationStatus === 'no-match') {
-      statusColor = 'error.main'
       statusText = 'No match'
+      statusColor = 'error.main'
     }
+
+    // Live-filter the list by the typed query, then paginate the matches
+    // (same PAGE_SIZE + pager as the dropdown). Empty query shows the full
+    // list so the text input doubles as a paged browser.
+    const query = inputText.trim().toLowerCase()
+    const matches = list
+      .map((item, i) => ({item, i}))
+      .filter(({item}) => item !== '' && (query === '' || String(item).toLowerCase().includes(query)))
+    const matchPageCount = Math.max(1, Math.ceil(matches.length / PAGE_SIZE))
+    const matchPage = Math.min(page, matchPageCount - 1)
+    const matchStart = matchPage * PAGE_SIZE
+    const visibleMatches = matches.slice(matchStart, matchStart + PAGE_SIZE)
 
     return (
       <Stack sx={{marginBottom: '.5em', width: '100%'}}>
@@ -185,6 +219,59 @@ export default function Selector({
           <Typography variant='caption' sx={{color: statusColor, ml: 1, mt: 0.25}}>
             {statusText}
           </Typography>
+        )}
+        {visibleMatches.length > 0 && (
+          <Stack
+            data-testid={`selector-matches-${label.toLowerCase()}`}
+            sx={{
+              mt: 0.25,
+              border: 1,
+              borderColor: 'divider',
+              borderRadius: 1,
+              maxHeight: '320px',
+              overflowY: 'auto',
+            }}
+          >
+            {matches.length > PAGE_SIZE && (
+              <Stack
+                direction='row'
+                sx={{alignItems: 'center', justifyContent: 'space-between', px: 1, py: 0.25}}
+              >
+                <IconButton
+                  size='small'
+                  aria-label='previous page'
+                  data-testid={`selector-prev-${label.toLowerCase()}`}
+                  disabled={matchPage === 0}
+                  onMouseDown={(e) => e.preventDefault()}
+                  onClick={() => setPage(Math.max(0, matchPage - 1))}
+                >
+                  <PrevIcon fontSize='small'/>
+                </IconButton>
+                <Typography variant='caption' sx={{color: 'text.secondary'}}>
+                  {`${matchStart + 1}–${matchStart + visibleMatches.length} of ${matches.length}`}
+                </Typography>
+                <IconButton
+                  size='small'
+                  aria-label='next page'
+                  data-testid={`selector-next-${label.toLowerCase()}`}
+                  disabled={matchPage >= matchPageCount - 1}
+                  onMouseDown={(e) => e.preventDefault()}
+                  onClick={() => setPage(Math.min(matchPageCount - 1, matchPage + 1))}
+                >
+                  <NextIcon fontSize='small'/>
+                </IconButton>
+              </Stack>
+            )}
+            {visibleMatches.map(({item, i}) => (
+              <MenuItem
+                key={i}
+                onMouseDown={(e) => e.preventDefault()}
+                onClick={() => selectMatch(i)}
+              >
+                <Typography variant='p'>{item}</Typography>
+              </MenuItem>
+            ))}
+          </Stack>
         )}
       </Stack>
     )

--- a/src/Components/Open/Selector.jsx
+++ b/src/Components/Open/Selector.jsx
@@ -224,9 +224,12 @@ export default function Selector({
               </IconButton>
             ),
           }}
+          // Keydown lives on the input element (not the TextField root) so
+          // tabbing to the clear button and pressing Enter clears the entry
+          // rather than bubbling up and accepting an exact match.
+          inputProps={{onKeyDown: handleKeyDown}}
           {...props}
           onChange={handleTextChange}
-          onKeyDown={handleKeyDown}
           onBlur={handleBlur}
         />
         {statusText && (
@@ -298,112 +301,113 @@ export default function Selector({
   const pageEnd = Math.min(pageStart + PAGE_SIZE, list.length)
   const pageItems = list.slice(pageStart, pageEnd)
   const isPaged = list.length > PAGE_SIZE
+  // The clear (×) lives OUTSIDE the input (a sibling), so the field is a
+  // single logical unit: it either holds a value (× shown beside it to
+  // reset) or it doesn't (no ×). Keeping × out of the input also stops it
+  // from sitting in the tab/Enter flow or overlaying the dropdown arrow.
+  const showClear = onClear && !isEmpty && selected !== '' && selected !== null && selected !== undefined
 
   return (
-    <TextField
-      value={isEmpty ? '' : selected}
-      onChange={(e) => handleSelect(e)}
-      variant='outlined'
-      label={label}
-      select
-      size='small'
-      sx={{
-        'width': '100%',
-        'marginBottom': '.5em',
-        '& .MuiSelect-select': {textAlign: 'left'},
-      }}
-      SelectProps={isEmpty ? {
-        displayEmpty: true,
-        renderValue: () => <span style={{opacity: 1}}>{emptyText}</span>,
-      } : {
-        open: isOpen,
-        onOpen: () => {
+    <Stack direction='row' alignItems='center' sx={{width: '100%', marginBottom: '.5em'}}>
+      <TextField
+        value={isEmpty ? '' : selected}
+        onChange={(e) => handleSelect(e)}
+        variant='outlined'
+        label={label}
+        select
+        size='small'
+        sx={{
+          'flex': 1,
+          'minWidth': 0,
+          '& .MuiSelect-select': {textAlign: 'left'},
+        }}
+        SelectProps={isEmpty ? {
+          displayEmpty: true,
+          renderValue: () => <span style={{opacity: 1}}>{emptyText}</span>,
+        } : {
+          open: isOpen,
+          onOpen: () => {
           // Jump to the page holding the current selection so its row is
           // rendered (keeps the highlight correct, avoids MUI's
           // out-of-range warning) and paging starts from context.
-          if (typeof selected === 'number' && selected >= 0) {
-            setPage(Math.floor(selected / PAGE_SIZE))
-          }
-          setIsOpen(true)
-        },
-        onClose: () => {
+            if (typeof selected === 'number' && selected >= 0) {
+              setPage(Math.floor(selected / PAGE_SIZE))
+            }
+            setIsOpen(true)
+          },
+          onClose: () => {
           // A pager row requested a page change — keep the menu open.
-          if (pagerClickRef.current) {
-            pagerClickRef.current = false
-            return
-          }
-          setIsOpen(false)
-        },
-        // Derive the field label straight from the value so a selection on
-        // any page still shows once the menu closes / repaginates. `?? ''`
-        // keeps a stale/out-of-range index from rendering `undefined`.
-        renderValue: (val) => (typeof val === 'number' ? (list[val] ?? '') : (val ?? '')),
-      }}
-      InputProps={(onClear && !isEmpty && selected !== '' && selected !== null && selected !== undefined) ? {
-        endAdornment: (
-          <IconButton
-            aria-label='clear'
-            data-testid={`selector-clear-select-${label.toLowerCase()}`}
-            onMouseDown={(e) => e.stopPropagation()}
-            onClick={(e) => {
-              e.stopPropagation()
-              onClear()
-            }}
-            sx={{mr: 2.5, p: 0.25}}
-          >
-            <ClearIcon fontSize='small'/>
-          </IconButton>
-        ),
-      } : undefined}
-      InputLabelProps={isEmpty ? {shrink: true} : undefined}
-      {...props}
-    >
-      {isEmpty ? (
-        <MenuItem value='' disabled>
-          <Typography variant='p'>{emptyText}</Typography>
-        </MenuItem>
-      ) : [
-        ...(validate ? [
-          <MenuItem key='other' value={OTHER_VALUE}>
-            <Typography variant='p'>Enter name...</Typography>
-          </MenuItem>,
-          <Divider key='divider'/>,
-        ] : []),
-        ...(isPaged ? [
-          <MenuItem
-            key='prev'
-            value={PREV_VALUE}
-            disabled={clampedPage === 0}
-            data-testid={`selector-prev-${label.toLowerCase()}`}
-          >
-            <PrevIcon fontSize='small' sx={{mr: 0.5}}/>
-            <Typography variant='caption'>
-              {`Prev · ${pageStart + 1}–${pageEnd} of ${list.length}`}
-            </Typography>
-          </MenuItem>,
-          <MenuItem
-            key='next'
-            value={NEXT_VALUE}
-            disabled={clampedPage >= pageCount - 1}
-            data-testid={`selector-next-${label.toLowerCase()}`}
-          >
-            <NextIcon fontSize='small' sx={{mr: 0.5}}/>
-            <Typography variant='caption'>Next</Typography>
-          </MenuItem>,
-          <Divider key='pager-divider'/>,
-        ] : []),
-        ...pageItems.map((listMember, j) => {
-          const globalIndex = pageStart + j
-          if (listMember === null || listMember === undefined) {
-            return null
-          }
-          return (
-            <MenuItem key={globalIndex} value={globalIndex}>
-              <Typography variant='p'>{listMember}</Typography>
-            </MenuItem>
-          )
-        }),
-      ]}
-    </TextField>
+            if (pagerClickRef.current) {
+              pagerClickRef.current = false
+              return
+            }
+            setIsOpen(false)
+          },
+          // Derive the field label straight from the value so a selection on
+          // any page still shows once the menu closes / repaginates. `?? ''`
+          // keeps a stale/out-of-range index from rendering `undefined`.
+          renderValue: (val) => (typeof val === 'number' ? (list[val] ?? '') : (val ?? '')),
+        }}
+        InputLabelProps={isEmpty ? {shrink: true} : undefined}
+        {...props}
+      >
+        {isEmpty ? (
+          <MenuItem value='' disabled>
+            <Typography variant='p'>{emptyText}</Typography>
+          </MenuItem>
+        ) : [
+          ...(validate ? [
+            <MenuItem key='other' value={OTHER_VALUE}>
+              <Typography variant='p'>Enter name...</Typography>
+            </MenuItem>,
+            <Divider key='divider'/>,
+          ] : []),
+          ...(isPaged ? [
+            <MenuItem
+              key='prev'
+              value={PREV_VALUE}
+              disabled={clampedPage === 0}
+              data-testid={`selector-prev-${label.toLowerCase()}`}
+            >
+              <PrevIcon fontSize='small' sx={{mr: 0.5}}/>
+              <Typography variant='caption'>
+                {`Prev · ${pageStart + 1}–${pageEnd} of ${list.length}`}
+              </Typography>
+            </MenuItem>,
+            <MenuItem
+              key='next'
+              value={NEXT_VALUE}
+              disabled={clampedPage >= pageCount - 1}
+              data-testid={`selector-next-${label.toLowerCase()}`}
+            >
+              <NextIcon fontSize='small' sx={{mr: 0.5}}/>
+              <Typography variant='caption'>Next</Typography>
+            </MenuItem>,
+            <Divider key='pager-divider'/>,
+          ] : []),
+          ...pageItems.map((listMember, j) => {
+            const globalIndex = pageStart + j
+            if (listMember === null || listMember === undefined) {
+              return null
+            }
+            return (
+              <MenuItem key={globalIndex} value={globalIndex}>
+                <Typography variant='p'>{listMember}</Typography>
+              </MenuItem>
+            )
+          }),
+        ]}
+      </TextField>
+      {showClear && (
+        <IconButton
+          aria-label='clear'
+          data-testid={`selector-clear-select-${label.toLowerCase()}`}
+          onClick={onClear}
+          sx={{ml: 0.5, p: 0.5, flexShrink: 0}}
+        >
+          <ClearIcon fontSize='small'/>
+        </IconButton>
+      )}
+    </Stack>
   )
 }

--- a/src/Components/Open/Selector.jsx
+++ b/src/Components/Open/Selector.jsx
@@ -152,6 +152,10 @@ export default function Selector({
       }
       handleAccept()
     } else if (e.key === 'Escape') {
+      // Escape only exits the field's text mode. Stop it bubbling to the MUI
+      // Dialog, whose default Escape handler would otherwise close the whole
+      // Open dialog out from under the user.
+      e.stopPropagation()
       handleClear()
     }
   }
@@ -351,11 +355,19 @@ export default function Selector({
         InputLabelProps={isEmpty ? {shrink: true} : undefined}
         {...props}
       >
-        {isEmpty ? (
-          <MenuItem value='' disabled>
+        {isEmpty ? [
+          <MenuItem key='empty' value='' disabled>
             <Typography variant='p'>{emptyText}</Typography>
-          </MenuItem>
-        ) : [
+          </MenuItem>,
+          // Even with no options to pick, a validated field must still let the
+          // user type a name (e.g. a File the extension filter hid, or one in a
+          // folder with no listed matches).
+          ...(validate ? [
+            <MenuItem key='other' value={OTHER_VALUE}>
+              <Typography variant='p'>Enter name...</Typography>
+            </MenuItem>,
+          ] : []),
+        ] : [
           ...(validate ? [
             <MenuItem key='other' value={OTHER_VALUE}>
               <Typography variant='p'>Enter name...</Typography>

--- a/src/Components/Open/Selector.test.jsx
+++ b/src/Components/Open/Selector.test.jsx
@@ -149,6 +149,62 @@ describe('Selector — dropdown pagination', () => {
 })
 
 
+describe('Selector — text-mode live filter', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockValidate.mockResolvedValue(false)
+  })
+
+  const repoList = ['acme', 'test-models', 'test-models-private', 'zeta']
+  const longList = Array.from({length: 25}, (_, i) => `repo-${i}`)
+
+  /**
+   * @param {Array} list option list
+   * @return {HTMLElement} the text input
+   */
+  async function enterFilterMode(list) {
+    renderSelector({validate: mockValidate, list})
+    openDropdown()
+    const other = await screen.findByText('Enter name...')
+    fireEvent.click(other)
+    return screen.getByRole('textbox')
+  }
+
+  it('filters the list live as the user types', async () => {
+    const input = await enterFilterMode(repoList)
+    fireEvent.change(input, {target: {value: 'test-models'}})
+    expect(screen.getByText('test-models')).toBeInTheDocument()
+    expect(screen.getByText('test-models-private')).toBeInTheDocument()
+    expect(screen.queryByText('acme')).not.toBeInTheDocument()
+  })
+
+  it('selects a filtered match with its list index', async () => {
+    const input = await enterFilterMode(repoList)
+    fireEvent.change(input, {target: {value: 'private'}})
+    fireEvent.click(screen.getByText('test-models-private'))
+    expect(mockSetSelected).toHaveBeenCalledWith(repoList.indexOf('test-models-private'))
+  })
+
+  it('paginates a long filtered result set', async () => {
+    const input = await enterFilterMode(longList)
+    fireEvent.change(input, {target: {value: 'repo-'}})
+    expect(screen.getByText('repo-0')).toBeInTheDocument()
+    expect(screen.queryByText('repo-10')).not.toBeInTheDocument()
+    fireEvent.click(screen.getByTestId('selector-next-organization'))
+    await waitFor(() => screen.getByText('repo-10'))
+  })
+
+  it('does not call the API validator for a query already in the list', async () => {
+    const input = await enterFilterMode(repoList)
+    fireEvent.change(input, {target: {value: 'test'}})
+    act(() => {
+      jest.runAllTimers()
+    })
+    expect(mockValidate).not.toHaveBeenCalled()
+  })
+})
+
+
 describe('Selector — text mode', () => {
   beforeEach(() => {
     jest.clearAllMocks()

--- a/src/Components/Open/Selector.test.jsx
+++ b/src/Components/Open/Selector.test.jsx
@@ -100,6 +100,55 @@ describe('Selector — dropdown mode', () => {
 })
 
 
+describe('Selector — dropdown pagination', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  const longList = Array.from({length: 25}, (_, i) => `repo-${i}`)
+
+  it('shows no pager when the list fits on one page', async () => {
+    renderSelector({list: ['a', 'b', 'c']})
+    openDropdown()
+    await waitFor(() => screen.getByRole('listbox'))
+    expect(screen.queryByTestId('selector-next-organization')).not.toBeInTheDocument()
+  })
+
+  it('shows only the first page plus a pager for a long list', async () => {
+    renderSelector({list: longList})
+    openDropdown()
+    await waitFor(() => screen.getByRole('listbox'))
+    expect(screen.getByText('repo-0')).toBeInTheDocument()
+    expect(screen.getByText('repo-9')).toBeInTheDocument()
+    expect(screen.queryByText('repo-10')).not.toBeInTheDocument()
+    expect(screen.getByTestId('selector-next-organization')).toBeInTheDocument()
+  })
+
+  it('pages forward to the next set of options without closing', async () => {
+    renderSelector({list: longList})
+    openDropdown()
+    await waitFor(() => screen.getByRole('listbox'))
+    fireEvent.click(screen.getByTestId('selector-next-organization'))
+    await waitFor(() => screen.getByText('repo-10'))
+    expect(screen.getByText('repo-19')).toBeInTheDocument()
+    expect(screen.queryByText('repo-0')).not.toBeInTheDocument()
+    // Menu stayed open across the page change.
+    expect(screen.getByRole('listbox')).toBeInTheDocument()
+  })
+
+  it('selects a later-page option with its global list index', async () => {
+    renderSelector({list: longList})
+    openDropdown()
+    await waitFor(() => screen.getByRole('listbox'))
+    fireEvent.click(screen.getByTestId('selector-next-organization'))
+    const target = 'repo-12'
+    await waitFor(() => screen.getByText(target))
+    fireEvent.click(screen.getByText(target))
+    expect(mockSetSelected).toHaveBeenCalledWith(longList.indexOf(target))
+  })
+})
+
+
 describe('Selector — text mode', () => {
   beforeEach(() => {
     jest.clearAllMocks()

--- a/src/Components/Open/Selector.test.jsx
+++ b/src/Components/Open/Selector.test.jsx
@@ -250,8 +250,9 @@ describe('Selector — defensive value handling', () => {
     const matches = screen.getByTestId('selector-matches-organization')
     expect(within(matches).getByText('acme')).toBeInTheDocument()
     expect(within(matches).getByText('beta')).toBeInTheDocument()
-    // Exactly two rows render — the null/undefined/'' holes produce no blanks.
-    expect(within(matches).getAllByText(/\w/)).toHaveLength(2)
+    // Exactly the two real names render as rows — the null/undefined/'' holes
+    // produce no blank entries.
+    expect(within(matches).getAllByText(/^(acme|beta)$/)).toHaveLength(2)
     expect(input).toBeInTheDocument()
   })
 
@@ -260,6 +261,56 @@ describe('Selector — defensive value handling', () => {
     // A stale index past the end of the list must not surface the literal
     // string "undefined" in the closed field.
     expect(screen.getByRole('combobox').textContent).not.toMatch(/undefined/)
+  })
+
+  it('offers Enter name... even when the list is empty (validated field)', async () => {
+    renderSelector({list: [], validate: mockValidate})
+    openDropdown()
+    fireEvent.click(await screen.findByText('Enter name...'))
+    // A validated field must always allow typing a name, even with no options
+    // (e.g. a File the extension filter hid).
+    expect(screen.getByRole('textbox')).toBeInTheDocument()
+  })
+})
+
+
+describe('Selector — Escape in text mode', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockValidate.mockResolvedValue(false)
+  })
+
+  /**
+   * @param {Function} onParentKeyDown ancestor keydown spy
+   * @return {HTMLElement} the text input, already in text mode
+   */
+  async function enterTextModeUnder(onParentKeyDown) {
+    render(
+      // eslint-disable-next-line jsx-a11y/no-static-element-interactions
+      <div onKeyDown={onParentKeyDown}>
+        <Selector {...defaultProps} validate={mockValidate}/>
+      </div>,
+      {wrapper: HelmetStoreRouteThemeCtx},
+    )
+    fireEvent.mouseDown(screen.getByRole('combobox'))
+    fireEvent.click(await screen.findByText('Enter name...'))
+    return screen.getByRole('textbox')
+  }
+
+  it('exits text mode without letting Escape reach an ancestor (e.g. the Dialog)', async () => {
+    const onParentKeyDown = jest.fn()
+    const input = await enterTextModeUnder(onParentKeyDown)
+    fireEvent.keyDown(input, {key: 'Escape'})
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument()
+    // stopPropagation kept Escape from bubbling up to close the Dialog.
+    expect(onParentKeyDown).not.toHaveBeenCalled()
+  })
+
+  it('lets other keys (Enter) bubble to ancestors normally', async () => {
+    const onParentKeyDown = jest.fn()
+    const input = await enterTextModeUnder(onParentKeyDown)
+    fireEvent.keyDown(input, {key: 'Enter'})
+    expect(onParentKeyDown).toHaveBeenCalled()
   })
 })
 

--- a/src/Components/Open/Selector.test.jsx
+++ b/src/Components/Open/Selector.test.jsx
@@ -202,6 +202,49 @@ describe('Selector — text-mode live filter', () => {
     })
     expect(mockValidate).not.toHaveBeenCalled()
   })
+
+  it('accepts an exact in-list match on Enter (even when it is also a prefix)', async () => {
+    const input = await enterFilterMode(repoList)
+    fireEvent.change(input, {target: {value: 'test-models'}})
+    fireEvent.keyDown(input, {key: 'Enter'})
+    expect(mockSetSelected).toHaveBeenCalledWith(repoList.indexOf('test-models'))
+  })
+
+  it('does not accept a prefix-only query on Enter', async () => {
+    const input = await enterFilterMode(repoList)
+    fireEvent.change(input, {target: {value: 'test-mod'}})
+    fireEvent.keyDown(input, {key: 'Enter'})
+    expect(mockSetSelected).not.toHaveBeenCalled()
+  })
+})
+
+
+describe('Selector — clear (×) affordance', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('shows the clear × only when onClear is set and a value is selected', () => {
+    renderSelector({onClear: jest.fn(), selected: 0})
+    expect(screen.getByTestId('selector-clear-select-organization')).toBeInTheDocument()
+  })
+
+  it('does not show the clear × without a selection', () => {
+    renderSelector({onClear: jest.fn(), selected: ''})
+    expect(screen.queryByTestId('selector-clear-select-organization')).not.toBeInTheDocument()
+  })
+
+  it('does not show the clear × without an onClear handler', () => {
+    renderSelector({selected: 0})
+    expect(screen.queryByTestId('selector-clear-select-organization')).not.toBeInTheDocument()
+  })
+
+  it('calls onClear when the × is clicked', () => {
+    const onClear = jest.fn()
+    renderSelector({onClear, selected: 0})
+    fireEvent.click(screen.getByTestId('selector-clear-select-organization'))
+    expect(onClear).toHaveBeenCalled()
+  })
 })
 
 

--- a/src/Components/Open/Selector.test.jsx
+++ b/src/Components/Open/Selector.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import {act, fireEvent, render, screen, waitFor} from '@testing-library/react'
+import {act, fireEvent, render, screen, waitFor, within} from '@testing-library/react'
 import {HelmetStoreRouteThemeCtx} from '../../Share.fixture'
 import Selector from './Selector'
 
@@ -215,6 +215,51 @@ describe('Selector — text-mode live filter', () => {
     fireEvent.change(input, {target: {value: 'test-mod'}})
     fireEvent.keyDown(input, {key: 'Enter'})
     expect(mockSetSelected).not.toHaveBeenCalled()
+  })
+})
+
+
+describe('Selector — defensive value handling', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockValidate.mockResolvedValue(false)
+  })
+
+  it('skips null/undefined entries in the dropdown but keeps their list index', async () => {
+    const sparse = ['acme', null, 'beta', undefined, 'gamma']
+    renderSelector({list: sparse})
+    openDropdown()
+    await waitFor(() => screen.getByRole('listbox'))
+    expect(screen.getByText('acme')).toBeInTheDocument()
+    expect(screen.getByText('beta')).toBeInTheDocument()
+    expect(screen.getByText('gamma')).toBeInTheDocument()
+    // 'gamma' is at index 4 in the full list — selecting it must report 4,
+    // not a compacted index, so the parent resolves the right entry.
+    fireEvent.click(screen.getByText('gamma'))
+    expect(mockSetSelected).toHaveBeenCalledWith(sparse.indexOf('gamma'))
+  })
+
+  it('filters null/undefined/empty entries out of the text-mode match list', async () => {
+    const sparse = ['acme', null, '', undefined, 'beta']
+    renderSelector({validate: mockValidate, list: sparse})
+    openDropdown()
+    fireEvent.click(await screen.findByText('Enter name...'))
+    const input = screen.getByRole('textbox')
+    // Empty query shows the full list, but the holes must not render as blank
+    // rows — only the two real names should appear as matches.
+    const matches = screen.getByTestId('selector-matches-organization')
+    expect(within(matches).getByText('acme')).toBeInTheDocument()
+    expect(within(matches).getByText('beta')).toBeInTheDocument()
+    // Exactly two rows render — the null/undefined/'' holes produce no blanks.
+    expect(within(matches).getAllByText(/\w/)).toHaveLength(2)
+    expect(input).toBeInTheDocument()
+  })
+
+  it('renders an out-of-range numeric selection as empty, never "undefined"', () => {
+    renderSelector({list: ['a', 'b'], selected: 99})
+    // A stale index past the end of the list must not surface the literal
+    // string "undefined" in the closed field.
+    expect(screen.getByRole('combobox').textContent).not.toMatch(/undefined/)
   })
 })
 


### PR DESCRIPTION
Consolidated Open-dialog GitHub-browser work. This branch now carries the full stack — **#1625 was merged into it** (commit `a123912`), so this single PR lands everything into `main`.

## Selector (generic, shared across every Open-dialog field)
- **Paginated dropdown** — `PAGE_SIZE = 10` with "Prev · N–M of total" / "Next" pager rows; controlled-open with an `onClose` guard so paging never closes the menu; `renderValue` derives the field label from the value; menu items carry their global list index so selection resolves regardless of page.
- **Live filter** — the "Enter name…" text field filters options live (case-insensitive substring) and paginates matches. API validation runs only as a fallback for a typed value not already in the list, so in-list queries never hit the network.
- **Enter accepts an exact in-list match** (prefix-only is left for the user to finish); defensive against `null`/`undefined`/`''` list entries.
- **Clear ×** lives outside the input (a sibling), so the field is one logical unit and the × never overlays the dropdown arrow or sits in the tab/Enter flow.
- **Escape** stays scoped to the field (`stopPropagation`) — it exits text mode instead of bubbling up and closing the whole Open dialog.
- The "Enter name…" affordance is offered **even when the option list is empty**, so a validated field can always accept a typed value.

## GitHub file browser
- **Private-repo opt-in (Pro).** Always shown once an org's repos load, so it's discoverable: free/non-Pro users see it greyed-out with an **"Enable private repos (Pro only)"** label; a Pro user's click opens `/popup-auth?scope=repo` (global `repo` grant — OAuth scopes are per-token, not per-org; the caption says so), then the token refreshes and the org refetches; an already-granted token shows it checked + locked ("enabled for this account"). `PopupAuth` adds `prompt: 'login'` so the widened scope is actually re-consented.
- **Extension filter.** The File list shows only extensions Share supports (`src/Filetype` `pathSuffixSupported`, case-insensitive), filtered at every listing site — GitHub's contents API has no server-side filter, so the client is the enforcement point.
- **Type any filename.** The File field gains "Enter name…" text entry, so a user can type **any** valid filename (unsupported extension or none); typed names bypass the list filter by design and `navigateToFile` opens any non-empty name, letting the loader decide.
- **Dialog-state persistence.** Org / repo / branch / folder-path saved to `localStorage` and restored (best-effort, chained) on reopen. Cleared fields stay cleared; the file is intentionally not persisted (reopen lands in the same folder, ready for a new file). Empty initial render never clobbers saved state.
- **Cascading clear.** Each field's × resets that field **and every field below it** — one click back to any level.
- **`[Parent]` fix.** Navigating to `[Parent]` keeps the leading-`/` path shape (`/step`, not a bare `step`), so the next fetch / navigate isn't malformed.

## Tests (all network-mocked — MSW / jest module mocks / Playwright)
- **Unit:** `Selector.test.jsx` (pagination, live filter, enter-exact, clear ×, defensive nulls, Escape stopPropagation, empty-list text entry) and `GitHubFileBrowser.test.jsx` (org→repo→file open flow, opt-in states, extension-filtered listing, typed-unsupported-filename opens, cascade clear, localStorage save/restore).
- **e2e:** `Github.spec.ts` "File browser Selector UI" — dropdown org→repo→file drill, live text filtering, and cascading clear, driven through the real browser against MSW handlers (asserts picker state only, no model load, so it sidesteps #1269).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S6gTXmrq1GbhqknPqQMRuz