### PR TITLE
Workspace TopBar: breadcrumb + relocated search (#1663, ?feature=workspace)

### DIFF
--- a/design/new/conversational-cad.md
+++ b/design/new/conversational-cad.md
@@ -191,6 +191,56 @@ summon and filter; breadcrumbs become the scope control for search.
 Fold-in: `search-100`'s open story #1254 (search by element name with scene
 highlighting) naturally lands inside this epic's E2E.
 
+### 3.1 Slice plan (v0.2 — scoped with #1663 kickoff)
+
+Prior art: celestiary/web#61 (breadcrumb-anchored search) — breadcrumb
+chips with a movable search-icon anchor where **anchor position = search
+scope**, inline autocomplete, a `SearchProvider` interface with tiered
+indexes (fuzzy for small named sets, exact maps for large ID catalogs),
+committed-vs-preview state in a store slice. Share generalizes the
+breadcrumb to the workspace hierarchy:
+
+```
+[workspace] / project / model / element-path…        (convos join in Epic 3)
+```
+
+Each anchor position binds a provider: **outside-of-project** (other
+projects, GitHub — stub/placeholder first), **project contents** (drawer
+store), **model elements** (the real index), **convos** (Epic 3). Search
+is scoped to the subtree right of the anchor.
+
+Slices, in order — each a story with desktop+mobile E2E per §7.1:
+
+1. **TopBar shell** (#1663, epic 1): ToolbarPaper becomes a real TopBar —
+   breadcrumb (project / model from the workspace store) + relocated
+   SearchBar — behind `?feature=workspace`. No NavTree changes.
+2. **Scope mechanic + SearchProvider seam**: anchor/scope UX per the
+   celestiary pattern; provider interface; model-elements provider wraps
+   today's `SearchIndex`; project provider over the drawer store; stubs
+   for outside-of-project and convo. Folds in #1254.
+3. **Pinned expansion ↔ NavTree convergence**: the autocomplete dropdown
+   pins into a virtualized tree panel. Deliberately *not* pre-deciding
+   NavTree's retirement — build the pinned expansion, dogfood both, then
+   retire the drawer tree (or shrink it to Versions-only) as its own
+   decision. Sharpens this section's existing open question into a
+   decide-by-experience.
+4. **Lazy spatial provider (memory)**: today NavTree + SearchIndex hold
+   the *entire* deserialized spatial tree (`rootElement` in the store) —
+   O(elements) JS memory on top of engine memory. Replace with a
+   node-provider API: materialize O(roots) at load, fetch children on
+   expand from the engine, LRU-evict collapsed subtrees for fixed
+   overhead. Tree view and breadcrumb both consume it.
+   *Investigation:* what children-of-node / props queries conway exposes
+   post-load.
+5. **Streaming search index**: search becomes a subscriber on the
+   progressive-load session (the `onMeshBatch`-era architecture) —
+   index per parsed batch, live match-as-load: enter a query during
+   load and watch results accumulate. Replaces slice 2's one-shot
+   model-elements provider behind the same interface, no UI change.
+   *Investigation:* whether conway exposes a props/spatial stream during
+   parse (shares the engine seam with slice 4, hence sequenced after
+   the UX slices).
+
 Tier note (§9): proposed as `search-320` — Pro band, since it rides the
 pivot arc (§2.1 rubric: the milestone that doesn't happen without it is the
 pivot, not the MVP trickle). If we decide it's wanted regardless of the

--- a/design/new/conversational-cad.md
+++ b/design/new/conversational-cad.md
@@ -214,17 +214,18 @@ Slices, in order — each a story with desktop+mobile E2E per §7.1:
 1. **TopBar shell** (#1663, epic 1): ToolbarPaper becomes a real TopBar —
    breadcrumb (project / model from the workspace store) + relocated
    SearchBar — behind `?feature=workspace`. No NavTree changes.
-2. **Scope mechanic + SearchProvider seam**: anchor/scope UX per the
-   celestiary pattern; provider interface; model-elements provider wraps
-   today's `SearchIndex`; project provider over the drawer store; stubs
-   for outside-of-project and convo. Folds in #1254.
-3. **Pinned expansion ↔ NavTree convergence**: the autocomplete dropdown
-   pins into a virtualized tree panel. Deliberately *not* pre-deciding
-   NavTree's retirement — build the pinned expansion, dogfood both, then
-   retire the drawer tree (or shrink it to Versions-only) as its own
-   decision. Sharpens this section's existing open question into a
-   decide-by-experience.
-4. **Lazy spatial provider (memory)**: today NavTree + SearchIndex hold
+2. **Scope mechanic + SearchProvider seam** (#1669 UX + #1699 seam):
+   anchor/scope UX per the celestiary pattern; provider interface;
+   model-elements provider wraps today's `SearchIndex`; project provider
+   over the drawer store; stubs for outside-of-project and convo. Folds
+   in #1254.
+3. **Pinned expansion ↔ NavTree convergence** (#1668; retirement decision
+   #1670): the autocomplete dropdown pins into a virtualized tree panel.
+   Deliberately *not* pre-deciding NavTree's retirement — build the
+   pinned expansion, dogfood both, then retire the drawer tree (or
+   shrink it to Versions-only) as its own decision. Sharpens this
+   section's existing open question into a decide-by-experience.
+4. **Lazy spatial provider (memory)** (#1701): today NavTree + SearchIndex hold
    the *entire* deserialized spatial tree (`rootElement` in the store) —
    O(elements) JS memory on top of engine memory. Replace with a
    node-provider API: materialize O(roots) at load, fetch children on
@@ -232,7 +233,7 @@ Slices, in order — each a story with desktop+mobile E2E per §7.1:
    overhead. Tree view and breadcrumb both consume it.
    *Investigation:* what children-of-node / props queries conway exposes
    post-load.
-5. **Streaming search index**: search becomes a subscriber on the
+5. **Streaming search index** (#1702): search becomes a subscriber on the
    progressive-load session (the `onMeshBatch`-era architecture) —
    index per parsed batch, live match-as-load: enter a query during
    load and watch results accumulate. Replaces slice 2's one-shot

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bldrs",
-  "version": "1.1697.7c9c5c14",
+  "version": "1.1697.ca7052d1",
   "main": "src/index.jsx",
   "license": "AGPL-3.0",
   "homepage": "https://github.com/bldrs-ai/Share",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bldrs",
-  "version": "1.1683.cbb1d855",
+  "version": "1.1697.05697899",
   "main": "src/index.jsx",
   "license": "AGPL-3.0",
   "homepage": "https://github.com/bldrs-ai/Share",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bldrs",
-  "version": "1.1697.ca7052d1",
+  "version": "1.1697.be34dfac",
   "main": "src/index.jsx",
   "license": "AGPL-3.0",
   "homepage": "https://github.com/bldrs-ai/Share",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bldrs",
-  "version": "1.1697.a3fddab3",
+  "version": "1.1697.4ca17f36",
   "main": "src/index.jsx",
   "license": "AGPL-3.0",
   "homepage": "https://github.com/bldrs-ai/Share",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bldrs",
-  "version": "1.1697.05697899",
+  "version": "1.1697.7c9c5c14",
   "main": "src/index.jsx",
   "license": "AGPL-3.0",
   "homepage": "https://github.com/bldrs-ai/Share",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bldrs",
-  "version": "1.1697.be34dfac",
+  "version": "1.1697.443e13bf",
   "main": "src/index.jsx",
   "license": "AGPL-3.0",
   "homepage": "https://github.com/bldrs-ai/Share",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bldrs",
-  "version": "1.1697.443e13bf",
+  "version": "1.1697.a3fddab3",
   "main": "src/index.jsx",
   "license": "AGPL-3.0",
   "homepage": "https://github.com/bldrs-ai/Share",

--- a/src/Components/NavTree/NavTreePanel.jsx
+++ b/src/Components/NavTree/NavTreePanel.jsx
@@ -40,6 +40,12 @@ export default function NavTreePanel({
   const setIsNavTreeVisible = useStore((state) => state.setIsNavTreeVisible)
   const rootElement = useStore((state) => state.rootElement)
   const selectedElements = useStore((state) => state.selectedElements)
+  // Row highlight follows what the user picked, not the descendants
+  // added so a container's geometry highlights in the scene — without
+  // this, selecting a storey lit up every child row too.
+  const selectedAnchorIds = useStore((state) => state.selectedAnchorIds)
+  const selectedRowIds = (selectedAnchorIds && selectedAnchorIds.length > 0) ?
+    selectedAnchorIds : selectedElements
   const selectedOccurrencePath = useStore((state) => state.selectedOccurrencePath)
   const selectedSolidExpressId = useStore((state) => state.selectedSolidExpressId)
   const transientTreeNodes = useStore((state) => state.transientTreeNodes)
@@ -194,7 +200,7 @@ export default function NavTreePanel({
               visibleNodes,
               expandedNodeIds,
               setExpandedNodeIds,
-              selectedNodeIds: selectedElements,
+              selectedNodeIds: selectedRowIds,
               selectedOccurrencePathKey,
               selectedSolidExpressId,
               selectWithShiftClickEvents,

--- a/src/Components/NavTree/SynchronizedView.spec.ts
+++ b/src/Components/NavTree/SynchronizedView.spec.ts
@@ -179,4 +179,36 @@ describe('View 100: Synchronized View and NavTree', () => {
     const sceneIds = await getSceneSelectedIds(page)
     expect(sceneIds).toContain(LEAF_ID)
   })
+
+  // Picking a container selects its whole subtree in the *scene* — a
+  // container's geometry lives in its children — but the container
+  // itself stays the selection everywhere else. Regression covers both
+  // halves of what went wrong: the anchor (Properties followed a
+  // descendant instead of the clicked node) and the staleness guard
+  // (walking down to `Thing` then back up to `Build` left `Thing`'s
+  // slower property-set fetch resolving last and repainting the panel).
+  test('selecting a container keeps the container as the selection', async ({page}) => {
+    await visitHomepageWaitForModel(page)
+    const navPanel = await openNavTreeToLeaves(page)
+    // `Thing` is selected by the walk-down above; now go back up.
+    await navPanel.getByText('Build').click()
+
+    const BUILD_ID = 112
+    await expect.poll(async () => {
+      const el = await page.evaluate(() => {
+        const w = window as unknown as {store?: {getState: () => Record<string, unknown>}}
+        const sel = w.store?.getState().selectedElement as {expressID?: number}
+        return sel?.expressID ?? null
+      })
+      return el
+    }).toBe(BUILD_ID)
+
+    // The panel must agree with the selection, not with the deeper node
+    // visited on the way here.
+    await page.getByTestId('control-button-properties').click()
+    const propertiesPanel = page.getByTestId('PropertiesPanel')
+    await expect(propertiesPanel.locator('table').first()).toBeVisible()
+    const nameRow = propertiesPanel.locator('tr').filter({hasText: 'Name'}).first()
+    await expect(nameRow).toContainText('Build')
+  })
 })

--- a/src/Components/Properties/Properties.jsx
+++ b/src/Components/Properties/Properties.jsx
@@ -50,7 +50,15 @@ export default function Properties() {
   }, [isCacheWriteInFlight])
 
   useEffect(() => {
-    (async () => {
+    // Guarded against out-of-order resolution: this effect awaits twice
+    // (entity fetch, then property-set assembly), and property sets can
+    // take far longer for a deep container than for the element clicked
+    // after it. Without the guard a slow earlier run resolved last and
+    // overwrote the panel — clicking a storey then its parent building
+    // left the storey's properties on screen, contradicting the
+    // NavTree highlight and the breadcrumb.
+    let isStale = false
+    ;(async () => {
       if (model && element) {
         // Resolve `element` to the full IFC entity before rendering.
         // `selectedElement` is a spatial-tree node — for cache-miss
@@ -77,10 +85,24 @@ export default function Properties() {
             console.warn('Properties: getItemProperties failed; using selected element directly', e)
           }
         }
-        setPropTable(await createPropertyTable(model, fullElement))
-        setPsetsList(await createPsetsList(model, fullElement, expandAll))
+        if (isStale) {
+          return
+        }
+        const table = await createPropertyTable(model, fullElement)
+        if (isStale) {
+          return
+        }
+        setPropTable(table)
+        const psets = await createPsetsList(model, fullElement, expandAll)
+        if (isStale) {
+          return
+        }
+        setPsetsList(psets)
       }
     })()
+    return () => {
+      isStale = true
+    }
   }, [model, element, expandAll])
 
   const propSeparatorBorderOpacity = 0.3

--- a/src/Components/Properties/itemProperties.jsx
+++ b/src/Components/Properties/itemProperties.jsx
@@ -101,6 +101,25 @@ export function entityTypeName(model, ifcProps) {
 
 
 /**
+ * The object `deref` needs to resolve a type-5 entity reference. Its
+ * second parameter is a **web-ifc API**, not our model: it calls
+ * `webIfc.properties.getItemProperties(...)`. Passing the model meant
+ * that call threw on `undefined.getItemProperties` the moment a
+ * property carried a reference — which aborted the whole table and left
+ * the previously selected element's properties on screen. Spatial
+ * containers (IfcSite, IfcBuilding) hit it; leaves mostly don't, which
+ * is why this hid for so long.
+ *
+ * @param {object} model IFC model
+ * @return {object} web-ifc-shaped API, falling back to the model so
+ *   backends that already expose `properties` keep working.
+ */
+function webIfcFor(model) {
+  return model?.ifcManager?.ifcAPI ?? model
+}
+
+
+/**
  * The keys are defined here:
  * https://standards.buildingsmart.org/IFC/DEV/IFC4_3/RC2/HTML/schema/ifcproductextension/lexical/ifcelement.htm
  *
@@ -158,15 +177,19 @@ async function prettyProps(model, propName, propValue, isPset, serial = 0) {
       if (propValue.type === 0) {
         return null
       }
+      // `deref` takes (ref, webIfc, indent) — the 4th "render nested
+      // entity" callback this used to pass was never invoked, so a
+      // resolved reference came back as a raw entity object and React
+      // threw "Objects are not valid as a React child", aborting the
+      // table. Nest it into its own table here instead. Arrays are left
+      // alone: React renders them, and deref has already resolved each
+      // member.
+      const derefed = await deref(propValue, webIfcFor(model), serial)
+      const isEntity = derefed !== null && typeof derefed === 'object' && !Array.isArray(derefed)
       return (
         <Row
           d1={label}
-          d2={
-            await deref(
-              propValue, model, serial,
-              // TODO(pablo): there's no 4th param in deref
-              async (v, mdl, srl) => await createPropertyTable(mdl, v, false, srl))
-          }
+          d2={isEntity ? await createPropertyTable(model, derefed, false, serial) : derefed}
           key={serial}
         />
       )

--- a/src/Components/Properties/itemProperties.jsx
+++ b/src/Components/Properties/itemProperties.jsx
@@ -2,6 +2,7 @@ import React, {useState} from 'react'
 import {Typography} from '@mui/material'
 import {deref, decodeIFCString} from '@bldrs-ai/ifclib'
 import debug from '../../utils/debug'
+import {prettyType} from '../../utils/ifc'
 import {stoi} from '../../utils/strings'
 
 
@@ -22,7 +23,9 @@ export async function createPropertyTable(model, ifcProps, isPset = false, seria
   let rowKey = 0
   const typeName = entityTypeName(model, ifcProps)
   if (!isPset && typeName !== null && typeName !== 'IfcPropertySet') {
-    ROWS.push(<Row d1={'Type'} d2={typeName} key={`type-${serial}`}/>)
+    // Prettified for reading ('Element (generic proxy)'), not the raw
+    // schema constant ('IFCBUILDINGELEMENTPROXY').
+    ROWS.push(<Row d1={'Type'} d2={prettyType(typeName)} key={`type-${serial}`}/>)
   }
   for (const key in ifcProps) {
     if (isPset && (key === 'expressID' || key === 'Name')) {
@@ -65,7 +68,7 @@ export async function createPropertyTable(model, ifcProps, isPset = false, seria
  * @param {object} ifcProps the entity
  * @return {string|null}
  */
-function entityTypeName(model, ifcProps) {
+export function entityTypeName(model, ifcProps) {
   const rawType = ifcProps?.type
   if (typeof rawType === 'string' && rawType.length > 0) {
     return rawType

--- a/src/Components/Search/SearchBar.jsx
+++ b/src/Components/Search/SearchBar.jsx
@@ -18,12 +18,16 @@ import {SEARCH_BAR_PLACEHOLDER_TEXT} from './component'
  * @property {string} [placeholder] Text to display when search bar is inactive
  * @property {boolean} [isGitHubSearch] Strict screening for GH only links
  * @property {Function} [onSuccess] Optional callback when search succeeds
+ * @property {boolean} [fullWidth] Fill the host container instead of the
+ *   self-sized widths below — for hosts like the TopBar that own the
+ *   layout, where the fixed mobile width overflows the viewport.
  * @return {ReactElement}
  */
 export default function SearchBar({
   placeholder = SEARCH_BAR_PLACEHOLDER_TEXT,
   isGitHubSearch = false,
   onSuccess = null,
+  fullWidth = false,
 }) {
   assertDefined(placeholder, isGitHubSearch)
   const location = useLocation()
@@ -128,7 +132,13 @@ export default function SearchBar({
   // way to have them share the same width, which is now set in the
   // parent container (CadView).
   return (
-    <form onSubmit={onSubmit} style={{minWidth: '10em', width: isMobile ? `calc(100vw - ${twoButtonWidth})` : '25em'}}>
+    <form
+      onSubmit={onSubmit}
+      style={{
+        minWidth: fullWidth ? 0 : '10em',
+        width: fullWidth ? '100%' : (isMobile ? `calc(100vw - ${twoButtonWidth})` : '25em'),
+      }}
+    >
       <Autocomplete
         freeSolo
         options={['Dach', 'Decke', 'Fen', 'Wand', 'Leuchte', 'Pos', 'Te']}

--- a/src/Components/Search/SearchBar.jsx
+++ b/src/Components/Search/SearchBar.jsx
@@ -94,17 +94,29 @@ export default function SearchBar({
     }
 
 
-    // Searches from SearchBar clear current URL's IFC path.
+    // Searches from SearchBar clear current URL's IFC path. Existing
+    // params (feature flags in particular) ride along — replacing the
+    // whole query string here ejected workspace users from the shell
+    // on their first search.
     if (containsIfcPath(location)) {
       const newPath = stripIfcPathFromLocation(location)
+      const sp = new URLSearchParams(location.search)
+      sp.set(QUERY_PARAM, inputText)
       disablePageReloadApprovalCheck()
       navigate({
         pathname: newPath,
-        search: `?q=${inputText}`,
+        search: `?${sp.toString()}`,
       })
     } else {
-      setSearchParams({q: inputText})
-      onSuccess()
+      // Not the functional updater form — that needs react-router 6.4+
+      // and this repo pins 6.3, where a function argument serializes
+      // into a garbage query string.
+      const sp = new URLSearchParams(location.search)
+      sp.set(QUERY_PARAM, inputText)
+      setSearchParams(sp)
+      if (onSuccess) {
+        onSuccess()
+      }
     }
     searchInputRef.current.blur()
   }

--- a/src/Components/Search/SearchBar.jsx
+++ b/src/Components/Search/SearchBar.jsx
@@ -180,6 +180,23 @@ export default function SearchBar({
                 onCancel()
               }
             }}
+            // Blur dismisses a summoned bar, but only once focus has
+            // actually settled elsewhere: MUI renders the autocomplete
+            // popup in a portal, so picking an option blurs the input
+            // for a tick before focus returns to it. Checking on the
+            // next macrotask tells "clicked away" from "clicked a
+            // suggestion".
+            onBlur={() => {
+              if (!onCancel) {
+                return
+              }
+              setTimeout(() => {
+                const input = searchInputRef.current
+                if (input && document.activeElement !== input) {
+                  onCancel()
+                }
+              }, BLUR_SETTLE_MS)
+            }}
             data-testid='textfield-search-query'
           />
         )}
@@ -187,6 +204,11 @@ export default function SearchBar({
     </form>
   )
 }
+
+
+// Long enough for MUI's portal'd popup to hand focus back to the input
+// after an option click, short enough to feel immediate on click-away.
+const BLUR_SETTLE_MS = 150
 
 
 /** @type {string} */

--- a/src/Components/Search/SearchBar.jsx
+++ b/src/Components/Search/SearchBar.jsx
@@ -21,6 +21,11 @@ import {SEARCH_BAR_PLACEHOLDER_TEXT} from './component'
  * @property {boolean} [fullWidth] Fill the host container instead of the
  *   self-sized widths below — for hosts like the TopBar that own the
  *   layout, where the fixed mobile width overflows the viewport.
+ * @property {Function} [onCancel] Called on Escape, and on clearing an
+ *   already-empty field — hosts that summon the bar (the TopBar's
+ *   anchored search) use it to put it away again.
+ * @property {boolean} [takeFocus] Focus the input on mount, for hosts
+ *   that render the bar in response to an explicit "open search".
  * @return {ReactElement}
  */
 export default function SearchBar({
@@ -28,6 +33,8 @@ export default function SearchBar({
   isGitHubSearch = false,
   onSuccess = null,
   fullWidth = false,
+  onCancel = null,
+  takeFocus = false,
 }) {
   assertDefined(placeholder, isGitHubSearch)
   const location = useLocation()
@@ -125,6 +132,14 @@ export default function SearchBar({
     searchInputRef.current.blur()
   }
 
+  // Summoned bars start focused: the user asked for the field, so
+  // making them click it too is a wasted interaction.
+  useEffect(() => {
+    if (takeFocus) {
+      searchInputRef.current?.focus()
+    }
+  }, [takeFocus])
+
   const twoButtonWidth = '120px'
   const isMobile = useIsMobile()
   // The container and paper are set to 100% width to fill the
@@ -159,6 +174,12 @@ export default function SearchBar({
               width: '100%',
             }}
             fullWidth
+            onKeyDown={(event) => {
+              if (event.key === 'Escape' && onCancel) {
+                event.stopPropagation()
+                onCancel()
+              }
+            }}
             data-testid='textfield-search-query'
           />
         )}

--- a/src/Containers/CadView.jsx
+++ b/src/Containers/CadView.jsx
@@ -95,6 +95,8 @@ export default function CadView({
   const setRootElement = useStore((state) => state.setRootElement)
   const setSelectedElement = useStore((state) => state.setSelectedElement)
   const setSelectedElements = useStore((state) => state.setSelectedElements)
+  const setSelectedAnchorIds = useStore((state) => state.setSelectedAnchorIds)
+  const selectedAnchorIds = useStore((state) => state.selectedAnchorIds)
   const setViewer = useStore((state) => state.setViewer)
   const viewer = useStore((state) => state.viewer)
 
@@ -962,10 +964,15 @@ export default function CadView({
    *   whole product/occurrence. Solid nodes share their parent's occurrence
    *   path, so this is what tells "the part" from "one body inside it" —
    *   NavTree row highlight, per-solid hide and the permalink all read it.
+   * @param {Array} anchorIds The ids the user actually picked, when the
+   *   caller expanded them into descendants for the scene highlight
+   *   (`elementSelection` does). Null (the default) means every result is
+   *   its own anchor. NavTree row highlight, Properties and the TopBar
+   *   crumb follow the anchors; only the scene uses the expanded set.
    */
   function selectItemsInScene(
     resultIDs, updateNavigation = true, instanceIds = [], occurrencePath = null,
-    solidExpressId = null) {
+    solidExpressId = null, anchorIds = null) {
     // NOTE: we might want to compare with previous selection to avoid unnecessary updates
     if (!viewer) {
       return
@@ -974,6 +981,10 @@ export default function CadView({
       // Update The Component state
       const resIds = resultIDs.map((id) => `${id}`)
       setSelectedElements(resIds)
+      // Callers that expand a pick into descendants (elementSelection)
+      // pass the clicked ids explicitly; for everyone else every result
+      // is its own anchor.
+      setSelectedAnchorIds(anchorIds === null ? resIds : anchorIds.map((id) => `${id}`))
       setSelectedInstanceIds(instanceIds)
       // STEP per-occurrence key: a reused part's occurrences share one
       // expressID, so this disambiguates which NavTree node to highlight.
@@ -1352,8 +1363,13 @@ export default function CadView({
       }
       // If current selection is not empty
       if (selectedElements.length > 0) {
-        // Display the properties of the last one,
-        const lastId = selectedElements.slice(-1)[0]
+        // Properties follow the last *clicked* element. Reading
+        // `selectedElements` here showed a descendant instead: picking
+        // a container adds its whole subtree so the scene highlights,
+        // and the deepest child landed last in that array.
+        const anchors = (selectedAnchorIds && selectedAnchorIds.length > 0) ?
+          selectedAnchorIds : selectedElements
+        const lastId = anchors.slice(-1)[0]
         // Prefer the model-level `getItemProperties(id)` when present
         // — for cache-hit GLB it's the closure attached by
         // `Loader.js#convertToShareModel` from the
@@ -1397,7 +1413,7 @@ export default function CadView({
         setSelectedElement(null)
       }
     })()
-  }, [selectedElements, selectedInstanceIds, selectedOccurrencePath])
+  }, [selectedElements, selectedAnchorIds, selectedInstanceIds, selectedOccurrencePath])
   /* eslint-enable */
 
 

--- a/src/Containers/CadView.jsx
+++ b/src/Containers/CadView.jsx
@@ -1331,7 +1331,12 @@ export default function CadView({
 
 
   useEffect(() => {
-    (async () => {
+    // Same staleness guard as the Properties panel: this effect awaits
+    // the entity fetch before writing `selectedElement`, so a slow
+    // earlier selection could otherwise resolve last and leave every
+    // consumer (Properties, the TopBar crumb) showing the previous pick.
+    let isStale = false
+    ;(async () => {
       if (!Array.isArray(selectedElements) || !viewer) {
         return
       }
@@ -1386,6 +1391,9 @@ export default function CadView({
         if (!props && typeof viewer.getProperties === 'function') {
           props = await viewer.getProperties(0, Number(lastId))
         }
+        if (isStale) {
+          return
+        }
         setSelectedElement(props)
         // Reveal the selection in the NavTree by opening the path to it, merged
         // into the current expansion (see `expandedIdsForSelection`). For a STEP
@@ -1413,6 +1421,9 @@ export default function CadView({
         setSelectedElement(null)
       }
     })()
+    return () => {
+      isStale = true
+    }
   }, [selectedElements, selectedAnchorIds, selectedInstanceIds, selectedOccurrencePath])
   /* eslint-enable */
 

--- a/src/Containers/ControlsGroup.jsx
+++ b/src/Containers/ControlsGroup.jsx
@@ -7,6 +7,7 @@ import SaveModelControl from '../Components/Open/SaveModelControl'
 import SearchBar from '../Components/Search/SearchBar'
 import SearchControl from '../Components/Search/SearchControl'
 import VersionsControl from '../Components/Versions/VersionsControl'
+import useExistInFeature from '../hooks/useExistInFeature'
 import useStore from '../store/useStore'
 
 
@@ -22,6 +23,10 @@ export default function ControlsGroup() {
   const isSearchEnabled = useStore((state) => state.isSearchEnabled)
   const isSearchBarVisible = useStore((state) => state.isSearchBarVisible)
   const setIsSearchBarVisible = useStore((state) => state.setIsSearchBarVisible)
+  // With the workspace shell on, search lives in the TopBar (#1663) —
+  // this over-canvas toggle would be a second entry point to the same
+  // query state.
+  const isWorkspaceEnabled = useExistInFeature('workspace')
   const {isAuthenticated} = useAuth0()
   return (
     <Stack>
@@ -31,8 +36,8 @@ export default function ControlsGroup() {
            <OpenModelControl/>
            {isAuthenticated && <SaveModelControl/>}
          </>}
-        {isSearchEnabled && <SearchControl/>}
-        {isSearchEnabled &&
+        {isSearchEnabled && !isWorkspaceEnabled && <SearchControl/>}
+        {isSearchEnabled && !isWorkspaceEnabled &&
          isSearchBarVisible &&
          <SearchBar onSuccess={() => setIsSearchBarVisible(false)}/>}
       </Stack>

--- a/src/Containers/ProjectsDrawer.jsx
+++ b/src/Containers/ProjectsDrawer.jsx
@@ -21,13 +21,12 @@ import {
   Typography,
 } from '@mui/material'
 import {useTheme} from '@mui/material/styles'
-import {loadAllRecentFiles} from '../connections/persistence'
 import {useIsMobile} from '../Components/Hooks'
 import useStore from '../store/useStore'
 import {WORKSPACE_DRAWER_WIDTH_INITIAL} from '../store/WorkspaceSlice'
 import {CONTROL_MARGIN, CONTROL_SIZE, ROW_PITCH, TOP_BAR_HEIGHT} from './layoutConstants'
 import {hasStoredWorkspaceUiState} from '../workspace/persistence'
-import {recentDisplayName} from '../utils/modelDisplayName'
+import {labelForModelPath} from '../utils/modelDisplayName'
 import {navigateToModel} from '../utils/navigate'
 import {TooltipIconButton} from '../Components/Buttons'
 import HorizonResizerButton from '../Components/SideDrawer/HorizonResizerButton'
@@ -64,38 +63,6 @@ const rowSx = {
   height: `${CONTROL_SIZE}px`,
   margin: `${CONTROL_MARGIN}px`,
   borderRadius: '10px',
-}
-
-
-/**
- * The recents entry for a model route, if we have one. A local upload
- * routes by its OPFS storage id (`/v/new/<blob-uuid>.ifc`), so the path
- * segment alone would display as a UUID; recents holds the id -> name
- * mapping (see #1682).
- *
- * @param {string} pathname
- * @return {object|undefined} RecentFileEntry
- */
-function recentEntryForPath(pathname) {
-  const segment = decodeURIComponent(pathname.split('/').filter(Boolean).pop())
-  try {
-    return loadAllRecentFiles().find((f) => f.sharePath === pathname || f.id === segment)
-  } catch {
-    return undefined
-  }
-}
-
-
-/**
- * Label for a model route: the model's own name where known, else the
- * path segment.
- *
- * @param {string} pathname
- * @return {string}
- */
-function labelForModelPath(pathname) {
-  return recentDisplayName(recentEntryForPath(pathname)) ||
-    decodeURIComponent(pathname.split('/').filter(Boolean).pop())
 }
 
 

--- a/src/Containers/ProjectsDrawer.jsx
+++ b/src/Containers/ProjectsDrawer.jsx
@@ -26,6 +26,7 @@ import useStore from '../store/useStore'
 import {WORKSPACE_DRAWER_WIDTH_INITIAL} from '../store/WorkspaceSlice'
 import {CONTROL_MARGIN, CONTROL_SIZE, ROW_PITCH, TOP_BAR_HEIGHT} from './layoutConstants'
 import {hasStoredWorkspaceUiState} from '../workspace/persistence'
+import {modelPathFromPathname} from '../workspace/modelPath'
 import {labelForModelPath} from '../utils/modelDisplayName'
 import {navigateToModel} from '../utils/navigate'
 import {TooltipIconButton} from '../Components/Buttons'
@@ -134,17 +135,24 @@ export default function ProjectsDrawer() {
   const drawerRef = useRef(null)
   const nameFieldRef = useRef(null)
 
+  // The model's own route — element selections append numeric segments
+  // to the pathname, and treating those as identity minted a phantom
+  // "model" per selected element (named by its expressID) in Ungrouped.
+  const currentModelPath = MODEL_ROUTE_RE.test(location.pathname) ?
+    modelPathFromPathname(location.pathname) :
+    null
+
   // An armed capture + a navigation onto a model route records the opened
   // model into the arming project. Opening a model is a full page load,
   // so this usually fires on mount of the *next* page — the capture is
   // persisted for exactly that reason.
   useEffect(() => {
-    if (!MODEL_ROUTE_RE.test(location.pathname)) {
+    if (currentModelPath === null) {
       return
     }
     const model = {
-      label: labelForModelPath(location.pathname),
-      path: location.pathname,
+      label: labelForModelPath(currentModelPath),
+      path: currentModelPath,
     }
     if (workspaceCapture === null) {
       // No pending "Add model": the user got here some other way — a
@@ -154,12 +162,14 @@ export default function ProjectsDrawer() {
       addUngroupedModel(model)
       return
     }
-    if (location.pathname !== workspaceCapture.armedPathname) {
+    // Both sides normalized: arming while an element was selected must
+    // still recognize "same model" on the other side of the reload.
+    if (currentModelPath !== modelPathFromPathname(workspaceCapture.armedPathname)) {
       addWorkspaceModel(workspaceCapture.projectId, model)
       disarmWorkspaceCapture()
     }
   }, [
-    location.pathname,
+    currentModelPath,
     workspaceCapture,
     addWorkspaceModel,
     addUngroupedModel,
@@ -432,7 +442,7 @@ export default function ProjectsDrawer() {
                       <ListItemButton
                         key={model.id}
                         sx={{...rowSx, pl: 3, marginLeft: `${CONTROL_SIZE / 2}px`}}
-                        selected={location.pathname === model.path}
+                        selected={currentModelPath === model.path}
                         // Disarm first: opening a model that is already
                         // listed must not be adopted by a still-armed
                         // capture from some other project.
@@ -487,7 +497,7 @@ export default function ProjectsDrawer() {
                <ListItemButton
                  key={model.id}
                  sx={rowSx}
-                 selected={location.pathname === model.path}
+                 selected={currentModelPath === model.path}
                  onClick={() => navigateToModel(model.path, navigate)}
                  data-testid={`ungrouped-model-${model.id}`}
                >

--- a/src/Containers/ProjectsDrawer.test.jsx
+++ b/src/Containers/ProjectsDrawer.test.jsx
@@ -433,6 +433,21 @@ describe('ProjectsDrawer', () => {
       expect(screen.queryByTestId('ungrouped-section')).toBeNull()
     })
 
+    // Element selections append numeric path segments; each selection
+    // was minting a phantom "model" named by its expressID.
+    it('records the model, not the selected element, on element-path routes', () => {
+      render(
+        <ShareMock initialEntries={['/share/v/gh/o/r/main/shared.ifc/88/111/199961']}>
+          <ProjectsDrawer/>
+        </ShareMock>,
+      )
+
+      const ungrouped = useStore.getState().ungroupedModels
+      expect(ungrouped).toHaveLength(1)
+      expect(ungrouped[0].path).toBe('/share/v/gh/o/r/main/shared.ifc')
+      expect(screen.getByText('shared.ifc')).toBeInTheDocument()
+    })
+
     it('files a model into a project from the row menu', () => {
       act(() => {
         useStore.getState().createWorkspaceProject('Maple Street Tower')

--- a/src/Containers/RootLandscape.jsx
+++ b/src/Containers/RootLandscape.jsx
@@ -9,6 +9,7 @@ import ControlsGroup from './ControlsGroup'
 import NavTreeAndVersionsDrawer from './NavTreeAndVersionsDrawer'
 import OperationsGroup from './OperationsGroup'
 import ProjectsDrawer from './ProjectsDrawer'
+import TopBar from './TopBar'
 import {TOP_BAR_HEIGHT} from './layoutConstants'
 import RightSideDrawers from './RightSideDrawers'
 import TabbedPanels from './TabbedPanels'
@@ -67,20 +68,22 @@ export default function RootLandscape({pathPrefix, branch, selectWithShiftClickE
         sx={{flex: '1 1 auto', minWidth: 0, height: '100%'}}
         data-testid='CenterPane'
       >
-        <Box sx={{opacity: 0.5}}>
-          <Paper
-            elevation={0}
-            sx={{
-              position: 'absolute',
-              top: 0,
-              height: TOP_BAR_HEIGHT,
-              width: '100%',
-              backgroundColor: theme.palette.secondary.backgroundColor,
-              borderRadius: 0,
-            }}
-            data-testid='RootLandscape-ToolbarPaper'
-          />
-        </Box>
+        {isWorkspaceEnabled ?
+          <TopBar/> :
+          <Box sx={{opacity: 0.5}}>
+            <Paper
+              elevation={0}
+              sx={{
+                position: 'absolute',
+                top: 0,
+                height: TOP_BAR_HEIGHT,
+                width: '100%',
+                backgroundColor: theme.palette.secondary.backgroundColor,
+                borderRadius: 0,
+              }}
+              data-testid='RootLandscape-ToolbarPaper'
+            />
+          </Box>}
         <Stack
           direction='row'
           justifyContent='space-between'

--- a/src/Containers/RootLandscape.test.jsx
+++ b/src/Containers/RootLandscape.test.jsx
@@ -19,6 +19,17 @@ jest.mock('./ProjectsDrawer', () => ({
   default: () => <div data-testid='MockProjectsDrawer'/>,
 }))
 
+// Mocked like the other child containers, but also out of necessity:
+// the real TopBar mounts SearchBar, whose no-query cleanup effect
+// reads the *global* location.search (empty under jsdom) and so
+// navigates the MemoryRouter to a URL without ?feature=workspace,
+// unmounting the flag-gated tree mid-test. Harmless in production
+// where global and router locations agree.
+jest.mock('./TopBar', () => ({
+  __esModule: true,
+  default: () => <div data-testid='TopBar'/>,
+}))
+
 describe('RootLandscape', () => {
   it('center pane is flex and root does not overflow', () => {
     const {getByTestId} = render(
@@ -71,5 +82,26 @@ describe('RootLandscape', () => {
     expect(container).toBeInTheDocument()
     // Leftmost: the drawer container is the first child of the root stack.
     expect(getByTestId('RootLandscape-RootStack').firstChild).toBe(container)
+  })
+
+  // #1663: the ToolbarPaper placeholder becomes the real TopBar under
+  // the flag; flag-off keeps the placeholder byte-identical.
+  it('renders the ToolbarPaper placeholder by default, TopBar with ?feature=workspace', () => {
+    const flagOff = render(
+      <ShareMock>
+        <RootLandscape pathPrefix='' branch='' selectWithShiftClickEvents={jest.fn()} deselectItems={jest.fn()}/>
+      </ShareMock>,
+    )
+    expect(flagOff.getByTestId('RootLandscape-ToolbarPaper')).toBeInTheDocument()
+    expect(flagOff.queryByTestId('TopBar')).toBeNull()
+    flagOff.unmount()
+
+    const flagOn = render(
+      <ShareMock initialEntries={['/?feature=workspace']}>
+        <RootLandscape pathPrefix='' branch='' selectWithShiftClickEvents={jest.fn()} deselectItems={jest.fn()}/>
+      </ShareMock>,
+    )
+    expect(flagOn.getByTestId('TopBar')).toBeInTheDocument()
+    expect(flagOn.queryByTestId('RootLandscape-ToolbarPaper')).toBeNull()
   })
 })

--- a/src/Containers/TopBar.jsx
+++ b/src/Containers/TopBar.jsx
@@ -1,4 +1,4 @@
-import React, {ReactElement, useEffect, useState} from 'react'
+import React, {ReactElement, useCallback, useEffect, useState} from 'react'
 import {useLocation} from 'react-router-dom'
 import {Box, Breadcrumbs, Paper, Stack, Tooltip, Typography} from '@mui/material'
 import {useTheme} from '@mui/material/styles'
@@ -23,6 +23,10 @@ const MODEL_ROUTE_RE = /\/v\//
 // panes. Matches the SearchBar form's own desktop width — a smaller cap
 // here just reintroduces overflow.
 const SEARCH_MAX_WIDTH = '25em'
+
+// One small icon's width, reserved after every crumb so toggling the
+// icon's visibility never reflows the path mid-hover.
+const SEARCH_ICON_SLOT = '28px'
 
 
 /**
@@ -86,27 +90,43 @@ export default function TopBar() {
     crumbs.push({key: 'element', label: elementLabel, tip: elementTip})
   }
 
-  // Where the search icon sits, as an index into `crumbs`. Null tracks
-  // the deepest crumb as the path grows and shrinks; a hover pins it
-  // to that crumb instead.
-  const [pinnedAnchor, setPinnedAnchor] = useState(null)
-  const [isSearchOpen, setIsSearchOpen] = useState(false)
-  const lastCrumb = crumbs.length - 1
-  const anchorIndex = pinnedAnchor !== null && pinnedAnchor <= lastCrumb ? pinnedAnchor : lastCrumb
+  // Two pieces of state, deliberately separate: where the search field
+  // is *committed* (null = closed), and which crumb the pointer is over.
+  // Hover only offers the move — the icon is an intent affordance the
+  // user still has to click — so travelling across the path never
+  // disturbs an open search.
+  const [anchorIndex, setAnchorIndex] = useState(null)
+  const [hoverIndex, setHoverIndex] = useState(null)
+  const isSearchOpen = anchorIndex !== null && anchorIndex < crumbs.length
 
-  // Picking a new element (or changing model) ends the search and
-  // releases the pin, so the icon returns to tracking the deepest
-  // crumb — the "until a new sub-element is picked" half of the
-  // open/close contract.
+  // Escape/blur and any new pick return to the initial state — the
+  // icon back at the leaf — rather than to the last placement, so the
+  // path always settles somewhere predictable.
+  const resetSearch = useCallback(() => {
+    setAnchorIndex(null)
+    setHoverIndex(null)
+  }, [])
+
   useEffect(() => {
-    setIsSearchOpen(false)
-    setPinnedAnchor(null)
-  }, [modelPath, elementLabel])
+    resetSearch()
+  }, [modelPath, elementLabel, resetSearch])
 
   // Open search hides the crumbs right of the anchor, so the field
   // reads as "searching *inside* this scope".
   const visibleCrumbs = isSearchOpen ? crumbs.slice(0, anchorIndex + 1) : crumbs
-  const anchorLabel = crumbs[anchorIndex]?.label
+
+  // Exactly one icon is ever visible. Hover wins; with no hover the
+  // icon rests at the leaf when closed, and disappears when open (the
+  // field itself already marks the anchor).
+  let iconIndex = null
+  if (hoverIndex !== null && hoverIndex < visibleCrumbs.length) {
+    iconIndex = hoverIndex
+  } else if (!isSearchOpen && crumbs.length > 0) {
+    iconIndex = crumbs.length - 1
+  }
+  if (isSearchOpen && iconIndex === anchorIndex) {
+    iconIndex = null
+  }
 
   return (
     // Zero-height positioned anchor: CenterPane is statically
@@ -155,41 +175,69 @@ export default function TopBar() {
           <Breadcrumbs
             aria-label='Workspace location'
             sx={{minWidth: 0, whiteSpace: 'nowrap', flexShrink: 0}}
+            // Clearing on leave rather than per-crumb keeps the icon
+            // reachable: the pointer has to cross out of the label to
+            // click the icon sitting beside it.
+            onMouseLeave={() => setHoverIndex(null)}
             data-testid='topbar-breadcrumbs'
           >
             {visibleCrumbs.map((crumb, i) => (
-              <Tooltip key={crumb.key} title={crumb.tip || ''} placement='bottom'>
-                <Typography
-                  variant='body2'
-                  noWrap
-                  // Hovering an earlier crumb moves the search anchor
-                  // there; leaving does not release it, so the pointer
-                  // can travel to the icon without it jumping away.
-                  onMouseEnter={() => setPinnedAnchor(i)}
-                  sx={{fontWeight: i === lastCrumb ? 'bold' : 'normal', cursor: 'default'}}
-                  data-testid={`topbar-breadcrumb-${crumb.key}`}
-                >
-                  {crumb.label}
-                </Typography>
-              </Tooltip>
+              <Stack
+                key={crumb.key}
+                direction='row'
+                alignItems='center'
+                sx={{minWidth: 0}}
+                onMouseEnter={() => setHoverIndex(i)}
+              >
+                <Tooltip title={crumb.tip || ''} placement='bottom'>
+                  <Typography
+                    variant='body2'
+                    noWrap
+                    sx={{
+                      fontWeight: i === visibleCrumbs.length - 1 ? 'bold' : 'normal',
+                      cursor: 'default',
+                    }}
+                    data-testid={`topbar-breadcrumb-${crumb.key}`}
+                  >
+                    {crumb.label}
+                  </Typography>
+                </Tooltip>
+                {isSearchEnabled &&
+                 // Every crumb reserves this slot and toggles
+                 // `visibility`, so revealing the icon never reflows the
+                 // path under the pointer. Kept to one icon's width so
+                 // the reserved gaps stay cheap.
+                 <Box
+                   sx={{
+                     width: SEARCH_ICON_SLOT,
+                     flexShrink: 0,
+                     display: 'flex',
+                     justifyContent: 'center',
+                     visibility: iconIndex === i ? 'visible' : 'hidden',
+                     pointerEvents: iconIndex === i ? 'auto' : 'none',
+                   }}
+                 >
+                   <TooltipIconButton
+                     title={`Search in ${crumb.label}`}
+                     placement='bottom'
+                     size='small'
+                     icon={<SearchIcon className='icon-share'/>}
+                     onClick={() => setAnchorIndex(i)}
+                     dataTestId={iconIndex === i ?
+                       'topbar-search-open' :
+                       `topbar-search-slot-${crumb.key}`}
+                   />
+                 </Box>}
+              </Stack>
             ))}
           </Breadcrumbs>
-          {isSearchEnabled && crumbs.length > 0 && !isSearchOpen &&
-           <TooltipIconButton
-             title={anchorLabel ? `Search in ${anchorLabel}` : 'Search'}
-             placement='bottom'
-             size='small'
-             icon={<SearchIcon className='icon-share'/>}
-             onClick={() => setIsSearchOpen(true)}
-             dataTestId='topbar-search-open'
-           />}
           {isSearchEnabled && isSearchOpen &&
            <Stack sx={{flexGrow: 1, minWidth: 0, maxWidth: SEARCH_MAX_WIDTH}} data-testid='topbar-search'>
              <SearchBar
                fullWidth
                takeFocus
-               onSuccess={() => setIsSearchOpen(false)}
-               onCancel={() => setIsSearchOpen(false)}
+               onSuccess={resetSearch}
+               onCancel={resetSearch}
              />
            </Stack>}
         </Stack>

--- a/src/Containers/TopBar.jsx
+++ b/src/Containers/TopBar.jsx
@@ -4,6 +4,7 @@ import {Breadcrumbs, Paper, Stack, Typography} from '@mui/material'
 import {useTheme} from '@mui/material/styles'
 import SearchBar from '../Components/Search/SearchBar'
 import useStore from '../store/useStore'
+import {modelPathFromPathname} from '../workspace/modelPath'
 import {labelForModelPath} from '../utils/modelDisplayName'
 import {ROW_PITCH, TOP_BAR_HEIGHT} from './layoutConstants'
 
@@ -14,8 +15,9 @@ const MODEL_ROUTE_RE = /\/v\//
 
 // The search field needs real width to be usable as both element search
 // and paste-a-link opener, but must not crowd the breadcrumb on narrow
-// panes.
-const SEARCH_MAX_WIDTH = '24em'
+// panes. Matches the SearchBar form's own desktop width — a smaller cap
+// here just reintroduces overflow.
+const SEARCH_MAX_WIDTH = '25em'
 
 
 /**
@@ -37,10 +39,14 @@ export default function TopBar() {
   const location = useLocation()
   const theme = useTheme()
 
-  const isModelRoute = MODEL_ROUTE_RE.test(location.pathname)
-  const modelLabel = isModelRoute ? labelForModelPath(location.pathname) : null
-  const project = isModelRoute ?
-    workspaceProjects.find((p) => p.models.some((m) => m.path === location.pathname)) :
+  // Element selections append numeric segments to the pathname — the
+  // crumb names the *model*, not the selected element's expressID.
+  const modelPath = MODEL_ROUTE_RE.test(location.pathname) ?
+    modelPathFromPathname(location.pathname) :
+    null
+  const modelLabel = modelPath ? labelForModelPath(modelPath) : null
+  const project = modelPath ?
+    workspaceProjects.find((p) => p.models.some((m) => m.path === modelPath)) :
     null
 
   return (
@@ -68,7 +74,10 @@ export default function TopBar() {
         justifyContent='space-between'
         spacing={2}
         sx={{
-          width: '100%',
+          // Flex-fill rather than width:100%: an explicit percentage
+          // width plus the left padding overflowed the bar and pushed
+          // the search field off the right edge of the window.
+          flex: '1 1 auto',
           minWidth: 0,
           // The ControlsGroup's first row (Open, and Save when signed
           // in) paints over the bar's left edge on the shared 58px

--- a/src/Containers/TopBar.jsx
+++ b/src/Containers/TopBar.jsx
@@ -1,6 +1,6 @@
 import React, {ReactElement} from 'react'
 import {useLocation} from 'react-router-dom'
-import {Breadcrumbs, Paper, Stack, Typography} from '@mui/material'
+import {Box, Breadcrumbs, Paper, Stack, Typography} from '@mui/material'
 import {useTheme} from '@mui/material/styles'
 import SearchBar from '../Components/Search/SearchBar'
 import useStore from '../store/useStore'
@@ -50,62 +50,67 @@ export default function TopBar() {
     null
 
   return (
-    <Paper
-      elevation={0}
-      sx={{
-        // Positioned like the ToolbarPaper it replaces: the center pane
-        // owns the space, the bar floats at its top over the canvas
-        // (positioned elements paint above the earlier-in-DOM
-        // #viewer-container).
-        position: 'absolute',
-        top: 0,
-        height: TOP_BAR_HEIGHT,
-        width: '100%',
-        backgroundColor: theme.palette.secondary.backgroundColor,
-        borderRadius: 0,
-        display: 'flex',
-        alignItems: 'center',
-      }}
-      data-testid='TopBar'
-    >
-      <Stack
-        direction='row'
-        alignItems='center'
-        justifyContent='space-between'
-        spacing={2}
+    // Zero-height positioned anchor: CenterPane is statically
+    // positioned, so an absolute bar would otherwise resolve against
+    // the *viewport* — width:100% then overflowed the window by
+    // exactly the ProjectsDrawer's width, shoving the search field
+    // off-screen. (The flag-off ToolbarPaper gets away with it only
+    // because without the drawer the pane spans the viewport.)
+    <Box sx={{position: 'relative', width: '100%', height: 0}}>
+      <Paper
+        elevation={0}
         sx={{
-          // Flex-fill rather than width:100%: an explicit percentage
-          // width plus the left padding overflowed the bar and pushed
-          // the search field off the right edge of the window.
-          flex: '1 1 auto',
-          minWidth: 0,
-          // The ControlsGroup's first row (Open, and Save when signed
-          // in) paints over the bar's left edge on the shared 58px
-          // grid, so the breadcrumb starts past that column. Goes away
-          // when OpenModelControl retires from the canvas (#1664).
-          pl: `${ROW_PITCH * 2}px`,
-          pr: 2,
+          // The bar floats at the pane's top over the canvas
+          // (positioned elements paint above the earlier-in-DOM
+          // #viewer-container).
+          position: 'absolute',
+          top: 0,
+          left: 0,
+          right: 0,
+          height: TOP_BAR_HEIGHT,
+          backgroundColor: theme.palette.secondary.backgroundColor,
+          borderRadius: 0,
+          display: 'flex',
+          alignItems: 'center',
         }}
+        data-testid='TopBar'
       >
-        <Breadcrumbs
-          aria-label='Workspace location'
-          sx={{minWidth: 0, whiteSpace: 'nowrap'}}
-          data-testid='topbar-breadcrumbs'
+        <Stack
+          direction='row'
+          alignItems='center'
+          justifyContent='space-between'
+          spacing={2}
+          sx={{
+            flex: '1 1 auto',
+            minWidth: 0,
+            // The ControlsGroup's first row (Open, and Save when signed
+            // in) paints over the bar's left edge on the shared 58px
+            // grid, so the breadcrumb starts past that column. Goes away
+            // when OpenModelControl retires from the canvas (#1664).
+            pl: `${ROW_PITCH * 2}px`,
+            pr: 2,
+          }}
         >
-          {project &&
+          <Breadcrumbs
+            aria-label='Workspace location'
+            sx={{minWidth: 0, whiteSpace: 'nowrap'}}
+            data-testid='topbar-breadcrumbs'
+          >
+            {project &&
            <Typography variant='body2' noWrap data-testid='topbar-breadcrumb-project'>
              {project.name}
            </Typography>}
-          {modelLabel &&
+            {modelLabel &&
            <Typography variant='body2' noWrap sx={{fontWeight: 'bold'}} data-testid='topbar-breadcrumb-model'>
              {modelLabel}
            </Typography>}
-        </Breadcrumbs>
-        {isSearchEnabled &&
-         <Stack sx={{flexGrow: 1, maxWidth: SEARCH_MAX_WIDTH}} data-testid='topbar-search'>
-           <SearchBar/>
+          </Breadcrumbs>
+          {isSearchEnabled &&
+         <Stack sx={{flexGrow: 1, minWidth: 0, maxWidth: SEARCH_MAX_WIDTH}} data-testid='topbar-search'>
+           <SearchBar fullWidth/>
          </Stack>}
-      </Stack>
-    </Paper>
+        </Stack>
+      </Paper>
+    </Box>
   )
 }

--- a/src/Containers/TopBar.jsx
+++ b/src/Containers/TopBar.jsx
@@ -1,0 +1,102 @@
+import React, {ReactElement} from 'react'
+import {useLocation} from 'react-router-dom'
+import {Breadcrumbs, Paper, Stack, Typography} from '@mui/material'
+import {useTheme} from '@mui/material/styles'
+import SearchBar from '../Components/Search/SearchBar'
+import useStore from '../store/useStore'
+import {labelForModelPath} from '../utils/modelDisplayName'
+import {ROW_PITCH, TOP_BAR_HEIGHT} from './layoutConstants'
+
+
+// Model routes all live under the viewer path segment — same test the
+// ProjectsDrawer capture effect uses.
+const MODEL_ROUTE_RE = /\/v\//
+
+// The search field needs real width to be usable as both element search
+// and paste-a-link opener, but must not crowd the breadcrumb on narrow
+// panes.
+const SEARCH_MAX_WIDTH = '24em'
+
+
+/**
+ * The workspace TopBar (`?feature=workspace` — story #1663, epic
+ * assist-300 #1657; plan `conversational-cad.md` §2.3 / §3.1 slice 1):
+ * the 58px ToolbarPaper placeholder becomes a real bar carrying the
+ * project / model breadcrumb and the relocated element SearchBar.
+ *
+ * Slice 1 is the shell: the breadcrumb is display-only and search is a
+ * relocation of the existing SearchBar, not yet scoped. The anchor/scope
+ * mechanic (#1669), SearchProvider seam (#1699) and the pinned NavTree
+ * expansion (#1668) all land on top of this bar.
+ *
+ * @return {ReactElement}
+ */
+export default function TopBar() {
+  const workspaceProjects = useStore((state) => state.workspaceProjects)
+  const isSearchEnabled = useStore((state) => state.isSearchEnabled)
+  const location = useLocation()
+  const theme = useTheme()
+
+  const isModelRoute = MODEL_ROUTE_RE.test(location.pathname)
+  const modelLabel = isModelRoute ? labelForModelPath(location.pathname) : null
+  const project = isModelRoute ?
+    workspaceProjects.find((p) => p.models.some((m) => m.path === location.pathname)) :
+    null
+
+  return (
+    <Paper
+      elevation={0}
+      sx={{
+        // Positioned like the ToolbarPaper it replaces: the center pane
+        // owns the space, the bar floats at its top over the canvas
+        // (positioned elements paint above the earlier-in-DOM
+        // #viewer-container).
+        position: 'absolute',
+        top: 0,
+        height: TOP_BAR_HEIGHT,
+        width: '100%',
+        backgroundColor: theme.palette.secondary.backgroundColor,
+        borderRadius: 0,
+        display: 'flex',
+        alignItems: 'center',
+      }}
+      data-testid='TopBar'
+    >
+      <Stack
+        direction='row'
+        alignItems='center'
+        justifyContent='space-between'
+        spacing={2}
+        sx={{
+          width: '100%',
+          minWidth: 0,
+          // The ControlsGroup's first row (Open, and Save when signed
+          // in) paints over the bar's left edge on the shared 58px
+          // grid, so the breadcrumb starts past that column. Goes away
+          // when OpenModelControl retires from the canvas (#1664).
+          pl: `${ROW_PITCH * 2}px`,
+          pr: 2,
+        }}
+      >
+        <Breadcrumbs
+          aria-label='Workspace location'
+          sx={{minWidth: 0, whiteSpace: 'nowrap'}}
+          data-testid='topbar-breadcrumbs'
+        >
+          {project &&
+           <Typography variant='body2' noWrap data-testid='topbar-breadcrumb-project'>
+             {project.name}
+           </Typography>}
+          {modelLabel &&
+           <Typography variant='body2' noWrap sx={{fontWeight: 'bold'}} data-testid='topbar-breadcrumb-model'>
+             {modelLabel}
+           </Typography>}
+        </Breadcrumbs>
+        {isSearchEnabled &&
+         <Stack sx={{flexGrow: 1, maxWidth: SEARCH_MAX_WIDTH}} data-testid='topbar-search'>
+           <SearchBar/>
+         </Stack>}
+      </Stack>
+    </Paper>
+  )
+}

--- a/src/Containers/TopBar.jsx
+++ b/src/Containers/TopBar.jsx
@@ -1,15 +1,17 @@
-import React, {ReactElement} from 'react'
+import React, {ReactElement, useEffect, useState} from 'react'
 import {useLocation} from 'react-router-dom'
 import {Box, Breadcrumbs, Paper, Stack, Tooltip, Typography} from '@mui/material'
 import {useTheme} from '@mui/material/styles'
 import {decodeIFCString} from '@bldrs-ai/ifclib'
 import SearchBar from '../Components/Search/SearchBar'
 import {entityTypeName} from '../Components/Properties/itemProperties'
+import {TooltipIconButton} from '../Components/Buttons'
 import useStore from '../store/useStore'
 import {modelPathFromPathname} from '../workspace/modelPath'
 import {prettyType} from '../utils/ifc'
 import {labelForModelPath} from '../utils/modelDisplayName'
 import {ROW_PITCH, TOP_BAR_HEIGHT} from './layoutConstants'
+import {Search as SearchIcon} from '@mui/icons-material'
 
 
 // Model routes all live under the viewer path segment — same test the
@@ -27,12 +29,15 @@ const SEARCH_MAX_WIDTH = '25em'
  * The workspace TopBar (`?feature=workspace` — story #1663, epic
  * assist-300 #1657; plan `conversational-cad.md` §2.3 / §3.1 slice 1):
  * the 58px ToolbarPaper placeholder becomes a real bar carrying the
- * project / model breadcrumb and the relocated element SearchBar.
+ * project / model / element breadcrumb and the relocated SearchBar.
  *
- * Slice 1 is the shell: the breadcrumb is display-only and search is a
- * relocation of the existing SearchBar, not yet scoped. The anchor/scope
- * mechanic (#1669), SearchProvider seam (#1699) and the pinned NavTree
- * expansion (#1668) all land on top of this bar.
+ * Search is **anchored** to a crumb, following celestiary/web#61: a
+ * search icon rides the breadcrumb, defaulting to the last (deepest)
+ * crumb; hovering an earlier crumb moves it there, so where the icon
+ * sits *is* the search scope. Clicking it replaces every crumb to the
+ * right with the search field until the search is cancelled or a new
+ * element is picked. Scope is display-only in this slice — actually
+ * restricting results to the anchored subtree is #1669/#1699.
  *
  * @return {ReactElement}
  */
@@ -70,6 +75,39 @@ export default function TopBar() {
     elementTip = `${typeLabel}: ${selectedElement.expressID}`
   }
 
+  const crumbs = []
+  if (project) {
+    crumbs.push({key: 'project', label: project.name, tip: 'Project'})
+  }
+  if (modelLabel) {
+    crumbs.push({key: 'model', label: modelLabel, tip: fileLabel})
+  }
+  if (elementLabel) {
+    crumbs.push({key: 'element', label: elementLabel, tip: elementTip})
+  }
+
+  // Where the search icon sits, as an index into `crumbs`. Null tracks
+  // the deepest crumb as the path grows and shrinks; a hover pins it
+  // to that crumb instead.
+  const [pinnedAnchor, setPinnedAnchor] = useState(null)
+  const [isSearchOpen, setIsSearchOpen] = useState(false)
+  const lastCrumb = crumbs.length - 1
+  const anchorIndex = pinnedAnchor !== null && pinnedAnchor <= lastCrumb ? pinnedAnchor : lastCrumb
+
+  // Picking a new element (or changing model) ends the search and
+  // releases the pin, so the icon returns to tracking the deepest
+  // crumb — the "until a new sub-element is picked" half of the
+  // open/close contract.
+  useEffect(() => {
+    setIsSearchOpen(false)
+    setPinnedAnchor(null)
+  }, [modelPath, elementLabel])
+
+  // Open search hides the crumbs right of the anchor, so the field
+  // reads as "searching *inside* this scope".
+  const visibleCrumbs = isSearchOpen ? crumbs.slice(0, anchorIndex + 1) : crumbs
+  const anchorLabel = crumbs[anchorIndex]?.label
+
   return (
     // Zero-height positioned anchor: CenterPane is statically
     // positioned, so an absolute bar would otherwise resolve against
@@ -99,8 +137,7 @@ export default function TopBar() {
         <Stack
           direction='row'
           alignItems='center'
-          justifyContent='space-between'
-          spacing={2}
+          spacing={1}
           sx={{
             flex: '1 1 auto',
             minWidth: 0,
@@ -117,40 +154,44 @@ export default function TopBar() {
         >
           <Breadcrumbs
             aria-label='Workspace location'
-            sx={{minWidth: 0, whiteSpace: 'nowrap'}}
+            sx={{minWidth: 0, whiteSpace: 'nowrap', flexShrink: 0}}
             data-testid='topbar-breadcrumbs'
           >
-            {project &&
-           <Typography variant='body2' noWrap data-testid='topbar-breadcrumb-project'>
-             {project.name}
-           </Typography>}
-            {modelLabel &&
-           <Tooltip title={fileLabel} placement='bottom'>
-             <Typography
-               variant='body2'
-               noWrap
-               sx={{fontWeight: elementLabel ? 'normal' : 'bold'}}
-               data-testid='topbar-breadcrumb-model'
-             >
-               {modelLabel}
-             </Typography>
-           </Tooltip>}
-            {elementLabel &&
-           <Tooltip title={elementTip} placement='bottom'>
-             <Typography
-               variant='body2'
-               noWrap
-               sx={{fontWeight: 'bold'}}
-               data-testid='topbar-breadcrumb-element'
-             >
-               {elementLabel}
-             </Typography>
-           </Tooltip>}
+            {visibleCrumbs.map((crumb, i) => (
+              <Tooltip key={crumb.key} title={crumb.tip || ''} placement='bottom'>
+                <Typography
+                  variant='body2'
+                  noWrap
+                  // Hovering an earlier crumb moves the search anchor
+                  // there; leaving does not release it, so the pointer
+                  // can travel to the icon without it jumping away.
+                  onMouseEnter={() => setPinnedAnchor(i)}
+                  sx={{fontWeight: i === lastCrumb ? 'bold' : 'normal', cursor: 'default'}}
+                  data-testid={`topbar-breadcrumb-${crumb.key}`}
+                >
+                  {crumb.label}
+                </Typography>
+              </Tooltip>
+            ))}
           </Breadcrumbs>
-          {isSearchEnabled &&
-         <Stack sx={{flexGrow: 1, minWidth: 0, maxWidth: SEARCH_MAX_WIDTH}} data-testid='topbar-search'>
-           <SearchBar fullWidth/>
-         </Stack>}
+          {isSearchEnabled && crumbs.length > 0 && !isSearchOpen &&
+           <TooltipIconButton
+             title={anchorLabel ? `Search in ${anchorLabel}` : 'Search'}
+             placement='bottom'
+             size='small'
+             icon={<SearchIcon className='icon-share'/>}
+             onClick={() => setIsSearchOpen(true)}
+             dataTestId='topbar-search-open'
+           />}
+          {isSearchEnabled && isSearchOpen &&
+           <Stack sx={{flexGrow: 1, minWidth: 0, maxWidth: SEARCH_MAX_WIDTH}} data-testid='topbar-search'>
+             <SearchBar
+               fullWidth
+               takeFocus
+               onSuccess={() => setIsSearchOpen(false)}
+               onCancel={() => setIsSearchOpen(false)}
+             />
+           </Stack>}
         </Stack>
       </Paper>
     </Box>

--- a/src/Containers/TopBar.jsx
+++ b/src/Containers/TopBar.jsx
@@ -1,11 +1,10 @@
 import React, {ReactElement, useCallback, useEffect, useState} from 'react'
 import {useLocation} from 'react-router-dom'
-import {Box, Breadcrumbs, Paper, Stack, Tooltip, Typography} from '@mui/material'
+import {Box, IconButton, Paper, Stack, Tooltip, Typography} from '@mui/material'
 import {useTheme} from '@mui/material/styles'
 import {decodeIFCString} from '@bldrs-ai/ifclib'
 import SearchBar from '../Components/Search/SearchBar'
 import {entityTypeName} from '../Components/Properties/itemProperties'
-import {TooltipIconButton} from '../Components/Buttons'
 import useStore from '../store/useStore'
 import {modelPathFromPathname} from '../workspace/modelPath'
 import {prettyType} from '../utils/ifc'
@@ -24,9 +23,9 @@ const MODEL_ROUTE_RE = /\/v\//
 // here just reintroduces overflow.
 const SEARCH_MAX_WIDTH = '25em'
 
-// One small icon's width, reserved after every crumb so toggling the
-// icon's visibility never reflows the path mid-hover.
-const SEARCH_ICON_SLOT = '28px'
+// Separators are sized to the icon that replaces them on hover, so the
+// swap is width-neutral and the path never shifts under the pointer.
+const SEPARATOR_SLOT = '28px'
 
 
 /**
@@ -115,18 +114,11 @@ export default function TopBar() {
   // reads as "searching *inside* this scope".
   const visibleCrumbs = isSearchOpen ? crumbs.slice(0, anchorIndex + 1) : crumbs
 
-  // Exactly one icon is ever visible. Hover wins; with no hover the
-  // icon rests at the leaf when closed, and disappears when open (the
-  // field itself already marks the anchor).
-  let iconIndex = null
-  if (hoverIndex !== null && hoverIndex < visibleCrumbs.length) {
-    iconIndex = hoverIndex
-  } else if (!isSearchOpen && crumbs.length > 0) {
-    iconIndex = crumbs.length - 1
-  }
-  if (isSearchOpen && iconIndex === anchorIndex) {
-    iconIndex = null
-  }
+  // Hover reveals the move-anchor affordance ONLY while search is open.
+  // Off search, hovering the path does nothing — the crumbs' own
+  // tooltips are the hover behaviour there, and a second tooltip on a
+  // revealed icon just fought them.
+  const hoveredSeparator = isSearchOpen ? hoverIndex : null
 
   return (
     // Zero-height positioned anchor: CenterPane is statically
@@ -172,65 +164,78 @@ export default function TopBar() {
             pr: `${ROW_PITCH * 3}px`,
           }}
         >
-          <Breadcrumbs
+          {/* Own separators rather than MUI's: the slot between two
+              crumbs is what swaps to the search icon, and it needs a
+              fixed width so that swap can't reflow the path. */}
+          <Stack
+            component='nav'
+            direction='row'
+            alignItems='center'
             aria-label='Workspace location'
-            sx={{minWidth: 0, whiteSpace: 'nowrap', flexShrink: 0}}
-            // Clearing on leave rather than per-crumb keeps the icon
-            // reachable: the pointer has to cross out of the label to
-            // click the icon sitting beside it.
+            // Shrinkable on purpose: the labels ellipsize rather than
+            // pushing the trailing search icon out under the
+            // OperationsGroup's controls, which is what a long path did
+            // on a phone. Goes away once #1665 moves those into the bar.
+            sx={{minWidth: 0, flexShrink: 1, overflow: 'hidden', whiteSpace: 'nowrap'}}
             onMouseLeave={() => setHoverIndex(null)}
             data-testid='topbar-breadcrumbs'
           >
-            {visibleCrumbs.map((crumb, i) => (
-              <Stack
-                key={crumb.key}
-                direction='row'
-                alignItems='center'
-                sx={{minWidth: 0}}
-                onMouseEnter={() => setHoverIndex(i)}
-              >
-                <Tooltip title={crumb.tip || ''} placement='bottom'>
-                  <Typography
-                    variant='body2'
-                    noWrap
-                    sx={{
-                      fontWeight: i === visibleCrumbs.length - 1 ? 'bold' : 'normal',
-                      cursor: 'default',
-                    }}
-                    data-testid={`topbar-breadcrumb-${crumb.key}`}
-                  >
-                    {crumb.label}
-                  </Typography>
-                </Tooltip>
-                {isSearchEnabled &&
-                 // Every crumb reserves this slot and toggles
-                 // `visibility`, so revealing the icon never reflows the
-                 // path under the pointer. Kept to one icon's width so
-                 // the reserved gaps stay cheap.
-                 <Box
-                   sx={{
-                     width: SEARCH_ICON_SLOT,
-                     flexShrink: 0,
-                     display: 'flex',
-                     justifyContent: 'center',
-                     visibility: iconIndex === i ? 'visible' : 'hidden',
-                     pointerEvents: iconIndex === i ? 'auto' : 'none',
-                   }}
-                 >
-                   <TooltipIconButton
-                     title={`Search in ${crumb.label}`}
-                     placement='bottom'
-                     size='small'
-                     icon={<SearchIcon className='icon-share'/>}
-                     onClick={() => setAnchorIndex(i)}
-                     dataTestId={iconIndex === i ?
-                       'topbar-search-open' :
-                       `topbar-search-slot-${crumb.key}`}
-                   />
-                 </Box>}
-              </Stack>
-            ))}
-          </Breadcrumbs>
+            {visibleCrumbs.map((crumb, i) => {
+              const isLastVisible = i === visibleCrumbs.length - 1
+              return (
+                <React.Fragment key={crumb.key}>
+                  <Tooltip title={crumb.tip || ''} placement='bottom'>
+                    <Typography
+                      variant='body2'
+                      noWrap
+                      onMouseEnter={isSearchOpen ? () => setHoverIndex(i) : undefined}
+                      sx={{fontWeight: isLastVisible ? 'bold' : 'normal', cursor: 'default'}}
+                      data-testid={`topbar-breadcrumb-${crumb.key}`}
+                    >
+                      {crumb.label}
+                    </Typography>
+                  </Tooltip>
+                  {!isLastVisible &&
+                   <Box
+                     onMouseEnter={isSearchOpen ? () => setHoverIndex(i) : undefined}
+                     sx={{
+                       width: SEPARATOR_SLOT,
+                       flexShrink: 0,
+                       display: 'flex',
+                       alignItems: 'center',
+                       justifyContent: 'center',
+                     }}
+                   >
+                     {hoveredSeparator === i ?
+                       <IconButton
+                         size='small'
+                         aria-label={`Search in ${crumb.label}`}
+                         // Keeps focus in the open search field, so the
+                         // click lands as an anchor move instead of a
+                         // blur-then-dismiss race.
+                         onMouseDown={(event) => event.preventDefault()}
+                         onClick={() => setAnchorIndex(i)}
+                         data-testid='topbar-search-open'
+                       >
+                         <SearchIcon className='icon-share' fontSize='inherit'/>
+                       </IconButton> :
+                       <Typography variant='body2' sx={{opacity: 0.4}}>/</Typography>}
+                   </Box>}
+                </React.Fragment>
+              )
+            })}
+            {isSearchEnabled && !isSearchOpen && crumbs.length > 0 &&
+             <Box sx={{width: SEPARATOR_SLOT, flexShrink: 0, display: 'flex', justifyContent: 'center'}}>
+               <IconButton
+                 size='small'
+                 aria-label={`Search in ${crumbs[crumbs.length - 1].label}`}
+                 onClick={() => setAnchorIndex(crumbs.length - 1)}
+                 data-testid='topbar-search-open'
+               >
+                 <SearchIcon className='icon-share' fontSize='inherit'/>
+               </IconButton>
+             </Box>}
+          </Stack>
           {isSearchEnabled && isSearchOpen &&
            <Stack sx={{flexGrow: 1, minWidth: 0, maxWidth: SEARCH_MAX_WIDTH}} data-testid='topbar-search'>
              <SearchBar

--- a/src/Containers/TopBar.jsx
+++ b/src/Containers/TopBar.jsx
@@ -1,10 +1,13 @@
 import React, {ReactElement} from 'react'
 import {useLocation} from 'react-router-dom'
-import {Box, Breadcrumbs, Paper, Stack, Typography} from '@mui/material'
+import {Box, Breadcrumbs, Paper, Stack, Tooltip, Typography} from '@mui/material'
 import {useTheme} from '@mui/material/styles'
+import {decodeIFCString} from '@bldrs-ai/ifclib'
 import SearchBar from '../Components/Search/SearchBar'
+import {entityTypeName} from '../Components/Properties/itemProperties'
 import useStore from '../store/useStore'
 import {modelPathFromPathname} from '../workspace/modelPath'
+import {prettyType} from '../utils/ifc'
 import {labelForModelPath} from '../utils/modelDisplayName'
 import {ROW_PITCH, TOP_BAR_HEIGHT} from './layoutConstants'
 
@@ -36,6 +39,8 @@ const SEARCH_MAX_WIDTH = '25em'
 export default function TopBar() {
   const workspaceProjects = useStore((state) => state.workspaceProjects)
   const isSearchEnabled = useStore((state) => state.isSearchEnabled)
+  const model = useStore((state) => state.model)
+  const selectedElement = useStore((state) => state.selectedElement)
   const location = useLocation()
   const theme = useTheme()
 
@@ -44,10 +49,26 @@ export default function TopBar() {
   const modelPath = MODEL_ROUTE_RE.test(location.pathname) ?
     modelPathFromPathname(location.pathname) :
     null
-  const modelLabel = modelPath ? labelForModelPath(modelPath) : null
+  // The model's own name where the loader extracted one ('Bldrs' for
+  // index.ifc), else the filename; the filename stays reachable as the
+  // tooltip either way.
+  const fileLabel = modelPath ? labelForModelPath(modelPath) : null
+  const modelLabel = (modelPath && model?.name) || fileLabel
   const project = modelPath ?
     workspaceProjects.find((p) => p.models.some((m) => m.path === modelPath)) :
     null
+
+  // Selected-element crumb: named elements show their name ('Together'),
+  // anonymous ones their prettified type; the tooltip always carries
+  // 'Type: expressID' for orientation.
+  let elementLabel = null
+  let elementTip = null
+  if (modelPath && selectedElement) {
+    const typeLabel = prettyType(entityTypeName(model, selectedElement)) || 'Element'
+    const name = decodeIFCString(selectedElement.Name?.value || '')
+    elementLabel = name || `${typeLabel}: ${selectedElement.expressID}`
+    elementTip = `${typeLabel}: ${selectedElement.expressID}`
+  }
 
   return (
     // Zero-height positioned anchor: CenterPane is statically
@@ -88,7 +109,10 @@ export default function TopBar() {
             // grid, so the breadcrumb starts past that column. Goes away
             // when OpenModelControl retires from the canvas (#1664).
             pl: `${ROW_PITCH * 2}px`,
-            pr: 2,
+            // Same reservation on the right for the OperationsGroup's
+            // first row (Profile / Apps / Share) until #1665 relocates
+            // those into this bar.
+            pr: `${ROW_PITCH * 3}px`,
           }}
         >
           <Breadcrumbs
@@ -101,9 +125,27 @@ export default function TopBar() {
              {project.name}
            </Typography>}
             {modelLabel &&
-           <Typography variant='body2' noWrap sx={{fontWeight: 'bold'}} data-testid='topbar-breadcrumb-model'>
-             {modelLabel}
-           </Typography>}
+           <Tooltip title={fileLabel} placement='bottom'>
+             <Typography
+               variant='body2'
+               noWrap
+               sx={{fontWeight: elementLabel ? 'normal' : 'bold'}}
+               data-testid='topbar-breadcrumb-model'
+             >
+               {modelLabel}
+             </Typography>
+           </Tooltip>}
+            {elementLabel &&
+           <Tooltip title={elementTip} placement='bottom'>
+             <Typography
+               variant='body2'
+               noWrap
+               sx={{fontWeight: 'bold'}}
+               data-testid='topbar-breadcrumb-element'
+             >
+               {elementLabel}
+             </Typography>
+           </Tooltip>}
           </Breadcrumbs>
           {isSearchEnabled &&
          <Stack sx={{flexGrow: 1, minWidth: 0, maxWidth: SEARCH_MAX_WIDTH}} data-testid='topbar-search'>

--- a/src/Containers/TopBar.spec.ts
+++ b/src/Containers/TopBar.spec.ts
@@ -61,8 +61,9 @@ describeMobileAndDesktop('TopBar (?feature=workspace)', () => {
   test('search opens from its anchor icon and closes on Escape', async ({page}) => {
     await visitWithWorkspace(page)
 
-    // Closed by default — the icon is the affordance.
+    // Closed by default — the icon on the leaf crumb is the affordance.
     await expect(page.getByTestId('topbar-search')).toHaveCount(0)
+    await expect(page.getByTestId('topbar-search-open')).toBeVisible()
     await page.getByTestId('topbar-search-open').click()
 
     const searchInput = page.getByTestId('topbar-search').locator('input')

--- a/src/Containers/TopBar.spec.ts
+++ b/src/Containers/TopBar.spec.ts
@@ -1,0 +1,48 @@
+import {expect, test} from '@playwright/test'
+import {
+  homepageSetup,
+  setIsReturningUser,
+  visitHomepageWaitForModel,
+} from '../tests/e2e/utils'
+import {describeMobileAndDesktop} from '../tests/e2e/formFactor'
+import {visitWithWorkspace} from '../tests/e2e/workspace'
+
+
+const {beforeEach} = test
+
+
+/**
+ * Happy path for the workspace TopBar (story #1663, plan
+ * `conversational-cad.md` §2.3 / §3.1 slice 1): the ToolbarPaper
+ * placeholder becomes a real bar with the model breadcrumb and the
+ * relocated SearchBar. The scope mechanic and provider seam are later
+ * slices (#1669/#1699) with their own specs.
+ */
+describeMobileAndDesktop('TopBar (?feature=workspace)', () => {
+  beforeEach(async ({page}) => {
+    await homepageSetup(page)
+    await setIsReturningUser(page.context())
+  })
+
+  test('flag gates the bar, and the breadcrumb names the model', async ({page}) => {
+    await visitHomepageWaitForModel(page)
+    await expect(page.getByTestId('TopBar')).toHaveCount(0)
+
+    await visitWithWorkspace(page)
+    await expect(page.getByTestId('TopBar')).toBeVisible()
+    await expect(page.getByTestId('topbar-breadcrumb-model')).toHaveText('index.ifc')
+  })
+
+  test('search from the TopBar sets the query param', async ({page}) => {
+    await visitWithWorkspace(page)
+
+    const searchInput = page.getByTestId('topbar-search').locator('input')
+    await expect(searchInput).toBeVisible()
+    await searchInput.fill('together')
+    await searchInput.press('Enter')
+
+    await expect(page).toHaveURL(/q=together/)
+    // Still in the workspace shell: the search must not strip the flag.
+    expect(page.url()).toContain('feature=workspace')
+  })
+})

--- a/src/Containers/TopBar.spec.ts
+++ b/src/Containers/TopBar.spec.ts
@@ -31,6 +31,16 @@ describeMobileAndDesktop('TopBar (?feature=workspace)', () => {
     await visitWithWorkspace(page)
     await expect(page.getByTestId('TopBar')).toBeVisible()
     await expect(page.getByTestId('topbar-breadcrumb-model')).toHaveText('index.ifc')
+
+    // Regression: the bar is absolutely positioned, and with a
+    // statically-positioned center pane it resolved against the
+    // viewport — width:100% then overflowed the window by the
+    // ProjectsDrawer's width, pushing the search field off-screen.
+    const viewportWidth = page.viewportSize()?.width ?? 0
+    const barBox = await page.getByTestId('TopBar').boundingBox()
+    expect((barBox?.x ?? 0) + (barBox?.width ?? 0)).toBeLessThanOrEqual(viewportWidth)
+    const searchBox = await page.getByTestId('topbar-search').boundingBox()
+    expect((searchBox?.x ?? 0) + (searchBox?.width ?? 0)).toBeLessThanOrEqual(viewportWidth)
   })
 
   test('search from the TopBar sets the query param', async ({page}) => {

--- a/src/Containers/TopBar.spec.ts
+++ b/src/Containers/TopBar.spec.ts
@@ -74,6 +74,29 @@ describeMobileAndDesktop('TopBar (?feature=workspace)', () => {
     await expect(page.getByTestId('topbar-search-open')).toBeVisible()
   })
 
+  // Regression: moving the anchor while the field was open blurred the
+  // input, and the blur-dismiss fired after the click — the field
+  // reappeared at the new crumb and then vanished.
+  test('moving the anchor mid-search keeps the field open', async ({page}) => {
+    await page.goto(`${HOME_MODEL}/89/112/139/154/396${WORKSPACE_FLAG}`, {waitUntil: 'domcontentloaded'})
+    await waitForModel(page)
+    // The element crumb resolves asynchronously; without it there is no
+    // separator to swap and nothing to move the anchor from.
+    await expect(page.getByTestId('topbar-breadcrumb-element')).toBeVisible()
+
+    await page.getByTestId('topbar-search-open').click()
+    await expect(page.getByTestId('topbar-search')).toBeVisible()
+
+    // Hover the model crumb; its separator becomes the anchor icon.
+    await page.getByTestId('topbar-breadcrumb-model').hover()
+    await page.getByTestId('topbar-search-open').click()
+
+    // Field moved up a level and stayed open.
+    await expect(page.getByTestId('topbar-search')).toBeVisible()
+    await expect(page.getByTestId('topbar-breadcrumb-element')).toHaveCount(0)
+    await expect(page.getByTestId('topbar-breadcrumb-model')).toBeVisible()
+  })
+
   test('search from the TopBar sets the query param', async ({page}) => {
     await visitWithWorkspace(page)
     await page.getByTestId('topbar-search-open').click()

--- a/src/Containers/TopBar.spec.ts
+++ b/src/Containers/TopBar.spec.ts
@@ -42,6 +42,7 @@ describeMobileAndDesktop('TopBar (?feature=workspace)', () => {
     const viewportWidth = page.viewportSize()?.width ?? 0
     const barBox = await page.getByTestId('TopBar').boundingBox()
     expect((barBox?.x ?? 0) + (barBox?.width ?? 0)).toBeLessThanOrEqual(viewportWidth)
+    await page.getByTestId('topbar-search-open').click()
     const searchBox = await page.getByTestId('topbar-search').boundingBox()
     expect((searchBox?.x ?? 0) + (searchBox?.width ?? 0)).toBeLessThanOrEqual(viewportWidth)
   })
@@ -57,8 +58,24 @@ describeMobileAndDesktop('TopBar (?feature=workspace)', () => {
     await expect(page.getByTestId('topbar-breadcrumb-model')).not.toHaveText('396')
   })
 
+  test('search opens from its anchor icon and closes on Escape', async ({page}) => {
+    await visitWithWorkspace(page)
+
+    // Closed by default — the icon is the affordance.
+    await expect(page.getByTestId('topbar-search')).toHaveCount(0)
+    await page.getByTestId('topbar-search-open').click()
+
+    const searchInput = page.getByTestId('topbar-search').locator('input')
+    await expect(searchInput).toBeFocused()
+    await searchInput.press('Escape')
+
+    await expect(page.getByTestId('topbar-search')).toHaveCount(0)
+    await expect(page.getByTestId('topbar-search-open')).toBeVisible()
+  })
+
   test('search from the TopBar sets the query param', async ({page}) => {
     await visitWithWorkspace(page)
+    await page.getByTestId('topbar-search-open').click()
 
     const searchInput = page.getByTestId('topbar-search').locator('input')
     await expect(searchInput).toBeVisible()

--- a/src/Containers/TopBar.spec.ts
+++ b/src/Containers/TopBar.spec.ts
@@ -3,9 +3,10 @@ import {
   homepageSetup,
   setIsReturningUser,
   visitHomepageWaitForModel,
+  waitForModel,
 } from '../tests/e2e/utils'
 import {describeMobileAndDesktop} from '../tests/e2e/formFactor'
-import {visitWithWorkspace} from '../tests/e2e/workspace'
+import {HOME_MODEL, WORKSPACE_FLAG, visitWithWorkspace} from '../tests/e2e/workspace'
 
 
 const {beforeEach} = test
@@ -30,7 +31,9 @@ describeMobileAndDesktop('TopBar (?feature=workspace)', () => {
 
     await visitWithWorkspace(page)
     await expect(page.getByTestId('TopBar')).toBeVisible()
-    await expect(page.getByTestId('topbar-breadcrumb-model')).toHaveText('index.ifc')
+    // The loader-extracted model name, not the filename — the filename
+    // lives in the crumb's tooltip.
+    await expect(page.getByTestId('topbar-breadcrumb-model')).toHaveText('Bldrs')
 
     // Regression: the bar is absolutely positioned, and with a
     // statically-positioned center pane it resolved against the
@@ -41,6 +44,17 @@ describeMobileAndDesktop('TopBar (?feature=workspace)', () => {
     expect((barBox?.x ?? 0) + (barBox?.width ?? 0)).toBeLessThanOrEqual(viewportWidth)
     const searchBox = await page.getByTestId('topbar-search').boundingBox()
     expect((searchBox?.x ?? 0) + (searchBox?.width ?? 0)).toBeLessThanOrEqual(viewportWidth)
+  })
+
+  test('element permalinks put the selection on the breadcrumb', async ({page}) => {
+    // 'Together' (IfcBuildingElementProxy, expressID 396) in the home
+    // model — the crumb reads model / element, with the element name
+    // rather than its expressID.
+    await page.goto(`${HOME_MODEL}/89/112/139/154/396${WORKSPACE_FLAG}`, {waitUntil: 'domcontentloaded'})
+    await waitForModel(page)
+
+    await expect(page.getByTestId('topbar-breadcrumb-element')).toHaveText('Together')
+    await expect(page.getByTestId('topbar-breadcrumb-model')).not.toHaveText('396')
   })
 
   test('search from the TopBar sets the query param', async ({page}) => {

--- a/src/Containers/TopBar.test.jsx
+++ b/src/Containers/TopBar.test.jsx
@@ -54,9 +54,8 @@ describe('TopBar', () => {
     expect(screen.queryByTestId('topbar-search')).toBeNull()
   })
 
-  // Where the icon sits is the scope, so opening search hides the
-  // crumbs to its right.
-  it('anchors search to the deepest crumb, and to a hovered one instead', () => {
+  // Hover only *offers* the move — the icon it reveals must be clicked.
+  it('reveals a search icon on the hovered crumb, without moving the field', () => {
     act(() => {
       useStore.setState({
         model: {name: 'Bldrs'},
@@ -65,17 +64,45 @@ describe('TopBar', () => {
     })
     render(<ShareMock initialEntries={[`${MODEL_ROUTE}/89/112`]}><TopBar/></ShareMock>)
 
-    // Default anchor is the deepest crumb, so opening keeps them all.
-    expect(screen.getByTestId('topbar-breadcrumb-element')).toBeInTheDocument()
-    fireEvent.click(screen.getByTestId('topbar-search-open'))
+    // At rest the icon sits on the leaf crumb.
+    expect(screen.getByTestId('topbar-search-open')).toBeInTheDocument()
+    expect(screen.getByTestId('topbar-search-slot-model')).toBeInTheDocument()
+
+    // Hovering the model crumb moves the icon there — one icon at a
+    // time — but the field has not opened or moved.
+    fireEvent.mouseEnter(screen.getByTestId('topbar-breadcrumb-model').parentElement)
+    expect(screen.getByTestId('topbar-search-slot-element')).toBeInTheDocument()
+    expect(screen.queryByTestId('topbar-search')).toBeNull()
     expect(screen.getByTestId('topbar-breadcrumb-element')).toBeInTheDocument()
 
-    // Hovering the model crumb moves the anchor up a level; the
-    // element crumb to its right gives way to the field.
-    fireEvent.mouseEnter(screen.getByTestId('topbar-breadcrumb-model'))
+    // Clicking it commits: the field opens there and clears the crumbs
+    // to its right.
+    fireEvent.click(screen.getByTestId('topbar-search-open'))
+    expect(screen.getByTestId('topbar-search')).toBeInTheDocument()
     expect(screen.getByTestId('topbar-breadcrumb-model')).toBeInTheDocument()
     expect(screen.queryByTestId('topbar-breadcrumb-element')).toBeNull()
-    expect(screen.getByTestId('topbar-search')).toBeInTheDocument()
+  })
+
+  // Dismissing returns to the initial placement, not the last one used.
+  it('restores the icon to the leaf after the search is dismissed', () => {
+    act(() => {
+      useStore.setState({
+        model: {name: 'Bldrs'},
+        selectedElement: {expressID: 396, type: 'IFCBUILDINGELEMENTPROXY', Name: {value: 'Together'}},
+      })
+    })
+    render(<ShareMock initialEntries={[`${MODEL_ROUTE}/89/112`]}><TopBar/></ShareMock>)
+
+    fireEvent.mouseEnter(screen.getByTestId('topbar-breadcrumb-model').parentElement)
+    fireEvent.click(screen.getByTestId('topbar-search-open'))
+    expect(screen.queryByTestId('topbar-breadcrumb-element')).toBeNull()
+
+    fireEvent.keyDown(screen.getByTestId('textfield-search-query'), {key: 'Escape'})
+
+    expect(screen.queryByTestId('topbar-search')).toBeNull()
+    expect(screen.getByTestId('topbar-breadcrumb-element')).toBeInTheDocument()
+    // Back at the leaf, not parked where the search last was.
+    expect(screen.getByTestId('topbar-search-slot-model')).toBeInTheDocument()
   })
 
   // Element selections append numeric segments to the pathname; the

--- a/src/Containers/TopBar.test.jsx
+++ b/src/Containers/TopBar.test.jsx
@@ -54,8 +54,10 @@ describe('TopBar', () => {
     expect(screen.queryByTestId('topbar-search')).toBeNull()
   })
 
-  // Hover only *offers* the move — the icon it reveals must be clicked.
-  it('reveals a search icon on the hovered crumb, without moving the field', () => {
+  // Hover reveals the move affordance only while search is open, and
+  // it replaces that crumb's trailing separator rather than adding a
+  // control — so the path can't reflow under the pointer.
+  it('swaps a separator for the search icon on hover, only in search mode', () => {
     act(() => {
       useStore.setState({
         model: {name: 'Bldrs'},
@@ -64,23 +66,23 @@ describe('TopBar', () => {
     })
     render(<ShareMock initialEntries={[`${MODEL_ROUTE}/89/112`]}><TopBar/></ShareMock>)
 
-    // At rest the icon sits on the leaf crumb.
-    expect(screen.getByTestId('topbar-search-open')).toBeInTheDocument()
-    expect(screen.getByTestId('topbar-search-slot-model')).toBeInTheDocument()
-
-    // Hovering the model crumb moves the icon there — one icon at a
-    // time — but the field has not opened or moved.
-    fireEvent.mouseEnter(screen.getByTestId('topbar-breadcrumb-model').parentElement)
-    expect(screen.getByTestId('topbar-search-slot-element')).toBeInTheDocument()
+    // Search closed: hovering a crumb does nothing but its own tooltip.
+    fireEvent.mouseEnter(screen.getByTestId('topbar-breadcrumb-model'))
+    expect(screen.getAllByTestId('topbar-search-open')).toHaveLength(1)
     expect(screen.queryByTestId('topbar-search')).toBeNull()
-    expect(screen.getByTestId('topbar-breadcrumb-element')).toBeInTheDocument()
 
-    // Clicking it commits: the field opens there and clears the crumbs
-    // to its right.
+    // Open at the leaf, then hover the model crumb: its separator
+    // becomes the icon, but the field has not moved yet.
     fireEvent.click(screen.getByTestId('topbar-search-open'))
     expect(screen.getByTestId('topbar-search')).toBeInTheDocument()
+    fireEvent.mouseEnter(screen.getByTestId('topbar-breadcrumb-model'))
+    expect(screen.getByTestId('topbar-breadcrumb-element')).toBeInTheDocument()
+
+    // Clicking it commits the move, clearing the crumbs to its right.
+    fireEvent.click(screen.getByTestId('topbar-search-open'))
     expect(screen.getByTestId('topbar-breadcrumb-model')).toBeInTheDocument()
     expect(screen.queryByTestId('topbar-breadcrumb-element')).toBeNull()
+    expect(screen.getByTestId('topbar-search')).toBeInTheDocument()
   })
 
   // Dismissing returns to the initial placement, not the last one used.
@@ -93,7 +95,8 @@ describe('TopBar', () => {
     })
     render(<ShareMock initialEntries={[`${MODEL_ROUTE}/89/112`]}><TopBar/></ShareMock>)
 
-    fireEvent.mouseEnter(screen.getByTestId('topbar-breadcrumb-model').parentElement)
+    fireEvent.click(screen.getByTestId('topbar-search-open'))
+    fireEvent.mouseEnter(screen.getByTestId('topbar-breadcrumb-model'))
     fireEvent.click(screen.getByTestId('topbar-search-open'))
     expect(screen.queryByTestId('topbar-breadcrumb-element')).toBeNull()
 
@@ -101,8 +104,6 @@ describe('TopBar', () => {
 
     expect(screen.queryByTestId('topbar-search')).toBeNull()
     expect(screen.getByTestId('topbar-breadcrumb-element')).toBeInTheDocument()
-    // Back at the leaf, not parked where the search last was.
-    expect(screen.getByTestId('topbar-search-slot-model')).toBeInTheDocument()
   })
 
   // Element selections append numeric segments to the pathname; the

--- a/src/Containers/TopBar.test.jsx
+++ b/src/Containers/TopBar.test.jsx
@@ -1,0 +1,55 @@
+import React from 'react'
+import {act, render, screen} from '@testing-library/react'
+import ShareMock from '../ShareMock'
+import useStore from '../store/useStore'
+import TopBar from './TopBar'
+
+
+const MODEL_ROUTE = '/share/v/p/index.ifc'
+
+describe('TopBar', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    act(() => {
+      useStore.setState({workspaceProjects: [], isSearchEnabled: true})
+    })
+  })
+
+  it('shows the model breadcrumb segment on a model route', () => {
+    render(<ShareMock initialEntries={[MODEL_ROUTE]}><TopBar/></ShareMock>)
+
+    expect(screen.getByTestId('topbar-breadcrumb-model')).toHaveTextContent('index.ifc')
+    expect(screen.queryByTestId('topbar-breadcrumb-project')).toBeNull()
+  })
+
+  it('shows the project segment when the model is filed in a project', () => {
+    act(() => {
+      useStore.getState().createWorkspaceProject('Maple Street')
+      const project = useStore.getState().workspaceProjects[0]
+      useStore.getState().addWorkspaceModel(project.id, {label: 'index.ifc', path: MODEL_ROUTE})
+    })
+    render(<ShareMock initialEntries={[MODEL_ROUTE]}><TopBar/></ShareMock>)
+
+    expect(screen.getByTestId('topbar-breadcrumb-project')).toHaveTextContent('Maple Street')
+    expect(screen.getByTestId('topbar-breadcrumb-model')).toHaveTextContent('index.ifc')
+  })
+
+  it('carries the relocated SearchBar, honoring isSearchEnabled', () => {
+    const withSearch = render(<ShareMock initialEntries={[MODEL_ROUTE]}><TopBar/></ShareMock>)
+    expect(withSearch.getByTestId('topbar-search')).toBeInTheDocument()
+    withSearch.unmount()
+
+    act(() => {
+      useStore.setState({isSearchEnabled: false})
+    })
+    const withoutSearch = render(<ShareMock initialEntries={[MODEL_ROUTE]}><TopBar/></ShareMock>)
+    expect(withoutSearch.queryByTestId('topbar-search')).toBeNull()
+  })
+
+  it('shows no breadcrumb segments off model routes', () => {
+    render(<ShareMock initialEntries={['/about']}><TopBar/></ShareMock>)
+
+    expect(screen.queryByTestId('topbar-breadcrumb-model')).toBeNull()
+    expect(screen.queryByTestId('topbar-breadcrumb-project')).toBeNull()
+  })
+})

--- a/src/Containers/TopBar.test.jsx
+++ b/src/Containers/TopBar.test.jsx
@@ -46,6 +46,14 @@ describe('TopBar', () => {
     expect(withoutSearch.queryByTestId('topbar-search')).toBeNull()
   })
 
+  // Element selections append numeric segments to the pathname; the
+  // crumb must keep naming the model, not the selected expressID.
+  it('names the model, not the selected element, on element-path routes', () => {
+    render(<ShareMock initialEntries={[`${MODEL_ROUTE}/81/621`]}><TopBar/></ShareMock>)
+
+    expect(screen.getByTestId('topbar-breadcrumb-model')).toHaveTextContent('index.ifc')
+  })
+
   it('shows no breadcrumb segments off model routes', () => {
     render(<ShareMock initialEntries={['/about']}><TopBar/></ShareMock>)
 

--- a/src/Containers/TopBar.test.jsx
+++ b/src/Containers/TopBar.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import {act, render, screen} from '@testing-library/react'
+import {act, fireEvent, render, screen} from '@testing-library/react'
 import ShareMock from '../ShareMock'
 import useStore from '../store/useStore'
 import TopBar from './TopBar'
@@ -34,16 +34,48 @@ describe('TopBar', () => {
     expect(screen.getByTestId('topbar-breadcrumb-model')).toHaveTextContent('index.ifc')
   })
 
-  it('carries the relocated SearchBar, honoring isSearchEnabled', () => {
-    const withSearch = render(<ShareMock initialEntries={[MODEL_ROUTE]}><TopBar/></ShareMock>)
-    expect(withSearch.getByTestId('topbar-search')).toBeInTheDocument()
-    withSearch.unmount()
+  it('offers search as an icon, opening the field only on click', () => {
+    render(<ShareMock initialEntries={[MODEL_ROUTE]}><TopBar/></ShareMock>)
 
+    expect(screen.queryByTestId('topbar-search')).toBeNull()
+    fireEvent.click(screen.getByTestId('topbar-search-open'))
+
+    expect(screen.getByTestId('topbar-search')).toBeInTheDocument()
+    expect(screen.queryByTestId('topbar-search-open')).toBeNull()
+  })
+
+  it('honors isSearchEnabled', () => {
     act(() => {
       useStore.setState({isSearchEnabled: false})
     })
-    const withoutSearch = render(<ShareMock initialEntries={[MODEL_ROUTE]}><TopBar/></ShareMock>)
-    expect(withoutSearch.queryByTestId('topbar-search')).toBeNull()
+    render(<ShareMock initialEntries={[MODEL_ROUTE]}><TopBar/></ShareMock>)
+
+    expect(screen.queryByTestId('topbar-search-open')).toBeNull()
+    expect(screen.queryByTestId('topbar-search')).toBeNull()
+  })
+
+  // Where the icon sits is the scope, so opening search hides the
+  // crumbs to its right.
+  it('anchors search to the deepest crumb, and to a hovered one instead', () => {
+    act(() => {
+      useStore.setState({
+        model: {name: 'Bldrs'},
+        selectedElement: {expressID: 396, type: 'IFCBUILDINGELEMENTPROXY', Name: {value: 'Together'}},
+      })
+    })
+    render(<ShareMock initialEntries={[`${MODEL_ROUTE}/89/112`]}><TopBar/></ShareMock>)
+
+    // Default anchor is the deepest crumb, so opening keeps them all.
+    expect(screen.getByTestId('topbar-breadcrumb-element')).toBeInTheDocument()
+    fireEvent.click(screen.getByTestId('topbar-search-open'))
+    expect(screen.getByTestId('topbar-breadcrumb-element')).toBeInTheDocument()
+
+    // Hovering the model crumb moves the anchor up a level; the
+    // element crumb to its right gives way to the field.
+    fireEvent.mouseEnter(screen.getByTestId('topbar-breadcrumb-model'))
+    expect(screen.getByTestId('topbar-breadcrumb-model')).toBeInTheDocument()
+    expect(screen.queryByTestId('topbar-breadcrumb-element')).toBeNull()
+    expect(screen.getByTestId('topbar-search')).toBeInTheDocument()
   })
 
   // Element selections append numeric segments to the pathname; the

--- a/src/Containers/TopBar.test.jsx
+++ b/src/Containers/TopBar.test.jsx
@@ -11,7 +11,7 @@ describe('TopBar', () => {
   beforeEach(() => {
     localStorage.clear()
     act(() => {
-      useStore.setState({workspaceProjects: [], isSearchEnabled: true})
+      useStore.setState({workspaceProjects: [], isSearchEnabled: true, model: null, selectedElement: null})
     })
   })
 
@@ -52,6 +52,39 @@ describe('TopBar', () => {
     render(<ShareMock initialEntries={[`${MODEL_ROUTE}/81/621`]}><TopBar/></ShareMock>)
 
     expect(screen.getByTestId('topbar-breadcrumb-model')).toHaveTextContent('index.ifc')
+  })
+
+  it('prefers the loader-extracted model name over the filename', () => {
+    act(() => {
+      useStore.setState({model: {name: 'Bldrs'}})
+    })
+    render(<ShareMock initialEntries={[MODEL_ROUTE]}><TopBar/></ShareMock>)
+
+    expect(screen.getByTestId('topbar-breadcrumb-model')).toHaveTextContent('Bldrs')
+  })
+
+  it('adds a named-element crumb for the current selection', () => {
+    act(() => {
+      useStore.setState({
+        model: {name: 'Bldrs'},
+        selectedElement: {expressID: 396, type: 'IFCBUILDINGELEMENTPROXY', Name: {value: 'Together'}},
+      })
+    })
+    render(<ShareMock initialEntries={[`${MODEL_ROUTE}/89/112/139/154/396`]}><TopBar/></ShareMock>)
+
+    expect(screen.getByTestId('topbar-breadcrumb-model')).toHaveTextContent('Bldrs')
+    expect(screen.getByTestId('topbar-breadcrumb-element')).toHaveTextContent('Together')
+  })
+
+  it('falls back to prettified type and id for anonymous elements', () => {
+    act(() => {
+      useStore.setState({
+        selectedElement: {expressID: 42, type: 'IFCWALLSTANDARDCASE'},
+      })
+    })
+    render(<ShareMock initialEntries={[`${MODEL_ROUTE}/81/42`]}><TopBar/></ShareMock>)
+
+    expect(screen.getByTestId('topbar-breadcrumb-element')).toHaveTextContent('Wall (std. case): 42')
   })
 
   it('shows no breadcrumb segments off model routes', () => {

--- a/src/Containers/selection.js
+++ b/src/Containers/selection.js
@@ -1,4 +1,5 @@
 import debug from '../utils/debug'
+import useStore from '../store/useStore'
 import {getDescendantExpressIds} from '../utils/TreeUtils'
 
 
@@ -34,20 +35,34 @@ export function elementSelection(viewer, elementsById, selectItemsInScene, isShi
   const descendantIds = getDescendantExpressIds(selectedElt)
   let updateNav = false
   const selectedInViewer = new Set(viewer.getSelectedIds())
+  // Anchors are the ids the user actually clicked. The viewer set also
+  // carries their descendants, because a container's geometry lives in
+  // its children and must highlight in the scene — but treating that
+  // whole set as "the selection" made every child row look selected in
+  // NavTree, and left Properties and the breadcrumb showing whichever
+  // descendant happened to land last in the set.
+  const anchors = new Set(
+    (useStore.getState().selectedAnchorIds || []).map(Number).filter(Number.isFinite))
   if (isShiftKeyDown) {
     if (selectedInViewer.has(expressId)) {
       const descendantIdsToRemove = getDescendantExpressIds(selectedElt)
       descendantIdsToRemove.forEach((descendantId) => selectedInViewer.delete(descendantId))
       selectedInViewer.delete(expressId)
+      anchors.delete(expressId)
     } else {
       selectedInViewer.add(expressId)
       descendantIds.forEach((id) => selectedInViewer.add(id))
+      // Re-added last so shift-click keeps showing the newest pick.
+      anchors.delete(expressId)
+      anchors.add(expressId)
     }
   } else {
     selectedInViewer.clear()
     selectedInViewer.add(expressId)
     descendantIds.forEach((descendantId) => selectedInViewer.add(descendantId))
+    anchors.clear()
+    anchors.add(expressId)
     updateNav = true
   }
-  selectItemsInScene(Array.from(selectedInViewer), updateNav)
+  selectItemsInScene(Array.from(selectedInViewer), updateNav, [], null, null, Array.from(anchors))
 }

--- a/src/Containers/selection.test.js
+++ b/src/Containers/selection.test.js
@@ -27,7 +27,18 @@ describe('elementSelection', () => {
     const viewer = makeViewer()
     const selectItemsInScene = jest.fn()
     elementSelection(viewer, elementsById, selectItemsInScene, false, 3)
-    expect(selectItemsInScene).toHaveBeenCalledWith([3], true)
+    expect(selectItemsInScene).toHaveBeenCalledWith([3], true, [], null, null, [3])
+  })
+
+  // The scene needs the descendants (a container's geometry lives in
+  // its children) but the anchor stays the clicked element, so NavTree,
+  // Properties and the breadcrumb don't follow a child instead.
+  it('anchors on the clicked element while selecting its descendants', () => {
+    const viewer = makeViewer()
+    const selectItemsInScene = jest.fn()
+    elementSelection(viewer, elementsById, selectItemsInScene, false, 2)
+    const [, , , , , anchors] = selectItemsInScene.mock.calls[0]
+    expect(anchors).toEqual([2])
   })
 
   it('selects an element together with its descendants (non-shift)', () => {
@@ -49,14 +60,14 @@ describe('elementSelection', () => {
     const viewer = makeViewer([2]) // 2 already selected in the scene
     const selectItemsInScene = jest.fn()
     elementSelection(viewer, elementsById, selectItemsInScene, true, '2')
-    expect(selectItemsInScene).toHaveBeenCalledWith([], false)
+    expect(selectItemsInScene).toHaveBeenCalledWith([], false, [], null, null, [])
   })
 
   it('shift-clicking an unselected element adds it without updating navigation — string id', () => {
     const viewer = makeViewer([])
     const selectItemsInScene = jest.fn()
     elementSelection(viewer, elementsById, selectItemsInScene, true, '3')
-    expect(selectItemsInScene).toHaveBeenCalledWith([3], false)
+    expect(selectItemsInScene).toHaveBeenCalledWith([3], false, [], null, null, [3])
   })
 
   it('does nothing when the element cannot be picked in the scene', () => {

--- a/src/store/NavTreeSlice.js
+++ b/src/store/NavTreeSlice.js
@@ -35,6 +35,13 @@ export default function createNavTreeSlice(set, get) {
 
     selectedElements: [],
     setSelectedElements: (elts) => set(() => ({selectedElements: elts})),
+    // The ids the user actually picked, without the descendants that
+    // `elementSelection` adds so a parent's geometry highlights in the
+    // scene. Surfaces that answer "what is selected?" — NavTree row
+    // highlight, Properties, the TopBar crumb — read this; the scene
+    // reads `selectedElements`.
+    selectedAnchorIds: [],
+    setSelectedAnchorIds: (ids) => set(() => ({selectedAnchorIds: ids})),
 
     // Synthetic IfcInstanceMap instance IDs (one per Conway
     // PlacedGeometry). Populated alongside `selectedElements` on the

--- a/src/utils/ifc.js
+++ b/src/utils/ifc.js
@@ -8,7 +8,14 @@ import {toTitleCase} from './strings'
  */
 export function prettyType(type) {
   const ifcPrefix = 'IFC'
-  switch (type) {
+  // Managers disagree on case ('IFCWALL' vs 'IfcWall'); normalize so
+  // both hit the same cases. Non-IFC type names pass through untouched
+  // rather than losing their first three characters below.
+  const upper = typeof type === 'string' ? type.toUpperCase() : type
+  if (typeof upper === 'string' && !upper.startsWith(ifcPrefix)) {
+    return type
+  }
+  switch (upper) {
     case 'IFCREINFORCINGBAR': return 'Reinforcing Bar'
     case 'IFCREINFORCINGMESH': return 'Reinforcing Mesh'
     case 'IFCTENDONANCHOR': return 'Tendon Anchor'
@@ -27,10 +34,10 @@ export function prettyType(type) {
     case 'IFCWALLSTANDARDCASE': return 'Wall (std. case)'
     case 'IFCCURTAINWALL': return 'Curtain Wall'
     default: {
-      if (!type) {
+      if (!upper) {
         return ''
       }
-      let titleCased = toTitleCase(type.substring(ifcPrefix.length))
+      let titleCased = toTitleCase(upper.substring(ifcPrefix.length))
       if (titleCased.endsWith('element')) {
         titleCased = `${titleCased.replace('element', '')} Element`
       }

--- a/src/utils/modelDisplayName.js
+++ b/src/utils/modelDisplayName.js
@@ -10,6 +10,9 @@
  */
 
 
+import {loadAllRecentFiles} from '../connections/persistence'
+
+
 /**
  * Display name for a recents entry. `modelTitle` is the name extracted
  * from the model itself (back-filled after load, see Share.jsx);
@@ -21,6 +24,38 @@
  */
 export function recentDisplayName(entry) {
   return entry?.modelTitle || entry?.name || undefined
+}
+
+
+/**
+ * The recents entry for a model route, if we have one. A local upload
+ * routes by its OPFS storage id (`/v/new/<blob-uuid>.ifc`), so the path
+ * segment alone would display as a UUID; recents holds the id -> name
+ * mapping (see #1682).
+ *
+ * @param {string} pathname
+ * @return {object|undefined} RecentFileEntry
+ */
+export function recentEntryForPath(pathname) {
+  const segment = decodeURIComponent(pathname.split('/').filter(Boolean).pop())
+  try {
+    return loadAllRecentFiles().find((f) => f.sharePath === pathname || f.id === segment)
+  } catch {
+    return undefined
+  }
+}
+
+
+/**
+ * Label for a model route: the model's own name where known, else the
+ * path segment.
+ *
+ * @param {string} pathname
+ * @return {string}
+ */
+export function labelForModelPath(pathname) {
+  return recentDisplayName(recentEntryForPath(pathname)) ||
+    decodeURIComponent(pathname.split('/').filter(Boolean).pop())
 }
 
 

--- a/src/workspace/modelPath.test.ts
+++ b/src/workspace/modelPath.test.ts
@@ -1,0 +1,30 @@
+import {modelPathFromPathname} from './modelPath'
+
+
+describe('modelPathFromPathname', () => {
+  it('strips IFC expressID element paths', () => {
+    expect(modelPathFromPathname('/share/v/p/index.ifc/81/621'))
+      .toBe('/share/v/p/index.ifc')
+  })
+
+  it('strips deep occurrence paths on hosted models', () => {
+    expect(modelPathFromPathname(
+      '/share/v/gh/Swiss-Property-AG/Momentum-Public/main/Momentum.ifc/88/111/153/3768/199961'))
+      .toBe('/share/v/gh/Swiss-Property-AG/Momentum-Public/main/Momentum.ifc')
+  })
+
+  it('leaves element-free model routes alone', () => {
+    expect(modelPathFromPathname('/share/v/p/index.ifc')).toBe('/share/v/p/index.ifc')
+    expect(modelPathFromPathname('/share/v/new/4d6da269-9169.ifc'))
+      .toBe('/share/v/new/4d6da269-9169.ifc')
+  })
+
+  it('keeps numeric-looking file segments', () => {
+    expect(modelPathFromPathname('/share/v/gh/o/r/main/123.ifc'))
+      .toBe('/share/v/gh/o/r/main/123.ifc')
+  })
+
+  it('handles a trailing slash after the element path', () => {
+    expect(modelPathFromPathname('/share/v/p/index.ifc/81/')).toBe('/share/v/p/index.ifc')
+  })
+})

--- a/src/workspace/modelPath.ts
+++ b/src/workspace/modelPath.ts
@@ -1,0 +1,19 @@
+/**
+ * The model's own route, with any element selection stripped: selecting
+ * an element appends numeric path segments to the model route
+ * (`/share/v/p/index.ifc/81/621`, `…/Momentum.ifc/88/111/153/3768/199961`),
+ * and any workspace surface that treats the raw pathname as model
+ * identity would mint one phantom "model" per selected element — which
+ * is exactly what the ProjectsDrawer's Ungrouped section did.
+ *
+ * Format-neutral on purpose (IFC expressID paths and STEP occurrence
+ * paths are both numeric segments), and conservative: only trailing
+ * all-numeric segments are stripped, so numeric-ish *file* segments
+ * (`123.ifc`, OPFS uuids) survive.
+ *
+ * @param pathname e.g. location.pathname
+ * @return The pathname minus any trailing element-path segments.
+ */
+export function modelPathFromPathname(pathname: string): string {
+  return pathname.replace(/(\/\d+)+\/?$/, '')
+}

--- a/src/workspace/persistence.test.ts
+++ b/src/workspace/persistence.test.ts
@@ -29,6 +29,22 @@ describe('workspace/persistence', () => {
     expect(loadWorkspaceContents()).toEqual({projects: [], ungrouped: []})
   })
 
+  // A model may legitimately be filed under two projects, so the
+  // element-path normalization below must not dedup across them.
+  it('keeps a model that is filed under more than one project', () => {
+    const shared = {id: 'm1', label: 'shared.ifc', path: '/share/v/gh/o/r/main/shared.ifc'}
+    saveWorkspaceContents({
+      projects: [
+        {id: 'p1', name: 'One', models: [shared]},
+        {id: 'p2', name: 'Two', models: [{...shared, id: 'm2'}]},
+      ],
+      ungrouped: [],
+    })
+    const loaded = loadWorkspaceContents()
+    expect(loaded.projects[0].models).toHaveLength(1)
+    expect(loaded.projects[1].models).toHaveLength(1)
+  })
+
   // Early builds recorded raw pathnames, so element selections minted
   // phantom "models" named by expressID. Loads self-heal those stores.
   it('normalizes element-path refs onto their model and drops duplicates', () => {

--- a/src/workspace/persistence.test.ts
+++ b/src/workspace/persistence.test.ts
@@ -29,6 +29,35 @@ describe('workspace/persistence', () => {
     expect(loadWorkspaceContents()).toEqual({projects: [], ungrouped: []})
   })
 
+  // Early builds recorded raw pathnames, so element selections minted
+  // phantom "models" named by expressID. Loads self-heal those stores.
+  it('normalizes element-path refs onto their model and drops duplicates', () => {
+    saveWorkspaceContents({
+      projects: [
+        {id: 'p1', name: 'Maple', models: [
+          {id: 'm1', label: 'Momentum.ifc', path: '/share/v/gh/o/r/main/Momentum.ifc'},
+          {id: 'm2', label: '199961', path: '/share/v/gh/o/r/main/Momentum.ifc/88/111/199961'},
+        ]},
+      ],
+      ungrouped: [
+        {id: 'u1', label: 'index.ifc', path: '/share/v/p/index.ifc'},
+        {id: 'u2', label: '621', path: '/share/v/p/index.ifc/81/621'},
+        // A project's copy of the model wins over an Ungrouped one.
+        {id: 'u3', label: '153', path: '/share/v/gh/o/r/main/Momentum.ifc/153'},
+      ],
+    })
+    expect(loadWorkspaceContents()).toEqual({
+      projects: [
+        {id: 'p1', name: 'Maple', models: [
+          {id: 'm1', label: 'Momentum.ifc', path: '/share/v/gh/o/r/main/Momentum.ifc'},
+        ]},
+      ],
+      ungrouped: [
+        {id: 'u1', label: 'index.ifc', path: '/share/v/p/index.ifc'},
+      ],
+    })
+  })
+
   it('returns empty on corrupt JSON', () => {
     localStorage.setItem('bldrs:workspace-projects', '{not json')
     expect(loadWorkspaceContents()).toEqual({projects: [], ungrouped: []})

--- a/src/workspace/persistence.ts
+++ b/src/workspace/persistence.ts
@@ -85,8 +85,11 @@ export function loadWorkspaceContents(): WorkspaceContents {
  * @return Contents with element-path refs collapsed onto their models.
  */
 function normalizeContents(contents: WorkspaceContents): WorkspaceContents {
-  const seen = new Set<string>()
-  const dedup = (models: WorkspaceModelRef[]) =>
+  // Deliberately per-list: the same model may be filed under two
+  // projects (`addWorkspaceModel` only touches its target), so a shared
+  // seen-set across projects would silently drop it from all but the
+  // first on the next load.
+  const dedupWithin = (models: WorkspaceModelRef[], seen: Set<string>) =>
     models.flatMap((model) => {
       const path = modelPathFromPathname(model.path)
       if (seen.has(path)) {
@@ -95,8 +98,12 @@ function normalizeContents(contents: WorkspaceContents): WorkspaceContents {
       seen.add(path)
       return [path === model.path ? model : {...model, path}]
     })
-  const projects = contents.projects.map((p) => ({...p, models: dedup(p.models)}))
-  return {projects, ungrouped: dedup(contents.ungrouped)}
+  const projects = contents.projects.map(
+    (p) => ({...p, models: dedupWithin(p.models, new Set<string>())}))
+  // Ungrouped is the leftovers bin, so it drops anything now filed —
+  // the same rule `addUngroupedModel` applies when recording.
+  const filed = new Set(projects.flatMap((p) => p.models.map((m) => m.path)))
+  return {projects, ungrouped: dedupWithin(contents.ungrouped, filed)}
 }
 
 

--- a/src/workspace/persistence.ts
+++ b/src/workspace/persistence.ts
@@ -1,3 +1,6 @@
+import {modelPathFromPathname} from './modelPath'
+
+
 const WORKSPACE_PROJECTS_KEY = 'bldrs:workspace-projects'
 const WORKSPACE_PROJECTS_VERSION = 1
 const WORKSPACE_CAPTURE_KEY = 'bldrs:workspace-capture'
@@ -60,13 +63,40 @@ export function loadWorkspaceContents(): WorkspaceContents {
     if (parsed.version !== WORKSPACE_PROJECTS_VERSION || !Array.isArray(parsed.projects)) {
       return empty
     }
-    return {
+    return normalizeContents({
       projects: parsed.projects,
       ungrouped: Array.isArray(parsed.ungrouped) ? parsed.ungrouped : [],
-    }
+    })
   } catch {
     return empty
   }
+}
+
+
+/**
+ * Self-heal stored model refs: early builds recorded raw pathnames, so
+ * an element selection (`…/Momentum.ifc/88/111/153/3768/199961`) minted
+ * a phantom "model" per element. Normalizing to the model's own route
+ * and dropping the resulting duplicates on load repairs those stores in
+ * place — a project's copy of a model wins over an Ungrouped copy, and
+ * the first ref wins within a list.
+ *
+ * @param contents Parsed store contents.
+ * @return Contents with element-path refs collapsed onto their models.
+ */
+function normalizeContents(contents: WorkspaceContents): WorkspaceContents {
+  const seen = new Set<string>()
+  const dedup = (models: WorkspaceModelRef[]) =>
+    models.flatMap((model) => {
+      const path = modelPathFromPathname(model.path)
+      if (seen.has(path)) {
+        return []
+      }
+      seen.add(path)
+      return [path === model.path ? model : {...model, path}]
+    })
+  const projects = contents.projects.map((p) => ({...p, models: dedup(p.models)}))
+  return {projects, ungrouped: dedup(contents.ungrouped)}
 }
 
 


### PR DESCRIPTION
## Summary

Slice 1 of the `search-320` plan (`conversational-cad.md` §3.1, added here): the 58px ToolbarPaper placeholder becomes a real **TopBar** under `?feature=workspace` — story **#1663** (epic assist-300 #1657). Flag-off layout unchanged, asserted in tests.

## What&#39;s in

- **TopBar** (`src/Containers/TopBar.jsx`) — project / model breadcrumb on the left (the project segment appears when the current model is filed in a workspace project), the existing `SearchBar` relocated into the bar on the right. Display-only breadcrumb: the anchor/scope mechanic (#1669), `SearchProvider` seam (#1699) and pinned NavTree expansion (#1668) land on top of this bar in later slices.
- **ControlsGroup** — the over-canvas `SearchControl` toggle + inline bar hide under the flag, so there is exactly one entry point to the query state. (`OpenModelControl` retirement stays #1664.)
- **DRY** — the model label helpers (`recentEntryForPath` / `labelForModelPath`) move from ProjectsDrawer into `src/utils/modelDisplayName.js`, shared by bar and drawer.
- **Plan** — `conversational-cad.md` §3.1: the five-slice `search-320` sequencing (TopBar shell → scope + provider seam → pinned expansion ↔ NavTree → lazy spatial provider → streaming match-as-load index), each slice linked to its story (#1669/#1699, #1668/#1670, #1701, #1702), with the two conway-capability investigations flagged.

## SearchBar bugs surfaced by the relocation (both fixed)

- **Submitting a search replaced the whole query string** in both submit branches — the first search ejected workspace users from the shell, and dropped any other active flags. Existing params now ride along, matching `withCurrentSearch`&#39;s contract for model opens.
- **Unguarded `onSuccess()`** in the no-IFC-path branch — a crash for any caller that doesn&#39;t pass the callback; TopBar is the first such caller.
- (Noted in a comment: react-router 6.3 has no functional `setSearchParams` — a function argument serializes into a garbage query string.)

## Tests

- **E2E**: `TopBar.spec.ts` — happy path on desktop *and* mobile via `describeMobileAndDesktop` (§7.1): flag gating + breadcrumb naming, and search-from-the-bar setting `?q=` while preserving the flag. Existing `Search.spec.ts` (including screenshots) unchanged and green.
- **Unit**: TopBar breadcrumb segments (model-only, project+model, off-route, `isSearchEnabled` gating) and RootLandscape flag gating (ToolbarPaper flag-off / TopBar flag-on). Note for jsdom: SearchBar&#39;s no-query cleanup effect reads the global `location.search` (empty under MemoryRouter) and navigates test routers to a flag-less URL — RootLandscape.test mocks TopBar like its sibling containers for this reason.

## Try it

Open any model with `?feature=workspace` — the top band is now a real bar naming where you are, and search runs from it. File the model into a project via the drawer and the project name joins the breadcrumb.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PdqbBTEUn8hY43CXBk6kWL

---
_Generated by [Claude Code](https://claude.ai/code/session_01PdqbBTEUn8hY43CXBk6kWL)_