### PR TITLE
Recenter georeferenced models in the demand render path (fix #1614 jitter)

### DIFF
--- a/src/viewer/ifc/flatMeshToBatchedModel.js
+++ b/src/viewer/ifc/flatMeshToBatchedModel.js
@@ -62,6 +62,45 @@ export const INDICES_PER_TRIANGLE = 3
 /** An instance is transparent (own blended batch) when alpha is below this. */
 export const OPAQUE_ALPHA = 1
 
+/**
+ * Translation magnitude (metres) past which a placement is treated as
+ * georeferenced and its whole model recentered to the origin for the render.
+ *
+ * Why: Conway's `COORDINATE_TO_ORIGIN` recenters a model's geometry to the
+ * origin on the classic open, but the browser demand open (`OpenModelStreamed`,
+ * shipped default-on in #1614) hands back RAW source-world placements. Swiss
+ * LV95 and other national grids put those at ~1e6–1e7 m, where float32 (the
+ * GPU vertex + BatchedMesh instance-matrix format) resolves to ~1 m — so the
+ * whole model swims by up to a metre as the camera rotates. Subtracting a
+ * single model-wide offset brings the render back to the origin (the local
+ * geometry is only ~100 m), restoring float32 precision. Normal near-origin
+ * models never cross this threshold, so the recenter is a strict no-op for
+ * them.
+ */
+export const LARGE_COORD_THRESHOLD = 1e4
+
+
+/**
+ * The origin-recenter offset for a georeferenced placement, or null when the
+ * placement is near enough to the origin to leave untouched. Rounded to whole
+ * metres so the offset is exactly float-representable and stable across the
+ * incremental demand batches (every batch subtracts the same value).
+ *
+ * @param {Array<number>} flatTransformation 16-element column-major matrix
+ * @return {?Array<number>} `[x, y, z]` to subtract, or null
+ */
+export function coordinationOffsetFor(flatTransformation) {
+  const x = flatTransformation[12]
+  const y = flatTransformation[13]
+  const z = flatTransformation[14]
+  if (Math.abs(x) > LARGE_COORD_THRESHOLD ||
+      Math.abs(y) > LARGE_COORD_THRESHOLD ||
+      Math.abs(z) > LARGE_COORD_THRESHOLD) {
+    return [Math.round(x), Math.round(y), Math.round(z)]
+  }
+  return null
+}
+
 
 /**
  * @typedef {object} BatchHandle
@@ -150,6 +189,9 @@ function collectGroups(flatMeshes, api, modelID) {
   const totals = {
     placements: 0, transparentPlacements: 0, vertexCount: 0, indexCount: 0,
     skippedFlatMeshes: 0, skippedPlacedGeometries: 0,
+    // Origin-recenter offset for georeferenced models, decided from the first
+    // placement (see coordinationOffsetFor); null for near-origin models.
+    coordOffset: undefined,
   }
   let occurrenceId = 0 // global, emission order — shared across both batches
   forEachVectorItem(flatMeshes, (flatMesh) => {
@@ -212,6 +254,9 @@ function collectGroups(flatMeshes, api, modelID) {
         totals.indexCount += indexSize
       }
       const color = placed.color ?? DEFAULT_COLOR
+      if (totals.coordOffset === undefined) {
+        totals.coordOffset = coordinationOffsetFor(placed.flatTransformation)
+      }
       group.placements.push({
         matrix: placed.flatTransformation,
         color,
@@ -241,9 +286,11 @@ function collectGroups(flatMeshes, api, modelID) {
  *
  * @param {Map} groups geometryExpressID → group
  * @param {boolean} transparent select transparent (alpha<1) placements
+ * @param {?Array<number>} coordOffset `[x,y,z]` origin-recenter offset to
+ *   subtract from every instance matrix, or null for no recenter.
  * @return {BatchHandle|null}
  */
-function buildBatch(groups, transparent) {
+function buildBatch(groups, transparent, coordOffset) {
   // Size the batch up front: a geometry slot for each shape with a matching
   // placement, an instance slot per matching placement.
   let vertexCount = 0
@@ -285,7 +332,15 @@ function buildBatch(groups, transparent) {
     const geometryId = mesh.addGeometry(group.geometry)
     for (const placement of placements) {
       const batchId = mesh.addInstance(geometryId)
-      mesh.setMatrixAt(batchId, matrix.fromArray(placement.matrix))
+      matrix.fromArray(placement.matrix)
+      if (coordOffset !== null && coordOffset !== undefined) {
+        // Recenter a georeferenced model to the origin (see
+        // coordinationOffsetFor) so its float32 render stays precise.
+        matrix.elements[12] -= coordOffset[0]
+        matrix.elements[13] -= coordOffset[1]
+        matrix.elements[14] -= coordOffset[2]
+      }
+      mesh.setMatrixAt(batchId, matrix)
       // Vector4 carries alpha into the batch's RGBA colours texture.
       mesh.setColorAt(batchId, rgba.set(
         placement.color.x, placement.color.y, placement.color.z, placement.color.w))
@@ -322,8 +377,12 @@ function buildBatch(groups, transparent) {
  */
 export function flatMeshToBatchedModel(flatMeshes, api, modelID) {
   const {groups, totals} = collectGroups(flatMeshes, api, modelID)
+  const coordOffset = totals.coordOffset ?? null
 
-  const batches = [buildBatch(groups, false), buildBatch(groups, true)].filter(Boolean)
+  const batches = [
+    buildBatch(groups, false, coordOffset),
+    buildBatch(groups, true, coordOffset),
+  ].filter(Boolean)
 
   const parents = new Set()
   for (const batch of batches) {
@@ -348,5 +407,9 @@ export function flatMeshToBatchedModel(flatMeshes, api, modelID) {
       skippedFlatMeshes: totals.skippedFlatMeshes,
       skippedPlacedGeometries: totals.skippedPlacedGeometries,
     },
+    // `[x,y,z]` origin offset already subtracted from the batch matrices for a
+    // georeferenced model (null for near-origin models). The caller stamps it
+    // on the model root so a rendered point maps back to true world coords.
+    coordinationOffset: coordOffset,
   }
 }

--- a/src/viewer/ifc/flatMeshToBatchedModel.test.js
+++ b/src/viewer/ifc/flatMeshToBatchedModel.test.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-magic-numbers */
-import {BatchedMesh} from 'three'
+import {BatchedMesh, Matrix4} from 'three'
 import {flatMeshToBatchedModel} from './flatMeshToBatchedModel'
 
 
@@ -135,6 +135,41 @@ describe('viewer/ifc/flatMeshToBatchedModel', () => {
     expect(stats.skippedPlacedGeometries).toBe(2) // each bad placement counted
     // GetGeometry called once for 999 + once for 777 (not twice) = 2.
     expect(getGeometryCalls).toBe(2)
+  })
+
+  it('recenters a georeferenced model to the origin and reports the offset', () => {
+    // Conway's browser demand open hands back raw source-world (e.g. Swiss
+    // LV95) placements at ~1e6-1e7 m, where float32 loses ~1m — the model
+    // must be recentered or it swims on rotate. Column-major translation in
+    // elements 12/13/14.
+    const far = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 2000000.4, 5, -8000000.6, 1]
+    const flatMeshes = [{
+      expressID: 100,
+      geometries: [{geometryExpressID: 999, flatTransformation: far, color: OPAQUE}],
+    }]
+    const {batches, coordinationOffset} = flatMeshToBatchedModel(flatMeshes, unitTriApi(), 0)
+    // Offset is the rounded translation of the first placement.
+    expect(coordinationOffset).toEqual([2000000, 5, -8000001])
+    // The instance renders back near the origin (raw − offset).
+    const m = new Matrix4()
+    batches[0].mesh.getMatrixAt(0, m)
+    expect(m.elements[12]).toBeCloseTo(0.4)
+    expect(m.elements[13]).toBeCloseTo(0)
+    expect(m.elements[14]).toBeCloseTo(0.4)
+  })
+
+  it('leaves a near-origin model untouched (no recenter)', () => {
+    const near = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 12, 3, -45, 1]
+    const flatMeshes = [{
+      expressID: 100,
+      geometries: [{geometryExpressID: 999, flatTransformation: near, color: OPAQUE}],
+    }]
+    const {batches, coordinationOffset} = flatMeshToBatchedModel(flatMeshes, unitTriApi(), 0)
+    expect(coordinationOffset).toBeNull()
+    const m = new Matrix4()
+    batches[0].mesh.getMatrixAt(0, m)
+    expect(m.elements[12]).toBeCloseTo(12)
+    expect(m.elements[14]).toBeCloseTo(-45)
   })
 
   it('skips FlatMeshes without an expressID', () => {

--- a/src/viewer/ifc/flatMeshToBufferGeometry.js
+++ b/src/viewer/ifc/flatMeshToBufferGeometry.js
@@ -6,6 +6,7 @@ import {
   Matrix4,
 } from 'three'
 import {makeSurfaceColor, makeSurfaceMaterial} from '../lookMaterial'
+import {coordinationOffsetFor} from './flatMeshToBatchedModel'
 
 
 /**
@@ -165,6 +166,16 @@ export function flatMeshToBufferGeometry(flatMeshes, api, modelID) {
     }
   }
   const placedGeometryCount = entries.length
+  // Origin-recenter a georeferenced model (see coordinationOffsetFor): this
+  // merged path bakes each vertex into world space on the CPU, so a raw
+  // ~1e7 m placement would store ~1 m-quantized float32 positions and jitter
+  // on rotate. Decide one offset from the first (valid) placement and fold it
+  // into every baked translation below. Null (near-origin) → no-op.
+  const coordOffset = placedGeometryCount > 0 ?
+    coordinationOffsetFor(entries[0].placed.flatTransformation) : null
+  const offX = coordOffset ? coordOffset[0] : 0
+  const offY = coordOffset ? coordOffset[1] : 0
+  const offZ = coordOffset ? coordOffset[2] : 0
   // Bin entries by colour. Insertion order on the Map determines
   // material indices — first-seen colour becomes material 0, etc.
   // We emit triangles in this bin order so each colour's triangle
@@ -249,9 +260,10 @@ export function flatMeshToBufferGeometry(flatMeshes, api, modelID) {
       const m13 = mat4.elements[8]
       const m23 = mat4.elements[9]
       const m33 = mat4.elements[10]
-      const m14 = mat4.elements[12]
-      const m24 = mat4.elements[13]
-      const m34 = mat4.elements[14]
+      // Fold the origin-recenter offset into the baked translation.
+      const m14 = mat4.elements[12] - offX
+      const m24 = mat4.elements[13] - offY
+      const m34 = mat4.elements[14] - offZ
       const n11 = normalMat.elements[0]
       const n21 = normalMat.elements[1]
       const n31 = normalMat.elements[2]
@@ -324,5 +336,9 @@ export function flatMeshToBufferGeometry(flatMeshes, api, modelID) {
     placedGeometryCount,
     skippedFlatMeshes,
     skippedPlacedGeometries,
+    // `[x,y,z]` origin offset already folded into the baked vertices for a
+    // georeferenced model (null for near-origin), so a rendered point maps
+    // back to true world coordinates.
+    coordinationOffset: coordOffset,
   }
 }

--- a/src/viewer/ifc/flatMeshToBufferGeometry.test.js
+++ b/src/viewer/ifc/flatMeshToBufferGeometry.test.js
@@ -133,6 +133,42 @@ describe('viewer/ifc/flatMeshToBufferGeometry', () => {
     expect(Array.from(geometry.getIndex().array)).toEqual([0, 1, 2])
   })
 
+  it('recenters a georeferenced model, folding the offset into baked vertices', () => {
+    // Raw ~1e7 m (LV95) placement from the browser demand open: the baked
+    // world vertices must come back near the origin (raw − offset), or the
+    // float32 merged buffer would quantize to ~1 m and jitter on rotate.
+    const api = wireGeomFetch(makeApi({
+      999: {vertexData: unitTriangleVerts(), indexData: new Uint32Array([0, 1, 2])},
+    }))
+    const flatMeshes = [{
+      expressID: 100,
+      geometries: {
+        size: () => 1,
+        get: () => ({geometryExpressID: 999, flatTransformation: translation(2000000, 5, -8000000)}),
+      },
+    }]
+    const {geometry, coordinationOffset} = flatMeshToBufferGeometry(flatMeshes, api, 0)
+    expect(coordinationOffset).toEqual([2000000, 5, -8000000])
+    // unit-triangle vertex 0 is the local origin → bakes to exactly (0,0,0).
+    const pos = geometry.getAttribute('position')
+    expect(pos.getX(0)).toBeCloseTo(0)
+    expect(pos.getY(0)).toBeCloseTo(0)
+    expect(pos.getZ(0)).toBeCloseTo(0)
+  })
+
+  it('leaves a near-origin merged model untouched (no offset)', () => {
+    const api = wireGeomFetch(makeApi({
+      999: {vertexData: unitTriangleVerts(), indexData: new Uint32Array([0, 1, 2])},
+    }))
+    const flatMeshes = [{
+      expressID: 100,
+      geometries: {size: () => 1, get: () => ({geometryExpressID: 999, flatTransformation: translation(7, 2, -3)})},
+    }]
+    const {geometry, coordinationOffset} = flatMeshToBufferGeometry(flatMeshes, api, 0)
+    expect(coordinationOffset).toBeNull()
+    expect(geometry.getAttribute('position').getX(0)).toBeCloseTo(7)
+  })
+
   it('carries each PlacedGeometry.occurrencePath onto its range (STEP)', () => {
     // Two occurrences of one reused part-type: same parentExpressId, distinct
     // occurrence paths. The ranges must preserve each path so the downstream

--- a/src/viewer/ifc/incrementalBatchedBuilder.js
+++ b/src/viewer/ifc/incrementalBatchedBuilder.js
@@ -6,6 +6,7 @@ import {
   INDICES_PER_TRIANGLE,
   OPAQUE_ALPHA,
   VERT_STRIDE,
+  coordinationOffsetFor,
   localGeometry,
 } from './flatMeshToBatchedModel'
 
@@ -71,6 +72,10 @@ export class IncrementalBatchedBuilder {
     // Conway exactly once per model.
     this.geometryCache = new Map()
     this.badGeometry = new Set()
+    // Origin-recenter offset for georeferenced models (see
+    // coordinationOffsetFor). `undefined` until the first placement decides
+    // it; then `[x,y,z]` (subtracted from every instance) or null (no-op).
+    this.coordOffset = undefined
     // Lazily created per transparency: see ensureBatch_.
     this.opaque = null
     this.transparent = null
@@ -199,6 +204,22 @@ export class IncrementalBatchedBuilder {
     }
     const batchId = state.mesh.addInstance(geometryId)
     const matrix = this.scratchMatrix.fromArray(placed.flatTransformation)
+    // Decide the model-wide origin-recenter offset from the first placement,
+    // then subtract it from every instance so a georeferenced model renders at
+    // the origin (float32-precise) instead of at ~1e7 m. See
+    // coordinationOffsetFor. Stamped on the root for consumers that need to
+    // map a rendered point back to true world coordinates.
+    if (this.coordOffset === undefined) {
+      this.coordOffset = coordinationOffsetFor(placed.flatTransformation)
+      if (this.coordOffset !== null) {
+        this.root.userData.coordinationOffset = this.coordOffset
+      }
+    }
+    if (this.coordOffset !== null) {
+      matrix.elements[12] -= this.coordOffset[0]
+      matrix.elements[13] -= this.coordOffset[1]
+      matrix.elements[14] -= this.coordOffset[2]
+    }
     state.mesh.setMatrixAt(batchId, matrix)
     state.mesh.setColorAt(batchId, this.scratchRgba.set(color.x, color.y, color.z, color.w))
     state.instanceParents.push(parentExpressId)

--- a/src/viewer/ifc/incrementalBatchedBuilder.test.js
+++ b/src/viewer/ifc/incrementalBatchedBuilder.test.js
@@ -1,5 +1,5 @@
-
-import {BatchedMesh} from 'three'
+/* eslint-disable no-magic-numbers */
+import {BatchedMesh, Matrix4} from 'three'
 import {IncrementalBatchedBuilder} from './incrementalBatchedBuilder'
 import {flatMeshToBatchedModel} from './flatMeshToBatchedModel'
 
@@ -110,6 +110,37 @@ describe('IncrementalBatchedBuilder', () => {
     expect(stats.uniqueGeometryCount).toBe(2)
     expect(batches).toHaveLength(1)
     expect(batches[0].instanceParents).toHaveLength(10)
+  })
+
+  it('recenters a georeferenced model across batches with one shared offset', () => {
+    // The browser demand open hands back raw LV95-scale placements. The
+    // offset is decided on the first placement and every later batch subtracts
+    // the SAME value, so the model stays coherent as it streams in.
+    const far = (tx, ty, tz) => ({
+      expressID: 1,
+      geometries: [{geometryExpressID: 999, flatTransformation:
+        [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, tx, ty, tz, 1], color: OPAQUE}],
+    })
+    const builder = new IncrementalBatchedBuilder(makeApi(shapes), 0)
+    builder.appendBatch([far(2000000, 5, -8000000)]) // first: sets the offset
+    builder.appendBatch([far(2000010, 5, -8000020)]) // 10m / 20m away
+    const {batches} = builder.finalize()
+    expect(builder.root.userData.coordinationOffset).toEqual([2000000, 5, -8000000])
+    const m = new Matrix4()
+    batches[0].mesh.getMatrixAt(0, m)
+    expect(m.elements[12]).toBeCloseTo(0)
+    expect(m.elements[14]).toBeCloseTo(0)
+    batches[0].mesh.getMatrixAt(1, m) // second instance recentered by the same offset
+    expect(m.elements[12]).toBeCloseTo(10)
+    expect(m.elements[14]).toBeCloseTo(-20)
+  })
+
+  it('leaves a near-origin model untouched (no offset stamped)', () => {
+    const builder = new IncrementalBatchedBuilder(makeApi(shapes), 0)
+    builder.appendBatch([flatMesh(1, [{geomExpressID: 999, color: OPAQUE}])])
+    builder.finalize()
+    expect(builder.coordOffset).toBeNull()
+    expect(builder.root.userData.coordinationOffset).toBeUndefined()
   })
 
   it('reports bounds per appended instance and skips bad geometry', () => {


### PR DESCRIPTION
## The bug

Georeferenced IFCs (Swiss LV95, etc.) **jitter on rotate, stable on zoom** since #1614 — the whole model swims by up to a metre. Root cause, confirmed with live `[DEBUG-COORD]` logging on the deploy preview:

- The model renders at **~8.3 million metres** from the origin (`center=(1661274, 16.6, -8178659)`), with an **identity** model matrix — so the offset is baked into the geometry conway hands Share.
- Conway's **classic** open (`OpenModel`, the pre-#1614 path) honors `COORDINATE_TO_ORIGIN` and recenters to ~70 m. The **browser demand** open (`OpenModelStreamed`, default-on since #1614) does **not** — it returns raw source-world placements (`first conway flatTransform trans=(1661282.9, -15.5, -8178626.0)`).
- At ~1e7 m, **float32** — the GPU vertex format and the `BatchedMesh` instance-matrix texture — resolves to **~1 m**, so every vertex snaps to a ~1 m grid and the whole model shifts as the view rotates.

(This also explains why the depth/sort flags in #1630 did nothing — they address z-fighting, not coordinate precision.)

## The fix

Recenter Share-side, so we don't depend on the conway streamed open:

- `coordinationOffsetFor(flatTransformation)` — returns the rounded translation as an `[x,y,z]` offset when any component exceeds `LARGE_COORD_THRESHOLD` (1e4 m), else `null`.
- The **first placement** decides one whole-model offset; **every** instance matrix subtracts it — in the demand `IncrementalBatchedBuilder` (the same offset across all streamed batches) and the one-shot `flatMeshToBatchedModel`.
- Local geometry is only ~100 m, so the recentered model renders **float32-precise at the origin**.
- The offset is stamped on the model root (`userData.coordinationOffset`) and returned in `stats.coordinationOffset`, so a rendered point still maps back to true world coordinates (georeference display, notes) in float64.
- **No-op for normal near-origin models** — they never cross the threshold.

## Verification

Headless, on ISSUE_129 opened with `COORDINATE_TO_ORIGIN:false` (raw LV95 — exactly the browser demand output):

```
raw conway flatTransform trans = (1661273, 8178608, -20)
DEMAND builder (fixed):  coordinationOffset=[1661273,8178608,-20]  maxDistFromOrigin=90.2m  -> RECENTERED ✓
ONE-SHOT builder (fixed): coordinationOffset=[1661273,8178608,-20]  maxDistFromOrigin=90.2m  -> RECENTERED ✓
```

Unit tests cover: the recenter + reported offset, one shared offset applied across streamed batches, and the near-origin no-op. `yarn jest` (12/12) + lint green.

**Please test the preview on a shaking model** (ISSUE_129, 388_4) — the jitter should be gone. Supersedes the diagnostic #1630 (I'll close it; happy to keep `batchedStableSort` as a separate latent z-fighting guard if you want).

Follow-up worth filing: fix `OpenModelStreamed` in conway to honor `COORDINATE_TO_ORIGIN` like the classic open, so the engine is correct regardless of this Share-side belt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S6gTXmrq1GbhqknPqQMRuz

---
_Generated by [Claude Code](https://claude.ai/code/session_01S6gTXmrq1GbhqknPqQMRuz)_