### PR TITLE
Request a stencil buffer: restore 24-bit depth precision (fixes haus.ifc z-fighting)

### DIFF
--- a/src/viewer/three/context/renderer/renderer.js
+++ b/src/viewer/three/context/renderer/renderer.js
@@ -22,6 +22,13 @@ export class IfcRenderer extends IfcComponent {
       antialias: true,
       logarithmicDepthBuffer: true,
       preserveDrawingBuffer: pdbEnabled,
+      // three r163 flipped the default to false, and without a stencil
+      // ANGLE/Chrome may allocate a 16-bit depth buffer (~2.4mm depth
+      // resolution at 15m under log-depth, vs ~9µm with the packed
+      // 24-bit D24S8) — coplanar BIM interfaces (soffits, rakes,
+      // ridges) z-fight visibly. Explicit so a default change can't
+      // silently downgrade depth precision again.
+      stencil: true,
     })
     // For debugger tracing
     this.renderer.preserveDrawingBufferENABLED = pdbEnabled
@@ -73,6 +80,9 @@ export class IfcRenderer extends IfcComponent {
         antialias: true,
         logarithmicDepthBuffer: true,
         preserveDrawingBuffer: process.env.THREE_PDB_IS_ENABLED || false,
+        // Same depth-precision requirement as the main renderer above:
+        // screenshots must not z-fight where the live view doesn't.
+        stencil: true,
       })
       this.tempRenderer.localClippingEnabled = true
     }


### PR DESCRIPTION
## The mechanism, finally

**three r163 changed `WebGLRenderer`'s default from `stencil: true` to `stencil: false`. Without a stencil buffer, ANGLE/Chrome may allocate a 16-bit depth buffer instead of the packed 24-bit D24S8.** Under our log-depth config (near 0.1, far ~3000 m), D16 gives ~**2.4 mm** depth resolution at 15 m viewing distance vs ~9 µm at 24-bit. The FZK-Haus roof interfaces (soffit, rake, ridge) sit 0–1.6 µm apart — coplanar for either format, but at D16 *everything within millimetres* z-fights, which is the speckle. The fix: request `stencil: true` explicitly on both renderer constructions (main + screenshot).

## How it was found

Preview bisection (probes #1644–#1651) narrowed Pablo's deploy-preview bisect to #1509's compression commits, but every static-analysis suspect there (keepNames, eager meshopt WASM init) was disproven by clean-cache probe tests. The breakthrough came from **building the good (`eafc88a0`) and bad (`e6f13bf8`) trees locally and diffing complete runtime renderer state headless** (via a `__THREE_DEVTOOLS__` hook — stable across reruns):

| | good tree | bad tree |
|---|---|---|
| granted context `stencil` | **true** | **false** |
| renderer `outputColorSpace` | *(property absent)* | `srgb-linear` |

The absent `outputColorSpace` (added in three ~r152) is the tell: the good tree's renderer was constructed by the **vendored web-ifc-viewer's three 0.135** (stencil default *true* → D24S8), while the compression commits' dependency reshuffle flipped module resolution so the same code constructed with **three 0.184** (stencil default *false* → D16). Nobody changed renderer code in #1509 — the *default* changed underneath it via which three copy resolved.

Today's `IfcRenderer` builds with 0.184 defaults directly, so the same D16 downgrade has been live on prod ever since — one continuous mechanism from May to now, and why the artifact survived the keepNames (#1644), draw-order (#1643), and lazy-WASM (#1651) probes untouched.

## Side effects and related issues

- Memory: the stencil8 attachment is the cost (the D24 half of D24S8 is typically allocated anyway on desktop GPUs); it's what Share shipped with for years pre-#1509.
- #1637's depth-budget analysis assumed 24-bit codes; at D16 its numbers are 256× worse — this fix restores the analysis's premise. #1637 stays open for near-plane tuning proper.
- #1643 (stable opaque draw order) remains correct and worth keeping: exactly-0-separation ties (ridge miter, rafters) resolve by draw order at *any* depth precision.
- Headless couldn't show the artifact because SwiftShader grants a float depth buffer regardless — the #1632 method note strikes again.

**Test:** haus.ifc (clean cache) on this preview vs prod — roof soffit/rake should be stable here. The diagnostic probe PRs #1644–#1651 can all be closed once this confirms.

Fixes the FZK-Haus z-fighting report (bisected to #1509 by Pablo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S6gTXmrq1GbhqknPqQMRuz

---
_Generated by [Claude Code](https://claude.ai/code/session_01S6gTXmrq1GbhqknPqQMRuz)_