### PR TITLE
Probe G / fix candidate: lazy-load meshopt decoder (no eager WASM at startup)

### DIFF
--- a/src/loader/Loader.js
+++ b/src/loader/Loader.js
@@ -7,7 +7,6 @@ import {OBJLoader} from 'three/examples/jsm/loaders/OBJLoader.js'
 import {PDBLoader} from 'three/examples/jsm/loaders/PDBLoader.js'
 import {STLLoader} from 'three/examples/jsm/loaders/STLLoader.js'
 import {XYZLoader} from 'three/examples/jsm/loaders/XYZLoader.js'
-import {MeshoptDecoder} from 'meshoptimizer/decoder'
 import * as Filetype from '../Filetype'
 import {reportModelInfo} from './loadProgress'
 import {
@@ -1573,10 +1572,14 @@ function newGltfLoader() {
     loader.setDRACOLoader(dracoLoader)
   }
   if (isFeatureEnabled('glbMeshopt')) {
-    // Lazy: MeshoptDecoder.ready resolves on first await; GLTFLoader
-    // awaits it internally before decoding a buffer view tagged with
-    // EXT_meshopt_compression, so registering here is cheap.
-    loader.setMeshoptDecoder(MeshoptDecoder)
+    // Dynamic import: meshopt_decoder runs WebAssembly.validate +
+    // WebAssembly.instantiate at module scope, so a top-level import
+    // executes that on EVERY page load, feature on or off. esbuild's
+    // lazy module wrapper defers evaluation to this first import()
+    // call. Registration may land after parse starts on the very first
+    // gated load; GLTFLoader awaits decoder.ready per buffer view.
+    import('meshoptimizer/decoder')
+      .then(({MeshoptDecoder}) => loader.setMeshoptDecoder(MeshoptDecoder))
   }
   return loader
 }


### PR DESCRIPTION
Dual-purpose: bisect probe on **today's tree** and, if it works, the actual fix.

`meshopt_decoder.mjs` runs `WebAssembly.validate(detector)` + `WebAssembly.instantiate(wasm, {})` **at module scope**. Loader.js has imported it at top level since #1509's `6911c419` — meaning that init executes on every Share page load with the glb flags off, from May through today's prod. It's the only #1509 side effect that both (a) is non-gated and (b) survived into the current bundle — the single-continuous-cause candidate for the haus.ifc roof z-fighting.

This PR defers it to a dynamic `import()` inside the gated `glbMeshopt` branch (esbuild's lazy module wrapper keeps the module unevaluated until first call; registration races the very first gated parse at worst, and GLTFLoader awaits `decoder.ready` per buffer view regardless).

**Test:** haus.ifc roof rake/soffit on this preview vs prod.
- Speckle **gone** → cause confirmed; mark this PR ready and it's the fix. (Mechanism of *how* an extra eager WASM instantiate perturbs depth rendering still to be understood — GPU process memory pressure at context creation is the leading guess — but the causal line is then established at both ends of the timeline.)
- Speckle **present** → today's cause lies elsewhere; probe F (May tree) still attributes the historical introduction.

Lint clean; `src/loader/Loader.test` fails to parse identically on unmodified main in the verification container (jest transform quirk), so CI is authoritative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S6gTXmrq1GbhqknPqQMRuz

---
_Generated by [Claude Code](https://claude.ai/code/session_01S6gTXmrq1GbhqknPqQMRuz)_