### PR TITLE
Bump @bldrs-ai/conway to 1.450.1353

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@babel/plugin-syntax-import-assertions": "7.18.6",
     "@babel/preset-env": "7.18.10",
     "@babel/preset-react": "7.18.6",
-    "@bldrs-ai/conway": "1.444.1334",
+    "@bldrs-ai/conway": "1.450.1353",
     "@bldrs-ai/ifclib": "5.3.3",
     "@emotion/react": "11.10.0",
     "@emotion/styled": "11.10.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2473,10 +2473,10 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@bldrs-ai/conway@1.444.1334":
-  version "1.444.1334"
-  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.444.1334.tgz#1ad7b0f6ccd6bdb85eccfe185e77fbf01a7cc9b3"
-  integrity sha512-m6GHPf+59AyYe2N6mGKhopk8nnKvIMQtT152E5t7tvdnsKy3iDJWyYKWjVcduyl0Nqcm/CQ24ShcYz2L5v24rg==
+"@bldrs-ai/conway@1.450.1353":
+  version "1.450.1353"
+  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.450.1353.tgz#7a4824f78545f6646481f989404361166601c726"
+  integrity sha512-V/nrGZBrlaGun+ZExJpfoDqWynR+mjevOAIi3ZD7aGQYSrawhUXjsUejGo15cBYPMJyOIlkfNhtu4xx/QZKSAQ==
   dependencies:
     gl-matrix "3.4.3"
     seedrandom "3.0.5"


### PR DESCRIPTION
## What

Bumps `@bldrs-ai/conway` **1.444.1334 → 1.450.1353** (`package.json` + `yarn.lock`). Dependency set is unchanged (gl-matrix, seedrandom, three, yargs), so the lockfile churn is limited to the conway block.

## Why

Brings Share up to the **rc-1.450.1353** engine, which is already published to npm (conway auto-publishes on every push to `main`; the rc-`*` tag is a post-hoc blessing gate, not the publisher). This release **resolves two real STEP baseline regressions** (`nist_ftc_08`, `nist_ftc_11`) with no new deterministic failures.

The [rc-1.450.1353 regression run](https://github.com/bldrs-ai/conway/actions/runs/31047961006) went red, but on diagnosis that was a **transient per-model timeout** on `ISSUE_159_kleine_Wohnung_R22.ifc` (empty code/signal = the batch's timeout path), i.e. CI flakiness — not an engine regression. That flake is fixed separately in conway CI: bldrs-ai/conway#452.

## Testing

Full pre-commit gate passed locally against the new version:
- `yarn typecheck` (`tsc`) — clean, no conway API breakage.
- `yarn eslint src netlify tools --max-warnings 0` — clean.
- `yarn test` — **230 suites, 2173 passed** (5 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CJ3nekfLtsEvV2cGScbHzN)_