### PR TITLE
PROBE: z-fight A/B lab — bakeXforms / logDepth / nearMin flags (+ stencil & draw order)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bldrs",
-  "version": "1.1642.7c1f9521",
+  "version": "1.1639.4efa7182",
   "main": "src/index.jsx",
   "license": "AGPL-3.0",
   "homepage": "https://github.com/bldrs-ai/Share",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bldrs",
-  "version": "1.1639.4efa7182",
+  "version": "1.1639.163c0618",
   "main": "src/index.jsx",
   "license": "AGPL-3.0",
   "homepage": "https://github.com/bldrs-ai/Share",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bldrs",
-  "version": "1.1533.772dc90",
+  "version": "1.1642.7c1f9521",
   "main": "src/index.jsx",
   "license": "AGPL-3.0",
   "homepage": "https://github.com/bldrs-ai/Share",

--- a/src/loader/Loader.js
+++ b/src/loader/Loader.js
@@ -1,4 +1,5 @@
 import axios from 'axios'
+import {ZFIGHT_BAKE_XFORMS} from '../viewer/ifc/zfightProbe'
 import {Box3, BufferAttribute, Group, Mesh, Object3D, Vector3} from 'three'
 import {DRACOLoader} from 'three/examples/jsm/loaders/DRACOLoader.js'
 import {FBXLoader} from 'three/examples/jsm/loaders/FBXLoader.js'
@@ -177,7 +178,10 @@ export async function load(
   // Set when we swap the IFC source with a cached GLB. Drives post-parse
   // diagnostics so the user can see what the GLTF parser produced.
   let cameFromGlbCache = false
-  const wantGlb = isFeatureEnabled('glb') && isIfc
+  // Z-fight probe: a GLB cache HIT swaps to the GLB pipeline, so the
+  // batched builder (and the bakeXforms probe) would never run — and the
+  // first probe run would silently test the wrong renderer path.
+  const wantGlb = isFeatureEnabled('glb') && isIfc && !ZFIGHT_BAKE_XFORMS
   if (wantGlb) {
     glbVerbose('feature enabled')
   }

--- a/src/viewer/ifc/flatMeshToBatchedModel.js
+++ b/src/viewer/ifc/flatMeshToBatchedModel.js
@@ -377,6 +377,13 @@ function buildBatch(groups, transparent, coordOffset) {
     material.depthWrite = false
   }
   const mesh = new BatchedMesh(instanceCount, vertexCount, indexCount, material)
+  // Exactly-coplanar BIM interfaces (wall top vs roof underside, layer
+  // faces) tie on depth, so the depth test resolves by draw order. The
+  // opaque batch keeps insertion order — three's default per-frame
+  // camera-distance sort would flip the winning surface as the camera
+  // moves (visible speckle/shimmer at soffits, rakes, ridges). The
+  // transparent batch must still sort for blend correctness.
+  mesh.sortObjects = transparent
   const instanceParents = new Uint32Array(instanceCount)
   const instanceOccurrenceIds = new Uint32Array(instanceCount)
   const instanceGeometryIds = new Uint32Array(instanceCount)

--- a/src/viewer/ifc/flatMeshToBatchedModel.test.js
+++ b/src/viewer/ifc/flatMeshToBatchedModel.test.js
@@ -103,6 +103,10 @@ describe('viewer/ifc/flatMeshToBatchedModel', () => {
     expect(opaque.material.transparent).toBe(false)
     expect(transparent.material.transparent).toBe(true)
     expect(transparent.material.depthWrite).toBe(false)
+    // Coplanar-tie stability: opaque draws in insertion order (no
+    // per-frame camera sort); transparent must keep sorting for blending.
+    expect(opaque.mesh.sortObjects).toBe(false)
+    expect(transparent.mesh.sortObjects).toBe(true)
     expect(stats.transparentInstanceCount).toBe(1)
     expect(stats.materialCount).toBe(2)
     // The occurrence id space is global across both batches (emission order).

--- a/src/viewer/ifc/incrementalBatchedBuilder.js
+++ b/src/viewer/ifc/incrementalBatchedBuilder.js
@@ -327,6 +327,11 @@ export class IncrementalBatchedBuilder {
     }
     const mesh = new BatchedMesh(
       this.initialInstances, this.initialVertices, this.initialIndices, material)
+    // Exactly-coplanar BIM interfaces tie on depth and resolve by draw
+    // order: keep insertion order for the opaque batch (three's default
+    // per-frame camera sort flips the coplanar winner as the camera
+    // moves); the transparent batch must still sort for blending.
+    mesh.sortObjects = transparent
     const state = {
       mesh,
       material,

--- a/src/viewer/ifc/incrementalBatchedBuilder.js
+++ b/src/viewer/ifc/incrementalBatchedBuilder.js
@@ -91,6 +91,20 @@ export class IncrementalBatchedBuilder {
     this.scratchMatrix = new Matrix4()
     this.scratchRgba = new Vector4()
     this.scratchBox = new Box3()
+    // Z-fight probe (?bakeXforms=1): bake each placement's transform into a
+    // per-instance copy of the geometry (CPU double precision, identity
+    // instance matrix), reproducing the classic merged-path vertex math
+    // inside the batched architecture. BatchedMesh normally applies the
+    // instance matrix in the float32 vertex shader, where one ulp at
+    // world coordinates of 10-50m is 1-4µm — the same scale as coplanar
+    // BIM interface separations. Diagnostic only: defeats geometry
+    // sharing, so memory scales with instance count.
+    this.bakeTransforms = zfightProbeFlag('bakeXforms')
+    if (this.bakeTransforms) {
+      // eslint-disable-next-line no-console
+      console.log('[zfight-probe] bakeXforms=1: baking instance transforms into batch geometry')
+    }
+    this.identityMatrix = new Matrix4()
   }
 
 
@@ -208,14 +222,8 @@ export class IncrementalBatchedBuilder {
     this.seenPlacements.add(dedupKey)
     const isTransparent = color.w < OPAQUE_ALPHA
     const state = this.ensureBatch_(isTransparent)
-    this.ensureCapacity_(state, entry)
+    this.ensureCapacity_(state, entry, this.bakeTransforms)
 
-    let geometryId = entry.idByBatch.get(state)
-    if (geometryId === undefined) {
-      geometryId = state.mesh.addGeometry(entry.geometry)
-      entry.idByBatch.set(state, geometryId)
-    }
-    const batchId = state.mesh.addInstance(geometryId)
     const matrix = this.scratchMatrix.fromArray(placed.flatTransformation)
     // Decide the model-wide origin-recenter offset from the first placement,
     // then subtract it from every instance so a georeferenced model renders at
@@ -233,7 +241,23 @@ export class IncrementalBatchedBuilder {
       matrix.elements[13] -= this.coordOffset[1]
       matrix.elements[14] -= this.coordOffset[2]
     }
-    state.mesh.setMatrixAt(batchId, matrix)
+    let geometryId
+    let renderGeometry = entry.geometry
+    if (this.bakeTransforms) {
+      // Vertices go through the placement matrix once here (JS double
+      // precision) instead of per-frame in the float32 vertex shader.
+      renderGeometry = entry.geometry.clone()
+      renderGeometry.applyMatrix4(matrix)
+      geometryId = state.mesh.addGeometry(renderGeometry)
+    } else {
+      geometryId = entry.idByBatch.get(state)
+      if (geometryId === undefined) {
+        geometryId = state.mesh.addGeometry(entry.geometry)
+        entry.idByBatch.set(state, geometryId)
+      }
+    }
+    const batchId = state.mesh.addInstance(geometryId)
+    state.mesh.setMatrixAt(batchId, this.bakeTransforms ? this.identityMatrix : matrix)
     state.mesh.setColorAt(batchId, this.scratchRgba.set(color.x, color.y, color.z, color.w))
     state.instanceParents.push(parentExpressId)
     state.instanceOccurrenceIds.push(this.occurrenceId)
@@ -241,7 +265,7 @@ export class IncrementalBatchedBuilder {
     // the batched consumers can narrow selection / hide to one occurrence.
     state.instanceGeometryIds.push(geomExpressID)
     state.instanceOccurrencePaths.push(placed.occurrencePath ?? null)
-    state.instanceGeometry.push(entry.geometry)
+    state.instanceGeometry.push(renderGeometry)
     state.instanceColors.push(color)
     state.cursor++
     this.occurrenceId++
@@ -363,13 +387,16 @@ export class IncrementalBatchedBuilder {
    *
    * @param {object} state batch state
    * @param {object} entry geometry cache entry
+   * @param {boolean} [forceGeometry] account vertex/index space even when
+   *   the geometry is already in this batch (bakeXforms probe: every
+   *   instance appends its own baked copy).
    */
-  ensureCapacity_(state, entry) {
+  ensureCapacity_(state, entry, forceGeometry = false) {
     if (state.cursor + 1 > state.maxInstances) {
       state.maxInstances = Math.max(state.maxInstances * GROWTH, state.cursor + 1)
       state.mesh.setInstanceCount(state.maxInstances)
     }
-    if (entry.idByBatch.has(state)) {
+    if (!forceGeometry && entry.idByBatch.has(state)) {
       return
     }
     const needVertices = state.usedVertices + entry.vertCount
@@ -385,5 +412,20 @@ export class IncrementalBatchedBuilder {
     }
     state.usedVertices = needVertices
     state.usedIndices = needIndices
+  }
+}
+
+/**
+ * Z-fight probe URL flag (diagnostic previews only), e.g. ?bakeXforms=1.
+ * Safe under jest/node where `window` is undefined.
+ *
+ * @param {string} name query parameter name
+ * @return {boolean} true when the parameter is exactly '1'
+ */
+function zfightProbeFlag(name) {
+  try {
+    return new URLSearchParams(window.location.search).get(name) === '1'
+  } catch (e) {
+    return false
   }
 }

--- a/src/viewer/ifc/incrementalBatchedBuilder.js
+++ b/src/viewer/ifc/incrementalBatchedBuilder.js
@@ -1,6 +1,7 @@
 import {BatchedMesh, Box3, DoubleSide, Group, Matrix4, Vector4} from 'three'
 import {forEachVectorItem} from './conwayVector'
 import {makeSurfaceMaterial} from '../lookMaterial'
+import {ZFIGHT_BAKE_XFORMS} from './zfightProbe'
 import {
   DEFAULT_COLOR,
   INDICES_PER_TRIANGLE,
@@ -99,7 +100,7 @@ export class IncrementalBatchedBuilder {
     // world coordinates of 10-50m is 1-4µm — the same scale as coplanar
     // BIM interface separations. Diagnostic only: defeats geometry
     // sharing, so memory scales with instance count.
-    this.bakeTransforms = zfightProbeFlag('bakeXforms')
+    this.bakeTransforms = ZFIGHT_BAKE_XFORMS
     if (this.bakeTransforms) {
       // eslint-disable-next-line no-console
       console.log('[zfight-probe] bakeXforms=1: baking instance transforms into batch geometry')
@@ -412,20 +413,5 @@ export class IncrementalBatchedBuilder {
     }
     state.usedVertices = needVertices
     state.usedIndices = needIndices
-  }
-}
-
-/**
- * Z-fight probe URL flag (diagnostic previews only), e.g. ?bakeXforms=1.
- * Safe under jest/node where `window` is undefined.
- *
- * @param {string} name query parameter name
- * @return {boolean} true when the parameter is exactly '1'
- */
-function zfightProbeFlag(name) {
-  try {
-    return new URLSearchParams(window.location.search).get(name) === '1'
-  } catch (e) {
-    return false
   }
 }

--- a/src/viewer/ifc/incrementalBatchedBuilder.test.js
+++ b/src/viewer/ifc/incrementalBatchedBuilder.test.js
@@ -92,6 +92,10 @@ describe('IncrementalBatchedBuilder', () => {
       expect(Array.from(a.instanceParents)).toEqual(Array.from(b.instanceParents))
       expect(Array.from(a.instanceOccurrenceIds)).toEqual(Array.from(b.instanceOccurrenceIds))
       expect(a.mesh).toBeInstanceOf(BatchedMesh)
+      // Coplanar-tie stability: opaque batches draw in insertion order
+      // (no per-frame camera sort); transparent keeps sorting to blend.
+      expect(a.mesh.sortObjects).toBe(a.transparent)
+      expect(b.mesh.sortObjects).toBe(b.transparent)
     }
   })
 

--- a/src/viewer/ifc/zfightProbe.js
+++ b/src/viewer/ifc/zfightProbe.js
@@ -1,0 +1,40 @@
+/**
+ * Z-fight probe flags (diagnostic previews only — see Share PR #1654).
+ *
+ * Captured once at module evaluation, NOT at call time: the router
+ * rewrites the URL shortly after boot and strips unknown query params,
+ * so a read at model-open time (batched builder construction, camera
+ * fit) sees an empty search string and the flag silently never takes.
+ * Bundle evaluation happens on the initial page load while the user's
+ * original URL is still live.
+ */
+
+/**
+ * @param {string} name query parameter name
+ * @return {string|null} raw value, null when absent or no window (jest)
+ */
+function readParam(name) {
+  try {
+    return new URLSearchParams(window.location.search).get(name)
+  } catch (e) {
+    return null
+  }
+}
+
+/**
+ * ?bakeXforms=1 — bake placement transforms into per-instance geometry
+ * copies (CPU double precision, identity instance matrices) in the
+ * incremental batched builder. Also bypasses the GLB cache in the
+ * loader: a cache HIT would swap to the GLB pipeline and the builder
+ * (and this probe) would never run.
+ */
+export const ZFIGHT_BAKE_XFORMS = readParam('bakeXforms') === '1'
+
+/**
+ * ?nearMin=N — near-plane floor override for depth-strategy A/B tests
+ * (meaningful with ?logDepth=0). Production floor when absent/invalid.
+ */
+const PROD_NEAR_FLOOR = 0.1
+const parsedNearMin = Number(readParam('nearMin') ?? NaN)
+export const ZFIGHT_NEAR_FLOOR =
+  Number.isFinite(parsedNearMin) && parsedNearMin > 0 ? parsedNearMin : PROD_NEAR_FLOOR

--- a/src/viewer/ifc/zfightProbe.js
+++ b/src/viewer/ifc/zfightProbe.js
@@ -38,3 +38,40 @@ const PROD_NEAR_FLOOR = 0.1
 const parsedNearMin = Number(readParam('nearMin') ?? NaN)
 export const ZFIGHT_NEAR_FLOOR =
   Number.isFinite(parsedNearMin) && parsedNearMin > 0 ? parsedNearMin : PROD_NEAR_FLOOR
+
+/**
+ * ?depth16=1 — force offscreen depth renderbuffers back to
+ * DEPTH_COMPONENT16, the format three 0.135 allocated for the
+ * postprocessing composer's target (measured: the May-era stable build
+ * ran D16; the three 0.184 upgrade moved it to DEPTH_COMPONENT24).
+ * Coarse quantization makes sub-mm coplanar interfaces tie uniformly
+ * so draw order resolves them stably; D24 resolves fine enough that
+ * per-fragment log-depth rounding noise picks a random winner per
+ * pixel. Applied at module evaluation, before any GL context exists.
+ */
+export const ZFIGHT_DEPTH16 = readParam('depth16') === '1'
+if (ZFIGHT_DEPTH16) {
+  try {
+    const DEPTH_COMPONENT24 = 0x81A6
+    const DEPTH_COMPONENT16 = 0x81A5
+    const proto = WebGL2RenderingContext.prototype
+    const origSingle = proto.renderbufferStorage
+    const origMulti = proto.renderbufferStorageMultisample
+    const remap = (internalformat) => {
+      if (internalformat === DEPTH_COMPONENT24) {
+        // eslint-disable-next-line no-console
+        console.log('[zfight-probe] depth16=1: DEPTH_COMPONENT24 -> DEPTH_COMPONENT16')
+        return DEPTH_COMPONENT16
+      }
+      return internalformat
+    }
+    proto.renderbufferStorage = function(target, internalformat, width, height) {
+      return origSingle.call(this, target, remap(internalformat), width, height)
+    }
+    proto.renderbufferStorageMultisample = function(target, samples, internalformat, width, height) {
+      return origMulti.call(this, target, samples, remap(internalformat), width, height)
+    }
+  } catch (e) {
+    console.warn('[zfight-probe] depth16 patch failed', e)
+  }
+}

--- a/src/viewer/three/context/camera/controls/orbit-control.js
+++ b/src/viewer/three/context/camera/controls/orbit-control.js
@@ -78,7 +78,10 @@ export class OrbitControl extends IfcComponent {
     // far must clear the pulled-back camera (maxDistance + model radius), near
     // must stay inside the closest dolly. Without this, zooming out on a large
     // model would clip it against the old far = 2000 plane.
-    camera.near = Math.max(controls.minDistance * 0.5, 0.1)
+    // Z-fight probe (?nearMin=1): raise the near-plane floor. Only
+    // meaningful with ?logDepth=0 — conventional depth resolution scales
+    // with near (dz ~ z^2/(near*2^24)); log depth doesn't depend on it.
+    camera.near = Math.max(controls.minDistance * 0.5, nearPlaneFloor())
     camera.far = (controls.maxDistance + sphere.radius) * 1.5
     camera.updateProjectionMatrix()
 
@@ -92,3 +95,20 @@ export class OrbitControl extends IfcComponent {
   }
 }
 // # sourceMappingURL=orbit-control.js.map
+
+/**
+ * Z-fight probe (?nearMin=1): near-plane floor override for depth
+ * strategy A/B tests. Defaults to the production floor of 0.1.
+ *
+ * @return {number} minimum near-plane distance in scene units
+ */
+function nearPlaneFloor() {
+  const PROD_NEAR_FLOOR = 0.1
+  try {
+    const raw = new URLSearchParams(window.location.search).get('nearMin')
+    const parsed = raw === null ? NaN : Number(raw)
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : PROD_NEAR_FLOOR
+  } catch (e) {
+    return PROD_NEAR_FLOOR
+  }
+}

--- a/src/viewer/three/context/camera/controls/orbit-control.js
+++ b/src/viewer/three/context/camera/controls/orbit-control.js
@@ -4,6 +4,7 @@
 
 import {Box3, MathUtils, Sphere, Vector3} from 'three'
 import {IfcComponent, NavigationModes} from '../../base-types'
+import {ZFIGHT_NEAR_FLOOR} from '../../../../ifc/zfightProbe'
 import {LiteEvent} from '../../LiteEvent'
 
 
@@ -81,7 +82,8 @@ export class OrbitControl extends IfcComponent {
     // Z-fight probe (?nearMin=1): raise the near-plane floor. Only
     // meaningful with ?logDepth=0 — conventional depth resolution scales
     // with near (dz ~ z^2/(near*2^24)); log depth doesn't depend on it.
-    camera.near = Math.max(controls.minDistance * 0.5, nearPlaneFloor())
+    // Module-scope capture: the router strips the query before this runs.
+    camera.near = Math.max(controls.minDistance * 0.5, ZFIGHT_NEAR_FLOOR)
     camera.far = (controls.maxDistance + sphere.radius) * 1.5
     camera.updateProjectionMatrix()
 
@@ -95,20 +97,3 @@ export class OrbitControl extends IfcComponent {
   }
 }
 // # sourceMappingURL=orbit-control.js.map
-
-/**
- * Z-fight probe (?nearMin=1): near-plane floor override for depth
- * strategy A/B tests. Defaults to the production floor of 0.1.
- *
- * @return {number} minimum near-plane distance in scene units
- */
-function nearPlaneFloor() {
-  const PROD_NEAR_FLOOR = 0.1
-  try {
-    const raw = new URLSearchParams(window.location.search).get('nearMin')
-    const parsed = raw === null ? NaN : Number(raw)
-    return Number.isFinite(parsed) && parsed > 0 ? parsed : PROD_NEAR_FLOOR
-  } catch (e) {
-    return PROD_NEAR_FLOOR
-  }
-}

--- a/src/viewer/three/context/renderer/renderer.js
+++ b/src/viewer/three/context/renderer/renderer.js
@@ -22,6 +22,13 @@ export class IfcRenderer extends IfcComponent {
       antialias: true,
       logarithmicDepthBuffer: true,
       preserveDrawingBuffer: pdbEnabled,
+      // three r163 flipped the default to false, and without a stencil
+      // ANGLE/Chrome may allocate a 16-bit depth buffer (~2.4mm depth
+      // resolution at 15m under log-depth, vs ~9µm with the packed
+      // 24-bit D24S8) — coplanar BIM interfaces (soffits, rakes,
+      // ridges) z-fight visibly. Explicit so a default change can't
+      // silently downgrade depth precision again.
+      stencil: true,
     })
     // For debugger tracing
     this.renderer.preserveDrawingBufferENABLED = pdbEnabled
@@ -73,6 +80,9 @@ export class IfcRenderer extends IfcComponent {
         antialias: true,
         logarithmicDepthBuffer: true,
         preserveDrawingBuffer: process.env.THREE_PDB_IS_ENABLED || false,
+        // Same depth-precision requirement as the main renderer above:
+        // screenshots must not z-fight where the live view doesn't.
+        stencil: true,
       })
       this.tempRenderer.localClippingEnabled = true
     }

--- a/src/viewer/three/context/renderer/renderer.js
+++ b/src/viewer/three/context/renderer/renderer.js
@@ -32,6 +32,17 @@ export class IfcRenderer extends IfcComponent {
     })
     // For debugger tracing
     this.renderer.preserveDrawingBufferENABLED = pdbEnabled
+    // Z-fight probe: report the depth/stencil format the driver actually
+    // granted, so real-GPU preview tests can read it from the console.
+    try {
+      const gl = this.renderer.getContext()
+      console.log('[zfight-probe] depthBits=', gl.getParameter(gl.DEPTH_BITS),
+        'stencilBits=', gl.getParameter(gl.STENCIL_BITS),
+        'samples=', gl.getParameter(gl.SAMPLES),
+        'contextAttributes=', JSON.stringify(gl.getContextAttributes()))
+    } catch (e) {
+      console.warn('[zfight-probe] context query failed', e)
+    }
     this.renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2))
     this.setupRenderers()
     this.postProduction = new Postproduction(this.context, this.renderer)

--- a/src/viewer/three/context/renderer/renderer.js
+++ b/src/viewer/three/context/renderer/renderer.js
@@ -20,14 +20,12 @@ export class IfcRenderer extends IfcComponent {
     this.renderer = new WebGLRenderer({
       alpha: true,
       antialias: true,
-      logarithmicDepthBuffer: true,
+      logarithmicDepthBuffer: logDepthEnabled(),
       preserveDrawingBuffer: pdbEnabled,
-      // three r163 flipped the default to false, and without a stencil
-      // ANGLE/Chrome may allocate a 16-bit depth buffer (~2.4mm depth
-      // resolution at 15m under log-depth, vs ~9µm with the packed
-      // 24-bit D24S8) — coplanar BIM interfaces (soffits, rakes,
-      // ridges) z-fight visibly. Explicit so a default change can't
-      // silently downgrade depth precision again.
+      // Probe leftover: measurement on a real GPU showed Chrome grants
+      // 24-bit depth with or without stencil, so this is precision-
+      // neutral (theory falsified — see Share#1653). Kept on this
+      // diagnostic branch for A/B continuity only.
       stencil: true,
     })
     // For debugger tracing
@@ -39,6 +37,7 @@ export class IfcRenderer extends IfcComponent {
       console.log('[zfight-probe] depthBits=', gl.getParameter(gl.DEPTH_BITS),
         'stencilBits=', gl.getParameter(gl.STENCIL_BITS),
         'samples=', gl.getParameter(gl.SAMPLES),
+        'logDepth=', this.renderer.capabilities.logarithmicDepthBuffer,
         'contextAttributes=', JSON.stringify(gl.getContextAttributes()))
     } catch (e) {
       console.warn('[zfight-probe] context query failed', e)
@@ -89,7 +88,7 @@ export class IfcRenderer extends IfcComponent {
       this.tempRenderer = new WebGLRenderer({
         canvas: tempCanvas,
         antialias: true,
-        logarithmicDepthBuffer: true,
+        logarithmicDepthBuffer: logDepthEnabled(),
         preserveDrawingBuffer: process.env.THREE_PDB_IS_ENABLED || false,
         // Same depth-precision requirement as the main renderer above:
         // screenshots must not z-fight where the live view doesn't.
@@ -122,3 +121,18 @@ export class IfcRenderer extends IfcComponent {
   }
 }
 // # sourceMappingURL=renderer.js.map
+
+/**
+ * Z-fight probe (?logDepth=0): disable the logarithmic depth buffer so
+ * alternative depth strategies can be A/B tested on a live preview.
+ * Defaults to enabled — the production configuration.
+ *
+ * @return {boolean} whether the logarithmic depth buffer is enabled
+ */
+function logDepthEnabled() {
+  try {
+    return new URLSearchParams(window.location.search).get('logDepth') !== '0'
+  } catch (e) {
+    return true
+  }
+}


### PR DESCRIPTION
**Diagnostic probe — do not merge.** Updated after the depth-format theory was falsified by Pablo's real-GPU measurement (prod already grants `depthBits 24` without stencil) and this preview still fought with stencil + stable draw order combined.

This round adds URL-flag A/B toggles — all renderer-side, none alter authored geometry:

| Flag | What it tests |
|---|---|
| `?bakeXforms=1` | Bakes each placement transform into a per-instance geometry copy (CPU double precision, identity instance matrices) in the incremental batched builder — reproducing the classic merged-path vertex math inside the batched architecture. Hypothesis: BatchedMesh's float32 vertex-shader instance transform (1 ulp ≈ 1–4 µm at 10–50 m world coordinates) is the tie-breaking noise behind the post-1.438 speckle; classic-era CPU-double baking is why it used to be stable. |
| `?logDepth=0` | Disables the logarithmic depth buffer (conventional D24). |
| `?nearMin=N` | Raises the near-plane floor (e.g. `nearMin=1`); only meaningful with `logDepth=0` — conventional depth resolution scales with near, log depth doesn't. |

The `[zfight-probe]` console line now also reports `logDepth=`. Headless-verified: flags activate on model routes, bake produces identity instance matrices with per-instance geometry, unit tests pass.

**Important:** flags only survive on a full model-route URL (bare `/share` redirects to the default model and strips the query). Test like:

```
…/share/v/gh/…/haus.ifc?bakeXforms=1
```

**Test sequence on haus.ifc roof (each vs. plain preview URL):**
1. `?bakeXforms=1` — if stable, the float32 batching-matrix noise theory is confirmed, and the production fix direction is precision-aware instance transforms (bake for small models / relative-to-anchor matrices), no geometry change.
2. `?logDepth=0&nearMin=1` — conventional-depth A/B for the depth-strategy redesign discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S6gTXmrq1GbhqknPqQMRuz