### PR TITLE
Auto-color colorless STEP/CAD assemblies by product (Onshape-style)

### DIFF
--- a/src/FeatureFlags.js
+++ b/src/FeatureFlags.js
@@ -105,6 +105,16 @@ export const flags = [
   // follow-ups. Flip on via `?feature=batchedMesh`.
   // Design: design/new/viewer-replacement.md §3b.iv.
   {name: 'batchedMesh', isActive: false},
+  // Synthetic per-product coloring for STEP/CAD models that carry no
+  // presentation data. When a batched model comes back entirely
+  // default-grey (no COLOUR_RGB / STYLED_ITEM, e.g. the Jetenginestep
+  // AP203 export), each product is repainted from a curated palette by a
+  // deterministic hash of its express id — Onshape-style, so a multi-part
+  // assembly is legible instead of a grey blob. Strictly no-op the moment
+  // any real color is present, so IFC and colored STEP are untouched.
+  // Default-on; it only changes models that had zero color to begin with.
+  // See src/viewer/ifc/productPalette.js.
+  {name: 'autoColorParts', isActive: true},
 ]
 
 

--- a/src/viewer/ifc/buildBatchedConwayModel.js
+++ b/src/viewer/ifc/buildBatchedConwayModel.js
@@ -1,10 +1,12 @@
 import {Group} from 'three'
+import {isFeatureEnabled} from '../../FeatureFlags'
 import {attachBatchedSubsets} from './batchedSubset'
 import {flatMeshToBatchedModel} from './flatMeshToBatchedModel'
 import {
   attachConwayDirectModelMethods,
   makeConwayDirectIfcManager,
 } from './conwayDirectIfcLoader'
+import {applyProductPalette} from './productPalette'
 import {occurrencePathKey} from '../../utils/occurrencePaths'
 
 
@@ -111,6 +113,16 @@ export function assembleBatchedModel(batches, ifcAPI, modelID, opts = {}) {
     // Degenerate (no renderable geometry). Throw so ShareIfcLoader falls
     // back to the merged path rather than adding an empty model.
     throw new Error('buildBatchedConwayModel: no renderable geometry')
+  }
+
+  // Colorless-model fallback: a STEP/CAD file with no presentation data
+  // comes back entirely default-grey. Repaint each product from a palette
+  // (Onshape-style) so a multi-part assembly is legible. Strictly no-op the
+  // moment any real color is present, so IFC and colored STEP are untouched.
+  // Runs before the pick-table stamp below so the `instanceColors` restore
+  // table `batchedHighlight` reads already carries the palette color.
+  if (isFeatureEnabled('autoColorParts')) {
+    applyProductPalette(batches)
   }
 
   // Each batch carries its own pick tables; CadView reads them off the

--- a/src/viewer/ifc/buildBatchedConwayModel.test.js
+++ b/src/viewer/ifc/buildBatchedConwayModel.test.js
@@ -40,9 +40,12 @@ function unitTriangleVerts() {
 }
 
 
-/** @return {object} api with one unit-triangle shape at id 999. */
+/** @return {object} api with a unit-triangle shape at ids 998 and 999. */
 function unitTriApi() {
-  const byId = {999: {vertexData: unitTriangleVerts(), indexData: new Uint32Array([0, 1, 2])}}
+  const byId = {
+    998: {vertexData: unitTriangleVerts(), indexData: new Uint32Array([0, 1, 2])},
+    999: {vertexData: unitTriangleVerts(), indexData: new Uint32Array([0, 1, 2])},
+  }
   return {
     GetGeometry(_m, id) {
       const g = byId[id]
@@ -67,8 +70,10 @@ function unitTriApi() {
  * @return {Array<object>} batches from flatMeshToBatchedModel
  */
 function twoProductBatches(colorA, colorB) {
+  // Distinct geometries (998, 999) so the geometry-keyed palette sees two
+  // parts — matching real instanced assemblies where color is by part.
   const flatMeshes = [
-    {expressID: 100, geometries: [{geometryExpressID: 999, flatTransformation: IDENTITY_MAT, color: colorA}]},
+    {expressID: 100, geometries: [{geometryExpressID: 998, flatTransformation: IDENTITY_MAT, color: colorA}]},
     {expressID: 200, geometries: [{geometryExpressID: 999, flatTransformation: IDENTITY_MAT, color: colorB}]},
   ]
   return flatMeshToBatchedModel(flatMeshes, unitTriApi(), 0).batches
@@ -103,11 +108,31 @@ describe('viewer/ifc/assembleBatchedModel colorless palette', () => {
     expect(c100).not.toEqual(c200)
 
     // Restore table (`batchedHighlight` reads it to un-highlight) carries
-    // the exact palette color the buffer was painted with.
+    // the exact palette color the buffer was painted with — keyed by the
+    // part's geometry id (998 for product 100), not the occurrence id.
     const restore100 = mesh.instanceColors[mesh.instanceParents.indexOf(100)]
-    const expected100 = productPaletteRgb(100)
+    const expected100 = productPaletteRgb(998)
     expect(restore100).toMatchObject({x: expected100.x, y: expected100.y, z: expected100.z, w: 1})
     expect(c100.x).toBeCloseTo(expected100.x, 5)
+  })
+
+  it('gives every instance of one part (shared geometry) the same color', () => {
+    mockIsFeatureEnabled.mockImplementation((name) => name === 'autoColorParts')
+    // Three blade occurrences (distinct product ids) sharing geometry 998,
+    // plus a shaft (geometry 999) — the Jetenginestep pattern.
+    const flatMeshes = [
+      {expressID: 31, geometries: [{geometryExpressID: 998, flatTransformation: IDENTITY_MAT, color: GREY}]},
+      {expressID: 32, geometries: [{geometryExpressID: 998, flatTransformation: IDENTITY_MAT, color: GREY}]},
+      {expressID: 33, geometries: [{geometryExpressID: 998, flatTransformation: IDENTITY_MAT, color: GREY}]},
+      {expressID: 40, geometries: [{geometryExpressID: 999, flatTransformation: IDENTITY_MAT, color: GREY}]},
+    ]
+    const batches = flatMeshToBatchedModel(flatMeshes, unitTriApi(), 0).batches
+    const mesh = assembleBatchedModel(batches, unitTriApi(), 0)
+
+    const blade = (id) => mesh.instanceColors[mesh.instanceParents.indexOf(id)]
+    expect(blade(31)).toEqual(blade(32))
+    expect(blade(32)).toEqual(blade(33))
+    expect(blade(40)).not.toEqual(blade(31))
   })
 
   it('leaves colors untouched when autoColorParts is off', () => {

--- a/src/viewer/ifc/buildBatchedConwayModel.test.js
+++ b/src/viewer/ifc/buildBatchedConwayModel.test.js
@@ -1,0 +1,127 @@
+// Integration test for the colorless-model palette wiring in
+// `assembleBatchedModel` (the single chokepoint both batched paths use).
+// The palette math itself is unit-tested in productPalette.test.js; this
+// pins that the feature gate + end-to-end repaint reach the live
+// BatchedMesh color buffer, readable back via getColorAt.
+
+import {Color} from 'three'
+import {flatMeshToBatchedModel, DEFAULT_COLOR} from './flatMeshToBatchedModel'
+import {isDefaultColor, productPaletteRgb} from './productPalette'
+import {assembleBatchedModel} from './buildBatchedConwayModel'
+
+
+// jest hoists this mock above the imports, so assembleBatchedModel binds the
+// mocked isFeatureEnabled — the palette gate is controllable per test.
+const mockIsFeatureEnabled = jest.fn()
+jest.mock('../../FeatureFlags', () => ({
+  isFeatureEnabled: (name) => mockIsFeatureEnabled(name),
+}))
+
+
+/* eslint-disable no-magic-numbers */
+const IDENTITY_MAT = [
+  1, 0, 0, 0,
+  0, 1, 0, 0,
+  0, 0, 1, 0,
+  0, 0, 0, 1,
+]
+
+const GREY = {x: DEFAULT_COLOR.x, y: DEFAULT_COLOR.y, z: DEFAULT_COLOR.z, w: 1}
+const ORANGE = {x: 1, y: 0.5, z: 0, w: 1}
+
+
+/** @return {Float32Array} single-triangle interleaved vert buffer (p+n). */
+function unitTriangleVerts() {
+  return new Float32Array([
+    0, 0, 0, 0, 0, 1,
+    1, 0, 0, 0, 0, 1,
+    0, 1, 0, 0, 0, 1,
+  ])
+}
+
+
+/** @return {object} api with one unit-triangle shape at id 999. */
+function unitTriApi() {
+  const byId = {999: {vertexData: unitTriangleVerts(), indexData: new Uint32Array([0, 1, 2])}}
+  return {
+    GetGeometry(_m, id) {
+      const g = byId[id]
+      return g ? {
+        GetVertexData: () => id,
+        GetIndexData: () => id,
+        GetVertexDataSize: () => g.vertexData.length,
+        GetIndexDataSize: () => g.indexData.length,
+      } : null
+    },
+    GetVertexArray: (ptr) => byId[ptr].vertexData,
+    GetIndexArray: (ptr) => byId[ptr].indexData,
+  }
+}
+
+
+/**
+ * Build batches for two products with the given colors.
+ *
+ * @param {object} colorA product 100's color
+ * @param {object} colorB product 200's color
+ * @return {Array<object>} batches from flatMeshToBatchedModel
+ */
+function twoProductBatches(colorA, colorB) {
+  const flatMeshes = [
+    {expressID: 100, geometries: [{geometryExpressID: 999, flatTransformation: IDENTITY_MAT, color: colorA}]},
+    {expressID: 200, geometries: [{geometryExpressID: 999, flatTransformation: IDENTITY_MAT, color: colorB}]},
+  ]
+  return flatMeshToBatchedModel(flatMeshes, unitTriApi(), 0).batches
+}
+
+
+/**
+ * @param {object} mesh BatchedMesh
+ * @param {number} batchId
+ * @return {object} `{x,y,z}` instance color at batchId
+ */
+function rgbAt(mesh, batchId) {
+  const c = mesh.getColorAt(batchId, new Color())
+  return {x: c.r, y: c.g, z: c.b}
+}
+
+
+describe('viewer/ifc/assembleBatchedModel colorless palette', () => {
+  afterEach(() => mockIsFeatureEnabled.mockReset())
+
+  it('repaints a fully-grey two-product model when autoColorParts is on', () => {
+    mockIsFeatureEnabled.mockImplementation((name) => name === 'autoColorParts')
+    const batches = twoProductBatches(GREY, GREY)
+    const mesh = assembleBatchedModel(batches, unitTriApi(), 0)
+
+    // Live color buffer no longer grey, and the two products differ.
+    // (getColorAt round-trips through float32, so compare approximately.)
+    const c100 = rgbAt(mesh, mesh.instanceParents.indexOf(100))
+    const c200 = rgbAt(mesh, mesh.instanceParents.indexOf(200))
+    expect(isDefaultColor(c100)).toBe(false)
+    expect(isDefaultColor(c200)).toBe(false)
+    expect(c100).not.toEqual(c200)
+
+    // Restore table (`batchedHighlight` reads it to un-highlight) carries
+    // the exact palette color the buffer was painted with.
+    const restore100 = mesh.instanceColors[mesh.instanceParents.indexOf(100)]
+    const expected100 = productPaletteRgb(100)
+    expect(restore100).toMatchObject({x: expected100.x, y: expected100.y, z: expected100.z, w: 1})
+    expect(c100.x).toBeCloseTo(expected100.x, 5)
+  })
+
+  it('leaves colors untouched when autoColorParts is off', () => {
+    mockIsFeatureEnabled.mockReturnValue(false)
+    const mesh = assembleBatchedModel(twoProductBatches(GREY, GREY), unitTriApi(), 0)
+    expect(isDefaultColor(rgbAt(mesh, 0))).toBe(true)
+    expect(isDefaultColor(rgbAt(mesh, 1))).toBe(true)
+  })
+
+  it('honors a real color: a mixed model keeps its grey sibling grey', () => {
+    mockIsFeatureEnabled.mockImplementation((name) => name === 'autoColorParts')
+    const batches = twoProductBatches(GREY, ORANGE)
+    const mesh = assembleBatchedModel(batches, unitTriApi(), 0)
+    const grey = rgbAt(mesh, mesh.instanceParents.indexOf(100))
+    expect(isDefaultColor(grey)).toBe(true)
+  })
+})

--- a/src/viewer/ifc/productPalette.js
+++ b/src/viewer/ifc/productPalette.js
@@ -1,0 +1,166 @@
+import {Vector4} from 'three'
+import {DEFAULT_COLOR} from './flatMeshToBatchedModel'
+
+
+/**
+ * productPalette — synthetic per-product coloring for STEP/CAD models that
+ * carry no presentation data at all.
+ *
+ * Many STEP exports (e.g. the GrabCAD Jetenginestep model, an AP203
+ * CONFIG_CONTROL_DESIGN file) contain pure geometry + assembly structure
+ * and zero COLOUR_RGB / STYLED_ITEM entities, so Conway hands every
+ * placement the same fallback grey (`DEFAULT_COLOR`) and the whole model
+ * renders monochrome. Onshape (and most MCAD viewers) instead auto-assign a
+ * distinct appearance per component on import; this reproduces that: when a
+ * model comes back with NO color information, give each product a stable
+ * color drawn from a curated palette by a deterministic hash of its key.
+ *
+ * Deliberately a display-only fallback, not a parse feature — it fires ONLY
+ * when the model is entirely default-grey. Any real color (an IFC material,
+ * a colored STEP part, even one) means the file has presentation intent, so
+ * we honor it verbatim and skip the palette, colorless siblings included
+ * (they stay grey, exactly as before). Keyed by the product's express id —
+ * the caller has no synchronous product name at assembly time, and the id
+ * is stable within a file; `hashKey` takes a string too, so swapping in a
+ * name resolver later is a one-line change at the call site.
+ */
+
+
+/**
+ * Curated qualitative palette (Tableau-derived), RGB in 0..1. Chosen for
+ * mutual separation and legibility on Share's neutral background; near-grey
+ * hues are omitted so synthesized parts never blend back into the default.
+ */
+export const PRODUCT_PALETTE = [
+  {x: 0.306, y: 0.475, z: 0.655}, // blue
+  {x: 0.949, y: 0.557, z: 0.169}, // orange
+  {x: 0.882, y: 0.341, z: 0.349}, // red
+  {x: 0.463, y: 0.718, z: 0.698}, // teal
+  {x: 0.349, y: 0.631, z: 0.310}, // green
+  {x: 0.929, y: 0.788, z: 0.282}, // yellow
+  {x: 0.690, y: 0.478, z: 0.631}, // purple
+  {x: 1.000, y: 0.616, z: 0.655}, // pink
+  {x: 0.612, y: 0.459, z: 0.373}, // brown
+  {x: 0.549, y: 0.792, z: 0.906}, // sky
+  {x: 1.000, y: 0.745, z: 0.490}, // apricot
+  {x: 0.549, y: 0.820, z: 0.490}, // lime
+  {x: 0.827, y: 0.447, z: 0.584}, // rose
+  {x: 0.286, y: 0.596, z: 0.580}, // deep teal
+  {x: 0.714, y: 0.600, z: 0.176}, // ochre
+  {x: 0.831, y: 0.651, z: 0.784}, // mauve
+]
+
+/**
+ * Max per-channel distance from `DEFAULT_COLOR` still counted as "the
+ * fallback grey". Conway emits exactly 0.8 for an unstyled part, so this
+ * only needs to absorb float noise; any authored color (the nearest real
+ * ones seen are ~0.75 blue-grey) sits well outside it.
+ */
+const DEFAULT_COLOR_EPSILON = 0.02
+
+
+/**
+ * Deterministic 32-bit FNV-1a hash of a key's string form. Stable across
+ * runs and platforms (integer math only), so a product maps to the same
+ * palette slot every load.
+ *
+ * @param {string|number} key
+ * @return {number} unsigned 32-bit hash
+ */
+export function hashKey(key) {
+  const str = String(key)
+  /* eslint-disable no-magic-numbers */
+  let hash = 0x811c9dc5
+  for (let i = 0; i < str.length; i++) {
+    hash ^= str.charCodeAt(i)
+    // FNV prime 16777619, folded to 32 bits via Math.imul.
+    hash = Math.imul(hash, 0x01000193)
+  }
+  return hash >>> 0
+  /* eslint-enable no-magic-numbers */
+}
+
+
+/**
+ * Palette RGB for a product key (its express id, or any stable string).
+ *
+ * @param {string|number} key
+ * @return {{x: number, y: number, z: number}} RGB 0..1
+ */
+export function productPaletteRgb(key) {
+  return PRODUCT_PALETTE[hashKey(key) % PRODUCT_PALETTE.length]
+}
+
+
+/**
+ * True when a color is within `DEFAULT_COLOR_EPSILON` of the fallback grey
+ * on every channel (alpha ignored — a translucent unstyled part is still
+ * unstyled).
+ *
+ * @param {{x: number, y: number, z: number}} color
+ * @return {boolean}
+ */
+export function isDefaultColor(color) {
+  return (
+    Math.abs(color.x - DEFAULT_COLOR.x) <= DEFAULT_COLOR_EPSILON &&
+    Math.abs(color.y - DEFAULT_COLOR.y) <= DEFAULT_COLOR_EPSILON &&
+    Math.abs(color.z - DEFAULT_COLOR.z) <= DEFAULT_COLOR_EPSILON
+  )
+}
+
+
+const _rgba = new Vector4()
+
+
+/**
+ * If a model has no color information — every instance across every batch is
+ * the fallback grey — repaint each instance by its product's palette color,
+ * so a multi-part colorless assembly reads like Onshape's per-component
+ * coloring instead of a grey blob. No-op (returns false) the moment any
+ * real color is present, or when there's only one product to color.
+ *
+ * Updates both the live per-instance color buffer (`setColorAt`) and the
+ * `instanceColors` restore table `batchedHighlight` reads, so selection /
+ * hover restore to the palette color and a batched→merged export carries it.
+ * Original alpha is preserved per instance.
+ *
+ * @param {Array<object>} batches `assembleBatchedModel` batches, each with
+ *   `mesh` (`setColorAt`), `instanceParents`, `instanceColors`
+ * @return {boolean} whether the palette was applied
+ */
+export function applyProductPalette(batches) {
+  const products = new Set()
+  for (const batch of batches) {
+    const {instanceColors, instanceParents} = batch
+    if (!instanceColors || !instanceParents) {
+      // A batch with no color/parent tables can't be classified; its
+      // presence means we can't prove the model is colorless. Bail.
+      return false
+    }
+    for (let i = 0; i < instanceColors.length; i++) {
+      if (!isDefaultColor(instanceColors[i])) {
+        return false
+      }
+      products.add(instanceParents[i])
+    }
+  }
+
+  if (products.size < 2) {
+    return false
+  }
+
+  for (const batch of batches) {
+    const {mesh, instanceColors, instanceParents} = batch
+    if (typeof mesh?.setColorAt !== 'function') {
+      continue
+    }
+    for (let i = 0; i < instanceColors.length; i++) {
+      const rgb = productPaletteRgb(instanceParents[i])
+      const alpha = instanceColors[i].w
+      instanceColors[i] = {x: rgb.x, y: rgb.y, z: rgb.z, w: alpha}
+      mesh.setColorAt(i, _rgba.set(rgb.x, rgb.y, rgb.z, alpha))
+    }
+  }
+
+  return true
+}

--- a/src/viewer/ifc/productPalette.js
+++ b/src/viewer/ifc/productPalette.js
@@ -19,10 +19,18 @@ import {DEFAULT_COLOR} from './flatMeshToBatchedModel'
  * when the model is entirely default-grey. Any real color (an IFC material,
  * a colored STEP part, even one) means the file has presentation intent, so
  * we honor it verbatim and skip the palette, colorless siblings included
- * (they stay grey, exactly as before). Keyed by the product's express id —
- * the caller has no synchronous product name at assembly time, and the id
- * is stable within a file; `hashKey` takes a string too, so swapping in a
- * name resolver later is a one-line change at the call site.
+ * (they stay grey, exactly as before).
+ *
+ * Keyed by the placement's GEOMETRY express id, not its product/occurrence
+ * id. A STEP assembly instances one part definition many times (e.g. the
+ * jet's ~130 turbine + compressor blades), and each instance is a distinct
+ * NAUO occurrence with its own product express id but shares the ONE
+ * geometry buffer the part was defined with (147 occurrences → 9 distinct
+ * geometries on Jetenginestep). Coloring by occurrence gives every blade a
+ * different color; coloring by geometry gives all instances of a part one
+ * color and a different part (the shaft, the casing) its own — which is
+ * what "color by product" means to a viewer. `hashKey` also takes a string,
+ * so a future by-name key is a one-line change at the call site.
  */
 
 
@@ -124,12 +132,23 @@ const _rgba = new Vector4()
  * hover restore to the palette color and a batched→merged export carries it.
  * Original alpha is preserved per instance.
  *
+ * The coloring key is `instanceGeometryIds` (per-part geometry) when present
+ * — so instanced parts get one color each — falling back to
+ * `instanceParents` (per-occurrence) only if a batch carries no geometry-id
+ * table.
+ *
  * @param {Array<object>} batches `assembleBatchedModel` batches, each with
- *   `mesh` (`setColorAt`), `instanceParents`, `instanceColors`
+ *   `mesh` (`setColorAt`), `instanceParents`, `instanceColors`, and
+ *   ideally `instanceGeometryIds`
  * @return {boolean} whether the palette was applied
  */
 export function applyProductPalette(batches) {
-  const products = new Set()
+  // Key each instance by its geometry (part) id, falling back to the
+  // product/occurrence id if a batch lacks the geometry-id table.
+  const keyOf = (batch, i) =>
+    (batch.instanceGeometryIds ? batch.instanceGeometryIds[i] : batch.instanceParents[i])
+
+  const parts = new Set()
   for (const batch of batches) {
     const {instanceColors, instanceParents} = batch
     if (!instanceColors || !instanceParents) {
@@ -141,21 +160,21 @@ export function applyProductPalette(batches) {
       if (!isDefaultColor(instanceColors[i])) {
         return false
       }
-      products.add(instanceParents[i])
+      parts.add(keyOf(batch, i))
     }
   }
 
-  if (products.size < 2) {
+  if (parts.size < 2) {
     return false
   }
 
   for (const batch of batches) {
-    const {mesh, instanceColors, instanceParents} = batch
+    const {mesh, instanceColors} = batch
     if (typeof mesh?.setColorAt !== 'function') {
       continue
     }
     for (let i = 0; i < instanceColors.length; i++) {
-      const rgb = productPaletteRgb(instanceParents[i])
+      const rgb = productPaletteRgb(keyOf(batch, i))
       const alpha = instanceColors[i].w
       instanceColors[i] = {x: rgb.x, y: rgb.y, z: rgb.z, w: alpha}
       mesh.setColorAt(i, _rgba.set(rgb.x, rgb.y, rgb.z, alpha))

--- a/src/viewer/ifc/productPalette.test.js
+++ b/src/viewer/ifc/productPalette.test.js
@@ -17,14 +17,17 @@ const grey = () => ({x: DEFAULT_COLOR.x, y: DEFAULT_COLOR.y, z: DEFAULT_COLOR.z,
  * live color buffer was repainted, not just the restore table.
  *
  * @param {Array<object>} instanceColors
- * @param {Array<number>} instanceParents
+ * @param {Array<number>} instanceParents per-occurrence product ids
+ * @param {Array<number>} [instanceGeometryIds] per-part geometry ids (the
+ *   preferred coloring key); omit to exercise the parent-id fallback
  * @return {object} batch with a recording `mesh.setColorAt`
  */
-function fakeBatch(instanceColors, instanceParents) {
+function fakeBatch(instanceColors, instanceParents, instanceGeometryIds) {
   const painted = new Map()
   return {
     instanceColors,
     instanceParents,
+    instanceGeometryIds,
     painted,
     mesh: {
       setColorAt(i, v) {
@@ -96,10 +99,26 @@ describe('isDefaultColor', () => {
 
 
 describe('applyProductPalette', () => {
-  it('repaints a fully-grey multi-product model, buffer and restore table', () => {
+  it('colors by geometry (part), so instances of one part share a color', () => {
+    // Two parts: geometry 500 instanced 3x (each its own occurrence id),
+    // geometry 600 once. The blades case: same part -> same color.
+    const colors = [grey(), grey(), grey(), grey()]
+    const parents = [11, 12, 13, 20] // all distinct occurrences
+    const geometryIds = [500, 500, 500, 600]
+    const batch = fakeBatch(colors, parents, geometryIds)
+
+    expect(applyProductPalette([batch])).toBe(true)
+    // The three instances of geometry 500 are identically colored...
+    expect(colors[0]).toEqual(colors[1])
+    expect(colors[1]).toEqual(colors[2])
+    // ...and geometry 600 is a different part -> different color.
+    expect(colors[3]).not.toEqual(colors[0])
+  })
+
+  it('falls back to the product/occurrence id when no geometry table', () => {
     const colors = [grey(), grey(), grey()]
     const parents = [10, 20, 10]
-    const batch = fakeBatch(colors, parents)
+    const batch = fakeBatch(colors, parents) // no instanceGeometryIds
 
     expect(applyProductPalette([batch])).toBe(true)
 

--- a/src/viewer/ifc/productPalette.test.js
+++ b/src/viewer/ifc/productPalette.test.js
@@ -1,0 +1,161 @@
+/* eslint-disable no-magic-numbers */
+import {
+  PRODUCT_PALETTE,
+  applyProductPalette,
+  hashKey,
+  isDefaultColor,
+  productPaletteRgb,
+} from './productPalette'
+import {DEFAULT_COLOR} from './flatMeshToBatchedModel'
+
+
+const grey = () => ({x: DEFAULT_COLOR.x, y: DEFAULT_COLOR.y, z: DEFAULT_COLOR.z, w: 1})
+
+
+/**
+ * Minimal batch double: records every setColorAt so a test can assert the
+ * live color buffer was repainted, not just the restore table.
+ *
+ * @param {Array<object>} instanceColors
+ * @param {Array<number>} instanceParents
+ * @return {object} batch with a recording `mesh.setColorAt`
+ */
+function fakeBatch(instanceColors, instanceParents) {
+  const painted = new Map()
+  return {
+    instanceColors,
+    instanceParents,
+    painted,
+    mesh: {
+      setColorAt(i, v) {
+        painted.set(i, {x: v.x, y: v.y, z: v.z, w: v.w})
+      },
+    },
+  }
+}
+
+
+describe('hashKey', () => {
+  it('is deterministic and stable across string/number forms of a key', () => {
+    expect(hashKey(42)).toBe(hashKey(42))
+    expect(hashKey(42)).toBe(hashKey('42'))
+  })
+
+  it('returns an unsigned 32-bit integer', () => {
+    for (const key of [0, 1, 999999, 'FRONTFAN', '']) {
+      const h = hashKey(key)
+      expect(Number.isInteger(h)).toBe(true)
+      expect(h).toBeGreaterThanOrEqual(0)
+      expect(h).toBeLessThanOrEqual(0xffffffff)
+    }
+  })
+
+  it('spreads distinct keys (no collision across a small product set)', () => {
+    const slots = new Set()
+    for (let id = 1; id <= PRODUCT_PALETTE.length; id++) {
+      slots.add(hashKey(id) % PRODUCT_PALETTE.length)
+    }
+    // Not a guarantee in general, but these small ids must not all collide.
+    expect(slots.size).toBeGreaterThan(1)
+  })
+})
+
+
+describe('productPaletteRgb', () => {
+  it('is deterministic per key', () => {
+    expect(productPaletteRgb(7)).toBe(productPaletteRgb(7))
+  })
+
+  it('only ever returns palette members', () => {
+    for (let id = 0; id < 100; id++) {
+      expect(PRODUCT_PALETTE).toContain(productPaletteRgb(id))
+    }
+  })
+
+  it('no palette entry is the fallback grey', () => {
+    for (const c of PRODUCT_PALETTE) {
+      expect(isDefaultColor(c)).toBe(false)
+    }
+  })
+})
+
+
+describe('isDefaultColor', () => {
+  it('accepts the exact fallback grey and tiny float noise', () => {
+    expect(isDefaultColor(grey())).toBe(true)
+    expect(isDefaultColor({x: 0.805, y: 0.795, z: 0.8})).toBe(true)
+  })
+
+  it('rejects authored colors, alpha-independent', () => {
+    expect(isDefaultColor({x: 0.6, y: 0.576, z: 0.749})).toBe(false)
+    expect(isDefaultColor({x: 1, y: 0.5, z: 0})).toBe(false)
+    // Same grey RGB but translucent is still "unstyled" — alpha ignored.
+    expect(isDefaultColor({x: 0.8, y: 0.8, z: 0.8, w: 0.3})).toBe(true)
+  })
+})
+
+
+describe('applyProductPalette', () => {
+  it('repaints a fully-grey multi-product model, buffer and restore table', () => {
+    const colors = [grey(), grey(), grey()]
+    const parents = [10, 20, 10]
+    const batch = fakeBatch(colors, parents)
+
+    expect(applyProductPalette([batch])).toBe(true)
+
+    // Restore table now carries palette colors, no longer grey.
+    for (const c of colors) {
+      expect(isDefaultColor(c)).toBe(false)
+    }
+    // Live buffer got the same colors (setColorAt called per instance).
+    expect(batch.painted.size).toBe(3)
+    for (let i = 0; i < 3; i++) {
+      expect(batch.painted.get(i)).toEqual(colors[i])
+    }
+    // Same product -> same color; different product -> (here) different.
+    expect(colors[0]).toEqual(colors[2])
+    expect(colors[0]).not.toEqual(colors[1])
+  })
+
+  it('keys by product across batches (opaque + transparent split)', () => {
+    // Product 10 appears in both batches; product 20 only in the opaque one,
+    // so the model has two distinct products and the palette fires.
+    const opaque = fakeBatch([grey(), grey()], [10, 20])
+    const transparent = fakeBatch([grey()], [10])
+    expect(applyProductPalette([opaque, transparent])).toBe(true)
+    // Product 10 gets one deterministic color in either batch.
+    expect(opaque.instanceColors[0]).toEqual(transparent.instanceColors[0])
+    // Product 20 is a different product -> a different color.
+    expect(opaque.instanceColors[1]).not.toEqual(opaque.instanceColors[0])
+  })
+
+  it('preserves per-instance alpha', () => {
+    const colors = [{x: 0.8, y: 0.8, z: 0.8, w: 0.25}, grey()]
+    const batch = fakeBatch(colors, [1, 2])
+    expect(applyProductPalette([batch])).toBe(true)
+    expect(colors[0].w).toBe(0.25)
+    expect(colors[1].w).toBe(1)
+  })
+
+  it('is a no-op when any real color is present (mixed model honored)', () => {
+    const colors = [grey(), {x: 1, y: 0.5, z: 0}]
+    const parents = [1, 2]
+    const batch = fakeBatch(colors, parents)
+    expect(applyProductPalette([batch])).toBe(false)
+    // Grey sibling stays grey — presentation intent honored.
+    expect(isDefaultColor(colors[0])).toBe(true)
+    expect(batch.painted.size).toBe(0)
+  })
+
+  it('is a no-op for a single-product colorless model', () => {
+    const batch = fakeBatch([grey(), grey()], [7, 7])
+    expect(applyProductPalette([batch])).toBe(false)
+    expect(batch.painted.size).toBe(0)
+  })
+
+  it('bails when a batch lacks color/parent tables', () => {
+    const noop = () => {/* recording not needed: this batch must be rejected */}
+    const batch = {instanceColors: null, instanceParents: null, mesh: {setColorAt: noop}}
+    expect(applyProductPalette([batch])).toBe(false)
+  })
+})


### PR DESCRIPTION
## What

Colorless multi-part STEP/CAD models now render with a distinct color per **part** instead of a uniform grey blob — the way Onshape (and most MCAD viewers) auto-assign an appearance per component on import.

Motivating case: the GrabCAD **Jetenginestep** model. It's an AP203 `CONFIG_CONTROL_DESIGN` export containing pure geometry + assembly structure and **zero** presentation entities (grepped: 0 × `COLOUR_RGB`, 0 × `STYLED_ITEM`, no materials). AP203e1 can't even encode appearance, so the colors seen in Onshape are Onshape's own default per-component scheme, not data in the file. Conway correctly hands every placement the same fallback grey; this gives the viewer the same fallback Onshape has.

## How

- **`productPalette.js`** (new, pure): a curated 16-color palette + `hashKey` (FNV-1a) → `productPaletteRgb(key)`, plus `isDefaultColor` and `applyProductPalette(batches)`.
- **Keyed by geometry (part), not occurrence.** A STEP assembly instances one part definition many times; each instance is a distinct NAUO occurrence with its own product express id but shares the ONE geometry buffer the part was defined with. Probing the jet's FlatMesh stream: **147 occurrences → 9 distinct `geometryExpressID`s** (every turbine blade is geometry `271914`). So the palette keys by `instanceGeometryIds` — all instances of a part get one color, a different part (the shaft, the casing) its own — falling back to the occurrence id only if a batch lacks the geometry table. (`hashKey` also takes a string, so a future by-name key is a one-line change.)
- **Detection is whole-model and conservative**: fires *only* when every instance across every batch is the fallback grey. The instant any real color is present — an IFC material, a colored STEP part, even one — the file has presentation intent, so we honor it and skip the palette (colorless siblings in a mixed model stay grey, as today).
- **Wired at `assembleBatchedModel`**, the single chokepoint both batched paths (incremental streaming + `?feature=batchedMesh`) funnel through, *before* the pick-table stamp so the `instanceColors` restore table `batchedHighlight` reads already carries the palette color — selection/hover restore, isolate, and batched→merged export all follow. Original per-instance alpha preserved.
- **Feature flag `autoColorParts`, default-on** (only changes models that had zero color).

## Tests

- `productPalette.test.js` — hash determinism / range / spread, palette membership, no entry is grey, default-grey epsilon; and `applyProductPalette`: **colors by geometry so instances of one part share a color**, parent-id fallback when no geometry table, buffer + restore-table repaint, cross-batch keying, alpha preservation, no-op on any real color (mixed model), no-op single-part, bail on missing tables.
- `buildBatchedConwayModel.test.js` — integration through a **real** `THREE.BatchedMesh` + `flatMeshToBatchedModel` + `assembleBatchedModel`, colors read back via `getColorAt`: **three blade occurrences sharing geometry get one color, the shaft another**; repaint on/off; honors a real color in a mixed model.
- Full `viewer/ifc` suite (187) green; precommit gate passed.

## Known nuance

Colors are a hash into 16 slots, so two unrelated parts can occasionally collide on the same color (birthday-paradox; ~2 collisions across the jet's 9 parts). Instanced parts are always internally consistent — this only ever affects whether two *different* parts happen to match. A collision-free variant (dense-index the distinct parts, or a larger palette) is a small follow-up if desired.

## Scope

Covers the batched render paths (the jet's actual path). The rare merged-geometry fallback (`buildConwayIfcModel`, used only if batched assembly throws) is not palettized. Independent of the conway release bump #1618; based on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J3A79iKimn7UheESvnumj7