### PR TITLE
Bump @bldrs-ai/conway to 1.438.1315: aggregate content-final demand extraction

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@babel/plugin-syntax-import-assertions": "7.18.6",
     "@babel/preset-env": "7.18.10",
     "@babel/preset-react": "7.18.6",
-    "@bldrs-ai/conway": "1.436.1311",
+    "@bldrs-ai/conway": "1.438.1315",
     "@bldrs-ai/ifclib": "5.3.3",
     "@emotion/react": "11.10.0",
     "@emotion/styled": "11.10.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2473,10 +2473,10 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@bldrs-ai/conway@1.436.1311":
-  version "1.436.1311"
-  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.436.1311.tgz#95e32270f59c78d2a14bc22bfe1aa9e5578ab08d"
-  integrity sha512-iABrSJ0Ppxa+e+TnnuFxgG7LWoXEd7U8doVgne//74ypkIZt9DvSD8aYnduJT1+XABEzAUJfDMG/zoNbwY54+A==
+"@bldrs-ai/conway@1.438.1315":
+  version "1.438.1315"
+  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.438.1315.tgz#a44e5e83ab3ddd134686315224743cde56618ce9"
+  integrity sha512-JrhG2IHvEH90HchCcLSNrfsPP+/V+IwclN/l76UR5VU9+eifxMoFHS6rD/nrkcy0Xmc/inZij/99+2bn0BXX3g==
   dependencies:
     gl-matrix "3.4.3"
     seedrandom "3.0.5"


### PR DESCRIPTION
Delivers the engine fix for #1640 / #1635 (landed in bldrs-ai/conway#438, published as 1.438.1315). The engine now extracts aggregate parts exactly once, in the rel-aggregates pass, so demand-path meshes carry final (master-cut) content at delivery and no duplicate placements are emitted. Dependency-only change (package.json + lock) on top of merged #1627.

## Verified against the published package (headless node)

| model | path | placements | triangles |
|---|---|---|---|
| ILNA (98 MB vyzn) | classic | 28,637 | 3,110,189 |
| ILNA | **demand** | **28,637** (parity) | **3,107,405** (0.09% MT boolean nondeterminism) |
| 388_4 | **demand** | **792**, `coincidentDupes=0` | 33,556 (exact classic match) |

- ILNA was the #1640 failure case: −20% triangles / whole facades (`IfcBuildingElementPart`) missing on the demand path. Now placement-parity with classic and content-final at delivery.
- ILNA placement counts drop vs the 1.436 measurements (37,667 → 28,637 on *both* paths) because the removed placements were the coincident duplicates from the append bug — same visible surface, drawn once.
- `coincidentDupes=0` on 388_4 confirms the #1635 acceptance criterion: the engine no longer emits duplicates, and #1627's dedup guard becomes the intended permanent no-op backstop.
- `?feature=disableStreamOpen` workaround for ILNA-class models is no longer needed once this lands.

Local jest note: `src/viewer` fails identically (9 suites / 99 tests, `window is not defined` — jsdom env quirk in the verification container) on main's 1.436 pin and on this branch — preexisting and environmental, not bump-related; CI is authoritative.

With this bump the #1632 retrospective chain is fully delivered: recenter (#1631) + dedup/cutting (#1627) + engine content parity (conway#438). Remaining open siblings are design follow-ups only (#1633 heuristic, #1634 coordination, #1637 near-plane).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S6gTXmrq1GbhqknPqQMRuz

---
_Generated by [Claude Code](https://claude.ai/code/session_01S6gTXmrq1GbhqknPqQMRuz)_