### PR TITLE
Quiet the test-run logs: canvas, viewer dispose, and act() warnings

### DIFF
--- a/src/Components/Connections/GitHubTab.test.jsx
+++ b/src/Components/Connections/GitHubTab.test.jsx
@@ -51,6 +51,21 @@ beforeEach(() => {
 })
 
 
+/**
+ * Settle the status useEffect that fires on mount when a connection exists
+ * (async validateAll → setStatuses). Call it right after rendering a connected
+ * tab so that trailing update lands inside act instead of logging an "update
+ * not wrapped in act(...)" warning once the checkStatus promise resolves.
+ *
+ * @return {Promise<void>}
+ */
+async function flushStatusEffect() {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0))
+  })
+}
+
+
 describe('GitHubTab — empty state', () => {
   it('renders the empty state with Connect GitHub when no github connections exist', () => {
     render(
@@ -93,7 +108,7 @@ describe('GitHubTab — connected state', () => {
     })
   })
 
-  it('renders the per-connection card and a Browse button', () => {
+  it('renders the per-connection card and a Browse button', async () => {
     render(
       <GitHubTab onPickerReady={jest.fn()} onOpenById={jest.fn()}/>,
       {wrapper: StoreRouteThemeCtx},
@@ -101,6 +116,7 @@ describe('GitHubTab — connected state', () => {
 
     expect(screen.getByTestId('github-tab')).toBeInTheDocument()
     expect(screen.getByTestId('button-browse-github-gh-1')).toBeInTheDocument()
+    await flushStatusEffect()
   })
 
   it('calls onPickerReady with (token, connection) when Browse is clicked', async () => {
@@ -154,7 +170,7 @@ describe('GitHubTab — connected state', () => {
 
 
 describe('GitHubTab — recents', () => {
-  it('only surfaces github recents tagged with this connection.id', () => {
+  it('only surfaces github recents tagged with this connection.id', async () => {
     loadAllRecentFiles.mockReturnValue([
       // Belongs to this connection — should appear.
       {id: '/share/path/a', source: 'github', name: 'a.ifc', sharePath: '/share/path/a', connectionId: 'gh-1'},
@@ -178,9 +194,10 @@ describe('GitHubTab — recents', () => {
     expect(screen.queryByText('b.ifc')).not.toBeInTheDocument()
     expect(screen.queryByText('c.ifc')).not.toBeInTheDocument()
     expect(screen.queryByText('d.ifc')).not.toBeInTheDocument()
+    await flushStatusEffect()
   })
 
-  it('calls onOpenById with the recent\'s id and name when a recent is clicked', () => {
+  it('calls onOpenById with the recent\'s id and name when a recent is clicked', async () => {
     loadAllRecentFiles.mockReturnValue([
       {id: '/share/path/a', source: 'github', name: 'a.ifc', sharePath: '/share/path/a', connectionId: 'gh-1'},
     ])
@@ -197,5 +214,6 @@ describe('GitHubTab — recents', () => {
     fireEvent.click(screen.getByText('a.ifc'))
 
     expect(onOpenById).toHaveBeenCalledWith(mockConnection, '/share/path/a', 'a.ifc')
+    await flushStatusEffect()
   })
 })

--- a/src/Components/Connections/GoogleDriveTab.test.jsx
+++ b/src/Components/Connections/GoogleDriveTab.test.jsx
@@ -31,10 +31,12 @@ const mockConnection = {
  * setState), so we drain generously.
  */
 async function flushValidateEffect() {
+  // A macrotask tick drains the whole microtask chain (Promise.all → each
+  // connection's checkStatus → setState) in one go — more robust than a fixed
+  // number of Promise.resolve hops — and doing it inside act keeps the
+  // trailing setStatuses from logging an un-acted-on update warning.
   await act(async () => {
-    for (let i = 0; i < 6; i++) {
-      await Promise.resolve()
-    }
+    await new Promise((resolve) => setTimeout(resolve, 0))
   })
 }
 
@@ -151,6 +153,9 @@ describe('GoogleDriveTab', () => {
       await waitFor(() => {
         expect(checkStatus).toHaveBeenCalledWith(expect.objectContaining({id: mockConnection.id}))
       })
+      // This test asserts only that checkStatus fired; settle the setStatuses
+      // it resolves into so that trailing update lands inside act.
+      await flushValidateEffect()
     })
 
     it('renders \'Reconnect\' label and stale hint when checkStatus returns \'expired\'', async () => {
@@ -193,6 +198,9 @@ describe('GoogleDriveTab', () => {
         expect(btn).toHaveTextContent('Browse')
       })
       expect(screen.queryByTestId(`stale-hint-${mockConnection.id}`)).not.toBeInTheDocument()
+      // 'Browse' is the default label, so the waitFor above passes before the
+      // 'connected' setStatuses resolves; settle it so it lands inside act.
+      await flushValidateEffect()
     })
 
     it('flips stale → healthy after a successful Reconnect click clears it', async () => {

--- a/src/Components/Open/GitHubFileBrowser.test.jsx
+++ b/src/Components/Open/GitHubFileBrowser.test.jsx
@@ -38,11 +38,37 @@ const GH_BROWSER_STATE_KEY = 'bldrs.openDialog.github'
  * @param {string|RegExp} optionName the option's accessible name
  * @return {Promise<void>}
  */
+/**
+ * Drain the component's async fetch cascade to rest inside act. Selecting an
+ * org/repo (or restoring one on mount) starts a chain of `await`ed fetches
+ * (org→repos, repo→branches+files) that each set state after resolving. A
+ * macrotask tick lets the whole microtask chain settle, and doing it inside
+ * act means those trailing settles are acted-on instead of logging one
+ * "update not wrapped in act(...)" warning per setState.
+ *
+ * @return {Promise<void>}
+ */
+async function flushCascade() {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0))
+  })
+}
+
+
+/**
+ * Open a Selector's dropdown and click the option with the given label, then
+ * settle the fetch cascade the selection starts.
+ *
+ * @param {string} testId the Selector root data-testid
+ * @param {string|RegExp} optionName the option's accessible name
+ * @return {Promise<void>}
+ */
 async function selectOption(testId, optionName) {
   const combo = within(screen.getByTestId(testId)).getByRole('combobox')
   fireEvent.mouseDown(combo)
   const option = await screen.findByRole('option', {name: optionName})
   fireEvent.click(option)
+  await flushCascade()
 }
 
 
@@ -64,10 +90,11 @@ async function renderBrowser(props = {}) {
     {wrapper: RouteThemeCtx},
   )
   await waitFor(() => expect(getOrganizations).toHaveBeenCalled())
-  // Flush the resolved org promise → setOrgNamesArr re-render.
-  await act(async () => {
-    await Promise.resolve()
-  })
+  // Settle the mount cascade inside act: the org-list resolve, plus (when
+  // localStorage carries a saved selection) the full restore chain
+  // org→repo→branches+files. A single microtask tick only reached the org
+  // resolve, so the deeper restore setStates fired outside act and warned.
+  await flushCascade()
   return utils
 }
 
@@ -286,6 +313,9 @@ describe('GitHubFileBrowser', () => {
       // The restore chain reselects the org, then its saved repo.
       await waitFor(() => expect(getRepositories).toHaveBeenCalledWith('bldrs-ai', 'test-token'))
       await waitFor(() => expect(getFilesAndFolders).toHaveBeenCalledWith('repoA', 'bldrs-ai', '/', 'test-token'))
+      // Settle the branch/file cascade the restore fetch kicks off (runs from
+      // the mount effect, not selectOption) so it doesn't warn on teardown.
+      await flushCascade()
     })
 
     it('does not restore anything when localStorage is empty', async () => {

--- a/src/Components/Open/Selector.test.jsx
+++ b/src/Components/Open/Selector.test.jsx
@@ -257,10 +257,22 @@ describe('Selector — defensive value handling', () => {
   })
 
   it('renders an out-of-range numeric selection as empty, never "undefined"', () => {
+    // Feeding MUI Select a value past the end of the list is exactly what's
+    // under test — but MUI logs its own "out-of-range value" console.error for
+    // it. Swallow just that expected message (passing everything else through)
+    // so the assertion below runs against clean logs.
+    const originalWarn = console.warn
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation((...args) => {
+      if (typeof args[0] === 'string' && args[0].includes('out-of-range value')) {
+        return
+      }
+      originalWarn(...args)
+    })
     renderSelector({list: ['a', 'b'], selected: 99})
     // A stale index past the end of the list must not surface the literal
     // string "undefined" in the closed field.
     expect(screen.getByRole('combobox').textContent).not.toMatch(/undefined/)
+    warnSpy.mockRestore()
   })
 
   it('offers Enter name... even when the list is empty (validated field)', async () => {

--- a/src/Containers/ViewerContainer.test.jsx
+++ b/src/Containers/ViewerContainer.test.jsx
@@ -66,10 +66,15 @@ describe('ViewerContainer', () => {
     window.DragEvent = null
   })
 
-  test('renders the container', () => {
+  test('renders the container', async () => {
     render(<ViewerContainer/>)
     const dropzone = screen.getByTestId('cadview-dropzone')
     expect(dropzone).toBeInTheDocument()
+    // CadView mounts async work (viewer setup) that sets state after this sync
+    // assertion; settle it inside act so the trailing update doesn't warn.
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
   })
 
   test('calls preventDefault and sets drag state on drag over', () => {

--- a/src/Containers/viewer.js
+++ b/src/Containers/viewer.js
@@ -55,23 +55,29 @@ export function disposeViewer() {
       currentViewer._resizeObserver = null
     }
 
+    // A degenerate scene (a partial test mock, or a viewer torn down before its
+    // scene was built) has no `traverse` — skip the per-object GPU cleanup
+    // rather than throwing into the outer catch, which logged "Error disposing
+    // viewer: scene.traverse is not a function" on every such teardown.
     const scene = currentViewer.context.getScene()
-    scene.traverse((obj) => {
-      if (obj.geometry) {
-        obj.geometry.dispose()
-      }
-      const materials = getMeshMaterials(obj)
-      if (materials.length > 0) {
-        materials.forEach((mat) => {
-          TEXTURE_MAP_SLOTS.forEach((slot) => {
-            if (mat[slot]) {
-              mat[slot].dispose()
-            }
+    if (scene && typeof scene.traverse === 'function') {
+      scene.traverse((obj) => {
+        if (obj.geometry) {
+          obj.geometry.dispose()
+        }
+        const materials = getMeshMaterials(obj)
+        if (materials.length > 0) {
+          materials.forEach((mat) => {
+            TEXTURE_MAP_SLOTS.forEach((slot) => {
+              if (mat[slot]) {
+                mat[slot].dispose()
+              }
+            })
+            mat.dispose()
           })
-          mat.dispose()
-        })
-      }
-    })
+        }
+      })
+    }
 
     const renderer = currentViewer.context.getRenderer()
     if (renderer && typeof renderer.dispose === 'function') {

--- a/tools/jest/setupTests.js
+++ b/tools/jest/setupTests.js
@@ -38,3 +38,19 @@ global.context = describe
 if (typeof Element !== 'undefined') {
   Element.prototype.scrollIntoView = jest.fn()
 }
+
+// jsdom implements neither canvas method below: calling them routes through
+// jsdom's "not implemented" path, which logs a noisy Error via its
+// VirtualConsole (console.error) before returning a falsy value. App code that
+// draws to a canvas (PerfMonitor's 2d overlay, screenshot capture) already
+// treats a missing context / empty data URL as "headless — skip", so return
+// those directly. Same runtime values the code already sees under jsdom, minus
+// the per-call error spam in the test logs. A test that needs a real context
+// still overrides these on its own canvas object (e.g. CustomPostProcessor).
+if (typeof HTMLCanvasElement !== 'undefined') {
+  HTMLCanvasElement.prototype.getContext = jest.fn(() => null)
+  // Return null (not ''), matching the value jsdom's un-implemented toDataURL
+  // already yielded — snapshots recorded against a headless canvas (svg sprite
+  // texture `url`) expect null, and callers treat a falsy data URL as "none".
+  HTMLCanvasElement.prototype.toDataURL = jest.fn(() => null)
+}


### PR DESCRIPTION
## Why

`yarn test` printed ~178 `console.error`/`console.warn` lines of noise (the `build` job's `test-ci` step), burying any real signal. This clears the tractable, non-expected ones — down to ~39, the rest being intentional error-path diagnostics (see *Left in place*).

## Fixed

| Noise | Count | Cause | Fix |
|---|---|---|---|
| `Not implemented: HTMLCanvasElement.getContext` / `toDataURL` | 28 | jsdom logs an Error via its VirtualConsole before returning a falsy value | global stub in `setupTests.js` returning the same values jsdom already gave (`null`), minus the spam |
| `Error disposing viewer: scene.traverse is not a function` | 24 | `disposeViewer` called `scene.traverse()` on a scene a partial mock (or an early teardown) never gave a `traverse` | guard it — skip per-object GPU cleanup when there's nothing to traverse (also a real robustness fix) |
| `An update to X was not wrapped in act(...)` | ~79 | async fetch/status cascades set state after the test's sync portion | settle inside `act` (a macrotask tick drains the whole chain) in GitHubFileBrowser, GitHubTab, GoogleDriveTab, ViewerContainer |
| MUI `out-of-range value` | 2 | Selector test intentionally feeds an out-of-range value to exercise that path | swallow just MUI's expected `console.warn`, pass everything else through |

`toDataURL` returns `null` (not `''`) to match the value the svg-sprite snapshot was recorded against — the one behavioral subtlety, verified by the svg suite staying green.

## Left in place on purpose

- **`[glb]` load/export diagnostics** and **"General error"** lines are the code-under-test's own logging for the failure scenarios those tests deliberately drive; silencing them would hide real behavior.
- **One `act()` warning** in the heavy `CadView`/`ViewerContainer` integration tests — higher risk to touch for one line; a focused follow-up.
- **`THREE.WARNING: Multiple instances of Three.js`** — a separate dependency-dedup question.

## Testing

Full jest suite green: **230 suites, 2173 passed** (5 skipped). Only test/setup files + one `viewer.js` guard changed; no `*.spec.ts` (Playwright) touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HLsefWrsH8W6PWY9qh9xaU)_