### PR TITLE
Docs: workspace-store.md — the repo-as-workspace persistence direction

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,7 @@ This file is the router for AI assistants working in this repo. Keep it small. T
 | Load-log report format (CLI + console + snackbar expando + "i" report dialog), stage/Total line semantics, per-format cascade, `loadProgress.js` (deep-imports conway `core/progress_log`)/`AlertDialogAndSnackbar.jsx` (live expando)/`LoadReportControl` | [design/new/load-log-format.md](design/new/load-log-format.md) |
 | Epic/Story/Track catalogue, milestone tier rubric (§2.1), MVP bar + phase plan (§6, ex-"Pro-MVP"), growth-funnel Phase G, AI-workspace pivot (§7), post-MVP loveables | [design/roadmap.md](design/roadmap.md) |
 | Conversational-CAD epic plan (workspace shell / ProjectsDrawer + TopBar, fluid Nav+search, convo panel, multi-user channels), wireframe→issue mapping, epic/sub-issue process | [design/new/conversational-cad.md](design/new/conversational-cad.md) |
+| Persistence direction: OPFS as a git-versioned workspace (repo-as-workspace, LFS-pointer blobs, record-vs-stream convo split, wasm-git vs isomorphic-git investigation, exit plan) | [design/new/workspace-store.md](design/new/workspace-store.md) |
 
 Anything not in this table is invisible to the router. When you create a doc that future assistants should consult, add a row above with a one-line "when to read" hint. Don't rely on filesystem discovery.
 

--- a/design/new/conversational-cad.md
+++ b/design/new/conversational-cad.md
@@ -88,7 +88,9 @@ name), don't invent a second one.
   and read at login — so it's a sync/merge target for the local store, not a
   live database. If/when projects need sharing or org scope, that's a real
   store decision that belongs to the T10 conversation-store question — don't
-  solve it here.
+  solve it here. The direction for that decision is now pre-scoped in
+  `workspace-store.md` (repo-as-workspace); these tiers are the
+  stepping stones toward it, not rivals to it.
 
 ### 2.3 TopBar (W2)
 
@@ -249,7 +251,9 @@ design, not code.
   backends — matrix.org, Discord, Slack — following the provider-pattern
   precedent already in the codebase (T3 `ConnectionProvider`, T4 sharing
   providers). This *is* the roadmap §10 "conversation store" open question,
-  sharpened: matrix.org is the structurally interesting candidate (open
+  sharpened (and now pre-scoped in `workspace-store.md` §1.3: the repo is
+  the durable record, the ChannelProvider is the live layer, distillation
+  connects them): matrix.org is the structurally interesting candidate (open
   protocol, rooms ≈ channels, ACLs ≈ grants, federation ≈ BYOS — the same
   bring-your-own-storage shape as the rest of the product), with
   Discord/Slack as bridge plugins for where teams already live. The scoping

--- a/design/new/workspace-store.md
+++ b/design/new/workspace-store.md
@@ -89,9 +89,8 @@ single-user convo panel (assist-310) and multi-user channels
 Either way this is an infrastructure project, not a dependency you add.
 
 - **wasm-git** (libgit2 → wasm): more complete git semantics. Costs:
-  browser→GitHub smart HTTP needs a CORS proxy (known territory —
-  `git.bldrs.dev`); libgit2's partial-clone/promisor support is limited;
-  the emscripten-FS↔OPFS bridge needs a worker + `syncAccessHandle` to
+  libgit2's partial-clone/promisor support is limited, and the
+  emscripten-FS↔OPFS bridge needs a worker + `syncAccessHandle` to
   perform.
 - **isomorphic-git** (pure JS): easier to embed, weaker merge, no
   rebase. **Prior finding to re-verify:** this came up before, and the
@@ -99,9 +98,33 @@ Either way this is an infrastructure project, not a dependency you add.
   semantics, which among other things caused shallow-clone trouble.
   Needs a real investigation with citations before the engine is chosen.
 
-The investigation should produce: protocol-v2 support status in both,
-shallow + partial clone behavior against GitHub through a CORS proxy,
-merge fidelity, OPFS throughput, and bundle-size cost.
+### 2.0 Do we need a CORS proxy? Only for the wire protocol
+
+Octokit works direct from the browser because `api.github.com` serves
+CORS headers. What doesn't is the **git smart-HTTP wire protocol**
+(`…/repo.git/info/refs`, `git-upload-pack`, `git-receive-pack`) —
+GitHub deliberately leaves CORS off those endpoints, which is the one
+and only reason browser git clients need a proxy (isomorphic-git's own
+hosted `cors.isomorphic-git.org` exists for exactly this).
+
+That gives sync two candidate paths, not one:
+
+- **Wire protocol through a CORS proxy** (known territory —
+  `git.bldrs.dev`): generic — works against any git remote, gets
+  packfiles/deltas — but adds hosted infrastructure on our side.
+- **GitHub Git Data API as the transport** (blobs/trees/commits/refs
+  via Octokit — CORS-clean, no proxy): the engine manages the local
+  OPFS repo, and push/fetch map onto REST calls. Chattier (a round
+  trip per object, no packfiles) and GitHub-only, but workspace repos
+  are small text files, so this may be entirely adequate for the
+  primary case — with the proxy path reserved for non-GitHub remotes.
+
+The investigation should produce: protocol-v2 support status in both
+engines, shallow + partial clone behavior against GitHub through a CORS
+proxy, a Data-API-transport feasibility check (round-trip counts for a
+realistic workspace sync, rate-limit exposure), whether the LFS batch
+endpoints are CORS-usable from the browser or also need proxying, merge
+fidelity, OPFS throughput, and bundle-size cost.
 
 ### 2.1 The rival to name: CRDTs
 

--- a/design/new/workspace-store.md
+++ b/design/new/workspace-store.md
@@ -1,0 +1,168 @@
+# Workspace store — the repo-as-workspace direction
+
+**Status:** v0.1 — direction agreed in principle; nothing below is
+committed scope. This doc exists so the thinking survives; the T10
+conversation-store decision and `ai-workspace.md` (roadmap §7.4 AI.0)
+will consume it.
+**Date:** 2026-07-28
+**Owner:** Pablo
+
+The question this answers: what are we persisting, where, and what's the
+exit plan? Today's answer is three ad-hoc pots — localStorage JSON docs
+(recents, workspace Tier 1), OPFS blobs (model cache), and Auth0
+`user_metadata` as a Tier-2 sync target. That's fine for a projects
+list; it does not scale to what the AI-workspace pivot needs: config,
+projects, conversation threads, and model references, versioned and
+syncable, with a user-private / team / public split.
+
+
+## 1. The direction
+
+**Treat OPFS as a normal workspace filesystem, versioned with git, and
+persist everything except large blobs.**
+
+- The workspace is a git repo living in OPFS: config files, project
+  structs, conversation transcripts, model *references* — all plain
+  files with history.
+- Large model blobs stay out of history, exactly as they'd be out of a
+  server-side repo via LFS. The repo stores pointer files; OPFS doubles
+  as the content-addressed blob cache it already almost is.
+- Sync is `git push`/`pull` to any remote. For GitHub-backed users this
+  means **no new backend**: a private repo is the workspace store, and
+  LFS on that repo is the blob store — consistent with the §2.2
+  "no new backend" theme and the product's BYOS shape.
+
+**Why this and not a database:** the exit plan becomes a property of the
+design rather than a promise. A user's workspace is a plain git repo —
+`git clone` *is* data liberation. Share is already git-native (GitHub as
+primary source, sha-anchored permalinks, Versions UI); this rhymes with
+everything the product does.
+
+### 1.1 The audience split
+
+- **Machine-local** (caches, device prefs): `.gitignore`. Ignore rules
+  separate tracked from untracked — the right tool for exactly this and
+  nothing more.
+- **User-private vs team vs public**: git has no per-file ACL, so
+  audience boundaries are **repo/remote boundaries** — a private
+  workspace repo vs shared project repos — not ignore rules. v0 may
+  approximate "user-private = untracked + mirrored to Auth0", knowing
+  that's a stand-in for repo separation, not the end state.
+- **Auth0 `user_metadata` shrinks to a bootstrap record**: identity
+  prefs + pointers to the user's workspace remotes. The §2.2 constraints
+  hold (small-JSON, per-user, read-at-login, sync target not live DB) —
+  this direction makes it *more* minimal, not less.
+
+### 1.2 The blob tier
+
+Don't invent a middle tier — **adopt the git-lfs pointer format**. If
+the repo stores real LFS pointer files and OPFS is the content-addressed
+cache, then any LFS-capable remote (GitHub) is already the blob store.
+A bldrs-hosted S3-compatible endpoint becomes just another LFS backend
+for anonymous/no-GitHub users, and is deferrable until something pulls
+on it.
+
+### 1.3 Record vs stream — where conversations live
+
+Git is the right store for artifacts, config, project history, and
+*settled* conversation. It is the wrong transport for live multi-user
+chat: snapshot-and-merge, no push, no presence, merge noise under
+concurrent appenders. Matrix's event DAG is essentially "git for chat"
+built for real-time.
+
+So the division is:
+
+- **The repo is the durable, canonical project record.**
+- **The ChannelProvider is the live layer** (matrix.org / Discord /
+  Slack — epic assist-400, `conversational-cad.md` §5).
+- **Distillation connects them**: streams checkpoint into the repo —
+  thread → file, like minutes into a logbook.
+
+AI conversation fits the same shape: the live exchange is a stream, the
+kept transcript is a file. This is the requirements overlap between the
+single-user convo panel (assist-310) and multi-user channels
+(assist-400), made structural.
+
+
+## 2. Engine question: wasm-git vs isomorphic-git (open — needs investigation)
+
+Either way this is an infrastructure project, not a dependency you add.
+
+- **wasm-git** (libgit2 → wasm): more complete git semantics. Costs:
+  browser→GitHub smart HTTP needs a CORS proxy (known territory —
+  `git.bldrs.dev`); libgit2's partial-clone/promisor support is limited;
+  the emscripten-FS↔OPFS bridge needs a worker + `syncAccessHandle` to
+  perform.
+- **isomorphic-git** (pure JS): easier to embed, weaker merge, no
+  rebase. **Prior finding to re-verify:** this came up before, and the
+  recollection is that isomorphic-git lacked git-2 wire/protocol
+  semantics, which among other things caused shallow-clone trouble.
+  Needs a real investigation with citations before the engine is chosen.
+
+The investigation should produce: protocol-v2 support status in both,
+shallow + partial clone behavior against GitHub through a CORS proxy,
+merge fidelity, OPFS throughput, and bundle-size cost.
+
+### 2.1 The rival to name: CRDTs
+
+Automerge/Yjs beat git for *concurrent small-document edits* (two people
+touching project config, live cursors); git beats CRDTs for history,
+audit, blobs, and interop. The mature answer is often hybrid — CRDT for
+the live doc, checkpointed into git — which slots into the record/stream
+split above (CRDTs live on the stream side). The eventual decision doc
+must treat CRDTs as a considered adoption or rejection, not an omission.
+
+
+## 3. Packaging: a separate engine repo, eventually
+
+The instinct: a standalone repo akin to conway — roughly "matrix.org's
+Hydrogen + wasm-git": a versioned local store plus a sync/replication
+layer, product-independent and testable headless.
+
+Agreed, with one caution from our own history: engine version-lag has a
+documented cost here (`adapter-removal.md`). So **prove the API seam
+inside Share first** — a `workspace/store` boundary, of which
+`src/workspace/persistence.ts` is the embryo — and extract to its own
+repo once the interface stops moving, not before.
+
+
+## 4. What this costs today: almost nothing, given two habits
+
+Everything Tier 1 persists is already a serializable document behind one
+seam; "JSON doc in localStorage" → "file in a repo" is a `mv`, not a
+migration. To keep it that way:
+
+1. **All new persistence goes through the `workspace/persistence.ts`
+   seam, document-shaped.** Never a second bespoke store.
+2. **Conversation logs are file-shaped from day one.** When the convo
+   tray stub (#1672) lands, its per-model/per-project log should be
+   stored as a JSONL-style document the repo store can adopt wholesale.
+
+Nothing in the shipped Tier-1 work (#1684) fights this direction.
+
+
+## 5. Relationship to existing plans
+
+- **T10 conversation store** (roadmap §10): this doc is the sharpened
+  input; the record/stream split (§1.3) is the proposed answer shape.
+- **`ai-workspace.md`** (roadmap §7.4 AI.0, not yet drafted): owns the
+  final storage decision alongside runtime/provider/sandbox; its storage
+  section should consume this doc rather than restate it.
+- **ChannelProvider** (`conversational-cad.md` §5): unchanged; this doc
+  assigns it the stream side of the split.
+- **§2.2 persistence tiers**: Tier 1 (localStorage) and Tier 2 (Auth0)
+  stand as shipped/planned; this is the tier *behind* them once the
+  workspace outgrows a projects list.
+
+
+## 6. Open questions
+
+1. Engine: wasm-git vs isomorphic-git (§2 investigation, with the
+   git-2-semantics recollection verified or retired).
+2. CRDT adoption/rejection for the live-doc layer (§2.1).
+3. Multi-tab coordination (single writer via Web Locks?) and OPFS quota
+   / `navigator.storage.persist()` behavior across browsers.
+4. Anonymous users: local-only repo until sign-in, then push to a
+   created remote? Where does the anonymous blob tier live before then?
+5. E2EE for private convo distillation if channels are Matrix-backed.
+6. Are channels and Notes one primitive or two (roadmap §10, restated).


### PR DESCRIPTION
## Summary

Docs-only. Captures the agreed persistence direction ahead of the T10 conversation-store decision and `ai-workspace.md` (roadmap §7.4 AI.0), so the thinking survives as a citable doc rather than a chat log. Explicitly **v0.1, direction-not-scope** — nothing here commits implementation work.

## What&#39;s in `design/new/workspace-store.md`

- **Repo-as-workspace**: OPFS as a normal workspace filesystem, versioned with git; persist everything except large blobs. The exit plan becomes a property of the design — `git clone` *is* data liberation.
- **Blob tier = git-lfs pointer format**, with OPFS as the content-addressed cache. For GitHub-backed users, a private repo + LFS is the whole backend (no new backend); a bldrs-hosted LFS endpoint is a deferrable add-on for anonymous users.
- **Audience split**: `.gitignore` is for machine-local only; user/team/public boundaries are repo boundaries (git has no per-file ACL). Auth0 `user_metadata` shrinks to a bootstrap record, keeping the §2.2 constraints.
- **Record vs stream**: the repo is the durable project record; the ChannelProvider (assist-400) is the live layer; distillation checkpoints streams into files. This makes the assist-310/assist-400 convo-store overlap structural.
- **§2.0 CORS nuance**: Octokit works browser-direct because `api.github.com` serves CORS headers — only the git smart-HTTP wire protocol lacks them. So sync has two candidate transports: wire protocol through a CORS proxy (generic, packfiles) vs the GitHub Git Data API via Octokit (proxyless, chattier, GitHub-only, likely adequate for small workspace repos).
- **Engine investigation flagged, not decided**: wasm-git vs isomorphic-git, including the prior recollection that isomorphic-git lacked git-2 wire semantics with shallow-clone fallout (to verify or retire), Data-API-transport feasibility, LFS-endpoint CORS status, OPFS throughput, bundle size. CRDTs named as the rival/complement to adopt or reject explicitly.
- **Packaging**: standalone engine repo à la conway (roughly Hydrogen + wasm-git), extracted only after the seam is proven inside Share — `adapter-removal.md` documents the version-lag cost.
- **What it costs today**: two habits — all persistence through the `workspace/persistence.ts`-style seam, document-shaped; convo logs file-shaped from day one (#1672).

## Cross-links

`conversational-cad.md` §2.2 (tiers are stepping stones toward this) and §5 (ChannelProvider gets the stream side); AGENTS.md router row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PdqbBTEUn8hY43CXBk6kWL

---
_Generated by [Claude Code](https://claude.ai/code/session_01PdqbBTEUn8hY43CXBk6kWL)_