### PR TITLE
Pin composer depth attachment to 16-bit: fix coplanar-interface z-fighting

### DIFF
--- a/src/viewer/three/CustomPostProcessor.js
+++ b/src/viewer/three/CustomPostProcessor.js
@@ -8,7 +8,7 @@ import {
   ToneMappingEffect,
   ToneMappingMode,
 } from 'postprocessing'
-import {WebGLRenderer, Scene, Camera} from 'three'
+import {WebGLRenderer, Scene, Camera, UnsignedShortType} from 'three'
 import {isFeatureEnabled} from '../../FeatureFlags'
 
 
@@ -53,6 +53,32 @@ export default class CustomPostProcessor {
    */
   constructor(renderer, scene, camera) {
     this._composer = new EffectComposer(renderer)
+    // The scene depth-tests in this composer's input buffer, not the
+    // canvas. Pin its depth attachment to 16 bits — the format three
+    // 0.135 allocated here, which the 0.184 upgrade (#1514) silently
+    // widened to 24-bit. BIM models author exactly-coincident interface
+    // faces (haus.ifc: 758 coplanar pairs at 0-1.6µm separation); at
+    // 16-bit those quantize to the same depth code everywhere and the
+    // deterministic draw order picks one stable winner, while at 24-bit
+    // the per-fragment log-depth rounding noise (~1e-7 of depth range)
+    // crosses code boundaries and the per-pixel winner is random —
+    // visible speckle/shimmer at soffits, rakes and ridges. 16-bit is
+    // the depth resolution prod shipped for years (~1.4mm at 15m under
+    // log depth); per-surface resolution of coincident interfaces
+    // belongs in the engine (conway interface culling, tracked
+    // separately). postprocessing re-assigns `composer.depthTexture`
+    // onto the current input buffer every frame (its ping-pong swaps
+    // buffer identities), and three rebinds changed depth textures and
+    // sizes them to the target, so this single assignment covers both
+    // buffers and all resizes. Going through createDepthTexture (rather
+    // than assigning composer.depthTexture directly) also builds the
+    // stable-depth target addPass dereferences; its default depth type
+    // is FloatType (32-bit), so both textures get re-pinned to 16-bit.
+    if (renderer) {
+      const stableDepthTexture = this._composer.createDepthTexture()
+      stableDepthTexture.type = UnsignedShortType
+      this._composer.depthTexture.type = UnsignedShortType
+    }
     this._composer.addPass(new RenderPass(scene, camera))
     // Ambient occlusion (§6e). SSAO needs a scene-normal buffer (NormalPass)
     // + the depth the composer already provides. Added before tone mapping so

--- a/src/viewer/three/CustomPostProcessor.test.js
+++ b/src/viewer/three/CustomPostProcessor.test.js
@@ -1,0 +1,37 @@
+import {Camera, Scene, UnsignedShortType} from 'three'
+import CustomPostProcessor from './CustomPostProcessor'
+
+
+/**
+ * Minimal WebGLRenderer stand-in satisfying EffectComposer.addPass
+ * (drawing-buffer size + context attributes queries).
+ *
+ * @return {object}
+ */
+function fakeRenderer() {
+  return {
+    getSize: (v) => v.set(4, 4),
+    getDrawingBufferSize: (v) => v.set(4, 4),
+    getContext: () => ({getContextAttributes: () => ({alpha: true})}),
+    capabilities: {},
+    autoClear: true,
+  }
+}
+
+
+describe('CustomPostProcessor', () => {
+  it('pins the composer depth attachment to 16-bit (UnsignedShortType)', () => {
+    // The z-fight fix: the scene depth-tests in the composer's input
+    // buffer; an explicit 16-bit depth texture restores the pre-r184
+    // format where coincident BIM interfaces tie uniformly and draw
+    // order resolves them stably. See the constructor comment.
+    const postProcessor = new CustomPostProcessor(fakeRenderer(), new Scene(), new Camera())
+    const composer = postProcessor.getComposer
+    expect(composer.depthTexture).not.toBeNull()
+    expect(composer.depthTexture.isDepthTexture).toBe(true)
+    expect(composer.depthTexture.type).toBe(UnsignedShortType)
+    // The stable-depth copy passes sample from must match, or a
+    // depth-consuming pass would silently read a different precision.
+    expect(composer.depthRenderTarget.depthTexture.type).toBe(UnsignedShortType)
+  })
+})


### PR DESCRIPTION
## The mechanism (finally, for real — A/B-confirmed on a real GPU)

**The scene depth-tests in the postprocessing composer's input buffer, not the canvas** — every canvas-level measurement and fix attempt in this saga was aimed at the wrong framebuffer. GL-allocation tracing across Pablo's bisect boundary (#1513 stable ↔ #1514 fighting, the three 0.135→0.184 upgrade) found the one depth-relevant delta:

| build | composer depth attachment |
|---|---|
| three 0.135 (stable era) | `DEPTH_COMPONENT16` |
| three 0.184 (#1514 → today) | `DEPTH_COMPONENT24` |

BIM models author exactly-coincident interface faces (haus.ifc: 758 coplanar product pairs at 0–1.6 µm separation — roof/rafter, roof/wall-top, ridge miter). Under log depth, the per-fragment `log2()` computation differs between two coplanar surfaces by ~1e-7 of depth range from float32 rounding:

- **At 16-bit** (code ≈ 1.5e-5): noise ≪ one code → both surfaces land on the same depth code everywhere → uniform tie → LEQUAL gives the last-drawn surface uniformly → **stable**. The coarseness was the tie-breaker all along.
- **At 24-bit** (code ≈ 6e-8): noise crosses code boundaries → per-pixel random winner → the **speckle/shimmer** at soffits, rakes and ridges.

Confirmed end-to-end: `?depth16=1` on the #1654 probe preview renders the haus.ifc roof solid on the reporting GPU; the same build without the flag speckles.

## The fix

Pin the composer's depth attachment to `UnsignedShortType` (D16) via the composer's own `createDepthTexture()` — the supported path (its stable-depth target is required by `addPass`); both the live and stable depth textures are re-typed. postprocessing re-assigns the depth texture to the current input buffer every frame (covering its ping-pong buffer swaps) and three rebinds/resizes changed depth textures automatically.

This restores the depth resolution prod shipped for all the classic years (~1.4 mm at 15 m viewing distance under log depth) — a deliberate re-pin of a format the #1514 upgrade changed silently.

## Verification

- Unit test: composer depth texture (and stable-depth copy) are `UnsignedShortType`.
- GL-allocation trace on the built bundle: scene depth attachment allocates as 2× `DEPTH_COMPONENT16` texStorage (was 6× D24 renderbuffers).
- Headless render smoke: scene draws with correct occlusion.
- Real-GPU visual confirmation: equivalent format change validated on the #1654 preview (`?depth16=1`), roof solid.
- Full jest suite green (pre-commit).

## Companions and follow-ups

- **#1643 (stable opaque draw order) should land with this**: at D16 the tie-winner is "whoever draws last," so the batched path needs deterministic insertion order — per-frame camera sorting would flip the uniform-tie winner as the camera moves.
- **Durable fix is engine-side** (tracked separately): conway coincident-interface culling — suppress/select interior faces at solid-solid contact by BIM semantics rather than draw-order luck. Fixes the class at any depth precision and reduces overdraw.
- Known limitation: the screenshot path (`tempRenderer`) renders directly to its own canvas (D24) and doesn't go through the composer; single-frame speckle may appear in screenshots of pathological models. Same behavior as any non-composer consumer; candidate for the engine-side fix.
- The diagnostic probe PR #1654 (URL flags incl. `?depth16=1`) can be closed once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S6gTXmrq1GbhqknPqQMRuz

---
_Generated by [Claude Code](https://claude.ai/code/session_01S6gTXmrq1GbhqknPqQMRuz)_