### PR TITLE
Open local recents by OPFS storage id, not display filename

### DIFF
--- a/src/Components/Connections/RecentFilesList.jsx
+++ b/src/Components/Connections/RecentFilesList.jsx
@@ -38,11 +38,21 @@ function FileTypeIcon({mimeType}) {
 /**
  * Formats a UTC timestamp (ms) as a relative or absolute date string.
  *
- * @param {number|null|undefined} utcMs
+ * Tolerates an ISO-8601 string as well as epoch ms: the drag-and-drop
+ * handler stored ISO strings until #1682, and those entries are still
+ * sitting in users' localStorage — arithmetic on them yielded NaN and
+ * rendered "NaNm ago". Anything unparseable returns null, same as a
+ * missing timestamp.
+ *
+ * @param {number|string|null|undefined} utc
  * @return {string|null}
  */
-function formatRelativeTime(utcMs) {
-  if (!utcMs) {
+function formatRelativeTime(utc) {
+  if (!utc) {
+    return null
+  }
+  const utcMs = typeof utc === 'number' ? utc : Date.parse(utc)
+  if (isNaN(utcMs)) {
     return null
   }
   const diffMs = Date.now() - utcMs

--- a/src/Components/Connections/RecentFilesList.test.jsx
+++ b/src/Components/Connections/RecentFilesList.test.jsx
@@ -91,6 +91,24 @@ describe('RecentFilesList', () => {
     expect(screen.getByText('2d ago')).toBeInTheDocument()
   })
 
+  // Drag-and-drop stored ISO strings until #1682; those entries are
+  // still in users' localStorage and must not render "NaNm ago".
+  it('renders a legacy ISO-string timestamp as relative time', () => {
+    const legacy = [{id: 'file-4', source: 'local', name: 'Old.ifc',
+      lastModifiedUtc: new Date(Date.now() - MS_PER_MINUTE).toISOString()}]
+    render(<RecentFilesList files={legacy} onOpen={jest.fn()}/>, {wrapper: ThemeCtx})
+
+    expect(screen.getByText('1m ago')).toBeInTheDocument()
+  })
+
+  it('renders no timestamp for an unparseable value', () => {
+    const bad = [{id: 'file-5', source: 'local', name: 'Bad.ifc', lastModifiedUtc: 'not-a-date'}]
+    render(<RecentFilesList files={bad} onOpen={jest.fn()}/>, {wrapper: ThemeCtx})
+
+    expect(screen.getByText('Bad.ifc')).toBeInTheDocument()
+    expect(screen.queryByText(/ago/)).not.toBeInTheDocument()
+  })
+
   it('shows column headers', () => {
     render(<RecentFilesList files={mockFiles} onOpen={jest.fn()}/>, {wrapper: ThemeCtx})
 

--- a/src/Components/Open/OpenModelDialog.jsx
+++ b/src/Components/Open/OpenModelDialog.jsx
@@ -206,16 +206,27 @@ export default function OpenModelDialog({
   }
 
   const openFile = () => {
-    const onLoad = (filename, lastModifiedUtc) => {
+    /**
+     * @param {string} storageId OPFS storage id, `<blob-uuid>.<ext>` — the
+     *   `/v/new/` path segment the Loader resolves against OPFS.
+     * @param {number} lastModifiedUtc Epoch ms from the picked File.
+     * @param {string} [originalName] The user's filename, e.g. `box.ifc`.
+     */
+    const onLoad = (storageId, lastModifiedUtc, originalName) => {
       disablePageReloadApprovalCheck()
-      navigateToModel(`${appPrefix}/v/new/${filename}`, navigate)
+      const sharePath = `${appPrefix}/v/new/${storageId}`
+      navigateToModel(sharePath, navigate)
       addRecentFileEntry({
-        id: filename,
+        id: storageId,
         source: 'local',
-        name: filename,
+        // `name` is the display name; `id` is what the Loader resolves.
+        // Keeping them distinct is what lets the recents row read
+        // "box.ifc" while navigation still targets the OPFS entry.
+        name: originalName || storageId,
         lastModifiedUtc: lastModifiedUtc || null,
+        sharePath,
       })
-      setPendingModelNameUpdate(filename)
+      setPendingModelNameUpdate(storageId)
     }
     if (isOpfsAvailable) {
       loadLocalFile(onLoad, false)
@@ -225,9 +236,24 @@ export default function OpenModelDialog({
     setIsDialogDisplayed(false)
   }
 
+  /**
+   * Re-open a local upload from Recents. The nav target must be the
+   * entry's OPFS storage id (`<blob-uuid>.<ext>`), NOT its display
+   * `name` (the user's original filename) — `Loader#load` recognises an
+   * upload by `testUuid(path)` and resolves it out of OPFS. A display
+   * name like `box.ifc` fails that test, gets classified as a locally
+   * hosted file, and fetches `/box.ifc` from the origin, where the SPA
+   * catch-all hands back index.html and the parse dies with the
+   * misleading "Loader could not read model" (#1682).
+   *
+   * `sharePath` is recorded at creation time; the `id` fallback covers
+   * entries already in localStorage from before that was stored.
+   *
+   * @param {object} entry A `local` RecentFileEntry.
+   */
   const handleOpenLocalRecent = (entry) => {
     disablePageReloadApprovalCheck()
-    navigateToModel(`${appPrefix}/v/new/${entry.name}`, navigate)
+    navigateToModel(entry.sharePath || `${appPrefix}/v/new/${entry.id}`, navigate)
     setIsDialogDisplayed(false)
   }
 

--- a/src/Components/Open/OpenModelDialog.spec.ts
+++ b/src/Components/Open/OpenModelDialog.spec.ts
@@ -46,25 +46,49 @@ describe('Open 100: Open model dialog', () => {
   })
 
   describe('DnD file appears in recently used', () => {
+    // An upload's OPFS storage id is the blob UUID plus the type suffix;
+    // the user's filename is only ever a display label. Keeping the two
+    // distinct here is what makes this cover #1682 — an entry whose id
+    // and name are the same string can't catch navigation by the wrong
+    // field.
+    const STORAGE_ID = 'ADD77535-D1B6-49A9-915B-41343B08BF83.ifc'
+
+    /**
+     * Simulate a completed file drop by writing a recent file entry to
+     * localStorage, mirroring what handleFileDrop does via
+     * addRecentFileEntry after saving to OPFS.
+     */
+    const seedRecent = (storageId: string) => {
+      const entry = {
+        id: storageId,
+        source: 'local',
+        name: 'box.ifc',
+        lastModifiedUtc: null,
+      }
+      localStorage.setItem('bldrs:recent-files', JSON.stringify({version: 1, files: [entry]}))
+    }
+
     test('dropped file is shown in Local tab recent list', async ({page}) => {
       await returningUserVisitsHomepageWaitForModel(page)
-
-      // Simulate a completed file drop by writing a recent file entry to localStorage,
-      // mirroring what handleFileDrop does via addRecentFileEntry after saving to OPFS.
-      await page.evaluate(() => {
-        const entry = {
-          id: 'box.ifc',
-          source: 'local',
-          name: 'box.ifc',
-          lastModifiedUtc: null,
-        }
-        localStorage.setItem('bldrs:recent-files', JSON.stringify({version: 1, files: [entry]}))
-      })
+      await page.evaluate(seedRecent, STORAGE_ID)
 
       // Open dialog and verify the filename appears in the Local tab recent list
       await page.getByTestId('control-button-open').click()
       await page.getByTestId('tab-local').click()
       await expect(page.getByText('box.ifc')).toBeVisible()
+    })
+
+    test('opening a recent navigates to its OPFS storage id, not its display name', async ({page}) => {
+      await returningUserVisitsHomepageWaitForModel(page)
+      await page.evaluate(seedRecent, STORAGE_ID)
+
+      await page.getByTestId('control-button-open').click()
+      await page.getByTestId('tab-local').click()
+      await page.getByTestId(`link-open-recent-${STORAGE_ID}`).click()
+
+      // /v/new/box.ifc would miss OPFS entirely and fetch the SPA
+      // catch-all from the origin — the #1682 crash.
+      await expect(page).toHaveURL(new RegExp(`/v/new/${STORAGE_ID}$`))
     })
   })
 

--- a/src/Components/Open/OpenModelDialog.test.jsx
+++ b/src/Components/Open/OpenModelDialog.test.jsx
@@ -3,8 +3,13 @@ import {act, fireEvent, render, screen, waitFor} from '@testing-library/react'
 import {HelmetStoreRouteThemeCtx} from '../../Share.fixture'
 import {useAuth0} from '../../Auth0/Auth0Proxy'
 import {NeedsReconnectError} from '../../connections/errors'
-import {loadRecentFilesBySource} from '../../connections/persistence'
+import {
+  addRecentFileEntry,
+  loadRecentFilesBySource,
+  setPendingModelNameUpdate,
+} from '../../connections/persistence'
 import {getProvider} from '../../connections/registry'
+import {loadLocalFileFallback} from '../../utils/loader'
 import {navigateToModel} from '../../utils/navigate'
 import useStore from '../../store/useStore'
 import OpenModelDialog from './OpenModelDialog'
@@ -46,6 +51,7 @@ jest.mock('../Connections/GitHubTab', () => function MockGitHubTab() {
 })
 jest.mock('../../OPFS/utils', () => ({checkOPFSAvailability: jest.fn().mockReturnValue(false)}))
 jest.mock('../../utils/navigate', () => ({navigateToModel: jest.fn()}))
+jest.mock('../../utils/loader', () => ({loadLocalFile: jest.fn(), loadLocalFileFallback: jest.fn()}))
 
 
 const mockNavigate = jest.fn()
@@ -289,5 +295,93 @@ describe('OpenModelDialog — Google Drive tab', () => {
       })
     })
     expect(navigateToModel).not.toHaveBeenCalled()
+  })
+})
+
+
+describe('OpenModelDialog — Local tab', () => {
+  // A local upload lives in OPFS under a blob-uuid storage id; the
+  // user's filename is only ever a display label. Regression cover for
+  // #1682, where navigating by the display name sent the Loader off to
+  // fetch /box.ifc from the origin (SPA catch-all → index.html → "Loader
+  // could not read model").
+  const STORAGE_ID = 'ADD77535-D1B6-49A9-915B-41343B08BF83.ifc'
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    useAuth0.mockReturnValue({
+      isAuthenticated: false,
+      loginWithRedirect: jest.fn(),
+      logout: jest.fn(),
+      user: null,
+    })
+    loadRecentFilesBySource.mockReturnValue([])
+    act(() => {
+      // The store defaults currentTab to 1 (GitHub); Local is index 0.
+      useStore.getState().setCurrentTab(0)
+      useStore.getState().setAppPrefix('/share')
+    })
+  })
+
+  afterEach(() => {
+    act(() => {
+      useStore.getState().setAppPrefix(null)
+    })
+  })
+
+  /**
+   * Render the Local tab (index 0) with the given local recents.
+   *
+   * @param {Array<object>} localFiles
+   * @return {void}
+   */
+  function renderLocalTab(localFiles) {
+    loadRecentFilesBySource.mockImplementation((source) => source === 'local' ? localFiles : [])
+    render(<OpenModelDialog {...defaultProps}/>, {wrapper: HelmetStoreRouteThemeCtx})
+  }
+
+  it('navigates by storage id, not display name, for a legacy entry with no sharePath', () => {
+    renderLocalTab([{id: STORAGE_ID, source: 'local', name: 'box.ifc'}])
+    fireEvent.click(screen.getByTestId(`link-open-recent-${STORAGE_ID}`))
+    expect(navigateToModel).toHaveBeenCalledWith(`/share/v/new/${STORAGE_ID}`, mockNavigate)
+  })
+
+  it('navigates to the stored sharePath when the entry carries one', () => {
+    renderLocalTab([
+      {id: STORAGE_ID, source: 'local', name: 'box.ifc', sharePath: `/share/v/new/${STORAGE_ID}`},
+    ])
+    fireEvent.click(screen.getByTestId(`link-open-recent-${STORAGE_ID}`))
+    expect(navigateToModel).toHaveBeenCalledWith(`/share/v/new/${STORAGE_ID}`, mockNavigate)
+  })
+
+  it('shows the original filename in the recents row', () => {
+    renderLocalTab([{id: STORAGE_ID, source: 'local', name: 'box.ifc'}])
+    expect(screen.getByText('box.ifc')).toBeInTheDocument()
+    expect(screen.queryByText(STORAGE_ID)).not.toBeInTheDocument()
+  })
+
+  it('records the picked filename as display name and the storage id as nav target', () => {
+    const lastModified = Date.now()
+    loadLocalFileFallback.mockImplementation((onLoad) => onLoad(STORAGE_ID, lastModified, 'box.ifc'))
+    renderLocalTab([])
+    fireEvent.click(screen.getByTestId('button_open_file'))
+    expect(addRecentFileEntry).toHaveBeenCalledWith({
+      id: STORAGE_ID,
+      source: 'local',
+      name: 'box.ifc',
+      lastModifiedUtc: lastModified,
+      sharePath: `/share/v/new/${STORAGE_ID}`,
+    })
+    expect(navigateToModel).toHaveBeenCalledWith(`/share/v/new/${STORAGE_ID}`, mockNavigate)
+    expect(setPendingModelNameUpdate).toHaveBeenCalledWith(STORAGE_ID)
+  })
+
+  it('falls back to the storage id as display name when the picker gives no filename', () => {
+    loadLocalFileFallback.mockImplementation((onLoad) => onLoad(STORAGE_ID, null))
+    renderLocalTab([])
+    fireEvent.click(screen.getByTestId('button_open_file'))
+    expect(addRecentFileEntry).toHaveBeenCalledWith(
+      expect.objectContaining({id: STORAGE_ID, name: STORAGE_ID}),
+    )
   })
 })

--- a/src/connections/persistence.ts
+++ b/src/connections/persistence.ts
@@ -16,7 +16,11 @@ export type RecentFileSource = 'local' | 'google-drive' | 'github'
 
 
 export interface RecentFileEntry {
-  /** Dedup key: fileId (google-drive) | sharePath (github) | filename (local) */
+  /**
+   * Dedup key: fileId (google-drive) | sharePath (github) | OPFS storage
+   * id, `<blob-uuid>.<ext>` (local). For local entries this — not `name` —
+   * is what `/v/new/` navigation and `Loader#load` resolve against OPFS.
+   */
   id: string
   source: RecentFileSource
   /** Original filename — used as tooltip and display fallback */
@@ -25,7 +29,7 @@ export interface RecentFileEntry {
   modelTitle?: string
   mimeType?: string
   lastModifiedUtc?: number | null
-  /** Navigate path for local (/v/new/filename) and github (/v/gh/...) */
+  /** Navigate path for local (/v/new/[storage-id]) and github (/v/gh/...) */
   sharePath?: string
   /** google-drive only */
   connectionId?: string

--- a/src/connections/persistence.ts
+++ b/src/connections/persistence.ts
@@ -28,6 +28,11 @@ export interface RecentFileEntry {
   /** Extracted IFC model name — preferred for display when available */
   modelTitle?: string
   mimeType?: string
+  /**
+   * Epoch ms. Entries written by drag-and-drop before #1682 hold an
+   * ISO-8601 string instead; `RecentFilesList` coerces on read so those
+   * still render, but nothing should write one.
+   */
   lastModifiedUtc?: number | null
   /** Navigate path for local (/v/new/[storage-id]) and github (/v/gh/...) */
   sharePath?: string

--- a/src/utils/dragAndDrop.js
+++ b/src/utils/dragAndDrop.js
@@ -55,16 +55,25 @@ export async function handleFileDrop(event, navigate, appPrefix, isOpfsAvailable
     return
   }
 
-  /** @param {string} fileName The filename the upload was given */
+  /**
+   * @param {string} fileName The OPFS storage id the upload was written
+   *   under (`<blob-uuid>.<ext>`) — the `/v/new/` segment the Loader
+   *   resolves, distinct from the user's `uploadedFile.name`.
+   */
   function onWritten(fileName) {
     disablePageReloadApprovalCheck()
     debug().log('handleFileDrop: navigate to:', fileName)
-    navigateToModel(`${appPrefix}/v/new/${fileName}`, navigate)
+    const sharePath = `${appPrefix}/v/new/${fileName}`
+    navigateToModel(sharePath, navigate)
     addRecentFileEntry({
       id: fileName,
       source: 'local',
       name: uploadedFile.name,
-      lastModifiedUtc: uploadedFile.lastModified ? new Date(uploadedFile.lastModified).toISOString() : null,
+      // Epoch ms, matching RecentFileEntry and RecentFilesList's
+      // `Date.now() - utcMs` arithmetic — an ISO string here rendered
+      // as "NaNm ago" in the Last-modified column (#1682).
+      lastModifiedUtc: uploadedFile.lastModified || null,
+      sharePath,
     })
     setPendingModelNameUpdate(fileName)
     if (onSuccess) {

--- a/src/utils/dragAndDrop.test.js
+++ b/src/utils/dragAndDrop.test.js
@@ -197,9 +197,31 @@ describe('dragAndDrop utility', () => {
         id: mockFileName,
         source: 'local',
         name: 'mymodel.ifc',
-        lastModifiedUtc: new Date(lastModified).toISOString(),
+        // Epoch ms, not an ISO string — RecentFilesList does
+        // `Date.now() - utcMs` and would render "NaNm ago" (#1682).
+        lastModifiedUtc: lastModified,
+        sharePath: `/prefix/v/new/${mockFileName}`,
       })
       expect(setPendingModelNameUpdate).toHaveBeenCalledWith(mockFileName)
+    })
+
+    // The recents row must navigate by the OPFS storage id the worker
+    // wrote under, never by the user's filename — see #1682.
+    it('records the storage id as the entry id and the user filename as display name', async () => {
+      const mockFile = {name: 'mymodel.ifc', type: 'application/octet-stream', size: 1024}
+      mockEvent.dataTransfer.files = [mockFile]
+      guessTypeFromFile.mockResolvedValue('ifc')
+      saveDnDFileToOpfs.mockImplementation((file, type, onWritten) => {
+        onWritten('ADD77535-D1B6-49A9-915B-41343B08BF83.ifc')
+      })
+
+      await handleFileDrop(mockEvent, mockNavigate, '/prefix', true, mockSetAlert)
+
+      expect(addRecentFileEntry).toHaveBeenCalledWith(expect.objectContaining({
+        id: 'ADD77535-D1B6-49A9-915B-41343B08BF83.ifc',
+        name: 'mymodel.ifc',
+        sharePath: '/prefix/v/new/ADD77535-D1B6-49A9-915B-41343B08BF83.ifc',
+      }))
     })
 
     it('records recent entry with null lastModifiedUtc when lastModified is absent', async () => {

--- a/src/utils/loader.js
+++ b/src/utils/loader.js
@@ -9,7 +9,7 @@ import debug from '../utils/debug'
 /**
  * Upload a local file for display.
  *
- * @param {Function} onLoad
+ * @param {Function} onLoad Called with (storageId, lastModifiedUtc, originalName)
  * @param {boolean} testingSkipAutoRemove
  */
 export function loadLocalFileFallback(onLoad, testingSkipAutoRemove = false) {
@@ -28,7 +28,7 @@ export function loadLocalFileFallback(onLoad, testingSkipAutoRemove = false) {
       const tmpUrl = parts[parts.length - 1]
       URL.revokeObjectURL(objectUrl)
       if (onLoad) {
-        onLoad(tmpUrl, lastModifiedUtc)
+        onLoad(tmpUrl, lastModifiedUtc, file.name)
       }
     },
     false,
@@ -44,7 +44,12 @@ export function loadLocalFileFallback(onLoad, testingSkipAutoRemove = false) {
 /**
  * Upload a local file for display.
  *
- * @param {Function} onLoad
+ * The first `onLoad` arg is the OPFS storage id the worker wrote under
+ * (`<blob-uuid>.<ext>`) — that's the `/v/new/` path segment. The third
+ * is the user's original filename, which callers need to keep as the
+ * recents display name (they are NOT interchangeable, see #1682).
+ *
+ * @param {Function} onLoad Called with (storageId, lastModifiedUtc, originalName)
  * @param {boolean} testingSkipAutoRemove
  * @param {boolean} testingDisableWebWorker
  */
@@ -83,12 +88,12 @@ export function loadLocalFile(onLoad, testingSkipAutoRemove = false, testingDisa
               debug().log('Worker finished writing file')
               workerRef.removeEventListener('message', listener)
               URL.revokeObjectURL(tmpUrl)
-              onLoad(workerEvent.data.fileName, lastModifiedUtc)
+              onLoad(workerEvent.data.fileName, lastModifiedUtc, file.name)
             } else if (workerEvent.data.event === 'read') {
               debug().log('Worker finished reading file')
               workerRef.removeEventListener('message', listener)
               URL.revokeObjectURL(tmpUrl)
-              onLoad(workerEvent.data.file.name, lastModifiedUtc)
+              onLoad(workerEvent.data.file.name, lastModifiedUtc, file.name)
             }
           }
         }
@@ -102,7 +107,7 @@ export function loadLocalFile(onLoad, testingSkipAutoRemove = false, testingDisa
         opfsWriteModel(tmpUrl, filename, `${fileNametmpUrl}.${ext}`)
       } else {
         URL.revokeObjectURL(tmpUrl)
-        onLoad(fileNametmpUrl, lastModifiedUtc)
+        onLoad(fileNametmpUrl, lastModifiedUtc, file.name)
       }
     },
     false,

--- a/src/utils/loader.test.js
+++ b/src/utils/loader.test.js
@@ -26,7 +26,9 @@ describe('loadLocalFile', () => {
     inputElement.dispatchEvent(event)
 
     expect(URL.createObjectURL).toHaveBeenCalledWith(file)
-    expect(onLoad).toHaveBeenCalledWith('testId', expect.any(Number))
+    // Third arg is the user's filename — callers keep it as the recents
+    // display name while navigating by the storage id (#1682).
+    expect(onLoad).toHaveBeenCalledWith('testId', expect.any(Number), 'test.ifc')
   })
 
   it('revokes the object URL when the worker is disabled (sync fallback path)', () => {
@@ -80,7 +82,7 @@ describe('loadLocalFileFallback', () => {
 
     expect(URL.createObjectURL).toHaveBeenCalledTimes(1)
     expect(URL.revokeObjectURL).toHaveBeenCalledWith('testId')
-    expect(onLoad).toHaveBeenCalledWith('testId', expect.any(Number))
+    expect(onLoad).toHaveBeenCalledWith('testId', expect.any(Number), 'test.ifc')
   })
 })
 


### PR DESCRIPTION
Fixes #1682.

Re-opening a local upload from Open > Local > Recents crashed with `Loader could not read model`.

## Root cause

A local `RecentFileEntry` carries two distinct name-ish fields, by design:

* `id` — the **OPFS storage id** the upload was written under, i.e. the blob UUID plus the type suffix (`ADD77535-….ifc`)
* `name` — the user's **original filename**, e.g. `box.ifc`

`Loader#uploadedDisplayFileName` already honours that split (looks up by `id`, displays `name`). The recents click handler did not — it navigated to `/v/new/${entry.name}`.

`Loader#load` recognises an upload by `testUuid(path)`. A display name like `box.ifc` fails that test, so the load fell out of the upload branch, was classified `isLocallyHostedFile`, and fetched `/box.ifc` from the origin — where the SPA catch-all returns `index.html`. Conway was handed HTML:

```
No type detected when constructing model
Error: parseIfcWithConway: OpenModel returned -1
Error: Loader could not read model
```

`index.ifc` re-loaded fine only because it is genuinely served at the site root (the default sample model) — the accidental origin fetch returned a real IFC. It never touched OPFS at all.

## Changes

* **`OpenModelDialog#handleOpenLocalRecent`** navigates by storage id. Local entries now record an explicit `sharePath` at creation so the nav target is stored rather than re-derived; the `entry.id` fallback covers entries already in localStorage.
* **`OpenModelDialog#openFile`** records the picked file's original name as the display `name` instead of the storage id — the picker's recents row rendered a raw UUID where drag-and-drop rendered `box.ifc`. `loadLocalFile`/`loadLocalFileFallback` now pass the filename as a third `onLoad` arg.
* **`handleFileDrop`** stores `lastModifiedUtc` as epoch ms. It was writing an ISO string where `RecentFileEntry` and `RecentFilesList`'s `Date.now() - utcMs` expect a number, so dropped files showed `NaNm ago` in the Last-modified column.
* **`RecentFilesList#formatRelativeTime`** coerces on read, so entries already carrying an ISO string from before this fix still render instead of showing `NaNm ago` until they roll out of the per-source top-4.
* `RecentFileEntry`'s `id` / `sharePath` / `lastModifiedUtc` docs now spell out the storage-id and epoch-ms contracts for local entries.

## Testing

`yarn lint` and the full Jest suite pass (2067 tests, via the precommit hook).

New Jest cover in `OpenModelDialog.test.jsx` (Local tab): navigation by storage id for a legacy entry with no `sharePath`, navigation via a stored `sharePath`, display name in the row, and the picker's id/name/sharePath recording. Verified these fail against the pre-fix handler (3 of 5 red).

`dragAndDrop.test.js` covers the id/name split and epoch-ms `lastModifiedUtc`; `loader.test.js` covers the new `onLoad` filename arg; `RecentFilesList.test.jsx` covers the legacy ISO-string and unparseable-value cases.

`OpenModelDialog.spec.ts` gains an e2e that seeds a realistic recent (uuid id, `box.ifc` name), clicks it, and asserts the URL lands on the storage id. The existing e2e seeded `id === name === 'box.ifc'`, which could not have caught this; it now uses the realistic shape too. Both pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LF3ZSRFpcXJmg5DXvGmD5Y