### PR TITLE
DIAGNOSTIC (do not merge): keepNames probe for haus.ifc z-fighting bisect

### DIFF
--- a/tools/esbuild/common.js
+++ b/tools/esbuild/common.js
@@ -50,7 +50,14 @@ export default {
   // behavior; the TODO that flagged "have had breakage without this"
   // predates the r184 upgrade and may no longer apply. Sourcemaps still
   // give debuggers readable names.
-  keepNames: false,
+  //
+  // DIAGNOSTIC (do not merge): temporarily restored to true to bisect
+  // the haus.ifc roof z-fighting that first appears at #1509 — this
+  // flip (4989a963) is one of only three flag-off changes in that PR.
+  // Compare this branch's deploy preview against prod on haus.ifc.
+  // Known cost while true: DRACO decode breaks on ?feature=glb,glbDraco
+  // cache hits (worker `__name` ReferenceError above) — gated path only.
+  keepNames: true,
   splitting: false,
   metafile: true,
   sourcemap: true,


### PR DESCRIPTION
Draft purely to mint a deploy preview — **do not merge**.

Pablo's bisect puts the haus.ifc roof soffit/rake z-fighting at #1509. That PR's pipeline is flag-gated (`?feature=glb` default off), so the candidate set is its three flag-off changes:

| commit | change | assessment |
|---|---|---|
| `4989a963` | esbuild `keepNames: true → false` | **this probe** — only affects minified builds; no `constructor.name`/`.name ===` runtime branches found in Share src or the vendored web-ifc-viewer dist, but it's the only global-effect build change |
| `eafc88a0` | Loader.js refactor (download plumbing moved, GLTF loader extracted) | moves look behavior-neutral for the flag-off IFC path; `fixupCb` survives |
| `ecb30a85` | OPFS cross-file collision fix | changes *which cached bytes* get served on collision — a wrong-model class, not a z-fight class |

This branch is current main + `keepNames: true` restored. **Test:** open `haus.ifc` on this preview vs prod on a real GPU, orbit the roof rake/soffit. Speckle gone here → `4989a963` confirmed as the introduction and we chase the actual name dependency. Speckle identical → keepNames exonerated; micro-bisect `eafc88a0` next.

Caveat while keepNames is true: DRACO decode breaks on `?feature=glb,glbDraco` cache hits (the worker `__name` issue that motivated the flip) — gated path only, irrelevant to this test.

Context: #1643 (stable opaque draw order) addresses the *mechanism class* (exactly-coplanar interfaces resolve by draw order — measured 0.0000–0.0016 mm separations at the FZK soffit/rake) and is worth keeping regardless, but per Pablo's bisect it is not what *introduced* the visible artifact at #1509.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S6gTXmrq1GbhqknPqQMRuz

---
_Generated by [Claude Code](https://claude.ai/code/session_01S6gTXmrq1GbhqknPqQMRuz)_