### PR TITLE
Capture [glb] diagnostics in tests instead of printing them

### DIFF
--- a/src/loader/Loader.js
+++ b/src/loader/Loader.js
@@ -45,7 +45,7 @@ import glbToThree from './glb'
 import {glbCacheKey} from './glbCacheKey'
 import {activeGlbCompressionMode, activeSchemaVersion} from './glbCompress'
 import {isBldrsGlbContainer, unpackGlbContainer} from './glbContainer'
-import {glbInfo, glbVerbose} from './glbLog'
+import {glbInfo, glbVerbose, glbWarn} from './glbLog'
 import {spillModelSource} from './opfsSourceByteStore'
 import {
   externalCacheKey,
@@ -756,8 +756,8 @@ export function restoreCacheHitPicking(model, cameFromGlbCache) {
           const recovery = perVertexTrusted ?
             'falling back to per-vertex attributes' :
             'skipping picking on this mesh'
-          console.warn(
-            `[glb] reader: face_ids ${which} failed on mesh ${meshIndex} ` +
+          glbWarn(
+            `reader: face_ids ${which} failed on mesh ${meshIndex} ` +
               `(payload first expressID ${faceIdsEntry.expressIds[0]}, ` +
               `recorded ${faceIdsEntry.firstExpressId}, ` +
               `geometry ${attrExpr && geomIndex ? attrExpr.getX(geomIndex.getX(0)) : 'n/a'}); ` +
@@ -766,8 +766,8 @@ export function restoreCacheHitPicking(model, cameFromGlbCache) {
           const recovery = perVertexTrusted ?
             'falling back to per-vertex attributes' :
             'skipping picking on this mesh (compressed, per-vertex IDs are corrupted)'
-          console.warn(
-            `[glb] reader: face_ids triangle count mismatch on mesh ${meshIndex} ` +
+          glbWarn(
+            `reader: face_ids triangle count mismatch on mesh ${meshIndex} ` +
               `(face_ids ${faceIdsEntry.expressIds.length}, geometry ${expectedTriCount}); ${recovery}`)
         }
       }
@@ -807,8 +807,8 @@ export function restoreCacheHitPicking(model, cameFromGlbCache) {
           `(${viaFaceIds} via BLDRS_face_ids, ${attached - viaFaceIds} via per-vertex)`)
     }
     if (skippedCompressedNoFaceIds > 0) {
-      console.warn(
-        `[glb] reader: skipped picking on ${skippedCompressedNoFaceIds} mesh(es) — ` +
+      glbWarn(
+        `reader: skipped picking on ${skippedCompressedNoFaceIds} mesh(es) — ` +
           `compressed (${compressionMode}) artifact with no BLDRS_face_ids coverage; ` +
           'per-vertex IDs would be corrupted')
     }

--- a/src/loader/bldrsElementProperties.test.js
+++ b/src/loader/bldrsElementProperties.test.js
@@ -14,6 +14,7 @@ import {
   parseGlb,
   serializeGlb,
 } from './injectGlbExtensions'
+import {getGlbLogs} from '../../tools/jest/glbLogCapture'
 
 
 describe('loader/bldrsElementProperties', () => {
@@ -889,6 +890,8 @@ describe('loader/bldrsElementProperties', () => {
       const gltf = {scene: {userData: {}}}
       await expect(reader.afterRoot(gltf)).resolves.toBe(gltf)
       expect(gltf.scene.userData.bldrsElementProperties).toBeUndefined()
+      // The skip announces itself through the captured [glb] channel.
+      expect(getGlbLogs().some((l) => l.text.includes('out-of-range bufferView 99'))).toBe(true)
     })
 
     it('survives a gltf with no default scene (no attach, no throw)', async () => {

--- a/src/loader/bldrsFaceIds.test.js
+++ b/src/loader/bldrsFaceIds.test.js
@@ -14,6 +14,7 @@ import {
   parseGlb,
   serializeGlb,
 } from './injectGlbExtensions'
+import {getGlbLogs} from '../../tools/jest/glbLogCapture'
 
 
 /**
@@ -358,6 +359,9 @@ describe('loader/bldrsFaceIds', () => {
       const gltf = {scene: {userData: {}}}
       await reader.afterRoot(gltf)
       expect(gltf.scene.userData.bldrsFaceIds).toBeUndefined()
+      // The skip announces itself through the captured [glb] channel — assert
+      // it fired rather than letting the diagnostic go unverified (and silent).
+      expect(getGlbLogs().some((l) => l.text.includes('out-of-range bufferView 99'))).toBe(true)
     })
   })
 

--- a/src/loader/bldrsSpatialTree.test.js
+++ b/src/loader/bldrsSpatialTree.test.js
@@ -9,6 +9,7 @@ import {
   parseGlb,
   serializeGlb,
 } from './injectGlbExtensions'
+import {getGlbLogs} from '../../tools/jest/glbLogCapture'
 
 
 describe('loader/bldrsSpatialTree', () => {
@@ -281,6 +282,8 @@ describe('loader/bldrsSpatialTree', () => {
       await expect(reader.afterRoot(gltf)).resolves.toBe(gltf)
       expect(gltf.scene.userData.bldrsSpatialTree).toBeUndefined()
       expect(reader.spatialTree).toBeNull()
+      // The skip announces itself through the captured [glb] channel.
+      expect(getGlbLogs().some((l) => l.text.includes('out-of-range bufferView 99'))).toBe(true)
     })
 
     it('skips a non-integer bufferView index without throwing', async () => {

--- a/src/loader/glbExport.js
+++ b/src/loader/glbExport.js
@@ -54,7 +54,7 @@ import {
   schemaVersionFor,
 } from './glbCompress'
 import {packGlbChunks} from './glbContainer'
-import {glbInfo, glbVerbose} from './glbLog'
+import {glbInfo, glbVerbose, glbWarn} from './glbLog'
 import {injectAndPackInWorker} from './GlbWriterService'
 import {injectGlbExtensions, parseGlb} from './injectGlbExtensions'
 
@@ -288,8 +288,8 @@ export async function exportAndCacheGlb({model, kindLabel, cacheKeyArgs, ifcMana
       // `preserveTriangleOrder` stays false, so compressGlb falls
       // back to the per-vertex-IDs-detected skip (uncompressed
       // write) rather than running DRACO with corrupted IDs.
-      console.warn(
-        '[glb] writer: parseGlb for face_ids capture threw; ' +
+      glbWarn(
+        'writer: parseGlb for face_ids capture threw; ' +
         'skipping face_ids (DRACO will skip too):', e)
     }
     // STEP per-occurrence identity. The per-triangle arrays above only

--- a/src/loader/glbLog.js
+++ b/src/loader/glbLog.js
@@ -18,15 +18,56 @@ import {isFeatureEnabled} from '../FeatureFlags'
 
 
 /**
+ * Default sink: write to the console with a stable `[glb]` prefix. `level` is
+ * a console method name ('info' | 'warn' | 'error').
+ *
+ * @param {string} level
+ * @param {Array<*>} args
+ */
+function consoleSink(level, args) {
+  // eslint-disable-next-line no-console
+  console[level]('[glb]', ...args)
+}
+
+
+let sink = consoleSink
+
+
+/**
+ * Swap the `[glb]` log sink. Tests install a capturing sink so these
+ * diagnostics are asserted against a buffer instead of printed — a clean load
+ * (and a clean test run) leaves a quiet console (conway #301 §6). Passing
+ * null/undefined restores the console sink.
+ *
+ * @param {?function(string, Array<*>): void} fn (level, args) => void
+ */
+export function setGlbLogSink(fn) {
+  sink = fn ?? consoleSink
+}
+
+
+/**
  * Milestone log: visible whenever called (the caller is expected to gate on
- * `isFeatureEnabled('glb')` already). Uses console.info so it's discoverable
- * without changing the debug level.
+ * `isFeatureEnabled('glb')` already). Routed through the sink (console.info by
+ * default) so it's discoverable without changing the debug level.
  *
  * @param {...*} args
  */
 export function glbInfo(...args) {
-  // eslint-disable-next-line no-console
-  console.info('[glb]', ...args)
+  sink('info', args)
+}
+
+
+/**
+ * Anomaly/error diagnostic for the GLB pipeline (cache-write skips, reader
+ * face_ids failures, out-of-range extension refs). Same `[glb]` prefix and
+ * sink as `glbInfo`, at warn level — one place for the pipeline's error-path
+ * console.warns so tests can capture and assert them.
+ *
+ * @param {...*} args
+ */
+export function glbWarn(...args) {
+  sink('warn', args)
 }
 
 
@@ -39,7 +80,6 @@ export function glbInfo(...args) {
  */
 export function glbVerbose(...args) {
   if (isFeatureEnabled('glbVerbose')) {
-    // eslint-disable-next-line no-console
-    console.info('[glb]', ...args)
+    sink('info', args)
   }
 }

--- a/src/loader/glbLog.js
+++ b/src/loader/glbLog.js
@@ -30,7 +30,22 @@ function consoleSink(level, args) {
 }
 
 
-let sink = consoleSink
+// The active sink lives on globalThis, not a module variable, so it survives
+// `jest.resetModules()`: a harness that resets the registry and re-imports this
+// file (e.g. GlbWriterService.test.js) still shares the one sink the test setup
+// installed — module state resets, globals don't. A module-local `sink` would
+// spring back to the console on re-import, letting that path's `[glb]` lines
+// both escape the capture buffer AND print. Unset in production ⇒ console.
+const SINK_KEY = '__bldrsGlbLogSink'
+
+
+/**
+ * @return {function(string, Array<*>): void} the active sink — the installed
+ *   capturing sink under test, else the console default.
+ */
+function activeSink() {
+  return (typeof globalThis !== 'undefined' && globalThis[SINK_KEY]) || consoleSink
+}
 
 
 /**
@@ -42,7 +57,9 @@ let sink = consoleSink
  * @param {?function(string, Array<*>): void} fn (level, args) => void
  */
 export function setGlbLogSink(fn) {
-  sink = fn ?? consoleSink
+  if (typeof globalThis !== 'undefined') {
+    globalThis[SINK_KEY] = fn ?? undefined
+  }
 }
 
 
@@ -54,7 +71,7 @@ export function setGlbLogSink(fn) {
  * @param {...*} args
  */
 export function glbInfo(...args) {
-  sink('info', args)
+  activeSink()('info', args)
 }
 
 
@@ -67,7 +84,7 @@ export function glbInfo(...args) {
  * @param {...*} args
  */
 export function glbWarn(...args) {
-  sink('warn', args)
+  activeSink()('warn', args)
 }
 
 
@@ -80,6 +97,6 @@ export function glbWarn(...args) {
  */
 export function glbVerbose(...args) {
   if (isFeatureEnabled('glbVerbose')) {
-    sink('info', args)
+    activeSink()('info', args)
   }
 }

--- a/tools/jest/glbLogCapture.js
+++ b/tools/jest/glbLogCapture.js
@@ -11,7 +11,7 @@
 // Wired up globally in `setupTests.js` (install once, clear before each test).
 // Import the getters directly in a spec to assert:
 //
-//   import {getGlbLogs} from '../../../tools/jest/glbLogCapture'
+//   import {getGlbLogs} from '../../tools/jest/glbLogCapture'
 //   expect(getGlbLogs().some((l) => l.text.includes('out-of-range'))).toBe(true)
 import {setGlbLogSink} from '../../src/loader/glbLog'
 

--- a/tools/jest/glbLogCapture.js
+++ b/tools/jest/glbLogCapture.js
@@ -1,0 +1,65 @@
+// Test capture for the `[glb]` pipeline logs.
+//
+// A clean load — and a clean test run — should leave a quiet console
+// (conway #301 §6). The GLB loader/writer emit `[glb]` milestone and
+// error-path diagnostics through `src/loader/glbLog.js`; in the app those go
+// to the console, but under jest we divert them into a buffer instead of
+// printing. Tests that exercise an error path assert the diagnostic fired via
+// `getGlbLogs()` (turning would-be console noise into positive coverage);
+// everything else stays silent.
+//
+// Wired up globally in `setupTests.js` (install once, clear before each test).
+// Import the getters directly in a spec to assert:
+//
+//   import {getGlbLogs} from '../../../tools/jest/glbLogCapture'
+//   expect(getGlbLogs().some((l) => l.text.includes('out-of-range'))).toBe(true)
+import {setGlbLogSink} from '../../src/loader/glbLog'
+
+
+/** @type {Array<{level: string, text: string}>} */
+const captured = []
+
+
+/**
+ * Stringify one sink arg for buffer matching. Errors keep their message;
+ * objects fall back to a safe tag rather than throwing on a cyclic value.
+ *
+ * @param {*} arg
+ * @return {string}
+ */
+function argToText(arg) {
+  if (arg instanceof Error) {
+    return arg.message
+  }
+  if (arg === null || arg === undefined || typeof arg !== 'object') {
+    return String(arg)
+  }
+  try {
+    return JSON.stringify(arg)
+  } catch {
+    return '[object]'
+  }
+}
+
+
+/** Install the capturing sink. Idempotent; call once from global setup. */
+export function installGlbLogCapture() {
+  setGlbLogSink((level, args) => {
+    captured.push({level, text: args.map(argToText).join(' ')})
+  })
+}
+
+
+/** Drop everything captured so far (call before each test). */
+export function clearGlbLogs() {
+  captured.length = 0
+}
+
+
+/**
+ * @return {Array<{level: string, text: string}>} a copy of the captured
+ *   `[glb]` log entries since the last clear.
+ */
+export function getGlbLogs() {
+  return captured.slice()
+}

--- a/tools/jest/setupTests.js
+++ b/tools/jest/setupTests.js
@@ -7,12 +7,18 @@ import '@testing-library/jest-dom'
 import 'regenerator-runtime/runtime'
 import {disableDebug} from '../../src/utils/debug'
 import {getAndExportEnvVars} from './vars.jest'
+import {installGlbLogCapture, clearGlbLogs} from './glbLogCapture'
 
 
 const {initServer} = require('../../src/__mocks__/server')
 
 
 disableDebug()
+
+// Divert the GLB pipeline's `[glb]` diagnostics into a buffer so a test run
+// leaves a quiet console; specs assert on them via getGlbLogs(). Cleared
+// before each test in the beforeEach below.
+installGlbLogCapture()
 
 const server = initServer(getAndExportEnvVars())
 
@@ -22,6 +28,9 @@ beforeAll(() => {
     onUnhandledRequest: 'error', // Warns about unhandled requests
   })
 })
+
+// Start each test with an empty `[glb]` capture buffer.
+beforeEach(() => clearGlbLogs())
 
 // Reset any request handlers that we may add during the tests,
 // so they don't affect other tests.


### PR DESCRIPTION
Follow-up #1 of 3 from the test-log cleanup (#1722), which left the `[glb]` pipeline diagnostics as noted-remaining. This diverts them so a jest run leaves a quiet console (conway #301 §6) and asserts the error-path ones.

## Change

- **`glbLog.js`**: `glbInfo` / `glbVerbose` (and a new **`glbWarn`**) route through a **swappable sink** — console by default. `setGlbLogSink()` lets a harness capture instead of print.
- Moved the pipeline's stray direct `console.warn('[glb] …')` calls onto `glbWarn` so they share the one channel: `glbExport.js` (face_ids-capture skip) and `Loader.js` ×3 (reader face_ids failures / compressed-no-coverage skip).
- **`tools/jest/glbLogCapture.js`** + `setupTests.js`: install a capturing sink for the whole suite (buffer, no console output), cleared before each test. Specs read it via `getGlbLogs()`.
- **Asserted** the diagnostic fires in the three out-of-range-bufferView error-path tests (`BLDRS_face_ids` / `_element_properties` / `_spatial_tree`) — turning would-be noise into positive coverage.

## Result

Full jest suite green (**230 suites, 2173 passed**); **0 `[glb]` console lines** (was ~115). No production behavior change — the console sink is the default; only tests swap it.

## Stacked follow-ups

This is the base of a 3-PR stack: **#2 CadView/ViewerContainer `act()` warnings** targets this branch, **#3 single-`three`-instance jest resolution** targets #2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HLsefWrsH8W6PWY9qh9xaU)_