### PR TITLE
Docs: guidance for keeping the test console clean

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,7 @@ This file is the router for AI assistants working in this repo. Keep it small. T
 | Asset pipeline, fonts, icons | [src/assets/README.md](src/assets/README.md) |
 | Sample-model thumbnails (Open dialog Samples tab), regenerating them, aiming them via `#c:` permalink cameras | [tools/thumbnails/README.md](tools/thumbnails/README.md) |
 | Route schemas, URL parsing | [src/routes/README.md](src/routes/README.md) |
+| Keeping the test console clean — fix `act()` warnings, divert+assert expected `[glb]` output, narrow `suppressActWarnings()`, back a global mute with a static test (`singleThreeInstance.test.js`), jsdom canvas stubs | [PLAYBOOK.md](PLAYBOOK.md) §"Keep the test console clean" (+ [STYLE.md](STYLE.md) §"Console hygiene") |
 | Dev HTTPS certificate setup | [tools/esbuild/certificates/README.md](tools/esbuild/certificates/README.md) |
 | Cloud sources, OAuth flows, token storage, Auth0 gate | [src/connections/README.md](src/connections/README.md) |
 | Sharing PR3 (GitHub adapter) carry-over notes | [design/new/sharing-pr3-github.md](design/new/sharing-pr3-github.md) |

--- a/PLAYBOOK.md
+++ b/PLAYBOOK.md
@@ -217,3 +217,97 @@ remote.
 
 After a push, verify with `git log origin/<branch>` or `git status` rather
 than trusting the push command's output alone.
+
+
+## Keep the test console clean
+
+**A test run should print nothing unexpected.** Noise isn't cosmetic: once a
+run logs a hundred lines of warnings, the one *new* warning that flags a real
+regression drowns in them and nobody sees it. So a green run is also a *quiet*
+run — treat a stray warning as a defect to resolve, not scenery. There are
+four moves, in priority order; reach for a lower one only when the one above
+it genuinely can't apply.
+
+**1. Fix the warning at the source.** Most React `act()` warnings mean a state
+update wasn't awaited. Await it — don't mute it. `actAsyncFlush()`
+(`src/utils/tests.js`) settles the pending microtask after a render:
+
+```js
+import {actAsyncFlush} from '../utils/tests'
+render(<Thing/>)
+await actAsyncFlush() // flush the mount effect's setState before asserting
+```
+
+Keep that helper **timer-agnostic** — a single awaited `Promise.resolve()`,
+never a `setTimeout(0)`. Under `jest.useFakeTimers()` a real timer never fires
+unless the clock is advanced, so a `setTimeout`-based flush would hang every
+caller that uses fake timers. Same rule for any flush helper you add.
+
+**2. Divert expected diagnostics into a buffer and assert on them.** When code
+is *supposed* to log — the `[glb]` loader emits error-path diagnostics by
+design — don't let it reach the console and don't silently swallow it either.
+Route it through a swappable sink and assert the expected line is present, so
+the diagnostic becomes a *tested signal* instead of spam:
+
+- `src/loader/glbLog.js` — the emit side. `glbInfo/glbWarn/glbVerbose` call an
+  active sink (default: console) that tests can swap via `setGlbLogSink`. The
+  sink lives on `globalThis` so it survives `jest.resetModules()`.
+- `tools/jest/glbLogCapture.js` — the test side. `installGlbLogCapture()`
+  (wired once in `setupTests.js`, cleared per test) buffers everything; a spec
+  reads it with `getGlbLogs()`:
+
+```js
+import {getGlbLogs} from '../../tools/jest/glbLogCapture'
+// ...trigger the malformed-GLB path...
+expect(getGlbLogs().some((l) => l.text.includes('out-of-range bufferView 99')))
+  .toBe(true)
+```
+
+Apply this pattern to any subsystem with intentional, assertable logging:
+give it a swappable sink rather than calling `console.*` directly.
+
+**3. Suppress only what you genuinely can't reach — narrowly, and restore it.**
+Some updates fire outside any `act` scope RTL can enclose: a mocked model load
+that resolves on its own timers and drives a `setState` *during* a `waitFor`.
+There's nothing to await. `suppressActWarnings()` (`src/utils/tests.js`)
+swallows **only** the `"not wrapped in act"` line and passes every other
+`console.error` through. Scope it to the one test and wrap in `try/finally` so
+a failed assertion can't leave `console.error` mocked for the rest of the file
+(which would hide every later test's real errors):
+
+```js
+const restore = suppressActWarnings()
+try {
+  // ...the one test whose cascade can't be awaited...
+} finally {
+  restore()
+}
+```
+
+This is the escape hatch, not the norm — prefer move 1 whenever the update is
+reachable.
+
+**4. If you mute a real signal globally, back it with a static test.** A global
+`console.warn` filter is a blunt instrument: it can hide a genuine problem
+alongside the false positive. `setupTests.js` mutes three's *"Multiple
+instances of Three.js"* warning because under jest it's a false positive (the
+harness resets the module registry and re-imports three against an already-set
+`window.__THREE__`). But that same warning would also fire for a *real* on-disk
+duplicate — a nested `node_modules/three` pulled in by some dependency's
+version range — which the filter would now swallow. So the mute is paired with
+`src/viewer/three/singleThreeInstance.test.js`, a static scan that fails if
+`three` appears in `node_modules` more than once. **Rule:** any global console
+filter that could mask a real defect needs a compensating detector for the case
+that actually ships.
+
+**Bonus — kill jsdom "not implemented" spam at the setup seam.** jsdom logs a
+`console.error` every time app code calls an unimplemented canvas method
+(`getContext`, `toDataURL` — PerfMonitor's overlay, screenshot capture). The
+code already treats their falsy return as "headless — skip", so
+`setupTests.js` stubs them to exactly those falsy values. Same runtime the code
+already saw under jsdom, minus the per-call error. A test needing a real
+context still overrides these on its own canvas object.
+
+The shared wiring lives in **`tools/jest/setupTests.js`** (glb capture install
++ per-test clear, the three filter, the canvas stubs); per-test helpers live in
+**`src/utils/tests.js`**.

--- a/STYLE.md
+++ b/STYLE.md
@@ -118,6 +118,25 @@ Use dash-separated, converted from CamelCase:
 - **Mock implementations**: Use `() => {}` freely for Jest mocks
 - **Test descriptions**: Clear, descriptive test names
 
+### Console hygiene
+A test run should print **nothing unexpected** — noise buries the one new
+warning that flags a real regression. Treat a stray warning as a defect, in
+this priority order:
+- **Fix it at the source.** An `act()` warning usually means an un-awaited
+  state update — await it with `actAsyncFlush()` (`src/utils/tests.js`), don't
+  mute it. Keep flush helpers timer-agnostic (a single microtask, never
+  `setTimeout` — it hangs under fake timers).
+- **Divert expected output and assert on it.** Code that logs *by design*
+  (the `[glb]` diagnostics) routes through a swappable sink and is checked via
+  `getGlbLogs()` — a tested signal, not console spam.
+- **Suppress only what you can't reach** — narrowly (`suppressActWarnings()`
+  swallows just the one line), scoped to one test, restored in `try/finally`.
+- **Back any global mute with a static test** — e.g. three's muted "Multiple
+  instances" warning is compensated by `singleThreeInstance.test.js`.
+
+Full rationale and worked examples: [PLAYBOOK.md](PLAYBOOK.md) §"Keep the test
+console clean".
+
 ## JSDoc Standards
 - **Check types**: Type checking enabled
 - **No required descriptions**: Focus on type safety over verbose docs


### PR DESCRIPTION
## What

Docs-only. Captures the console-hygiene constraints established while landing the test-log-noise cleanup (#1723 / #1736 / #1737) so future contributors follow the same priority order instead of re-deriving it. No code changes.

## Changes

- **`PLAYBOOK.md`** — new Specific Guide, **"Keep the test console clean"**. A quiet run is the baseline (noise buries the one new warning that flags a real regression), then four moves in priority order:
  1. **Fix the warning at the source** — await the un-awaited update with `actAsyncFlush()`; keep flush helpers timer-agnostic (a microtask, never `setTimeout`, which hangs under fake timers).
  2. **Divert expected diagnostics and assert on them** — the `[glb]` pattern: a swappable sink (`glbLog.js`) + capture buffer (`glbLogCapture.js` → `getGlbLogs()`), so intentional logging becomes a tested signal, not spam.
  3. **Suppress only what you can't reach** — `suppressActWarnings()` swallows just the `"not wrapped in act"` line, scoped to one test, restored in `try/finally`.
  4. **Back any global mute with a static test** — three's muted "Multiple instances" warning is compensated by `singleThreeInstance.test.js`.
  Plus the jsdom canvas-stub seam that kills "not implemented" spam.
- **`STYLE.md`** — concise **"Console hygiene"** subsection under Testing Conventions, linking to the PLAYBOOK guide.
- **`AGENTS.md`** (`CLAUDE.md`) — router row so the guidance is discoverable.

## Test

Docs-only; husky gate ran green on commit (234 suites / 2236 tests). No behavior change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HLsefWrsH8W6PWY9qh9xaU)_