### PR TITLE
Collision-free part colors: dense-index the palette instead of hashing

### DIFF
--- a/src/FeatureFlags.js
+++ b/src/FeatureFlags.js
@@ -105,14 +105,15 @@ export const flags = [
   // follow-ups. Flip on via `?feature=batchedMesh`.
   // Design: design/new/viewer-replacement.md §3b.iv.
   {name: 'batchedMesh', isActive: false},
-  // Synthetic per-product coloring for STEP/CAD models that carry no
+  // Synthetic per-part coloring for STEP/CAD models that carry no
   // presentation data. When a batched model comes back entirely
   // default-grey (no COLOUR_RGB / STYLED_ITEM, e.g. the Jetenginestep
-  // AP203 export), each product is repainted from a curated palette by a
-  // deterministic hash of its express id — Onshape-style, so a multi-part
-  // assembly is legible instead of a grey blob. Strictly no-op the moment
-  // any real color is present, so IFC and colored STEP are untouched.
-  // Default-on; it only changes models that had zero color to begin with.
+  // AP203 export), each part is repainted from a curated palette (colors
+  // assigned by dense index over the sorted distinct parts, so ≤ palette
+  // -size parts never collide) — Onshape-style, so a multi-part assembly is
+  // legible instead of a grey blob. Strictly no-op the moment any real
+  // color is present, so IFC and colored STEP are untouched. Default-on; it
+  // only changes models that had zero color to begin with.
   // See src/viewer/ifc/productPalette.js.
   {name: 'autoColorParts', isActive: true},
 ]

--- a/src/viewer/ifc/buildBatchedConwayModel.test.js
+++ b/src/viewer/ifc/buildBatchedConwayModel.test.js
@@ -6,7 +6,7 @@
 
 import {Color} from 'three'
 import {flatMeshToBatchedModel, DEFAULT_COLOR} from './flatMeshToBatchedModel'
-import {isDefaultColor, productPaletteRgb} from './productPalette'
+import {PRODUCT_PALETTE, isDefaultColor} from './productPalette'
 import {assembleBatchedModel} from './buildBatchedConwayModel'
 
 
@@ -110,8 +110,9 @@ describe('viewer/ifc/assembleBatchedModel colorless palette', () => {
     // Restore table (`batchedHighlight` reads it to un-highlight) carries
     // the exact palette color the buffer was painted with — keyed by the
     // part's geometry id (998 for product 100), not the occurrence id.
+    // Dense index over sorted parts [998, 999] -> 998 is palette slot 0.
     const restore100 = mesh.instanceColors[mesh.instanceParents.indexOf(100)]
-    const expected100 = productPaletteRgb(998)
+    const expected100 = PRODUCT_PALETTE[0]
     expect(restore100).toMatchObject({x: expected100.x, y: expected100.y, z: expected100.z, w: 1})
     expect(c100.x).toBeCloseTo(expected100.x, 5)
   })

--- a/src/viewer/ifc/productPalette.js
+++ b/src/viewer/ifc/productPalette.js
@@ -12,8 +12,8 @@ import {DEFAULT_COLOR} from './flatMeshToBatchedModel'
  * placement the same fallback grey (`DEFAULT_COLOR`) and the whole model
  * renders monochrome. Onshape (and most MCAD viewers) instead auto-assign a
  * distinct appearance per component on import; this reproduces that: when a
- * model comes back with NO color information, give each product a stable
- * color drawn from a curated palette by a deterministic hash of its key.
+ * model comes back with NO color information, give each part a color from a
+ * curated palette.
  *
  * Deliberately a display-only fallback, not a parse feature — it fires ONLY
  * when the model is entirely default-grey. Any real color (an IFC material,
@@ -23,14 +23,22 @@ import {DEFAULT_COLOR} from './flatMeshToBatchedModel'
  *
  * Keyed by the placement's GEOMETRY express id, not its product/occurrence
  * id. A STEP assembly instances one part definition many times (e.g. the
- * jet's ~130 turbine + compressor blades), and each instance is a distinct
+ * jet's ~140 turbine + compressor blades), and each instance is a distinct
  * NAUO occurrence with its own product express id but shares the ONE
  * geometry buffer the part was defined with (147 occurrences → 9 distinct
  * geometries on Jetenginestep). Coloring by occurrence gives every blade a
  * different color; coloring by geometry gives all instances of a part one
  * color and a different part (the shaft, the casing) its own — which is
- * what "color by product" means to a viewer. `hashKey` also takes a string,
- * so a future by-name key is a one-line change at the call site.
+ * what "color by product" means to a viewer.
+ *
+ * Colors are assigned by DENSE INDEX over the model's sorted distinct parts,
+ * not by hashing each key independently — so as long as a model has ≤ palette
+ * -size parts, every part gets a different color (a per-key hash collided 3
+ * of the jet's 9 parts into 6 colors). The tradeoff is that a part's color
+ * depends on the whole part set, but the set is fixed per file, so colors are
+ * stable across reloads of the same model. Beyond palette size the index
+ * wraps (unavoidable with a finite palette); only parts a full palette apart
+ * in sort order then share a color.
  */
 
 
@@ -68,35 +76,26 @@ const DEFAULT_COLOR_EPSILON = 0.02
 
 
 /**
- * Deterministic 32-bit FNV-1a hash of a key's string form. Stable across
- * runs and platforms (integer math only), so a product maps to the same
- * palette slot every load.
+ * Assign a palette color to each distinct part key by dense index over the
+ * SORTED distinct keys, so a model with ≤ palette-size parts is collision-
+ * free (every part a different color). Deterministic: same key set → same
+ * mapping. Sort order only decides which color a part gets, not whether two
+ * parts collide.
  *
- * @param {string|number} key
- * @return {number} unsigned 32-bit hash
+ * @param {Array<string|number>} keys per-instance part keys (duplicates ok)
+ * @return {Map<string|number, {x: number, y: number, z: number}>} key → RGB
  */
-export function hashKey(key) {
-  const str = String(key)
-  /* eslint-disable no-magic-numbers */
-  let hash = 0x811c9dc5
-  for (let i = 0; i < str.length; i++) {
-    hash ^= str.charCodeAt(i)
-    // FNV prime 16777619, folded to 32 bits via Math.imul.
-    hash = Math.imul(hash, 0x01000193)
-  }
-  return hash >>> 0
-  /* eslint-enable no-magic-numbers */
-}
+export function assignPartColors(keys) {
+  const distinct = [...new Set(keys)].sort(
+    (a, b) => (a < b ? -1 : (a > b ? 1 : 0)))
 
+  const colors = new Map()
 
-/**
- * Palette RGB for a product key (its express id, or any stable string).
- *
- * @param {string|number} key
- * @return {{x: number, y: number, z: number}} RGB 0..1
- */
-export function productPaletteRgb(key) {
-  return PRODUCT_PALETTE[hashKey(key) % PRODUCT_PALETTE.length]
+  distinct.forEach((key, index) => {
+    colors.set(key, PRODUCT_PALETTE[index % PRODUCT_PALETTE.length])
+  })
+
+  return colors
 }
 
 
@@ -148,7 +147,7 @@ export function applyProductPalette(batches) {
   const keyOf = (batch, i) =>
     (batch.instanceGeometryIds ? batch.instanceGeometryIds[i] : batch.instanceParents[i])
 
-  const parts = new Set()
+  const keys = []
   for (const batch of batches) {
     const {instanceColors, instanceParents} = batch
     if (!instanceColors || !instanceParents) {
@@ -160,11 +159,14 @@ export function applyProductPalette(batches) {
       if (!isDefaultColor(instanceColors[i])) {
         return false
       }
-      parts.add(keyOf(batch, i))
+      keys.push(keyOf(batch, i))
     }
   }
 
-  if (parts.size < 2) {
+  // Dense-index the distinct parts so ≤ palette-size parts never collide.
+  const colors = assignPartColors(keys)
+
+  if (colors.size < 2) {
     return false
   }
 
@@ -174,7 +176,7 @@ export function applyProductPalette(batches) {
       continue
     }
     for (let i = 0; i < instanceColors.length; i++) {
-      const rgb = productPaletteRgb(keyOf(batch, i))
+      const rgb = colors.get(keyOf(batch, i))
       const alpha = instanceColors[i].w
       instanceColors[i] = {x: rgb.x, y: rgb.y, z: rgb.z, w: alpha}
       mesh.setColorAt(i, _rgba.set(rgb.x, rgb.y, rgb.z, alpha))

--- a/src/viewer/ifc/productPalette.test.js
+++ b/src/viewer/ifc/productPalette.test.js
@@ -2,9 +2,8 @@
 import {
   PRODUCT_PALETTE,
   applyProductPalette,
-  hashKey,
+  assignPartColors,
   isDefaultColor,
-  productPaletteRgb,
 } from './productPalette'
 import {DEFAULT_COLOR} from './flatMeshToBatchedModel'
 
@@ -38,45 +37,42 @@ function fakeBatch(instanceColors, instanceParents, instanceGeometryIds) {
 }
 
 
-describe('hashKey', () => {
-  it('is deterministic and stable across string/number forms of a key', () => {
-    expect(hashKey(42)).toBe(hashKey(42))
-    expect(hashKey(42)).toBe(hashKey('42'))
+describe('assignPartColors', () => {
+  it('is collision-free for up to palette-size parts', () => {
+    // The jet's case: 9 distinct parts must map to 9 distinct colors.
+    const keys = [18538, 18862, 38147, 130231, 234366, 270832, 271423, 271914, 273867]
+    const colors = assignPartColors(keys)
+    expect(colors.size).toBe(9)
+    expect(new Set(colors.values()).size).toBe(9)
   })
 
-  it('returns an unsigned 32-bit integer', () => {
-    for (const key of [0, 1, 999999, 'FRONTFAN', '']) {
-      const h = hashKey(key)
-      expect(Number.isInteger(h)).toBe(true)
-      expect(h).toBeGreaterThanOrEqual(0)
-      expect(h).toBeLessThanOrEqual(0xffffffff)
-    }
+  it('gives distinct colors to every part when count === palette size', () => {
+    const keys = Array.from({length: PRODUCT_PALETTE.length}, (_, i) => (i * 7) + 3)
+    const colors = assignPartColors(keys)
+    expect(new Set(colors.values()).size).toBe(PRODUCT_PALETTE.length)
   })
 
-  it('spreads distinct keys (no collision across a small product set)', () => {
-    const slots = new Set()
-    for (let id = 1; id <= PRODUCT_PALETTE.length; id++) {
-      slots.add(hashKey(id) % PRODUCT_PALETTE.length)
-    }
-    // Not a guarantee in general, but these small ids must not all collide.
-    expect(slots.size).toBeGreaterThan(1)
-  })
-})
-
-
-describe('productPaletteRgb', () => {
-  it('is deterministic per key', () => {
-    expect(productPaletteRgb(7)).toBe(productPaletteRgb(7))
+  it('is deterministic and order-independent (dedupes + sorts)', () => {
+    const a = assignPartColors([30, 10, 20, 10])
+    const b = assignPartColors([10, 20, 30])
+    expect(a.size).toBe(3)
+    expect([...a.entries()]).toEqual([...b.entries()])
   })
 
-  it('only ever returns palette members', () => {
-    for (let id = 0; id < 100; id++) {
-      expect(PRODUCT_PALETTE).toContain(productPaletteRgb(id))
-    }
+  it('wraps only beyond palette size', () => {
+    const n = PRODUCT_PALETTE.length + 1
+    const keys = Array.from({length: n}, (_, i) => i)
+    const colors = assignPartColors(keys)
+    // Part 0 and part `palette.length` (a full wrap apart) share a color;
+    // everything in between is distinct.
+    expect(colors.get(0)).toBe(colors.get(PRODUCT_PALETTE.length))
+    expect(new Set(colors.values()).size).toBe(PRODUCT_PALETTE.length)
   })
 
-  it('no palette entry is the fallback grey', () => {
-    for (const c of PRODUCT_PALETTE) {
+  it('only ever returns palette members, none the fallback grey', () => {
+    const colors = assignPartColors([5, 9, 1])
+    for (const c of colors.values()) {
+      expect(PRODUCT_PALETTE).toContain(c)
       expect(isDefaultColor(c)).toBe(false)
     }
   })


### PR DESCRIPTION
Follow-up to #1626. The auto-color feature hashed each part key independently into the 16-slot palette, so unrelated parts could collide on the same color.

## The collision was real on the jet

Probed `Jetenginestep.stp`: 9 distinct part geometries, but the per-key hash mapped them to only **6 colors** — three pairs collided:

| slot | parts |
|---|---|
| 0 | geom18538, geom271423 |
| 4 | geom18862, geom38147 |
| 15 | geom130231, geom270832 |

(Hard to notice because each colliding part is single-instance and spatially separated — the 140-instance blade geometry was never involved.)

## Fix

Assign colors by **dense index over the model's sorted distinct parts** — `part[i] → palette[i % len]` — instead of hashing each key. A model with ≤ palette-size parts is now collision-free: the jet's **9 parts → 9 distinct colors**.

- **Tradeoff**: a part's color now depends on the whole part set rather than its id alone. But the set is fixed per file, so colors stay stable across reloads of the same model.
- **Beyond palette size** the index wraps (unavoidable with a finite palette); only parts a full palette apart in sort order then share a color.
- Replaces `hashKey` / `productPaletteRgb` with `assignPartColors(keys)` (nothing else imported them).

## Tests

`assignPartColors`: collision-free for ≤ palette-size parts (incl. the jet's exact 9 geometry ids), all-distinct at exactly palette size, deterministic + order-independent (dedupes + sorts), wraps only beyond palette size, returns only palette members. Existing `applyProductPalette` + integration tests updated for the dense-index expectation. Full `viewer/ifc` suite (186) green; precommit gate passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J3A79iKimn7UheESvnumj7

---
_Generated by [Claude Code](https://claude.ai/code/session_01J3A79iKimn7UheESvnumj7)_