### PR TITLE
Co-locate E2E specs with their subjects; reserve src/tests/e2e for helpers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,7 @@ This file is the router for AI assistants working in this repo. Keep it small. T
 | Render loop, `setRenderUpdate` seam, `?feature=perf` panel | [DESIGN.md](DESIGN.md) §"Render loop & perf monitor" |
 | Code style, lint rules | [STYLE.md](STYLE.md) |
 | Build, dev server, CI, Playwright setup | [PLAYBOOK.md](PLAYBOOK.md) |
+| Where to put an E2E `*.spec.ts` (co-locate near the subject; `src/tests/e2e` is shared helpers only) | [src/tests/e2e/README.md](src/tests/e2e/README.md) |
 | Asset pipeline, fonts, icons | [src/assets/README.md](src/assets/README.md) |
 | Sample-model thumbnails (Open dialog Samples tab), regenerating them, aiming them via `#c:` permalink cameras | [tools/thumbnails/README.md](tools/thumbnails/README.md) |
 | Route schemas, URL parsing | [src/routes/README.md](src/routes/README.md) |

--- a/design/new/step-occurrence-selection.md
+++ b/design/new/step-occurrence-selection.md
@@ -200,7 +200,7 @@ order; BVH permutes only the index buffer, not the numbering).
   suffix at a path boundary (`fileSuffixBoundaryRegex`) — the bare type-name
   regex also matched directory segments like `/step/` and silently dropped
   the element path — and the NavTree row highlight applies to assembly rows,
-  not only leaves. E2E: `src/tests/e2e/navTreePermalink.spec.ts`.
+  not only leaves. E2E: `src/Components/NavTree/navTreePermalink.spec.ts`.
 
 ### Remaining (follow-up)
 

--- a/design/new/viewer-replacement.md
+++ b/design/new/viewer-replacement.md
@@ -1413,7 +1413,7 @@ imports.
   `USE_WEBIFC_SHIM=false`, serves it isolated
   (`tools/esbuild/serveStaticIsolated.mjs` — COOP `same-origin` + COEP
   `require-corp`; kept off the default/prod servers because COEP breaks the
-  Drive Picker), and runs `src/tests/e2e/webIfcEngine.webifc.spec.ts` — a
+  Drive Picker), and runs `src/viewer/webIfcEngine.webifc.spec.ts` — a
   smoke that loads `index.ifc`, asserts `crossOriginIsolated`, and forwards
   the browser console so isolated-runtime errors are legible without a local
   browser. The job is **advisory** (a standalone, non-required check).

--- a/src/Components/Camera/permalinkCamera.spec.ts
+++ b/src/Components/Camera/permalinkCamera.spec.ts
@@ -1,7 +1,7 @@
 import {Page, expect, test} from '@playwright/test'
-import {setupVirtualPathIntercept, waitForModelReady} from './models'
-import {homepageSetup, setIsReturningUser} from './utils'
-import {describeMobileAndDesktop} from './formFactor'
+import {setupVirtualPathIntercept, waitForModelReady} from '../../tests/e2e/models'
+import {homepageSetup, setIsReturningUser} from '../../tests/e2e/utils'
+import {describeMobileAndDesktop} from '../../tests/e2e/formFactor'
 
 
 /**

--- a/src/Components/NavTree/navTreeGlbNodeNames.spec.ts
+++ b/src/Components/NavTree/navTreeGlbNodeNames.spec.ts
@@ -1,6 +1,6 @@
 import {expect, test} from '@playwright/test'
-import {setupVirtualPathIntercept, waitForModelReady} from './models'
-import {homepageSetup, setIsReturningUser} from './utils'
+import {setupVirtualPathIntercept, waitForModelReady} from '../../tests/e2e/models'
+import {homepageSetup, setIsReturningUser} from '../../tests/e2e/utils'
 
 
 /**

--- a/src/Components/NavTree/navTreeOccurrenceSelection.spec.ts
+++ b/src/Components/NavTree/navTreeOccurrenceSelection.spec.ts
@@ -1,6 +1,6 @@
 import {expect, test} from '@playwright/test'
-import {setupVirtualPathIntercept, waitForModelReady} from './models'
-import {homepageSetup, setIsReturningUser} from './utils'
+import {setupVirtualPathIntercept, waitForModelReady} from '../../tests/e2e/models'
+import {homepageSetup, setIsReturningUser} from '../../tests/e2e/utils'
 
 
 /**

--- a/src/Components/NavTree/navTreePermalink.spec.ts
+++ b/src/Components/NavTree/navTreePermalink.spec.ts
@@ -1,6 +1,6 @@
 import {expect, test} from '@playwright/test'
-import {setupVirtualPathIntercept, waitForModelReady} from './models'
-import {homepageSetup, setIsReturningUser} from './utils'
+import {setupVirtualPathIntercept, waitForModelReady} from '../../tests/e2e/models'
+import {homepageSetup, setIsReturningUser} from '../../tests/e2e/utils'
 
 
 /**

--- a/src/Components/Residency/residencySlider.spec.ts
+++ b/src/Components/Residency/residencySlider.spec.ts
@@ -1,6 +1,6 @@
 import {Page, expect, test} from '@playwright/test'
-import {waitForModelReady} from './models'
-import {homepageSetup, setIsReturningUser} from './utils'
+import {waitForModelReady} from '../../tests/e2e/models'
+import {homepageSetup, setIsReturningUser} from '../../tests/e2e/utils'
 
 
 /**

--- a/src/Containers/sceneHighlightPermalink.spec.ts
+++ b/src/Containers/sceneHighlightPermalink.spec.ts
@@ -1,6 +1,6 @@
 import {expect, test} from '@playwright/test'
-import {setupVirtualPathIntercept, waitForModelReady} from './models'
-import {homepageSetup, setIsReturningUser} from './utils'
+import {setupVirtualPathIntercept, waitForModelReady} from '../tests/e2e/models'
+import {homepageSetup, setIsReturningUser} from '../tests/e2e/utils'
 
 
 /**

--- a/src/tests/e2e/README.md
+++ b/src/tests/e2e/README.md
@@ -1,0 +1,43 @@
+# E2E shared helpers
+
+This directory holds **shared Playwright E2E helpers only** — not test
+specs. Keep it that way.
+
+- `formFactor.ts` — `describeMobileAndDesktop`: run a suite once per form
+  factor (`[desktop]` / `[mobile]`) by flipping the viewport width.
+- `models.ts` — `setupVirtualPathIntercept` (serve a repo fixture for a
+  `/share/v/gh/...` model URL) and `waitForModelReady`.
+- `utils.ts` — `homepageSetup`, returning-user/auth setup, snackbar/grace
+  dismissal, and the rest of the page-bootstrap helpers.
+- `homepage.ts`, `workspace.ts` — page-object-ish helpers for those areas.
+
+## Put specs next to their subject, not here
+
+A new E2E `*.spec.ts` belongs **next to the code it exercises**, so the
+test travels with its subject and a reader finds it where they'd look:
+
+| Subject | Put the spec in |
+|---|---|
+| A component | `src/Components/<Area>/` (e.g. `src/Components/Camera/permalinkCamera.spec.ts`) |
+| A container / page-level flow | `src/Containers/` (e.g. `src/Containers/sceneHighlightPermalink.spec.ts`) |
+| Engine / viewer internals with no component home | `src/viewer/` (e.g. `src/viewer/webIfcEngine.webifc.spec.ts`) |
+
+Co-location is already the norm across `src/Components/**` — match it.
+Only add files here when they are genuinely **shared** across specs.
+
+## How this still works after co-locating
+
+Both Playwright configs set `testDir: ../src` with a `**/*.spec.ts`
+(and `**/*.webifc.spec.ts`) glob, so a spec anywhere under `src/` is
+discovered — location is purely organizational.
+
+Import the helpers by their path back to this directory, e.g. from a spec
+in `src/Components/<Area>/`:
+
+```ts
+import {setupVirtualPathIntercept, waitForModelReady} from '../../tests/e2e/models'
+import {describeMobileAndDesktop} from '../../tests/e2e/formFactor'
+```
+
+from `src/Containers/` or `src/viewer/` it's one fewer `..`
+(`../tests/e2e/...`).

--- a/src/viewer/webIfcEngine.webifc.spec.ts
+++ b/src/viewer/webIfcEngine.webifc.spec.ts
@@ -1,5 +1,5 @@
 import {expect, test} from '@playwright/test'
-import {homepageSetup, setIsReturningUser, waitForModel} from './utils'
+import {homepageSetup, setIsReturningUser, waitForModel} from '../tests/e2e/utils'
 
 
 /**


### PR DESCRIPTION
## What

E2E specs read best next to the code they exercise (matching the existing co-location convention across `src/Components/**`). This moves the specs out of the catch-all `src/tests/e2e/` to their subjects and reserves that directory for shared helpers.

| Spec | New home | Subject |
|---|---|---|
| `navTreeGlbNodeNames`, `navTreeOccurrenceSelection`, `navTreePermalink` | `src/Components/NavTree/` | NavTree |
| `permalinkCamera` | `src/Components/Camera/` | `#c:` camera permalink |
| `residencySlider` | `src/Components/Residency/` | Residency control |
| `sceneHighlightPermalink` | `src/Containers/` | `CadView#selectElementBasedOnFilepath` |
| `webIfcEngine.webifc` | `src/viewer/` | web-ifc engine smoke (no component home) |

Only the helper-import paths change in each spec; **test bodies are untouched** (`git` tracks these as renames).

## src/tests/e2e is now helpers-only

- Left in place: `formFactor.ts`, `models.ts`, `utils.ts`, `homepage.ts`, `workspace.ts`.
- New `src/tests/e2e/README.md`: states the directory is shared helpers only and tells you to put a new `*.spec.ts` next to its subject (Component/Container, or `src/viewer` for engine-level), with the import-path recipe. Registered in the `AGENTS.md` (CLAUDE.md) router table.
- Updated two design-doc references to the moved spec paths.

## Why this is safe

Both Playwright configs use `testDir: ../src` with a `**/*.spec.ts` (and `**/*.webifc.spec.ts`) glob, so location is purely organizational.

## Testing

- `playwright test --list` on **both** configs: all specs discovered at their new paths, imports resolve (175 tests default config; the webifc spec under the webifc config).
- Re-ran the moved `src/Components/Camera/permalinkCamera.spec.ts` → **2 passed** (desktop + mobile) from its new home.
- Lint + typecheck clean; the pre-commit gate (eslint + tsc + jest) passed. Jest ignores `*.spec.ts`, so the moves don't affect it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HLsefWrsH8W6PWY9qh9xaU)_