### PR TITLE
Collapse diagnostics into one-line summary in load report

### DIFF
--- a/design/new/load-log-format.md
+++ b/design/new/load-log-format.md
@@ -48,6 +48,14 @@ the metrics after it — hold a fixed column. This is browser display layout
 only — the canonical string still comes from conway's `progress_log`; the CLI
 renderer does its own terminal layout.
 
+The snackbar **hugs its one line while collapsed** (so `Loaded <name>` doesn't
+leave a wide right gap) but takes a **viewport-relative band while expanded** —
+50%–80% of the viewport on desktop, edge-to-edge below `sm` — because the
+report's lines (the Model line, the diagnostics summary) are long and a
+hugged box renders them as a narrow clipped column. Expanding also grows
+MUI's message slot (`flexGrow`), which otherwise stays content-sized and turns
+the extra width into empty space on the right.
+
 A user pasting any of these into a bug report produces the same text; Sentry
 receives the same trail as breadcrumbs plus the final report string in the
 `load` context.
@@ -70,9 +78,7 @@ Download: 2.145s, +40.001234 MB heap              ← 4. completed stage (no bar
 Parsing: 3.201s, +210.512000 MB heap
 Geometry [0%........56%] 41.004s, +388.250000 MB heap   ← live OR failed-at-56% stage
 Total: 46.310s, 214.000000 → 852.000000 MB heap   ← 5. separate before/after
-Warnings & errors (12):                           ← 6. captured console diagnostics
-CDT Exception (hemisphere: 0, svg: 2) … (×8)
-No basis found for brep!
+Warnings & errors (1247, 224 distinct): CDT Exception (hemisphere: 0) (×892)  ← 6. one-line summary
 ```
 
 1. **Host line** — Share version + used-JS-heap before the load begins
@@ -100,10 +106,17 @@ No basis found for brep!
 5. **Total line** — *not* a sum of stages: a separate before/after
    observation of wall clock and heap (`start → end MB heap`). Stages can
    overlap, skip, or leave gaps; Total stays honest regardless.
-6. **Warnings & errors** — the text of every `console.warn`/`console.error`
-   emitted during the load (this captures conway's engine warnings + CDT
-   exceptions, which route through the console), deduplicated with `(×N)`
-   counts and capped, appended below Total so the report is self-contained.
+6. **Warnings & errors** — a **single** summary line for every
+   `console.warn`/`console.error` emitted during the load (this captures
+   conway's engine warnings + CDT exceptions, which route through the
+   console): total count, distinct count when >1, and the most frequent
+   message with its `(×N)` count, truncated to ~80 chars. It is deliberately
+   not a listing — engines emit per-entity diagnostics ("Error processing
+   representation #NNN") that dedup can't collapse because each is textually
+   distinct, and a STEP model producing hundreds of them buried the rest of
+   the report in the snackbar expando and the copyable "i" report alike.
+   Nothing is lost: the console tee passes every message through to the real
+   console, so full detail is one devtools panel away.
 
 **Precision** — seconds to millisecond precision (3 decimals), memory to
 byte precision (6 decimals of MB), per the report's diagnostic purpose.

--- a/src/Containers/AlertDialogAndSnackbar.jsx
+++ b/src/Containers/AlertDialogAndSnackbar.jsx
@@ -54,6 +54,23 @@ const SNACK_CONTENT_SELECTOR = '[data-testid="snackbar"] .MuiSnackbarContent-roo
 // display layout only.
 const BAR_INNER_WIDTH = 22
 
+// Collapsed, the snackbar hugs its one line (no 288px MUI min-width sprawl)
+// so "Loaded <name>" doesn't leave a wide right gap.
+const COLLAPSED_CONTENT_SX = {minWidth: 'auto', width: 'fit-content', maxWidth: '94vw'}
+// Expanded, hugging is wrong: the report's lines are long (the Model line, the
+// diagnostics summary) and would render as a narrow column of clipped text.
+// Give the box a floor and a ceiling instead — half to four-fifths of the
+// viewport on desktop, edge-to-edge on mobile, where there's no room to be
+// choosy. MUI sizes the message slot to its content, so it needs flexGrow to
+// follow the wider box (otherwise the extra width is just a gap on the right);
+// minWidth:0 lets the inner overflow-x scroller shrink below its content.
+const EXPANDED_CONTENT_SX = {
+  'minWidth': {xs: '100%', sm: '50vw'},
+  'width': {xs: '100%', sm: 'fit-content'},
+  'maxWidth': {xs: '100%', sm: '80vw'},
+  '& .MuiSnackbarContent-message': {flexGrow: 1, minWidth: 0},
+}
+
 
 /**
  * Space-pad a live stage line's bar to a fixed inner width so the closing "]"
@@ -280,11 +297,17 @@ export default function AlertAndSnackbar() {
   )
 
   const loadMessage = (
-    // Hug the current line's width so the snackbar doesn't sprawl. The
-    // collapsed report history (a long "Model: …" line) would otherwise widen
-    // the box even while hidden — width:0 keeps it out of the width calc, and
-    // minWidth:100% stretches it to the box (scrolling) only once expanded.
-    <Box sx={{width: 'fit-content', maxWidth: '92vw'}} data-testid='LoadStatusMessage'>
+    // Collapsed: hug the current line's width so the snackbar doesn't sprawl
+    // (the hidden history's long "Model: …" line would otherwise widen the box
+    // even while collapsed — the history's width:0 below keeps it out of the
+    // width calc). Expanded: fill the widened content box so the history's
+    // minWidth:100% resolves against that width, not against one short line.
+    <Box
+      sx={isLoadExpanded ?
+        {width: '100%', maxWidth: '100%'} :
+        {width: 'fit-content', maxWidth: '92vw'}}
+      data-testid='LoadStatusMessage'
+    >
       <Collapse in={isLoadExpanded}>
         <Box
           sx={{...LOAD_LINE_SX, opacity: 0.8, mb: 0.5, width: 0, minWidth: '100%', overflowX: 'auto'}}
@@ -375,10 +398,13 @@ export default function AlertAndSnackbar() {
         // through the dismiss animation) so it can't fight or flash the
         // shrink-to-"i" animation, which drives the content box itself.
         transitionDuration={(showLoadView || isDismissing) ? 0 : undefined}
-        // Hug the content (no 288px min-width sprawl) so short lines like
-        // "Loaded <name>" don't leave a wide right gap; the animation's inline
-        // style overrides this while it runs.
-        ContentProps={{style: animStyle, sx: {minWidth: 'auto', width: 'fit-content', maxWidth: '94vw'}}}
+        // Hug one line when collapsed, take a viewport-relative band when
+        // expanded (see the two *_CONTENT_SX above); the animation's inline
+        // style overrides both while it runs.
+        ContentProps={{
+          style: animStyle,
+          sx: (showLoadView && isLoadExpanded) ? EXPANDED_CONTENT_SX : COLLAPSED_CONTENT_SX,
+        }}
         data-testid='snackbar'
       />
     </>

--- a/src/Containers/AlertDialogAndSnackbar.test.jsx
+++ b/src/Containers/AlertDialogAndSnackbar.test.jsx
@@ -5,6 +5,22 @@ import useStore from '../store/useStore'
 import AlertAndSnackbar from './AlertDialogAndSnackbar'
 
 
+/**
+ * Every emitted CSS rule that targets one of an element's emotion classes,
+ * media queries included — jsdom's getComputedStyle can't see either.
+ *
+ * @param {Element} element
+ * @return {string}
+ */
+function cssOf(element) {
+  const classes = Array.from(element.classList).filter((name) => name.startsWith('css-'))
+  return Array.from(document.querySelectorAll('style'))
+    .flatMap((style) => style.textContent.split('\n'))
+    .filter((rule) => classes.some((name) => rule.includes(`.${name}`)))
+    .join('\n')
+}
+
+
 // Grace-period state machine (conway #301 UX). The shrink-to-"i" animation
 // itself has no measurable target in jsdom (no LoadReportControl rendered
 // here, and getBoundingClientRect is zeroed), so the success auto-dismiss
@@ -89,6 +105,30 @@ describe('AlertAndSnackbar grace period', () => {
     expect(line.textContent).toContain('1.114s, +89.034761 MB heap')
     // The bar is space-padded past "98%" so "]" holds a fixed column.
     expect(line.textContent).toMatch(/98% +\]/)
+  })
+
+  it('widens the content box when the report is expanded', () => {
+    render(<ShareMock><AlertAndSnackbar/></ShareMock>)
+    act(() => {
+      useStore.getState().setLoadReportLines(['Model: Arty_Z7.stp — AP214, 38.1 MB'])
+      useStore.getState().setLoadResult({status: 'success', summaryLine: 'Loaded Arty_Z7.stp'})
+    })
+    const content = document.querySelector('[data-testid="snackbar"] .MuiSnackbarContent-root')
+    // Read the emitted rules rather than getComputedStyle: jsdom drops
+    // `fit-content` as an unsupported width and never applies media queries,
+    // so both bands are only visible in the stylesheet emotion inserted.
+    expect(cssOf(content)).toContain('max-width:94vw')
+
+    fireEvent.click(screen.getByTestId('LoadStatusExpandToggle'))
+    const expandedCss = cssOf(content)
+    // Mobile band (base declarations) — edge to edge.
+    expect(expandedCss).toContain('min-width:100%')
+    expect(expandedCss).toContain('max-width:100%')
+    // Desktop band (sm and up) — half the viewport at least, four fifths at most.
+    expect(expandedCss).toMatch(/@media \(min-width:600px\)[^}]*min-width:50vw/)
+    expect(expandedCss).toMatch(/@media \(min-width:600px\)[^}]*max-width:80vw/)
+    // The message slot grows with the box, or the extra width is dead space.
+    expect(expandedCss).toMatch(/MuiSnackbarContent-message\{[^}]*flex-grow:1/)
   })
 
   it('prefers the page-title model name for the success grace line', () => {

--- a/src/loader/loadProgress.js
+++ b/src/loader/loadProgress.js
@@ -29,9 +29,10 @@ import {LoadLogAccumulator, formatMb} from '@bldrs-ai/conway/src/core/progress_l
 
 const BREADCRUMB_INTERVAL_MS = 1000
 const STATUS_LINE_INTERVAL_MS = 100
-// Cap on distinct warning/error lines appended to the report so a model
-// that throws thousands of CDT exceptions stays copy-pasteable.
-const MAX_DIAGNOSTIC_LINES = 50
+// Cap on the sample message carried by the one-line diagnostics summary —
+// long enough to recognize which family of warning dominated, short enough
+// that the line still reads as a summary.
+const MAX_DIAGNOSTIC_SAMPLE_CHARS = 80
 
 /**
  * No event during a tickable phase for this long → stalled. Long enough
@@ -388,23 +389,38 @@ class LoadProgressReporter {
     useStore.getState().setCurrentLoadLine(null)
   }
 
-  /** Append the deduplicated console warnings/errors below the Total line. */
+  /**
+   * Summarize the captured console warnings/errors as a *single* line below
+   * Total: counts plus the most frequent message.
+   *
+   * Deliberately one line and not a listing. Engines emit per-entity
+   * diagnostics ("Error processing representation #NNN"), which dedup can't
+   * collapse because each is textually distinct — a STEP model can produce
+   * hundreds, which buried the rest of the report in the snackbar expando and
+   * in the copyable "i" report alike. Nothing is lost: the console tee passes
+   * every message through to the real console, so full detail stays one
+   * devtools panel away.
+   */
   appendDiagnostics() {
     if (this.diagnostics.size === 0) {
       return
     }
-    const total = Array.from(this.diagnostics.values()).reduce((sum, count) => sum + count, 0)
-    this.addReportLine(`Warnings & errors (${total}):`, false)
-
-    let shown = 0
+    let total = 0
+    let topText = ''
+    let topCount = 0
     for (const [text, count] of this.diagnostics) {
-      if (shown >= MAX_DIAGNOSTIC_LINES) {
-        this.addReportLine(`(+${this.diagnostics.size - shown} more distinct)`, false)
-        break
+      total += count
+      if (count > topCount) {
+        topCount = count
+        topText = text
       }
-      this.addReportLine(count > 1 ? `${text} (×${count})` : text, false)
-      shown++
     }
+    const distinctNote = this.diagnostics.size > 1 ? `, ${this.diagnostics.size} distinct` : ''
+    const sample = topText.length > MAX_DIAGNOSTIC_SAMPLE_CHARS ?
+      `${topText.slice(0, MAX_DIAGNOSTIC_SAMPLE_CHARS - 1)}…` :
+      topText
+    const sampleNote = topCount > 1 ? `${sample} (×${topCount})` : sample
+    this.addReportLine(`Warnings & errors (${total}${distinctNote}): ${sampleNote}`, false)
   }
 
   /** Stop watching (load finished or failed); restore the console tee. */

--- a/src/loader/loadProgress.test.js
+++ b/src/loader/loadProgress.test.js
@@ -145,7 +145,7 @@ describe('loadProgress', () => {
       expect(useStore.getState().currentLoadLine).toBe(null)
     })
 
-    it('appends captured console warnings/errors after the Total line', () => {
+    it('summarizes captured console warnings/errors after the Total line', () => {
       const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
       beginLoadProgress({fileInfo: 'index.ifc'})
       reportLoadProgress({phase: 'geometry', completed: 1, total: 10, elapsedMs: 50})
@@ -156,11 +156,50 @@ describe('loadProgress', () => {
 
       const lines = reportLines()
       const totalIndex = lines.findIndex((line) => /^Total: /.test(line))
-      const diagHeaderIndex = lines.findIndex((line) => /^Warnings & errors \(/.test(line))
+      const diagIndex = lines.findIndex((line) => /^Warnings & errors \(/.test(line))
       expect(totalIndex).toBeGreaterThanOrEqual(0)
-      expect(diagHeaderIndex).toBeGreaterThan(totalIndex)
-      expect(lines).toContain('CDT Exception (hemisphere: 0) (×2)')
+      expect(diagIndex).toBeGreaterThan(totalIndex)
+      // One line only: counts + the message. A single distinct message drops
+      // the "N distinct" note.
+      expect(lines[diagIndex]).toBe('Warnings & errors (2): CDT Exception (hemisphere: 0) (×2)')
       consoleErrorSpy.mockRestore()
+    })
+
+    it('collapses many distinct warnings into that one line', () => {
+      const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+      beginLoadProgress({fileInfo: 'Arty_Z7_PCB.stp'})
+      // Per-entity engine diagnostics: textually distinct, so dedup can't
+      // collapse them — a STEP model emits hundreds.
+      const distinctCount = 200
+      for (let i = 0; i < distinctCount; i++) {
+        console.warn(`Error processing representation #${i}`)
+      }
+      // ...plus one repeated message, which wins the "most common" sample.
+      console.warn('No basis found for brep!')
+      console.warn('No basis found for brep!')
+      endLoadProgress()
+
+      const lines = reportLines()
+      const diagLines = lines.filter((line) => /^Warnings & errors/.test(line))
+      expect(diagLines).toHaveLength(1)
+      expect(diagLines[0]).toBe('Warnings & errors (202, 201 distinct): No basis found for brep! (×2)')
+      // Nothing else from the diagnostics leaks into the report.
+      expect(lines.some((line) => /Error processing representation/.test(line))).toBe(false)
+      consoleWarnSpy.mockRestore()
+    })
+
+    it('truncates a long sample message', () => {
+      const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+      const overlongChars = 200
+      const readableLineChars = 120
+      beginLoadProgress({fileInfo: 'index.ifc'})
+      console.warn(`long ${'x'.repeat(overlongChars)}`)
+      endLoadProgress()
+
+      const diagLine = reportLines().find((line) => /^Warnings & errors/.test(line))
+      expect(diagLine).toMatch(/^Warnings & errors \(1\): long x+…$/)
+      expect(diagLine.length).toBeLessThan(readableLineChars)
+      consoleWarnSpy.mockRestore()
     })
 
     it('a new load clears the previous report', () => {


### PR DESCRIPTION
## Summary

Refactors the load-progress diagnostics reporting from a multi-line listing to a single-line summary. This prevents per-entity engine warnings (e.g., "Error processing representation #NNN") from overwhelming the snackbar expando and copyable report, while preserving full detail in the console.

## Changes

**Load progress reporting** (`src/loader/loadProgress.js`):
- Changed `appendDiagnostics()` to emit a single summary line instead of listing all distinct warnings
- Summary format: `Warnings & errors (total[, N distinct]): most_frequent_message (×count)`
- Replaced `MAX_DIAGNOSTIC_LINES` cap (50) with `MAX_DIAGNOSTIC_SAMPLE_CHARS` (80) to truncate long sample messages
- Tracks the most frequent message and distinct count; nothing is lost—all messages still pass through to the real console

**Snackbar layout** (`src/Containers/AlertDialogAndSnackbar.jsx`):
- Added responsive sizing: collapsed state hugs content width (no 288px MUI sprawl), expanded state takes a viewport-relative band (50–80% on desktop, edge-to-edge on mobile)
- Introduced `COLLAPSED_CONTENT_SX` and `EXPANDED_CONTENT_SX` constants for clarity
- Expanded state grows the message slot (`flexGrow: 1, minWidth: 0`) so the extra width isn't dead space on the right

**Tests**:
- Updated existing test to verify the new one-line format
- Added test for collapsing many distinct warnings (201 distinct + 1 repeated = 202 total)
- Added test for truncating long sample messages to ~80 characters
- Added test verifying snackbar widens correctly when report is expanded

**Documentation** (`design/new/load-log-format.md`):
- Updated format spec and example to reflect the new one-line diagnostics summary
- Clarified the rationale: per-entity diagnostics can't be deduplicated and would bury the report in the UI; full detail remains in devtools

## Implementation notes

- The summary deliberately shows only the most frequent message (not a top-N list) to keep it scannable as a single line
- Distinct count is omitted when there's only one unique message (cleaner output)
- Message truncation preserves readability while keeping the line within ~120 characters
- All console output still reaches devtools; this is purely a UI summarization

https://claude.ai/code/session_01Pga1GkDAKJSAYuZP9Ea5QJ