### PR TITLE
Don't let IFC/STEP auto-fit override a #c: permalink camera

### DIFF
--- a/src/viewer/ProgressiveLoadSession.js
+++ b/src/viewer/ProgressiveLoadSession.js
@@ -63,13 +63,19 @@ export default class ProgressiveLoadSession {
    * @param {Function} [args.getControls] () => camera-controls instance
    *   (resolved lazily — controls may not exist at construction).
    * @param {Function} [args.getCamera] () => perspective camera.
+   * @param {boolean} [args.frameCamera] whether the load-time camera
+   *   follow may move the camera. Default true. Pass false when a `#c:`
+   *   permalink pins the camera to an exact pose: the preview still
+   *   renders, but the follow leaves the camera where the permalink put
+   *   it instead of framing the streaming geometry.
    * @param {Function} [args.onProgress] stage-label reporter.
    */
-  constructor({scene = null, getControls, getCamera, onProgress}) {
+  constructor({scene = null, getControls, getCamera, frameCamera = true, onProgress}) {
     this.state = SessionState.IDLE
     this.scene = scene
     this.getControls = getControls ?? (() => null)
     this.getCamera = getCamera ?? (() => null)
+    this.frameCamera = frameCamera
     this.onProgress = onProgress ?? null
     this.previewGroup = scene !== null ? new Group() : null
     this.previewInstalled = false
@@ -324,6 +330,12 @@ export default class ProgressiveLoadSession {
 
   /** Start the follow: instant first fit + the timer backstop chain. */
   startFollow_() {
+    // A permalink pinned the camera: render the preview but never move the
+    // camera. Latching followStopped keeps maybeRefit_/followTick_ inert too.
+    if (!this.frameCamera) {
+      this.followStopped = true
+      return
+    }
     if (this.followStopped || this.followTimer !== null) {
       return
     }

--- a/src/viewer/ProgressiveLoadSession.test.js
+++ b/src/viewer/ProgressiveLoadSession.test.js
@@ -158,6 +158,25 @@ describe('ProgressiveLoadSession', () => {
     expect(controls.maxDistance).toBe(grown)
   })
 
+  it('with frameCamera:false, previews render but the camera never moves', () => {
+    // A `#c:` permalink pinned the camera: streaming geometry must not drag
+    // it off the pinned pose. The preview still installs; no fit is issued,
+    // even for a mesh far outside any framed volume.
+    const pinned = new ProgressiveLoadSession({
+      scene,
+      getControls: () => controls,
+      getCamera: () => camera,
+      frameCamera: false,
+      onProgress: jest.fn(),
+    })
+    pinned.addPreviewMesh(cubeAt(0))
+    expect(scene.children).toContain(pinned.previewGroup)
+    pinned.lastFitMs = Date.now() - 10000
+    pinned.addPreviewMesh(cubeAt(100))
+    expect(controls.fits).toHaveLength(0)
+    pinned.finish()
+  })
+
   it('stampCoordination re-frames the union under the group transform', () => {
     session.addPreviewMesh(cubeAt(0))
     session.lastFitMs = Date.now() - 10000

--- a/src/viewer/ifc/ShareIfcLoader.js
+++ b/src/viewer/ifc/ShareIfcLoader.js
@@ -26,6 +26,8 @@ import {flatMeshToBufferGeometry} from './flatMeshToBufferGeometry'
 import {flatMeshToInstancedModel} from './flatMeshToInstancedModel'
 import {payloadToPreviewMesh} from './parsePreviewMesh'
 import {isOutOfMemoryError} from '../../utils/oom'
+import {hasParams} from '../../utils/location'
+import {HASH_PREFIX_CAMERA} from '../../Components/Camera/hashState'
 import {isFeatureEnabled} from '../../FeatureFlags'
 import {runIfcItemsMapParityCheck} from './ifcItemsMapParity'
 import ProgressiveLoadSession from '../ProgressiveLoadSession'
@@ -159,10 +161,19 @@ export default class ShareIfcLoader {
     // knowledge stays below (payload/batch → mesh conversion).
     const scene = typeof ifc.context?.getScene === 'function' ?
       ifc.context.getScene() : null
+    // A `#c:` permalink pins the camera to an exact pose — the user asked
+    // for THAT view, not an auto-frame. Suppress the load-time camera
+    // follow so streaming geometry can't drag the camera off the pinned
+    // pose (the follow's last portrait fit was overriding the permalink on
+    // uncached mobile loads, where a desktop cache-hit — which runs no
+    // progressive session — showed the permalink correctly). The preview
+    // meshes still render; only the camera stays put.
+    const frameCamera = !hasParams(HASH_PREFIX_CAMERA)
     const session = new ProgressiveLoadSession({
       scene: scene !== null && isFeatureEnabled('demandGeometry') ? scene : null,
       getControls: () => ifc.context?.ifcCamera?.cameraControls,
       getCamera: () => ifc.context?.ifcCamera?.perspectiveCamera,
+      frameCamera,
       onProgress,
     })
 
@@ -293,7 +304,15 @@ export default class ShareIfcLoader {
         ifcModel.matrixAutoUpdate = false
       }
 
-      ifc.context.fitToFrame()
+      // Framing the freshly loaded model is the cross-format caller's job
+      // (CadView, right after it adds the model to the scene): it applies a
+      // `#c:` permalink pose when the URL carries one, and only auto-frames
+      // otherwise. A loader-local `fitToFrame()` here fought that — it ran
+      // unconditionally, so on the IFC/STEP path a permalink camera got
+      // overwritten by the auto-fit (the mobile "camera way off" bug),
+      // while other formats framed correctly through CadView alone. Keep
+      // scene/camera management uniform across formats: no format-specific
+      // fit lives in the loader.
 
       // `getStatistics` / `getConwayVersion` are Conway-adapter extensions
       // (Logger-backed); stock web-ifc (the USE_WEBIFC_SHIM=false engine)


### PR DESCRIPTION
## Problem

A permalink that pins the camera via a `#c:` hash — e.g.
``'https://bldrs.ai/share/v/gh/bldrs-ai/test-models/main/step/pollen-robotics/AmazingHand/Right_Hand.step/54051/983/940#c:-0.132,-0.272,-0.481,0.031,-0.046,-0.098;share:'`` —
landed with the camera **way off on mobile** (model shrunk to a speck), while the
same link framed correctly on desktop. The selection carried, so only the camera
was wrong.

The difference is **cache state, not screen size**:

- **Desktop** loaded this model from the GLB cache → no progressive-load session,
  no auto-fit → the permalink pose was the only thing that moved the camera.
- **Mobile** did a fresh (uncached) parse, which ran two format-specific camera
  moves that fought the permalink:
  1. `ShareIfcLoader.parse()` called `ifc.context.fitToFrame()` **unconditionally**,
     so the IFC/STEP path auto-framed even when the URL pinned the camera.
  2. `ProgressiveLoadSession`'s camera-follow kept re-fitting streaming geometry;
     its last portrait fit pulled the camera far out.

## Fix

Framing the loaded model is the **cross-format caller's** job. `CadView` already
applies the `#c:` pose when present and only auto-frames otherwise, right after it
adds the model to the scene. Keep scene/camera management uniform across formats —
no format-specific fit in the loader:

- **`ShareIfcLoader`**: drop the loader-local `fitToFrame()`. `CadView` is the
  single framer.
- **`ProgressiveLoadSession`**: add a `frameCamera` flag (default `true`) and set
  it `false` when a `#c:` camera hash is present, so the preview still streams but
  the follow never moves the pinned camera.

On a normal (no-`#c:`) load, behavior is unchanged: the follow runs and `CadView`
frames the model.

## Testing

- New `ProgressiveLoadSession` test: with `frameCamera:false`, previews still
  install but `fitToSphere` is never called, even for geometry far outside the
  framed volume.
- `ProgressiveLoadSession`, `Loader`, `Loader.cover`, `Loader.github` suites pass;
  changed files lint + typecheck clean (full pre-commit gate green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HLsefWrsH8W6PWY9qh9xaU)_