### PR TITLE
Security: Potential XSS via innerHTML in Event Logger

### DIFF
--- a/public/mod.js
+++ b/public/mod.js
@@ -4,7 +4,9 @@ const {ClientWidgetApi, PostmessageTransport} = mxwidgets()
 /** @param {string} msg */
 function log(msg) {
   const logElt = document.getElementById('logItems')
-  logElt.innerHTML += `<li>${msg}</li>`
+  const li = document.createElement('li')
+  li.textContent = msg
+  logElt.appendChild(li)
 }
 
 // Define the widget configuration


### PR DESCRIPTION
## Summary

Security: Potential XSS via innerHTML in Event Logger

## Problem

**Severity**: `Medium` | **File**: `public/mod.js:L5`

The `log` function in `public/mod.js` constructs an HTML string by directly interpolating a `msg` parameter into an `<li>` element and assigning it to `innerHTML`. If `msg` originates from an untrusted source (like the iframe's postMessage events), it could lead to Cross-Site Scripting (XSS).

## Solution

Use `textContent` instead of `innerHTML`, or properly sanitize/escape the `msg` string before inserting it into the DOM.

## Changes

- `public/mod.js` (modified)