### PR TITLE
Cut aggregate geometry correctly: conway 1.436.1311 bump + drop coincident duplicate placements

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@babel/plugin-syntax-import-assertions": "7.18.6",
     "@babel/preset-env": "7.18.10",
     "@babel/preset-react": "7.18.6",
-    "@bldrs-ai/conway": "1.432.1305",
+    "@bldrs-ai/conway": "1.436.1311",
     "@bldrs-ai/ifclib": "5.3.3",
     "@emotion/react": "11.10.0",
     "@emotion/styled": "11.10.0",

--- a/src/viewer/ifc/ShareIfcLoader.js
+++ b/src/viewer/ifc/ShareIfcLoader.js
@@ -370,7 +370,8 @@ export default class ShareIfcLoader {
         `instances=${buildStats.instanceCount} parents=${buildStats.parentCount} ` +
         `materials=${buildStats.materialCount} ` +
         `skippedFlatMeshes=${buildStats.skippedFlatMeshes} ` +
-        `skippedPlaced=${buildStats.skippedPlacedGeometries}`)
+        `skippedPlaced=${buildStats.skippedPlacedGeometries} ` +
+        `skippedCoincident=${buildStats.skippedCoincidentPlacements ?? 0}`)
 
       return ifcModel
     } catch (err) {

--- a/src/viewer/ifc/flatMeshToBatchedModel.js
+++ b/src/viewer/ifc/flatMeshToBatchedModel.js
@@ -62,6 +62,55 @@ export const INDICES_PER_TRIANGLE = 3
 /** An instance is transparent (own blended batch) when alpha is below this. */
 export const OPAQUE_ALPHA = 1
 
+/**
+ * Quantization for coincident-placement keys: 1e4 → 0.1 mm on translation,
+ * 1e-4 on the rotation/scale terms. Fine enough that two genuinely distinct
+ * placements never collide, coarse enough that float noise in an emitted
+ * matrix can't split a true duplicate.
+ */
+const COINCIDENCE_QUANT = 1e4
+
+/** Elements in a flat 4x4 matrix. */
+const MAT4_LENGTH = 16
+
+
+/**
+ * Stable identity key for a placement: parent product + geometry + its
+ * (quantized) world transform + colour. Two placements with the same key are
+ * the SAME geometry drawn the SAME way at the SAME spot — a coincident
+ * duplicate that renders as z-fighting (two coplanar `DoubleSide` surfaces
+ * fighting per pixel, the winner flipping as the camera moves). Conway's
+ * rel-aggregates re-extraction pass replaces a cut part's geometry under its
+ * existing `geometryExpressID` but *appends* a second placement instead of
+ * replacing the first, so georeferenced aggregate models (e.g. romana/DOWA)
+ * emit hundreds of these. De-duplicating on this key drops the redundant draw;
+ * the proper fix is in the conway pass, this is the belt-and-suspenders guard.
+ *
+ * Colour is part of the identity so a genuinely distinct draw of the same
+ * shape at the same spot in a different colour (e.g. an opaque solid plus a
+ * glass overlay) is kept — only an EXACT duplicate is dropped.
+ *
+ * @param {number} parentExpressId
+ * @param {number} geometryExpressId
+ * @param {Array<number>} matrix 16-element flatTransformation
+ * @param {{x: number, y: number, z: number, w: number}} color
+ * @return {string}
+ */
+export function coincidenceKey(parentExpressId, geometryExpressId, matrix, color) {
+  // `| 0` collapses -0 and +0 to the same token so a signed-zero component
+  // can't split a duplicate.
+  let key = `${parentExpressId}:${geometryExpressId}`
+  for (let i = 0; i < MAT4_LENGTH; i++) {
+    key += `:${Math.round(matrix[i] * COINCIDENCE_QUANT) | 0}`
+  }
+  const c = color ?? DEFAULT_COLOR
+  key += `:${Math.round(c.x * COINCIDENCE_QUANT) | 0}` +
+    `:${Math.round(c.y * COINCIDENCE_QUANT) | 0}` +
+    `:${Math.round(c.z * COINCIDENCE_QUANT) | 0}` +
+    `:${Math.round(c.w * COINCIDENCE_QUANT) | 0}`
+  return key
+}
+
 
 /**
  * @typedef {object} BatchHandle
@@ -147,9 +196,10 @@ export function localGeometry(rawVerts, rawIndices, vertCount) {
 function collectGroups(flatMeshes, api, modelID) {
   const groups = new Map()
   const bad = new Set() // geomExpressIDs that resolved to no usable geometry
+  const seen = new Set() // coincidenceKeys already placed (drop exact overlaps)
   const totals = {
     placements: 0, transparentPlacements: 0, vertexCount: 0, indexCount: 0,
-    skippedFlatMeshes: 0, skippedPlacedGeometries: 0,
+    skippedFlatMeshes: 0, skippedPlacedGeometries: 0, skippedCoincidentPlacements: 0,
   }
   let occurrenceId = 0 // global, emission order — shared across both batches
   forEachVectorItem(flatMeshes, (flatMesh) => {
@@ -212,6 +262,14 @@ function collectGroups(flatMeshes, api, modelID) {
         totals.indexCount += indexSize
       }
       const color = placed.color ?? DEFAULT_COLOR
+      // Drop an exact coincident duplicate (same part + geometry + transform +
+      // colour): it would z-fight the one already placed. See coincidenceKey.
+      const dedupKey = coincidenceKey(parentExpressId, geomExpressID, placed.flatTransformation, color)
+      if (seen.has(dedupKey)) {
+        totals.skippedCoincidentPlacements++
+        return
+      }
+      seen.add(dedupKey)
       group.placements.push({
         matrix: placed.flatTransformation,
         color,
@@ -347,6 +405,7 @@ export function flatMeshToBatchedModel(flatMeshes, api, modelID) {
       transparentInstanceCount: totals.transparentPlacements,
       skippedFlatMeshes: totals.skippedFlatMeshes,
       skippedPlacedGeometries: totals.skippedPlacedGeometries,
+      skippedCoincidentPlacements: totals.skippedCoincidentPlacements,
     },
   }
 }

--- a/src/viewer/ifc/flatMeshToBatchedModel.test.js
+++ b/src/viewer/ifc/flatMeshToBatchedModel.test.js
@@ -65,7 +65,14 @@ describe('viewer/ifc/flatMeshToBatchedModel', () => {
       expressID: 100,
       geometries: {
         size: () => 3,
-        get: () => ({geometryExpressID: 999, flatTransformation: IDENTITY_MAT, color: OPAQUE}),
+        // Three real instances of the shared shape at DISTINCT transforms
+        // (translated along x). Distinct so the coincident-duplicate guard
+        // doesn't (correctly) fold them into one — see the dedup test below.
+        get: (where) => ({
+          geometryExpressID: 999,
+          flatTransformation: [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, where, 0, 0, 1],
+          color: OPAQUE,
+        }),
       },
     }]
     const {batches, stats} = flatMeshToBatchedModel(flatMeshes, unitTriApi(), 0)
@@ -135,6 +142,38 @@ describe('viewer/ifc/flatMeshToBatchedModel', () => {
     expect(stats.skippedPlacedGeometries).toBe(2) // each bad placement counted
     // GetGeometry called once for 999 + once for 777 (not twice) = 2.
     expect(getGeometryCalls).toBe(2)
+  })
+
+  it('drops exact coincident duplicate placements (same part+geometry+transform+colour)', () => {
+    // Conway's rel-aggregates re-extraction appends a second placement of a
+    // cut part instead of replacing it → the same solid drawn twice at the
+    // same spot → z-fighting. The builder must keep only one.
+    const flatMeshes = [{
+      expressID: 100,
+      geometries: [
+        {geometryExpressID: 999, flatTransformation: IDENTITY_MAT, color: OPAQUE},
+        {geometryExpressID: 999, flatTransformation: IDENTITY_MAT, color: OPAQUE}, // exact dup
+      ],
+    }]
+    const {batches, stats} = flatMeshToBatchedModel(flatMeshes, unitTriApi(), 0)
+    expect(stats.instanceCount).toBe(1)
+    expect(stats.skippedCoincidentPlacements).toBe(1)
+    expect(Array.from(batches[0].instanceParents)).toEqual([100])
+  })
+
+  it('keeps coincident placements that differ in transform or colour', () => {
+    const moved = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 5, 0, 0, 1] // same shape, +5 on x
+    const flatMeshes = [{
+      expressID: 100,
+      geometries: [
+        {geometryExpressID: 999, flatTransformation: IDENTITY_MAT, color: OPAQUE},
+        {geometryExpressID: 999, flatTransformation: moved, color: OPAQUE}, // different transform
+        {geometryExpressID: 999, flatTransformation: IDENTITY_MAT, color: GLASS}, // different colour
+      ],
+    }]
+    const {stats} = flatMeshToBatchedModel(flatMeshes, unitTriApi(), 0)
+    expect(stats.instanceCount).toBe(3)
+    expect(stats.skippedCoincidentPlacements).toBe(0)
   })
 
   it('skips FlatMeshes without an expressID', () => {

--- a/src/viewer/ifc/incrementalBatchedBuilder.js
+++ b/src/viewer/ifc/incrementalBatchedBuilder.js
@@ -6,6 +6,7 @@ import {
   INDICES_PER_TRIANGLE,
   OPAQUE_ALPHA,
   VERT_STRIDE,
+  coincidenceKey,
   localGeometry,
 } from './flatMeshToBatchedModel'
 
@@ -71,13 +72,16 @@ export class IncrementalBatchedBuilder {
     // Conway exactly once per model.
     this.geometryCache = new Map()
     this.badGeometry = new Set()
+    // coincidenceKeys already appended, across all batches — drops exact
+    // duplicate placements that would z-fight (see coincidenceKey).
+    this.seenPlacements = new Set()
     // Lazily created per transparency: see ensureBatch_.
     this.opaque = null
     this.transparent = null
     this.occurrenceId = 0
     this.totals = {
       placements: 0, transparentPlacements: 0, vertexCount: 0, indexCount: 0,
-      skippedFlatMeshes: 0, skippedPlacedGeometries: 0,
+      skippedFlatMeshes: 0, skippedPlacedGeometries: 0, skippedCoincidentPlacements: 0,
     }
     this.scratchMatrix = new Matrix4()
     this.scratchRgba = new Vector4()
@@ -165,6 +169,7 @@ export class IncrementalBatchedBuilder {
         transparentInstanceCount: this.totals.transparentPlacements,
         skippedFlatMeshes: this.totals.skippedFlatMeshes,
         skippedPlacedGeometries: this.totals.skippedPlacedGeometries,
+        skippedCoincidentPlacements: this.totals.skippedCoincidentPlacements,
       },
     }
   }
@@ -188,6 +193,14 @@ export class IncrementalBatchedBuilder {
       return
     }
     const color = placed.color ?? DEFAULT_COLOR
+    // Drop an exact coincident duplicate (same part + geometry + transform +
+    // colour): it would z-fight the one already appended. See coincidenceKey.
+    const dedupKey = coincidenceKey(parentExpressId, geomExpressID, placed.flatTransformation, color)
+    if (this.seenPlacements.has(dedupKey)) {
+      this.totals.skippedCoincidentPlacements++
+      return
+    }
+    this.seenPlacements.add(dedupKey)
     const isTransparent = color.w < OPAQUE_ALPHA
     const state = this.ensureBatch_(isTransparent)
     this.ensureCapacity_(state, entry)

--- a/src/viewer/ifc/incrementalBatchedBuilder.test.js
+++ b/src/viewer/ifc/incrementalBatchedBuilder.test.js
@@ -112,6 +112,34 @@ describe('IncrementalBatchedBuilder', () => {
     expect(batches[0].instanceParents).toHaveLength(10)
   })
 
+  it('drops an exact coincident duplicate that arrives in a later delta batch', () => {
+    // The demand pump can re-emit the same placement in a later batch
+    // (conway's rel-aggregates re-extraction). Across batches, the coincident
+    // duplicate must be dropped, not drawn twice (z-fighting).
+    const builder = new IncrementalBatchedBuilder(makeApi(shapes), 0)
+    builder.appendBatch([flatMesh(1, [{geomExpressID: 999, color: OPAQUE}])])
+    builder.appendBatch([flatMesh(1, [{geomExpressID: 999, color: OPAQUE}])]) // exact dup
+    const {stats, batches} = builder.finalize()
+    expect(stats.instanceCount).toBe(1)
+    expect(stats.skippedCoincidentPlacements).toBe(1)
+    expect(batches[0].instanceParents).toHaveLength(1)
+  })
+
+  it('keeps same-shape placements that differ in transform', () => {
+    const moved = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 5, 0, 0, 1]
+    const builder = new IncrementalBatchedBuilder(makeApi(shapes), 0)
+    builder.appendBatch([{
+      expressID: 1,
+      geometries: [
+        {geometryExpressID: 999, flatTransformation: IDENTITY_MAT, color: OPAQUE},
+        {geometryExpressID: 999, flatTransformation: moved, color: OPAQUE},
+      ],
+    }])
+    const {stats} = builder.finalize()
+    expect(stats.instanceCount).toBe(2)
+    expect(stats.skippedCoincidentPlacements).toBe(0)
+  })
+
   it('reports bounds per appended instance and skips bad geometry', () => {
     const boxes = []
     const builder = new IncrementalBatchedBuilder(makeApi(shapes), 0, {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2473,10 +2473,10 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@bldrs-ai/conway@1.432.1305":
-  version "1.432.1305"
-  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.432.1305.tgz#2e55afe3449a9fc2c5730058fd7479dc535eb4e5"
-  integrity sha512-Xnl6uDQQta7Lsgs/umL2f4TBRcyBVGwUdZ9X1JJxwPZfTYnE4hyWH+vQahinwguq5QKdmImTho0Hx+lkjSLCwA==
+"@bldrs-ai/conway@1.436.1311":
+  version "1.436.1311"
+  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.436.1311.tgz#95e32270f59c78d2a14bc22bfe1aa9e5578ab08d"
+  integrity sha512-iABrSJ0Ppxa+e+TnnuFxgG7LWoXEd7U8doVgne//74ypkIZt9DvSD8aYnduJT1+XABEzAUJfDMG/zoNbwY54+A==
   dependencies:
     gl-matrix "3.4.3"
     seedrandom "3.0.5"


### PR DESCRIPTION
## What this PR does (and doesn't)

**Does:** fixes *wrong solids* on aggregate IFCs — parts render uncut on the current pin — and removes the duplicate-draw z-fighting the newer engine introduces. Two halves, both needed:

- **`main` pins conway 1.432.1305:** the demand pump never runs the rel-aggregates / master-voids cutting pass → aggregate parts render **uncut** (`388_4 (EDITED).ifc`: 792 placements, wrong shapes).
- **1.436.1311 cuts correctly** — but the pass replaces the geometry under an existing `geometryExpressID` while **appending a second placement instead of replacing the first**, so every cut part is drawn twice at the identical transform (1135 placements, **343 coincident duplicates**) → coplanar `DoubleSide` z-fighting.

So: **bump to 1.436.1311** (cut) + **drop exact coincident duplicate placements** in both batched builders (drawn once). `coincidenceKey(parent, geometryExpressID, quantized transform, colour)` in `flatMeshToBatchedModel.collectGroups` and `IncrementalBatchedBuilder` (across delta batches). Colour is part of the identity, so a genuine distinct draw of the same shape in a different colour (opaque + glass overlay) is kept — only an *exact* duplicate is dropped. `skippedCoincidentPlacements` surfaced in stats + the `[conwayDirect]` log line. The engine-side fix (re-extraction should *replace*, not append) is tracked in #1635; this guard is a permanent invariant regardless of engine version.

**Does NOT fix (and was originally mis-scoped as):** the rotation jitter/tearing on georeferenced models. This PR was opened when the duplicate z-fighting was the leading theory for that — the body previously claimed "looks like float32 precision jitter; it isn't." **That was wrong.** The jitter was precisely LV95 coordinates + float32 precision: the browser streamed open returns raw ~8.3×10⁶ m placements, where float32 resolves to ~1 m. Fixed in **#1631** (origin recenter). Full story: retrospective **#1632**; this PR is tracked there by **#1636**.

## Note on ILNA (added after ILNA facade investigation)

Measurements on `ILNA 3D_SIA2040_optimized.ifc` confirm this PR is a **strict improvement but not a complete fix** for demand-path aggregate models:

| conway | path | placements | triangles |
|---|---|---|---|
| 1.432 (prod) | classic | 37,667 | 4,096,277 |
| 1.432 (prod) | demand | 28,637 | 2,704,552 (−34%) |
| **1.436 (this PR)** | demand | **37,667** ✅ | 3,287,759 (−20%) |

The bump restores the 9,030 placements the 1.432 demand pump drops (the visible facade improvement vs prod). The remaining −20% is an **engine bug**: 2,047 facade parts (`IfcBuildingElementPart`/`IfcColumn`) are delivered with their shared geometry content empty/truncated (probe: gid 1324977 = 10,619 tris classic, 0 at demand delivery, same build). Not addressable in Share — tracked in **#1640**. Until that lands, `?feature=disableStreamOpen` renders ILNA fully via the classic path.

## Current state

Rebased on post-#1631 main (merge `b6842538`) — the two features compose in the same builders: dedup keys on the **raw** transform (duplicates are bit-identical pre-recenter), then the recenter offset applies to survivors.

## Verification

- Combined, on the `388_4` raw demand stream, conway 1.436.1311: **792 instances, 343 coincident duplicates dropped, recenter offset applied**.
- Unit tests on both builders (exact dup dropped + counted; distinct transform/colour kept; cross-batch delta dedup) — 32/32 builder tests, full `src/viewer/ifc` suite, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S6gTXmrq1GbhqknPqQMRuz