### PR TITLE
Write OPFS bytes via sync access handle, not createWritable (Safari GLB cache)

### DIFF
--- a/src/OPFS/OPFS.worker.js
+++ b/src/OPFS/OPFS.worker.js
@@ -1434,9 +1434,14 @@ export async function renameFileInOPFS(parentDirectory, fileHandle, newFileName,
   // interface, so we slice the source ourselves to hold the same memory
   // profile.
   const srcFile = await fileHandle.getFile()
-  const destHandle = await parentDirectory.getFileHandle(newFileName, {create: true})
-  const {handle: destAccess} = await openSyncAccessHandleWithRetry(
-    parentDirectory, destHandle, newFileName)
+  const openedDest = await parentDirectory.getFileHandle(newFileName, {create: true})
+  // Take the handle the helper hands back, not the one we passed in: on
+  // the Safari `InvalidStateError` retry it removes and recreates the
+  // entry, so `openedDest` is stale from that point on and the bytes
+  // land in the fresh handle. Returning the stale one would hand the
+  // caller a handle to a file it never wrote.
+  const {handle: destAccess, fileHandle: destHandle} = await openSyncAccessHandleWithRetry(
+    parentDirectory, openedDest, newFileName)
   try {
     for (let at = 0; at < srcFile.size; at += COPY_CHUNK_BYTES) {
       const slice = await srcFile.slice(at, Math.min(at + COPY_CHUNK_BYTES, srcFile.size)).arrayBuffer()

--- a/src/OPFS/OPFS.worker.js
+++ b/src/OPFS/OPFS.worker.js
@@ -13,6 +13,14 @@ let GITHUB_BASE_URL_AUTHENTICATED = null
 let GITHUB_BASE_URL_UNAUTHENTICATED = null
 
 
+// Slice size for the chunked file copy in `renameFileInOPFS`'s fallback.
+// 4MiB matches the source-spill window size Conway pages from OPFS, and
+// keeps peak memory bounded on iOS where the whole point of copying in
+// pieces is to avoid materializing a large ArrayBuffer.
+// eslint-disable-next-line no-magic-numbers
+const COPY_CHUNK_BYTES = 4 * 1024 * 1024
+
+
 /**
  * Pick the GitHub API base URL: use the OAuth-injecting bldrs proxy when a
  * user token is present, otherwise hit GitHub directly.
@@ -1417,12 +1425,30 @@ export async function renameFileInOPFS(parentDirectory, fileHandle, newFileName,
     }
   }
 
-  // Fallback: stream copy + delete (avoids large ArrayBuffer on iOS).
+  // Fallback: chunked copy + delete (avoids large ArrayBuffer on iOS).
+  //
+  // Copied in slices rather than read whole: keeping peak memory to one
+  // chunk is the entire point of this fallback on iOS. This used to be a
+  // `stream().pipeTo(createWritable())`, but Safari has no
+  // `createWritable` (#1686) — and a sync access handle has no stream
+  // interface, so we slice the source ourselves to hold the same memory
+  // profile.
   const srcFile = await fileHandle.getFile()
   const destHandle = await parentDirectory.getFileHandle(newFileName, {create: true})
-  const readable = srcFile.stream()
-  const writable = await destHandle.createWritable()
-  await readable.pipeTo(writable) // closes writable on completion
+  const {handle: destAccess} = await openSyncAccessHandleWithRetry(
+    parentDirectory, destHandle, newFileName)
+  try {
+    for (let at = 0; at < srcFile.size; at += COPY_CHUNK_BYTES) {
+      const slice = await srcFile.slice(at, Math.min(at + COPY_CHUNK_BYTES, srcFile.size)).arrayBuffer()
+      await destAccess.write(new Uint8Array(slice), {at})
+    }
+    await destAccess.truncate(srcFile.size)
+    await destAccess.flush()
+  } finally {
+    try {
+      await destAccess.close()
+    } catch (_) {/* idempotent */}
+  }
 
   try {
     if (typeof fileHandle.remove === 'function') {
@@ -1513,13 +1539,28 @@ export async function writeBytesByPathToOPFS(bytes, commitHash, originalFilePath
       // writeFileToPath already posted an error message
       return
     }
+    const parentDirectory = handles[0]
     const fileHandle = handles[1]
-    const writable = await fileHandle.createWritable()
+    // Sync access handle, NOT createWritable(): Safari implements OPFS
+    // writes only through FileSystemSyncAccessHandle (worker-only), so
+    // `createWritable` is undefined there and every GLB cache write threw
+    // — silently, since the writer is fail-soft — leaving Safari with a
+    // permanently cold cache (#1686). Every other write in this worker
+    // already goes through the sync-handle path.
+    const {handle: accessHandle} = await openSyncAccessHandleWithRetry(
+      parentDirectory, fileHandle, fileHandle.name)
     try {
       const payload = bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes)
-      await writable.write(payload)
+      await accessHandle.write(payload, {at: 0})
+      // Unlike a writable stream, a sync handle doesn't implicitly discard
+      // the previous contents — truncate so re-writing a shorter payload
+      // over an existing entry can't leave a stale tail.
+      await accessHandle.truncate(payload.byteLength)
+      await accessHandle.flush()
     } finally {
-      await writable.close()
+      try {
+        await accessHandle.close()
+      } catch (_) {/* idempotent */}
     }
     self.postMessage({completed: true, event: 'wrote', commitHash: commitHash})
   } catch (error) {

--- a/src/OPFS/OPFS.worker.test.js
+++ b/src/OPFS/OPFS.worker.test.js
@@ -568,6 +568,38 @@ describe('OPFS writes on a handle without createWritable (Safari)', () => {
     await expect(rootDir.getFileHandle('safari-old.txt', {create: false})).rejects.toThrow('not found')
   })
 
+  /*
+   * `openSyncAccessHandleWithRetry` recovers from Safari's
+   * `InvalidStateError` by removing and RECREATING the entry, so the
+   * handle passed in goes stale and the bytes land in a fresh one. The
+   * copy must hand back the helper's handle, not the pre-retry object.
+   */
+  test('renameFileInOPFS copy fallback returns the handle the retry recreated', async () => {
+    const src = await rootDir.getFileHandle('retry-src.txt', {create: true})
+    src.data = new Uint8Array(Buffer.from('retry-payload'))
+
+    const realGetFileHandle = rootDir.getFileHandle.bind(rootDir)
+    let staleDest = null
+    rootDir.getFileHandle = jest.fn(async (name, opts) => {
+      const handle = await realGetFileHandle(name, opts)
+      if (name === 'retry-dest.txt' && staleDest === null) {
+        staleDest = handle
+        // First sync-handle attempt on this entry fails the way Safari
+        // does when it still holds an internal reference.
+        // eslint-disable-next-line require-await
+        handle.createSyncAccessHandle = jest.fn(async () => {
+          throw new DOMException('The object is in an invalid state.', 'InvalidStateError')
+        })
+      }
+      return handle
+    })
+
+    const dest = await worker.renameFileInOPFS(rootDir, src, 'retry-dest.txt')
+
+    expect(dest).not.toBe(staleDest)
+    expect(await (await dest.getFile()).text()).toBe('retry-payload')
+  })
+
   test('renameFileInOPFS copy fallback spans multiple chunks', async () => {
     // Larger than COPY_CHUNK_BYTES (4MiB), so the slice loop runs more
     // than once — the chunking is the reason this path exists on iOS.

--- a/src/OPFS/OPFS.worker.test.js
+++ b/src/OPFS/OPFS.worker.test.js
@@ -144,6 +144,26 @@ class FileHandle {
         return arr.length
       },
       /**
+       * Truncates the file to the given size.
+       *
+       * @param {number} size - New file size in bytes.
+       * @return {Promise<void>}
+       */
+      async truncate(size) {
+        await Promise.resolve()
+        const next = new Uint8Array(size)
+        next.set(handle.data.slice(0, Math.min(size, handle.data.length)))
+        handle.data = next
+      },
+      /**
+       * Flushes buffered writes. No-op for the in-memory stub.
+       *
+       * @return {Promise<void>}
+       */
+      async flush() {
+        await Promise.resolve()
+      },
+      /**
        * Closes the synchronous access handle.
        *
        * @return {Promise<void>}
@@ -488,6 +508,82 @@ test('renameFileInOPFS falls back to copy+delete when native move throws', async
   await expect(rootDir.getFileHandle('boom.txt', {create: false})).rejects.toThrow('not found')
   /* eslint-enable require-await */
 })
+
+// ------------------------------------------------------------
+// Safari-shaped writes (no createWritable)
+// ------------------------------------------------------------
+
+/*
+ * Safari implements OPFS writes ONLY through FileSystemSyncAccessHandle
+ * (worker-only) — `FileSystemFileHandle.createWritable` is undefined
+ * there. The stub above models Chrome by implementing both, which is
+ * exactly how #1686 shipped green: every GLB cache write threw on Safari,
+ * silently, because the writer is fail-soft. Pin the write paths against
+ * a handle that lacks the method.
+ */
+describe('OPFS writes on a handle without createWritable (Safari)', () => {
+  let savedCreateWritable
+
+  beforeEach(() => {
+    savedCreateWritable = FileHandle.prototype.createWritable
+    delete FileHandle.prototype.createWritable
+  })
+
+  afterEach(() => {
+    FileHandle.prototype.createWritable = savedCreateWritable
+  })
+
+  test('writeBytesByPathToOPFS writes the bytes and reports success', async () => {
+    const bytes = new Uint8Array(Buffer.from('glb-artifact-bytes'))
+
+    await worker.writeBytesByPathToOPFS(bytes, 'commit123', 'model.ifc', 'owner', 'repo', 'main')
+
+    expect(self.postMessage).toHaveBeenCalledWith({completed: true, event: 'wrote', commitHash: 'commit123'})
+    const dir = await (await (await rootDir.getDirectoryHandle('owner')).getDirectoryHandle('repo'))
+      .getDirectoryHandle('main')
+    const written = await dir.getFileHandle('model.ifc.null.commit123', {create: false})
+    expect(await (await written.getFile()).text()).toBe('glb-artifact-bytes')
+  })
+
+  test('writeBytesByPathToOPFS truncates a longer previous entry', async () => {
+    await worker.writeBytesByPathToOPFS(
+      new Uint8Array(Buffer.from('the-long-original-payload')), 'c1', 'model.ifc', 'o', 'r', 'main')
+    await worker.writeBytesByPathToOPFS(
+      new Uint8Array(Buffer.from('short')), 'c1', 'model.ifc', 'o', 'r', 'main')
+
+    const dir = await (await (await rootDir.getDirectoryHandle('o')).getDirectoryHandle('r'))
+      .getDirectoryHandle('main')
+    const written = await dir.getFileHandle('model.ifc.null.c1', {create: false})
+    // No stale tail from the longer first write.
+    expect(await (await written.getFile()).text()).toBe('short')
+  })
+
+  test('renameFileInOPFS copy fallback still copies when move is unavailable', async () => {
+    const oldHandle = await rootDir.getFileHandle('safari-old.txt', {create: true})
+    oldHandle.data = new Uint8Array(Buffer.from('safari-payload'))
+
+    const newHandle = await worker.renameFileInOPFS(rootDir, oldHandle, 'safari-new.txt')
+
+    expect(await (await newHandle.getFile()).text()).toBe('safari-payload')
+    await expect(rootDir.getFileHandle('safari-old.txt', {create: false})).rejects.toThrow('not found')
+  })
+
+  test('renameFileInOPFS copy fallback spans multiple chunks', async () => {
+    // Larger than COPY_CHUNK_BYTES (4MiB), so the slice loop runs more
+    // than once — the chunking is the reason this path exists on iOS.
+    // eslint-disable-next-line no-magic-numbers
+    const BIG = (4 * 1024 * 1024) + 1024
+    const src = await rootDir.getFileHandle('big.bin', {create: true})
+    src.data = new Uint8Array(BIG).fill(7)
+
+    const dest = await worker.renameFileInOPFS(rootDir, src, 'big-renamed.bin')
+
+    const copied = new Uint8Array(await (await dest.getFile()).arrayBuffer())
+    expect(copied.length).toBe(BIG)
+    expect(copied.every((b) => b === 7)).toBe(true)
+  })
+})
+
 
 // ------------------------------------------------------------
 // fetchLatestCommitHash tests


### PR DESCRIPTION
Fixes #1686.

On Safari every load was a GLB cache MISS — the model rendered fine, but the post-parse writer always threw, so the next load re-parsed from source. Chrome reached the cache-hit path normally.

```
[glb] "writer: skipped (threw); reader will fall back to source on next load"
      Error: writeBytesByPath: i[1].createWritable is not a function — utils.js:404
[glb] "source spill: released resident source buffer (2526544B); property reads now page 4MiB windows from OPFS on demand"
```

That last line matters: OPFS itself is healthy on Safari — reads work and the source spill pages windows out of it successfully. This is not an "OPFS unavailable" case, so `checkOPFSAvailability()` correctly returns true and no fallback engages.

## Root cause

Safari implements OPFS writes **only** through `FileSystemSyncAccessHandle` (worker-only). `FileSystemFileHandle.createWritable()` is undefined there.

`OPFS.worker.js` already handles this correctly nearly everywhere: every other write goes through `createSyncAccessHandle()`, and `openSyncAccessHandleWithRetry()` exists specifically to absorb Safari's `InvalidStateError` on stale internal handle refs. `renameFileInOPFS` even documents Safari's two-arg `move()` signature.

Two sites broke that convention:

1. **`writeBytesByPathToOPFS`** — the GLB cache writer. The live break. Silent, because the writer is deliberately fail-soft, so the only symptom is a permanently cold cache.
2. **`renameFileInOPFS`'s copy fallback** — latent. The preferred `fileHandle.move()` does work on Safari, so the stream-copy leg only runs if that fails.

## Changes

* Both sites now go through `openSyncAccessHandleWithRetry()`, inheriting the existing Safari retry.
* `writeBytesByPathToOPFS` truncates after writing — unlike a writable stream, a sync handle doesn't implicitly discard prior contents, so overwriting an entry with a shorter payload would otherwise leave a stale tail.
* The rename fallback keeps its memory profile. It exists to avoid a large `ArrayBuffer` on iOS, and a sync handle has no stream interface, so the source is copied in 4MiB slices rather than read whole.

## Why this shipped green

The in-memory `FileHandle` stub in `OPFS.worker.test.js` implements **both** `createSyncAccessHandle()` and `createWritable()` — it models Chrome, so a Safari-only API gap was invisible.

The stub now also carries `truncate()`/`flush()` (both real API), and a new describe block deletes `createWritable` from it to exercise both write paths against the browser that actually lacks it. Verified those tests fail against the old code with the exact production error (`createWritable is not a function`), each reverted site independently.

Coverage added: bytes land correctly; a shorter re-write truncates rather than leaving a tail; the rename copy fallback works; and a >4MiB payload spans multiple chunks so the slice loop is actually exercised.

## Scan

Per review request, swept `src/` for the rest of this class of hazard. All OPFS filesystem access is confined to `OPFS.worker.js` — nothing in `Loader.js`, `OPFSService.js`, or `GlbWriter.worker.js` touches handles directly — so these two were the complete `createWritable` surface. `requestIdleCallback` is feature-detected (`Loader.js:85`) and `fileHandle.move()` already has cross-browser fallbacks. `crypto.randomUUID()` is unguarded in the two OAuth providers, but that's Safari 15.4+ in a secure context, within a reasonable baseline; left alone.

## Testing

`yarn lint` clean; full Jest suite passes (2071 tests) via the precommit hook.

Not verified on a real Safari — I don't have one in this environment. The fix moves both sites onto the exact API the rest of this worker already uses successfully on Safari, but a spot-check that the second load now logs a cache HIT would be worth doing before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LF3ZSRFpcXJmg5DXvGmD5Y

---
_Generated by [Claude Code](https://claude.ai/code/session_01LF3ZSRFpcXJmg5DXvGmD5Y)_