### PR TITLE
Add usage quotas: server-authoritative load gating with 30-day rolling window

### DIFF
--- a/design/new/quotas.md
+++ b/design/new/quotas.md
@@ -18,46 +18,31 @@ This is the design of record for the feature. The Open-dialog UI wiring is in
 
 ## Status & remaining work
 
-*Handoff snapshot, 2026-08-07. Work is paused here; each numbered item below
-is sized to be picked up as its own work thread. They are ordered — (1) and
-(2) unblock the rest.*
+*Updated 2026-08-07 with the #1740 re-land.*
 
-**Where things stand:** the four stacked PRs (#1550 → #1551 → #1552 → #1553,
-branches `quota/1-core-lib` … `quota/4-wire-load-sites`; see the
-Implementation map) are pushed, one commit per branch, each husky-gated green
-(eslint `--max-warnings 0`, tsc, full Jest) on `main@845298d7` (2026-06-29).
-\#1550's CI is fully green on that base — `build`, `playwright-run`, and
-`playwright-webifc-run`. Enforcement ships dark behind the `quotas` flag.
+**Where things stand:** the core lib + this doc landed on `main` via #1550.
+The other three stacked PRs (#1551 → #1553) were merged into their stacked
+*branch* bases rather than `main` — GitHub only retargets a stacked PR to
+`main` when the merged base branch is deleted — so their content initially
+landed nowhere reachable. **#1740** (`quota/5-reland`) re-lands all three
+layers (server gate, client hook + UI + flag, load-site wiring) onto current
+`main` in one reviewed merge, with the Open-dialog conflicts resolved in
+favor of main's shapes (sampleModelRoster cards, the #1682 storage-id
+semantics, the loosened GitHub file gate) and the click-handler ordering
+contract preserved (§UI surfaces below; Open/README §Gating wiring).
+Enforcement ships dark behind the `quotas` flag.
 
-1. **Re-integrate the stack onto current main.** main has moved ~317 commits
-   since the stack's base (workspace store, batched/instanced viewer, USD +
-   splat formats, Node 24, Open-dialog evolution). 10 of the stack's 25 files
-   were also touched on main — by layer:
-   - #1550: `AGENTS.md` (router table only; GitHub reports the PR merely
-     "behind", not conflicting)
-   - #1551: none — the server layer is clean
-   - #1552: `src/FeatureFlags.js`, `src/net/http.js`
-   - #1553: `OpenModelDialog.jsx` + `.test.jsx`, `GitHubFileBrowser.jsx`,
-     `SampleModels.jsx`, `SampleModelFileSelector.jsx`,
-     `src/utils/dragAndDrop.js`, `src/tests/e2e/utils.ts`
-   Re-stack bottom-up (each branch is a single commit, so this is four
-   rebases). When resolving the Open-dialog files, preserve the
-   click-handler ordering contract (§UI surfaces below; Open/README §Gating
-   wiring) — hasCapacity gate, then getAccessToken *inside* the click
-   handler before any other await, then record(). Husky-gate and
-   force-push each branch.
-2. **Review & land the stack bottom-up.** Merge #1550 first; GitHub
-   auto-retargets each remaining PR to `main` as its base merges. Caveat:
-   `Quota.spec.ts` gets its *first CI run* only when #1553 retargets to
-   `main` (workflows don't run for PRs based on another branch) — watch it.
-3. **Close #1494 as superseded** (a pointer comment is already on that PR).
-4. **Deploy-preview smoke test** (checklist in #1553): with `?feature=quotas`
+1. **Land #1740** — watch its CI (this is `Quota.spec.ts`'s first-ever CI
+   run), then merge. Afterwards delete the spent `quota/*` branches; leaving
+   merged stacked branches undeleted is exactly what caused the stranding.
+2. **Close #1494 as superseded** (a pointer comment is already on that PR).
+3. **Deploy-preview smoke test** (checklist in #1740): with `?feature=quotas`
    and a real Auth0 free user — public GH repo loads without counting;
    private repo counts; 5th private load → 403 + `QuotaLimitDialog`, no
    navigation; `sharePro` unlimited; `/share/quotas` renders.
-5. **Bake, then roll out.** Test per-session via `?feature=quotas`; when
+4. **Bake, then roll out.** Test per-session via `?feature=quotas`; when
    satisfied, flip the flag's `isActive` to `true` in `src/FeatureFlags.js`.
-6. **Follow-ups** — each small and independent: see §Out of scope below.
+5. **Follow-ups** — each small and independent: see §Out of scope below.
 
 ## Tiers & limits
 
@@ -195,6 +180,9 @@ Summary only; the wiring lives in
 | Server gate | `netlify/functions/record-load.js`, `src/__mocks__/api-handlers.js` | [#1551](https://github.com/bldrs-ai/Share/pull/1551) (`quota/2-server-enforcement`) |
 | Client hook + UI + flag | `src/hooks/useQuota.js`, `QuotaBadge.jsx`, `QuotaLimitDialog.jsx`, `src/FeatureFlags.js` | [#1552](https://github.com/bldrs-ai/Share/pull/1552) (`quota/3-client-hook-ui`) |
 | Load-site wiring + docs page | Open dialog + containers, `src/pages/share/Quotas.jsx`, `Quota.spec.ts` | [#1553](https://github.com/bldrs-ai/Share/pull/1553) (`quota/4-wire-load-sites`) |
+
+The per-layer PRs carry the review history; layers 2–4 reached `main` via the
+[#1740](https://github.com/bldrs-ai/Share/pull/1740) re-land (see §Status).
 
 ## Out of scope / follow-ups
 

--- a/design/new/quotas.md
+++ b/design/new/quotas.md
@@ -104,7 +104,7 @@ limit must never wrongly burn a user's quota. Lookups are cached module-scope
 
 ## Client (`useQuota`)
 
-`src/hooks/useQuota.js` exposes `{used, limit, tier, hasCapacity, record}`.
+`src/hooks/useQuota.js` exposes `{used, limit, tier, hasCapacity, check, record}`.
 
 - **Signed in:** `record(key)` awaits `record-load`, mirrors the authoritative
   response into OPFS, and force-refreshes the JWT so other `app_metadata`
@@ -189,9 +189,13 @@ The per-layer PRs carry the review history; layers 2–4 reached `main` via the
 - `WidgetApi` / `LoadModelEventHandler` programmatic loads bypass the React hook
   and are not metered (flagged).
 - Migrate quota storage off Auth0 `app_metadata` to a KV store when
-  Management-API limits bite.
+  Management-API limits bite. This also fixes the known read-modify-write
+  race: `record-load` has no compare-and-set, so two concurrent loads for
+  one user can last-write-win a `loads` entry away (loss direction is a
+  free extra load, never a wrongful block).
 - Authenticated GitHub API to dodge the 60/hr unauth privacy-lookup limit.
 - Free-tier "at-limit dialog" / "public sample doesn't count" e2e (flaky around
-  navigation timing; unit-covered in `src/quota/quota.test.js`).
-- Dedupe the local `HTTP_FORBIDDEN = 403` in `useQuota` against the shared
-  `src/net/http.js` constant.
+  navigation timing; unit-covered in `src/quota/quota.test.js`). Relatedly, the
+  Pro-tier `Quota.spec.ts` currently early-returns (passes vacuously) because
+  its seeded Drive recent renders only under a connection card no test
+  connection creates — fixing it needs the same connection-seeding pattern.

--- a/netlify/functions/record-load.js
+++ b/netlify/functions/record-load.js
@@ -1,0 +1,344 @@
+/*
+ * Netlify Function: record-load.js
+ * --------------------------------
+ * Authoritative gate for usage-quota counting.
+ *
+ *   POST /.netlify/functions/record-load
+ *   Headers: Authorization: Bearer <user access token>
+ *   Body:    { key: string }   // share path, e.g. /share/v/g/<id>
+ *
+ * Flow:
+ *   1. Validate the access token via Auth0 /userinfo → sub.
+ *   2. Read user app_metadata via Auth0 Management API
+ *      (mgmt token cached in module scope).
+ *   3. Derive tier: subscriptionStatus === 'sharePro' → PAID, else FREE.
+ *   4. For /v/gh/, resolve repo privacy via unauth api.github.com
+ *      (cached per "owner/repo" in module scope, 15-minute TTL).
+ *   5. Prune loads outside the rolling 30-day window.
+ *   6. Idempotent: if key already counted, return current state.
+ *   7. If FREE && used >= limit, return 403 — client surfaces dialog.
+ *   8. Otherwise PATCH app_metadata.usageQuota.loads with the new entry.
+ *
+ * Response: { allowed, used, limit, tier, alreadyCounted }
+ *   limit is null for paid (unlimited).
+ *
+ * Storage shape under app_metadata.usageQuota:
+ *   { loads: [{ key, loadedAt }, ...] }
+ */
+
+const axios = require('axios')
+const Sentry = require('@sentry/serverless')
+
+
+Sentry.AWSLambda.init({
+  dsn: process.env.SENTRY_DSN,
+  tracesSampleRate: 1.0,
+  environment: process.env.NODE_ENV,
+})
+
+// HTTP status codes
+const HTTP_OK = 200
+const HTTP_BAD_REQUEST = 400
+const HTTP_UNAUTHORIZED = 401
+const HTTP_FORBIDDEN = 403
+const HTTP_METHOD_NOT_ALLOWED = 405
+const HTTP_BAD_GATEWAY = 502
+
+// Tier constants (kept in lock-step with src/quota/quota.js)
+const TIER_FREE = 'free'
+const TIER_PAID = 'paid'
+const FREE_LIMIT = 4
+
+// Time
+const SECONDS_PER_MIN = 60
+const MINUTES_PER_HOUR = 60
+const HOURS_PER_DAY = 24
+const MILLIS_PER_SECOND = 1000
+const ROLLING_WINDOW_DAYS = 30
+const ROLLING_WINDOW_MS =
+  ROLLING_WINDOW_DAYS * HOURS_PER_DAY * MINUTES_PER_HOUR * SECONDS_PER_MIN * MILLIS_PER_SECOND
+
+// Mgmt-token refresh safety margin
+const MGMT_TOKEN_REFRESH_SAFETY_SEC = 60
+
+// GH privacy cache TTL
+const GH_PRIVACY_CACHE_TTL_MIN = 15
+const GH_PRIVACY_CACHE_TTL_MS = GH_PRIVACY_CACHE_TTL_MIN * MINUTES_PER_HOUR * MILLIS_PER_SECOND
+
+// Module-scope caches — survive across warm Lambda invocations.
+let cachedMgmtToken = null
+let cachedMgmtTokenExpiresAt = 0
+const ghPrivacyCache = new Map() // "owner/repo" -> {private: bool, fetchedAt: ms}
+
+/**
+ * Fetch (or reuse) an Auth0 Management API token via Client Credentials.
+ *
+ * @return {Promise<string>}
+ */
+async function getManagementApiToken() {
+  const now = Date.now()
+  if (cachedMgmtToken && now < cachedMgmtTokenExpiresAt) {
+    return cachedMgmtToken
+  }
+  const resp = await axios.post(
+    `https://${process.env.AUTH0_DOMAIN}/oauth/token`,
+    {
+      client_id: process.env.AUTH0_CLIENT_ID,
+      client_secret: process.env.AUTH0_CLIENT_SECRET,
+      audience: `https://${process.env.AUTH0_DOMAIN}/api/v2/`,
+      grant_type: 'client_credentials',
+    },
+    {headers: {'Content-Type': 'application/json'}},
+  )
+  cachedMgmtToken = resp.data.access_token
+  const expiresInSec = Number(resp.data.expires_in) || 0
+  cachedMgmtTokenExpiresAt = now + ((expiresInSec - MGMT_TOKEN_REFRESH_SAFETY_SEC) * MILLIS_PER_SECOND)
+  return cachedMgmtToken
+}
+
+/**
+ * @param {string} userToken Bearer token presented by the caller
+ * @return {Promise<string|null>} Auth0 user_id (sub)
+ */
+async function getUserIdFromToken(userToken) {
+  const resp = await axios.get(
+    `https://${process.env.AUTH0_DOMAIN}/userinfo`,
+    {headers: {Authorization: `Bearer ${userToken}`}},
+  )
+  return resp.data && resp.data.sub
+}
+
+/**
+ * @param {string} mgmtToken Management API token
+ * @param {string} auth0UserId
+ * @return {Promise<object>} Full user record (includes app_metadata)
+ */
+async function getUserRecord(mgmtToken, auth0UserId) {
+  const resp = await axios.get(
+    `https://${process.env.AUTH0_DOMAIN}/api/v2/users/${encodeURIComponent(auth0UserId)}`,
+    {headers: {Authorization: `Bearer ${mgmtToken}`}},
+  )
+  return resp.data || {}
+}
+
+/**
+ * @param {string} mgmtToken
+ * @param {string} auth0UserId
+ * @param {Array} loads New loads list to persist under app_metadata.usageQuota
+ * @return {Promise<void>}
+ */
+async function patchUsageQuota(mgmtToken, auth0UserId, loads) {
+  await axios.patch(
+    `https://${process.env.AUTH0_DOMAIN}/api/v2/users/${encodeURIComponent(auth0UserId)}`,
+    {app_metadata: {usageQuota: {loads}}},
+    {
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${mgmtToken}`,
+      },
+    },
+  )
+}
+
+/**
+ * @param {object} appMetadata
+ * @return {string}
+ */
+function getTier(appMetadata) {
+  if (appMetadata && appMetadata.subscriptionStatus === 'sharePro') {
+    return TIER_PAID
+  }
+  return TIER_FREE
+}
+
+/**
+ * @param {Array} loads
+ * @param {number} now
+ * @return {Array}
+ */
+function pruneLoads(loads, now) {
+  if (!Array.isArray(loads)) {
+    return []
+  }
+  const cutoff = now - ROLLING_WINDOW_MS
+  return loads.filter((l) => Date.parse(l.loadedAt) >= cutoff)
+}
+
+/**
+ * Resolve whether a `/v/gh/{owner}/{repo}/...` path points at a private
+ * repo. Returns true (=quotable) for private/missing/error responses.
+ * Cached in module scope per (owner, repo) for GH_PRIVACY_CACHE_TTL_MS.
+ *
+ * @param {string} owner
+ * @param {string} repo
+ * @return {Promise<boolean>}
+ */
+async function isPrivateGhRepo(owner, repo) {
+  const cacheKey = `${owner.toLowerCase()}/${repo.toLowerCase()}`
+  const now = Date.now()
+  const hit = ghPrivacyCache.get(cacheKey)
+  if (hit && (now - hit.fetchedAt) < GH_PRIVACY_CACHE_TTL_MS) {
+    return hit.private
+  }
+  try {
+    const resp = await axios.get(
+      `https://api.github.com/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}`,
+      {validateStatus: () => true},
+    )
+    let isPrivate
+    if (resp.status === HTTP_OK) {
+      isPrivate = false
+    } else if (resp.status === HTTP_FORBIDDEN || resp.status >= HTTP_BAD_GATEWAY) {
+      // Rate-limited or upstream hiccup — don't penalize the user; treat
+      // as not-quotable. Do NOT cache this so we retry next time.
+      Sentry.captureException(new Error(`GH repo lookup status=${resp.status} for ${cacheKey}`))
+      return false
+    } else {
+      // 404 (private or missing) and other 4xx -> count it.
+      isPrivate = true
+    }
+    ghPrivacyCache.set(cacheKey, {private: isPrivate, fetchedAt: now})
+    return isPrivate
+  } catch (err) {
+    Sentry.captureException(err)
+    return false
+  }
+}
+
+/**
+ * @param {string} key Share path
+ * @return {Promise<boolean>}
+ */
+async function isQuotableLoad(key) {
+  if (key.includes('/v/new/') || key.includes('/v/g/')) {
+    return true
+  }
+  // /v/gh/<owner>/<repo>/<branch>/<path>
+  const ghMatch = key.match(/\/v\/gh\/([^/]+)\/([^/]+)\//)
+  if (ghMatch) {
+    const owner = decodeURIComponent(ghMatch[1])
+    const repo = decodeURIComponent(ghMatch[2])
+    return await isPrivateGhRepo(owner, repo)
+  }
+  return false
+}
+
+/**
+ * Build the response payload for a given decision.
+ *
+ * @param {boolean} allowed
+ * @param {number} used
+ * @param {string} tier
+ * @param {boolean} alreadyCounted
+ * @param {Array} [loads] Authoritative loads array to mirror to client
+ * @return {object}
+ */
+function buildResponse(allowed, used, tier, alreadyCounted, loads) {
+  const limit = tier === TIER_PAID ? null : FREE_LIMIT
+  const body = {allowed, used, limit, tier, alreadyCounted}
+  if (loads) {
+    body.loads = loads
+  }
+  return body
+}
+
+exports.handler = Sentry.AWSLambda.wrapHandler(async (event) => {
+  if (event.httpMethod !== 'POST') {
+    return {statusCode: HTTP_METHOD_NOT_ALLOWED, body: 'Method Not Allowed'}
+  }
+
+  const authHeader = event.headers.authorization || event.headers.Authorization || ''
+  const match = authHeader.match(/^Bearer\s+(.+)$/i)
+  if (!match) {
+    return {statusCode: HTTP_UNAUTHORIZED, body: 'Missing or invalid Authorization header'}
+  }
+  const userToken = match[1]
+
+  let bodyStr = event.body || ''
+  if (event.isBase64Encoded) {
+    bodyStr = Buffer.from(bodyStr, 'base64').toString('utf8')
+  }
+  let body
+  try {
+    body = JSON.parse(bodyStr)
+  } catch {
+    return {statusCode: HTTP_BAD_REQUEST, body: 'Invalid JSON body'}
+  }
+  const {key} = body || {}
+  if (typeof key !== 'string' || !key) {
+    return {statusCode: HTTP_BAD_REQUEST, body: 'Missing key'}
+  }
+
+  let auth0UserId
+  try {
+    auth0UserId = await getUserIdFromToken(userToken)
+  } catch (err) {
+    Sentry.captureException(err)
+    return {statusCode: HTTP_UNAUTHORIZED, body: 'Invalid access token'}
+  }
+  if (!auth0UserId) {
+    return {statusCode: HTTP_UNAUTHORIZED, body: 'Unable to resolve user'}
+  }
+
+  let mgmtToken
+  let userRecord
+  try {
+    mgmtToken = await getManagementApiToken()
+    userRecord = await getUserRecord(mgmtToken, auth0UserId)
+  } catch (err) {
+    Sentry.captureException(err)
+    return {statusCode: HTTP_BAD_GATEWAY, body: 'Failed to look up user'}
+  }
+
+  const appMetadata = userRecord.app_metadata || {}
+  const tier = getTier(appMetadata)
+  const now = Date.now()
+  const existingLoads = pruneLoads((appMetadata.usageQuota && appMetadata.usageQuota.loads) || [], now)
+
+  // Paid: never gated, never recorded (no point burning Mgmt API writes).
+  if (tier === TIER_PAID) {
+    return jsonResponse(HTTP_OK, buildResponse(true, existingLoads.length, tier, false))
+  }
+
+  let quotable
+  try {
+    quotable = await isQuotableLoad(key)
+  } catch (err) {
+    Sentry.captureException(err)
+    quotable = false
+  }
+  if (!quotable) {
+    return jsonResponse(HTTP_OK, buildResponse(true, existingLoads.length, tier, false))
+  }
+
+  if (existingLoads.some((l) => l.key === key)) {
+    return jsonResponse(HTTP_OK, buildResponse(true, existingLoads.length, tier, true, existingLoads))
+  }
+
+  if (existingLoads.length >= FREE_LIMIT) {
+    return jsonResponse(HTTP_FORBIDDEN, buildResponse(false, existingLoads.length, tier, false, existingLoads))
+  }
+
+  const newLoads = [...existingLoads, {key, loadedAt: new Date(now).toISOString()}]
+  try {
+    await patchUsageQuota(mgmtToken, auth0UserId, newLoads)
+  } catch (err) {
+    Sentry.captureException(err)
+    return {statusCode: HTTP_BAD_GATEWAY, body: 'Failed to record load'}
+  }
+
+  return jsonResponse(HTTP_OK, buildResponse(true, newLoads.length, tier, false, newLoads))
+})
+
+/**
+ * @param {number} status HTTP status code
+ * @param {object} body JSON body
+ * @return {object} Netlify function response
+ */
+function jsonResponse(status, body) {
+  return {
+    statusCode: status,
+    body: JSON.stringify(body),
+    headers: {'Content-Type': 'application/json'},
+  }
+}

--- a/netlify/functions/record-load.js
+++ b/netlify/functions/record-load.js
@@ -42,6 +42,7 @@ const HTTP_BAD_REQUEST = 400
 const HTTP_UNAUTHORIZED = 401
 const HTTP_FORBIDDEN = 403
 const HTTP_METHOD_NOT_ALLOWED = 405
+const HTTP_INTERNAL_SERVER_ERROR = 500
 const HTTP_BAD_GATEWAY = 502
 
 // Tier constants (kept in lock-step with src/quota/quota.js)
@@ -63,7 +64,7 @@ const MGMT_TOKEN_REFRESH_SAFETY_SEC = 60
 
 // GH privacy cache TTL
 const GH_PRIVACY_CACHE_TTL_MIN = 15
-const GH_PRIVACY_CACHE_TTL_MS = GH_PRIVACY_CACHE_TTL_MIN * MINUTES_PER_HOUR * MILLIS_PER_SECOND
+const GH_PRIVACY_CACHE_TTL_MS = GH_PRIVACY_CACHE_TTL_MIN * SECONDS_PER_MIN * MILLIS_PER_SECOND
 
 // Module-scope caches — survive across warm Lambda invocations.
 let cachedMgmtToken = null
@@ -188,9 +189,10 @@ async function isPrivateGhRepo(owner, repo) {
     let isPrivate
     if (resp.status === HTTP_OK) {
       isPrivate = false
-    } else if (resp.status === HTTP_FORBIDDEN || resp.status >= HTTP_BAD_GATEWAY) {
-      // Rate-limited or upstream hiccup — don't penalize the user; treat
-      // as not-quotable. Do NOT cache this so we retry next time.
+    } else if (resp.status === HTTP_FORBIDDEN || resp.status >= HTTP_INTERNAL_SERVER_ERROR) {
+      // Rate-limited (403) or any 5xx upstream hiccup — don't penalize the
+      // user; treat as not-quotable (design/new/quotas.md §GitHub privacy
+      // detection: "403 / 5xx → No"). Do NOT cache this so we retry next time.
       Sentry.captureException(new Error(`GH repo lookup status=${resp.status} for ${cacheKey}`))
       return false
     } else {

--- a/src/Components/Onboarding/OnboardingOverlay.jsx
+++ b/src/Components/Onboarding/OnboardingOverlay.jsx
@@ -4,6 +4,8 @@ import {Box, Fade, Paper, Stack, Typography} from '@mui/material'
 import {useTheme} from '@mui/material/styles'
 import {FileUpload as FileUploadIcon} from '@mui/icons-material'
 import useStore from '../../store/useStore'
+import useQuota from '../../hooks/useQuota'
+import QuotaLimitDialog from '../Open/QuotaLimitDialog'
 import {handleFileDrop, handleDragOverOrEnter, handleDragLeave} from '../../utils/dragAndDrop'
 
 
@@ -18,12 +20,14 @@ export default function OnboardingOverlay({isVisible, onClose}) {
   const [openButtonPosition, setOpenButtonPosition] = useState(null)
   const [shareButtonPosition, setShareButtonPosition] = useState(null)
   const [isDragActive, setIsDragActive] = useState(false)
+  const [showQuotaDialog, setShowQuotaDialog] = useState(false)
 
   // Store state and navigation
   const appPrefix = useStore((state) => state.appPrefix)
   const isOpfsAvailable = useStore((state) => state.isOpfsAvailable)
   const setAlert = useStore((state) => state.setAlert)
   const navigate = useNavigate()
+  const {tier, hasCapacity, record} = useQuota()
 
   // Find actual button positions when overlay becomes visible
   useEffect(() => {
@@ -73,132 +77,158 @@ export default function OnboardingOverlay({isVisible, onClose}) {
       isOpfsAvailable,
       setAlert,
       () => onClose(true), // onSuccess callback - close overlay and skip help dialog
+      undefined,
+      // Same quota gate as ViewerContainer's dropzone — a first-visit drop
+      // through the overlay is still a /v/new/ private load and must count.
+      {
+        hasCapacity,
+        record,
+        onExceeded: () => {
+          // Close the overlay first: its zIndex (9999) sits above MUI's
+          // modal layer, so the dialog would otherwise open underneath it.
+          onClose(false)
+          setShowQuotaDialog(true)
+        },
+      },
     )
   }
 
+  // Rendered outside the isVisible guard so the limit dialog survives the
+  // overlay closing itself in onExceeded above.
+  const quotaDialog = (
+    <QuotaLimitDialog
+      tier={tier}
+      isOpen={showQuotaDialog}
+      onClose={() => setShowQuotaDialog(false)}
+    />
+  )
+
   if (!isVisible) {
-    return null
+    return quotaDialog
   }
 
   return (
-    <Fade in={isVisible} timeout={300}>
-      <Box
-        onClick={() => onClose(false)}
-        onDragOver={(event) => {
-          event.preventDefault()
-          event.stopPropagation()
-          handleDragOverOrEnter(event, setIsDragActive)
-        }}
-        onDragEnter={(event) => {
-          event.preventDefault()
-          event.stopPropagation()
-          handleDragOverOrEnter(event, setIsDragActive)
-        }}
-        onDragLeave={(event) => {
-          event.preventDefault()
-          event.stopPropagation()
-          handleDragLeave(event, setIsDragActive)
-        }}
-        onDrop={handleDrop}
-        sx={{
-          position: 'fixed',
-          top: 0,
-          left: 0,
-          right: 0,
-          bottom: 0,
-          backgroundColor: isDragActive ? 'rgba(0, 100, 200, 0.3)' : 'rgba(0, 0, 0, 0.5)',
-          zIndex: 9999,
-          pointerEvents: 'auto',
-          margin: '0 !important',
-          padding: '0 !important',
-          marginLeft: '0 !important',
-          marginRight: '0 !important',
-          marginTop: '0 !important',
-          marginBottom: '0 !important',
-          transition: 'background-color 0.2s ease',
-          // Create cutout mask for button positions - single mask with multiple holes
-          ...(openButtonPosition && shareButtonPosition && {
-            WebkitMask: `
-              radial-gradient(circle 35px at ${openButtonPosition.left}px ${openButtonPosition.top}px, 
-                transparent 0px, transparent 35px, black 36px),
-              radial-gradient(circle 35px at ${shareButtonPosition.left}px ${shareButtonPosition.top}px, 
-                transparent 0px, transparent 35px, black 36px)
-            `,
-            WebkitMaskComposite: 'source-in',
-            mask: `
-              radial-gradient(circle 35px at ${openButtonPosition.left}px ${openButtonPosition.top}px, 
-                transparent 0px, transparent 35px, black 36px),
-              radial-gradient(circle 35px at ${shareButtonPosition.left}px ${shareButtonPosition.top}px, 
-                transparent 0px, transparent 35px, black 36px)
-            `,
-            maskComposite: 'intersect',
-          }),
-        }}
-        data-testid='onboarding-overlay'
-      >
-        {/* Open Button Highlight */}
-        {openButtonPosition && (
-          <OnboardingHighlight
-            position={openButtonPosition}
-            text="Open models"
-            arrowDirection="bottom-right"
-          />
-        )}
-
-        {/* Share Button Highlight */}
-        {shareButtonPosition && (
-          <OnboardingHighlight
-            position={shareButtonPosition}
-            text="Share model"
-            arrowDirection="bottom-left"
-          />
-        )}
-
-        {/* Central Message */}
+    <>
+      <Fade in={isVisible} timeout={300}>
         <Box
-          sx={{
-            position: 'absolute',
-            top: '50%',
-            left: '50%',
-            transform: 'translate(-50%, -50%)',
-            textAlign: 'center',
-            zIndex: 10000,
+          onClick={() => onClose(false)}
+          onDragOver={(event) => {
+            event.preventDefault()
+            event.stopPropagation()
+            handleDragOverOrEnter(event, setIsDragActive)
           }}
+          onDragEnter={(event) => {
+            event.preventDefault()
+            event.stopPropagation()
+            handleDragOverOrEnter(event, setIsDragActive)
+          }}
+          onDragLeave={(event) => {
+            event.preventDefault()
+            event.stopPropagation()
+            handleDragLeave(event, setIsDragActive)
+          }}
+          onDrop={handleDrop}
+          sx={{
+            position: 'fixed',
+            top: 0,
+            left: 0,
+            right: 0,
+            bottom: 0,
+            backgroundColor: isDragActive ? 'rgba(0, 100, 200, 0.3)' : 'rgba(0, 0, 0, 0.5)',
+            zIndex: 9999,
+            pointerEvents: 'auto',
+            margin: '0 !important',
+            padding: '0 !important',
+            marginLeft: '0 !important',
+            marginRight: '0 !important',
+            marginTop: '0 !important',
+            marginBottom: '0 !important',
+            transition: 'background-color 0.2s ease',
+            // Create cutout mask for button positions - single mask with multiple holes
+            ...(openButtonPosition && shareButtonPosition && {
+              WebkitMask: `
+                radial-gradient(circle 35px at ${openButtonPosition.left}px ${openButtonPosition.top}px, 
+                  transparent 0px, transparent 35px, black 36px),
+                radial-gradient(circle 35px at ${shareButtonPosition.left}px ${shareButtonPosition.top}px, 
+                  transparent 0px, transparent 35px, black 36px)
+              `,
+              WebkitMaskComposite: 'source-in',
+              mask: `
+                radial-gradient(circle 35px at ${openButtonPosition.left}px ${openButtonPosition.top}px, 
+                  transparent 0px, transparent 35px, black 36px),
+                radial-gradient(circle 35px at ${shareButtonPosition.left}px ${shareButtonPosition.top}px, 
+                  transparent 0px, transparent 35px, black 36px)
+              `,
+              maskComposite: 'intersect',
+            }),
+          }}
+          data-testid='onboarding-overlay'
         >
-          <Stack spacing={3} alignItems='center'>
-            <FileUploadIcon
-              sx={{
-                fontSize: '4rem',
-                color: '#ffffff',
-                filter: 'drop-shadow(0px 0px 10px rgba(255,255,255,0.3))',
-              }}
+          {/* Open Button Highlight */}
+          {openButtonPosition && (
+            <OnboardingHighlight
+              position={openButtonPosition}
+              text="Open models"
+              arrowDirection="bottom-right"
             />
-            <Typography
-              variant='h1'
-              sx={{
-                fontWeight: 600,
-                color: isDragActive ? '#00ff88' : '#ffffff',
-                textShadow: '2px 2px 8px rgba(0,0,0,0.8)',
-                letterSpacing: '0.5px',
-                transition: 'color 0.2s ease',
-              }}
-            >
-              {isDragActive ? 'Drop your file here!' : 'Drag and drop models into page to open'}
-            </Typography>
-            <Typography
-              variant='body1'
-              sx={{
-                color: 'rgba(255,255,255,0.9)',
-                textShadow: '1px 1px 4px rgba(0,0,0,0.8)',
-                fontSize: '1.1rem',
-              }}
-            >
-              Click anywhere to continue
-            </Typography>
-          </Stack>
+          )}
+
+          {/* Share Button Highlight */}
+          {shareButtonPosition && (
+            <OnboardingHighlight
+              position={shareButtonPosition}
+              text="Share model"
+              arrowDirection="bottom-left"
+            />
+          )}
+
+          {/* Central Message */}
+          <Box
+            sx={{
+              position: 'absolute',
+              top: '50%',
+              left: '50%',
+              transform: 'translate(-50%, -50%)',
+              textAlign: 'center',
+              zIndex: 10000,
+            }}
+          >
+            <Stack spacing={3} alignItems='center'>
+              <FileUploadIcon
+                sx={{
+                  fontSize: '4rem',
+                  color: '#ffffff',
+                  filter: 'drop-shadow(0px 0px 10px rgba(255,255,255,0.3))',
+                }}
+              />
+              <Typography
+                variant='h1'
+                sx={{
+                  fontWeight: 600,
+                  color: isDragActive ? '#00ff88' : '#ffffff',
+                  textShadow: '2px 2px 8px rgba(0,0,0,0.8)',
+                  letterSpacing: '0.5px',
+                  transition: 'color 0.2s ease',
+                }}
+              >
+                {isDragActive ? 'Drop your file here!' : 'Drag and drop models into page to open'}
+              </Typography>
+              <Typography
+                variant='body1'
+                sx={{
+                  color: 'rgba(255,255,255,0.9)',
+                  textShadow: '1px 1px 4px rgba(0,0,0,0.8)',
+                  fontSize: '1.1rem',
+                }}
+              >
+                Click anywhere to continue
+              </Typography>
+            </Stack>
+          </Box>
         </Box>
-      </Box>
-    </Fade>
+      </Fade>
+      {quotaDialog}
+    </>
   )
 }
 

--- a/src/Components/Open/GitHubFileBrowser.jsx
+++ b/src/Components/Open/GitHubFileBrowser.jsx
@@ -38,6 +38,7 @@ function resolveValue(value, list) {
  * @property {object}   [activeConnection] The Connection driving the
  *   override token, used to tag recents with a connectionId so they
  *   land in the right card on the Sources tab.
+ * @property {Function} [checkQuota] Optional async gate; receives sharePath, returns boolean (true = proceed)
  * @return {ReactElement}
  */
 export default function GitHubFileBrowser({
@@ -46,6 +47,7 @@ export default function GitHubFileBrowser({
   onCancel,
   accessTokenOverride,
   activeConnection,
+  checkQuota,
 }) {
   // Prefer the override (connection-derived token) over the legacy
   // Auth0-federated `useStore.accessToken`. Once the legacy path retires
@@ -201,25 +203,32 @@ export default function GitHubFileBrowser({
     }
   }
 
-  const navigateToFile = () => {
-    if (pathSuffixSupported(fileName)) {
-      const branch = branchName || 'main'
-      const sharePath = navigateBaseOnModelPath(orgName, repoName, branch, `${currentPath}/${fileName}`)
-      navigateToModel({pathname: sharePath}, navigate)
-      // Tag with connectionId when the connection-based path drove this
-      // browse. Without it, GitHubTab can't filter recents to the card
-      // they belong to (parity with how Drive recents are scoped).
-      addRecentFileEntry({
-        id: sharePath,
-        source: 'github',
-        name: fileName,
-        sharePath,
-        lastModifiedUtc: null,
-        ...(activeConnection ? {connectionId: activeConnection.id} : {}),
-      })
-      setPendingModelNameUpdate(sharePath)
-      setIsDialogDisplayed(false)
+  const navigateToFile = async () => {
+    if (!pathSuffixSupported(fileName)) {
+      return
     }
+    const branch = branchName || 'main'
+    const sharePath = navigateBaseOnModelPath(orgName, repoName, branch, `${currentPath}/${fileName}`)
+    if (checkQuota) {
+      const allowed = await checkQuota(sharePath)
+      if (!allowed) {
+        return
+      }
+    }
+    navigateToModel({pathname: sharePath}, navigate)
+    // Tag with connectionId when the connection-based path drove this
+    // browse. Without it, GitHubTab can't filter recents to the card
+    // they belong to (parity with how Drive recents are scoped).
+    addRecentFileEntry({
+      id: sharePath,
+      source: 'github',
+      name: fileName,
+      sharePath,
+      lastModifiedUtc: null,
+      ...(activeConnection ? {connectionId: activeConnection.id} : {}),
+    })
+    setPendingModelNameUpdate(sharePath)
+    setIsDialogDisplayed(false)
   }
 
   return (

--- a/src/Components/Open/OpenModelControl.jsx
+++ b/src/Components/Open/OpenModelControl.jsx
@@ -1,8 +1,10 @@
 import React, {ReactElement} from 'react'
 import {useNavigate} from 'react-router-dom'
 import useStore from '../../store/useStore'
+import useQuota from '../../hooks/useQuota'
 import {ControlButtonWithHashState} from '../Buttons'
 import OpenModelDialog from './OpenModelDialog'
+import QuotaBadge from './QuotaBadge'
 import {HASH_PREFIX_OPEN_MODEL} from './hashState'
 import {FolderOpen as FolderOpenIcon} from '@mui/icons-material'
 
@@ -16,12 +18,18 @@ export default function OpenModelControl() {
   const isOpenModelVisible = useStore((state) => state.isOpenModelVisible)
   const setIsOpenModelVisible = useStore((state) => state.setIsOpenModelVisible)
 
+  const {used, limit, tier} = useQuota()
+
   const navigate = useNavigate()
 
   return (
     <ControlButtonWithHashState
       title='Open Models and Samples'
-      icon={<FolderOpenIcon className='icon-share'/>}
+      icon={
+        <QuotaBadge used={used} limit={limit} tier={tier}>
+          <FolderOpenIcon className='icon-share'/>
+        </QuotaBadge>
+      }
       isDialogDisplayed={isOpenModelVisible}
       setIsDialogDisplayed={setIsOpenModelVisible}
       hashPrefix={HASH_PREFIX_OPEN_MODEL}

--- a/src/Components/Open/OpenModelDialog.jsx
+++ b/src/Components/Open/OpenModelDialog.jsx
@@ -3,6 +3,7 @@ import {Box, Button, Divider, Slide, Stack, Typography} from '@mui/material'
 import {useAuth0} from '../../Auth0/Auth0Proxy'
 import {checkOPFSAvailability} from '../../OPFS/utils'
 import useStore from '../../store/useStore'
+import useQuota from '../../hooks/useQuota'
 import {loadLocalFile, loadLocalFileFallback} from '../../utils/loader'
 import {NeedsReconnectError} from '../../connections/errors'
 import {
@@ -25,6 +26,7 @@ import GoogleDriveTab from '../Connections/GoogleDriveTab'
 import GitHubTab from '../Connections/GitHubTab'
 import GoogleDrivePickerDialog from '../Connections/GoogleDrivePickerDialog'
 import RecentFilesBrowseSection from '../Connections/RecentFilesBrowseSection'
+import QuotaLimitDialog from './QuotaLimitDialog'
 import {LABEL_LOCAL, LABEL_GITHUB, LABEL_GOOGLE, LABEL_SAMPLES} from './component'
 import {FolderOpen as FolderOpenIcon, GitHub as GitHubIcon} from '@mui/icons-material'
 
@@ -49,14 +51,17 @@ export default function OpenModelDialog({
   const appPrefix = useStore((state) => state.appPrefix)
   const setCurrentTab = useStore((state) => state.setCurrentTab)
   const currentTab = useStore((state) => state.currentTab)
+  const setAlert = useStore((state) => state.setAlert)
   const isOpfsAvailable = checkOPFSAvailability()
   const isMobile = useIsMobile()
+  const {tier, record, hasCapacity} = useQuota()
 
   const [pickerToken, setPickerToken] = useState(null)
   const [pickerConnection, setPickerConnection] = useState(null)
   const [localRecents, setLocalRecents] = useState([])
   const [githubRecents, setGithubRecents] = useState([])
   const [showGithubBrowser, setShowGithubBrowser] = useState(false)
+  const [showQuotaDialog, setShowQuotaDialog] = useState(false)
   // When the user clicks Browse on a connection in GitHubTab, we feed the
   // connection-derived token through to GitHubFileBrowser instead of the
   // legacy Auth0-federated useStore.accessToken. Both stay null on the
@@ -80,8 +85,6 @@ export default function OpenModelDialog({
     setPickerConnection(connection)
   }
 
-  const setAlert = useStore((state) => state.setAlert)
-
   /**
    * GitHubTab's Browse-on-connection handler: stash the connection token
    * and reveal the GitHubFileBrowser inline (slide-over). The browser
@@ -98,11 +101,19 @@ export default function OpenModelDialog({
   }
 
   const handleOpenById = async (connection, fileId, fileName) => {
+    // Cheap client-side gate first — if we already know we're at limit,
+    // surface the dialog without bothering with token acquisition or a
+    // round-trip to record-load.
+    if (!hasCapacity) {
+      setShowQuotaDialog(true)
+      return
+    }
     // Pre-flight token acquisition INSIDE this user-gesture click handler so
     // that if GIS needs to pop a consent window, the popup inherits the click
     // activation and the browser allows it. If we navigate first, the gesture
     // is gone by the time CadView's load chain calls getAccessToken — and a
-    // stale token there hits popup_failed_to_open and bricks the load.
+    // stale token there hits popup_failed_to_open and bricks the load. This
+    // must remain BEFORE the record() await for the same reason.
     const provider = getProvider(connection.providerId)
     if (provider) {
       try {
@@ -120,6 +131,12 @@ export default function OpenModelDialog({
         return
       }
     }
+    const key = `${appPrefix}/v/g/${fileId}`
+    const {allowed} = await record(key)
+    if (!allowed) {
+      setShowQuotaDialog(true)
+      return
+    }
     disablePageReloadApprovalCheck()
     addRecentFileEntry({
       id: fileId,
@@ -129,9 +146,9 @@ export default function OpenModelDialog({
       lastModifiedUtc: null,
       connectionId: connection.id,
       fileId,
-      sharePath: `${appPrefix}/v/g/${fileId}`,
+      sharePath: key,
     })
-    navigateToModel(`${appPrefix}/v/g/${fileId}`, navigate)
+    navigateToModel(key, navigate)
     setIsDialogDisplayed(false)
   }
 
@@ -146,6 +163,10 @@ export default function OpenModelDialog({
    * @param {string} fileName Recent's display name.
    */
   const handleGithubOpenById = async (connection, fileId, fileName) => {
+    if (!hasCapacity) {
+      setShowQuotaDialog(true)
+      return
+    }
     const provider = getProvider(connection.providerId)
     if (provider) {
       try {
@@ -163,6 +184,11 @@ export default function OpenModelDialog({
         return
       }
     }
+    const {allowed} = await record(fileId)
+    if (!allowed) {
+      setShowQuotaDialog(true)
+      return
+    }
     disablePageReloadApprovalCheck()
     addRecentFileEntry({
       id: fileId,
@@ -176,11 +202,19 @@ export default function OpenModelDialog({
     setIsDialogDisplayed(false)
   }
 
-  const handlePickerSelect = (docs) => {
+  const handlePickerSelect = async (docs) => {
     if (!pickerConnection || !docs || docs.length === 0) {
       return
     }
     const doc = docs[0]
+    const key = `${appPrefix}/v/g/${doc.id}`
+    const {allowed} = await record(key)
+    if (!allowed) {
+      setPickerToken(null)
+      setPickerConnection(null)
+      setShowQuotaDialog(true)
+      return
+    }
     const connection = pickerConnection
     setPickerToken(null)
     setPickerConnection(null)
@@ -193,9 +227,9 @@ export default function OpenModelDialog({
       lastModifiedUtc: doc.lastModifiedUtc || null,
       connectionId: connection.id,
       fileId: doc.id,
-      sharePath: `${appPrefix}/v/g/${doc.id}`,
+      sharePath: key,
     })
-    navigateToModel(`${appPrefix}/v/g/${doc.id}`, navigate)
+    navigateToModel(key, navigate)
     setIsDialogDisplayed(false)
   }
 
@@ -206,9 +240,19 @@ export default function OpenModelDialog({
   }
 
   const openFile = () => {
-    const onLoad = (filename, lastModifiedUtc) => {
+    if (!hasCapacity) {
+      setShowQuotaDialog(true)
+      return
+    }
+    const onLoad = async (filename, lastModifiedUtc) => {
+      const key = `${appPrefix}/v/new/${filename}`
+      const {allowed} = await record(key)
+      if (!allowed) {
+        setShowQuotaDialog(true)
+        return
+      }
       disablePageReloadApprovalCheck()
-      navigateToModel(`${appPrefix}/v/new/${filename}`, navigate)
+      navigateToModel(key, navigate)
       addRecentFileEntry({
         id: filename,
         source: 'local',
@@ -225,15 +269,35 @@ export default function OpenModelDialog({
     setIsDialogDisplayed(false)
   }
 
-  const handleOpenLocalRecent = (entry) => {
+  const handleOpenLocalRecent = async (entry) => {
+    const key = `${appPrefix}/v/new/${entry.name}`
+    const {allowed} = await record(key)
+    if (!allowed) {
+      setShowQuotaDialog(true)
+      return
+    }
     disablePageReloadApprovalCheck()
-    navigateToModel(`${appPrefix}/v/new/${entry.name}`, navigate)
+    navigateToModel(key, navigate)
     setIsDialogDisplayed(false)
   }
 
-  const handleOpenGithubRecent = (entry) => {
+  const handleOpenGithubRecent = async (entry) => {
+    const {allowed} = await record(entry.sharePath)
+    if (!allowed) {
+      setShowQuotaDialog(true)
+      return
+    }
     navigateToModel(entry.sharePath, navigate)
     setIsDialogDisplayed(false)
+  }
+
+  const handleGithubBrowserOpen = async (sharePath) => {
+    const {allowed} = await record(sharePath)
+    if (!allowed) {
+      setShowQuotaDialog(true)
+      return false
+    }
+    return true
   }
 
   const BLDRS_IDENTITIES_CLAIM = 'https://bldrs.ai/identities'
@@ -317,6 +381,7 @@ export default function OpenModelDialog({
                     }}
                     accessTokenOverride={githubBrowserToken}
                     activeConnection={githubBrowserConnection}
+                    checkQuota={handleGithubBrowserOpen}
                   />
                 </Stack>
               </Slide>
@@ -339,6 +404,7 @@ export default function OpenModelDialog({
                     navigate={navigate}
                     setIsDialogDisplayed={setIsDialogDisplayed}
                     onCancel={() => setShowGithubBrowser(false)}
+                    checkQuota={handleGithubBrowserOpen}
                   />
                 </Stack>
               </Slide>
@@ -398,6 +464,12 @@ export default function OpenModelDialog({
         mode='file'
         onSelect={handlePickerSelect}
         onCancel={handlePickerCancel}
+      />
+
+      <QuotaLimitDialog
+        tier={tier}
+        isOpen={showQuotaDialog}
+        onClose={() => setShowQuotaDialog(false)}
       />
     </>
   )

--- a/src/Components/Open/OpenModelDialog.jsx
+++ b/src/Components/Open/OpenModelDialog.jsx
@@ -54,7 +54,7 @@ export default function OpenModelDialog({
   const setAlert = useStore((state) => state.setAlert)
   const isOpfsAvailable = checkOPFSAvailability()
   const isMobile = useIsMobile()
-  const {tier, record, hasCapacity} = useQuota()
+  const {tier, record, check, hasCapacity} = useQuota()
 
   const [pickerToken, setPickerToken] = useState(null)
   const [pickerConnection, setPickerConnection] = useState(null)
@@ -103,8 +103,11 @@ export default function OpenModelDialog({
   const handleOpenById = async (connection, fileId, fileName) => {
     // Cheap client-side gate first — if we already know we're at limit,
     // surface the dialog without bothering with token acquisition or a
-    // round-trip to record-load.
-    if (!hasCapacity) {
+    // round-trip to record-load. check(key), not hasCapacity: an
+    // already-counted key stays openable at limit (server idempotency;
+    // /share/quotas promises re-opens from recents are free).
+    const key = `${appPrefix}/v/g/${fileId}`
+    if (!check(key).allowed) {
       setShowQuotaDialog(true)
       return
     }
@@ -131,7 +134,6 @@ export default function OpenModelDialog({
         return
       }
     }
-    const key = `${appPrefix}/v/g/${fileId}`
     const {allowed} = await record(key)
     if (!allowed) {
       setShowQuotaDialog(true)
@@ -163,7 +165,9 @@ export default function OpenModelDialog({
    * @param {string} fileName Recent's display name.
    */
   const handleGithubOpenById = async (connection, fileId, fileName) => {
-    if (!hasCapacity) {
+    // check(fileId), not hasCapacity — see handleOpenById; fileId is the
+    // recent's share path, so an already-counted repo file reopens at limit.
+    if (!check(fileId).allowed) {
       setShowQuotaDialog(true)
       return
     }

--- a/src/Components/Open/OpenModelDialog.test.jsx
+++ b/src/Components/Open/OpenModelDialog.test.jsx
@@ -233,6 +233,8 @@ describe('OpenModelDialog — Google Drive tab', () => {
     })
     render(<OpenModelDialog {...defaultProps}/>, {wrapper: HelmetStoreRouteThemeCtx})
     fireEvent.click(screen.getByTestId('button-open-by-id'))
+    // getAccessToken preflights inside the click, then record() awaits the
+    // MSW-backed record-load handler before navigateToModel fires.
     await waitFor(() => {
       expect(navigateToModel).toHaveBeenCalledWith(
         expect.stringMatching(/\/v\/g\/file-id-abc$/),

--- a/src/Components/Open/Quota.spec.ts
+++ b/src/Components/Open/Quota.spec.ts
@@ -1,0 +1,146 @@
+import {expect, test, Page} from '@playwright/test'
+import {
+  auth0Login,
+  homepageSetup,
+  returningUserVisitsHomepageWaitForModel,
+  setupAuthenticationIntercepts,
+} from '../../tests/e2e/utils'
+
+
+const {beforeEach, describe} = test
+
+
+type WindowWithQuotaState = Window & {
+  __mockQuotaLoads?: Array<{key: string, loadedAt: string}>
+  __mockQuotaForce5xx?: boolean
+  store?: {
+    getState: () => {
+      setAppMetadata: (meta: {
+        userEmail?: string
+        stripeCustomerId?: string | null
+        subscriptionStatus?: 'sharePro' | 'free' | 'shareProPendingReauth' | 'freePendingReauth'
+      }) => void
+    }
+  }
+}
+
+
+const SETTLE_MS = 500
+
+
+/** Reset the MSW mock's in-memory loads list and 5xx flag. */
+async function resetMockQuota(page: Page, preloadedKeys: string[] = []) {
+  await page.evaluate((keys) => {
+    const w = window as unknown as WindowWithQuotaState
+    w.__mockQuotaForce5xx = false
+    w.__mockQuotaLoads = keys.map((key) => ({key, loadedAt: new Date().toISOString()}))
+  }, preloadedKeys)
+}
+
+
+/** Inject app_metadata into the Zustand store to set the user's tier. */
+async function setSubscriptionTier(page: Page, tier: 'sharePro' | 'free') {
+  await page.evaluate((subscriptionTier) => {
+    const w = window as unknown as WindowWithQuotaState
+    if (!w.store) {
+      throw new Error('Zustand store not on window — test build flag missing')
+    }
+    w.store.getState().setAppMetadata({
+      userEmail: 'cypress@bldrs.ai',
+      stripeCustomerId: subscriptionTier === 'sharePro' ? 'cus_test_123' : null,
+      subscriptionStatus: subscriptionTier === 'sharePro' ? 'sharePro' as const : 'free' as const,
+    })
+  }, tier)
+}
+
+
+/** Seed a Drive recent-file entry into localStorage so the dialog renders it. */
+async function seedRecentFile(page: Page, fileId: string, name: string) {
+  await page.evaluate(({id, fileName}) => {
+    const RECENT_FILES_KEY = 'bldrs:recent-files'
+    const raw = localStorage.getItem(RECENT_FILES_KEY)
+    let store: {version: number, files: Array<object>}
+    try {
+      store = raw ? JSON.parse(raw) : {version: 1, files: []}
+    } catch {
+      store = {version: 1, files: []}
+    }
+    store.files.unshift({
+      id,
+      source: 'google-drive',
+      name: fileName,
+      mimeType: 'application/octet-stream',
+      lastModifiedUtc: null,
+      connectionId: 'test',
+      fileId: id,
+      sharePath: `/share/v/g/${id}`,
+      lastOpenedUtc: new Date().toISOString(),
+    })
+    localStorage.setItem(RECENT_FILES_KEY, JSON.stringify(store))
+  }, {id: fileId, fileName: name})
+}
+
+
+/**
+ * Quota gating end-to-end.
+ *
+ * Most quota correctness lives in unit tests (src/quota/quota.test.js,
+ * src/Components/Open/OpenModelDialog.test.jsx). This spec exercises
+ * the integration of the MSW mock + useQuota + OpenModelDialog for
+ * the Pro tier — the case where mock state and tier-aware logic are
+ * both load-bearing.
+ *
+ * Enforcement is gated behind the `quotas` feature flag (off by default),
+ * so the model is loaded with `?feature=quotas` to turn the gate on.
+ */
+describe('Quota: usage limit enforcement', () => {
+  beforeEach(async ({page}) => {
+    await homepageSetup(page)
+    await setupAuthenticationIntercepts(page)
+  })
+
+
+  describe('Pro user', () => {
+    beforeEach(async ({page}) => {
+      await returningUserVisitsHomepageWaitForModel(page, '?feature=quotas')
+      await auth0Login(page)
+    })
+
+
+    test('paid tier never sees the limit dialog, even past the free cap', async ({page}) => {
+      // Mock has 5 prior loads — already past the 4-load free cap.
+      await resetMockQuota(page, [
+        '/share/v/g/old-1',
+        '/share/v/g/old-2',
+        '/share/v/g/old-3',
+        '/share/v/g/old-4',
+        '/share/v/g/old-5',
+      ])
+      await setSubscriptionTier(page, 'sharePro')
+
+      // Seed a Drive recent and click it.
+      await seedRecentFile(page, 'pro-attempt', 'pro-attempt.ifc')
+      await page.getByTestId('control-button-open').click()
+      const recent = page.getByTestId('link-open-recent-pro-attempt')
+      if (!await recent.isVisible().catch(() => false)) {
+        // Drive (Sources) tab requires googleDrive feature flag; skip if off.
+        return
+      }
+      await recent.click()
+
+      // Subscribe button should never appear for a paid user.
+      await page.waitForTimeout(SETTLE_MS)
+      await expect(page.getByTestId('button-quota-subscribe')).toHaveCount(0)
+    })
+  })
+
+
+  // TODO: Free-tier "at-limit triggers dialog" and "public sample doesn't
+  // count" cases were initially attempted here but are flaky in CI due to
+  // the page-navigation interaction with `page.evaluate` after click.
+  // The same logic is covered by:
+  //   - src/quota/quota.test.js (28 unit tests)
+  //   - src/Components/Open/OpenModelDialog.test.jsx (records + check wiring)
+  //   - The MSW mock's path heuristic for repos containing "Public"
+  // Re-add once we have a robust pattern for asserting state mid-navigation.
+})

--- a/src/Components/Open/QuotaBadge.jsx
+++ b/src/Components/Open/QuotaBadge.jsx
@@ -1,0 +1,41 @@
+import React, {ReactElement} from 'react'
+import {Badge} from '@mui/material'
+import {TIERS} from '../../quota/quota'
+
+
+/** Show badge once this fraction of the quota is consumed */
+const SHOW_THRESHOLD = 1 / 2
+/** Switch badge to amber once this fraction is consumed */
+const WARN_THRESHOLD = 3 / 4
+
+
+/**
+ * Wraps children with a usage-quota badge on the Open toolbar button.
+ * Shown only when >= 50% of the quota is used; turns amber at >= 75%.
+ *
+ * @property {number} used Number of private models loaded this period
+ * @property {number} limit Maximum allowed for this tier
+ * @property {string} tier One of TIERS.*
+ * @property {ReactElement} children The button to wrap
+ * @return {ReactElement}
+ */
+export default function QuotaBadge({used, limit, tier, children}) {
+  if (tier === TIERS.PAID || limit === Infinity || used === 0) {
+    return children
+  }
+
+  const pct = used / limit
+  if (pct < SHOW_THRESHOLD) {
+    return children
+  }
+
+  return (
+    <Badge
+      badgeContent={`${used}/${limit}`}
+      color={pct >= WARN_THRESHOLD ? 'warning' : 'default'}
+      sx={{'& .MuiBadge-badge': {fontSize: '0.6rem', height: '16px', minWidth: '30px', right: -4, top: 4}}}
+    >
+      {children}
+    </Badge>
+  )
+}

--- a/src/Components/Open/QuotaLimitDialog.jsx
+++ b/src/Components/Open/QuotaLimitDialog.jsx
@@ -1,0 +1,91 @@
+import React, {ReactElement} from 'react'
+import {Button, Dialog, DialogActions, DialogContent, DialogTitle, Divider, Link, Stack, Typography} from '@mui/material'
+import {useAuth0} from '../../Auth0/Auth0Proxy'
+import {LIMITS, ROLLING_WINDOW_DAYS, TIERS} from '../../quota/quota'
+
+
+/**
+ * Modal shown when the user hits their usage quota.
+ * Anonymous users see both Subscribe and Sign up options.
+ * Free-tier users see only the Subscribe option.
+ *
+ * @property {string} tier One of TIERS.*
+ * @property {boolean} isOpen Controls dialog visibility
+ * @property {Function} onClose Called when the dialog should close
+ * @return {ReactElement}
+ */
+export default function QuotaLimitDialog({tier, isOpen, onClose}) {
+  const {loginWithRedirect, user} = useAuth0()
+
+  const handleSubscribe = () => {
+    onClose()
+    const email = user?.email ? `&userEmail=${encodeURIComponent(user.email)}` : ''
+    window.location.href = `/subscribe/?${email}`
+  }
+
+  const handleSignUp = () => {
+    onClose()
+    loginWithRedirect()
+  }
+
+  const isAnonymous = !tier || tier === TIERS.ANONYMOUS
+  const limitText = isAnonymous ?
+    `${LIMITS[TIERS.ANONYMOUS]} private models (lifetime)` :
+    `${LIMITS[TIERS.FREE]} private models in any rolling ${ROLLING_WINDOW_DAYS}-day window`
+
+  return (
+    <Dialog
+      open={isOpen}
+      onClose={onClose}
+      maxWidth='xs'
+      fullWidth
+      closeAfterTransition={false}
+    >
+      <DialogTitle sx={{pb: 1}}>Open more models</DialogTitle>
+      <DialogContent>
+        <Typography variant='body2' sx={{mb: 2}}>
+          You&apos;ve reached your limit of {limitText}.
+          {' '}<Link href='/share/quotas'>What counts as a load?</Link>
+        </Typography>
+        <Stack divider={<Divider/>} spacing={2}>
+          <Stack direction='row' alignItems='center' spacing={2}>
+            <Typography variant='body2' sx={{flex: 1}}>
+              Unlimited private models, priority loading, and team sharing.
+            </Typography>
+            <Button
+              onClick={handleSubscribe}
+              variant='contained'
+              color='accent'
+              sx={{textTransform: 'none', whiteSpace: 'nowrap'}}
+              data-testid='button-quota-subscribe'
+            >
+              Subscribe
+            </Button>
+          </Stack>
+          {isAnonymous && (
+            <Stack direction='row' alignItems='center' spacing={2}>
+              <Typography variant='body2' sx={{flex: 1}}>
+                Sign up free to open {LIMITS[TIERS.FREE]} private models per
+                rolling {ROLLING_WINDOW_DAYS} days and sync across devices.
+              </Typography>
+              <Button
+                onClick={handleSignUp}
+                variant='contained'
+                color='accent'
+                sx={{textTransform: 'none', whiteSpace: 'nowrap'}}
+                data-testid='button-quota-signup'
+              >
+                Sign up free
+              </Button>
+            </Stack>
+          )}
+        </Stack>
+      </DialogContent>
+      <DialogActions sx={{px: 3, pb: 2}}>
+        <Button onClick={onClose} sx={{textTransform: 'none'}}>
+          Not now
+        </Button>
+      </DialogActions>
+    </Dialog>
+  )
+}

--- a/src/Components/Open/QuotaLimitDialog.jsx
+++ b/src/Components/Open/QuotaLimitDialog.jsx
@@ -1,5 +1,6 @@
 import React, {ReactElement} from 'react'
 import {Button, Dialog, DialogActions, DialogContent, DialogTitle, Divider, Link, Stack, Typography} from '@mui/material'
+import {useTheme} from '@mui/material/styles'
 import {useAuth0} from '../../Auth0/Auth0Proxy'
 import {LIMITS, ROLLING_WINDOW_DAYS, TIERS} from '../../quota/quota'
 
@@ -16,11 +17,15 @@ import {LIMITS, ROLLING_WINDOW_DAYS, TIERS} from '../../quota/quota'
  */
 export default function QuotaLimitDialog({tier, isOpen, onClose}) {
   const {loginWithRedirect, user} = useAuth0()
+  const theme = useTheme()
 
   const handleSubscribe = () => {
     onClose()
+    // Same URL shape as ProfileControl's onSubscriptionClick, so the
+    // subscribe page keeps the viewer's theme and prefills the email.
+    const themeParam = theme.palette.mode === 'light' ? 'light' : 'dark'
     const email = user?.email ? `&userEmail=${encodeURIComponent(user.email)}` : ''
-    window.location.href = `/subscribe/?${email}`
+    window.location.href = `/subscribe/?theme=${themeParam}${email}`
   }
 
   const handleSignUp = () => {

--- a/src/Components/Open/README.md
+++ b/src/Components/Open/README.md
@@ -1,0 +1,159 @@
+# Open — Component Design
+
+The Open subsystem lets users load models from multiple sources. It is
+surfaced as a toolbar button that opens a tabbed dialog.
+
+## Component tree
+
+```
+OpenModelControl
+└── OpenModelDialog
+    ├── Tabs (Local | Google* | GitHub | Samples)
+    ├── [Local tab]
+    │   └── RecentFilesBrowseSection   (recent files + Browse button)
+    ├── [Google tab]*
+    │   └── SourcesTab
+    │       ├── ConnectProviderButton  (first-time connect)
+    │       ├── RecentFilesBrowseSection
+    │       └── ConnectionCard
+    ├── [GitHub tab]
+    │   ├── RecentFilesBrowseSection   (when authenticated)
+    │   └── GitHubFileBrowser          (cascading selectors)
+    │       ├── Selector               (Org, Repo, Branch, File)
+    │       └── SelectorSeparator      (Folder — shows current path)
+    └── [Samples tab]
+        └── SampleModels               (chip grid of public models)
+
+GoogleDrivePickerDialog                (rendered outside Dialog, activated
+                                        after SourcesTab hands back a token)
+```
+
+`*` Google tab is gated behind the `googleDrive` feature flag.
+
+## Entry point: `OpenModelControl`
+
+Renders a `ControlButtonWithHashState` toolbar button. When the dialog
+becomes visible it fetches the authenticated user's GitHub organisations so
+`GitHubFileBrowser` has them ready. Dialog visibility is stored in Zustand
+(`isOpenModelVisible`) and reflected in the URL hash (`#open:`).
+
+## `OpenModelDialog`
+
+Owns all tab state and model-loading callbacks. Responsibilities:
+
+| Concern | Detail |
+|---|---|
+| Tab list | `[Local, Google*, GitHub, Samples]`; tab index in Zustand `currentTab` |
+| Local open | `loadLocalFile` / `loadLocalFileFallback` → OPFS → navigate `/v/new/<filename>` |
+| Local recents | `loadRecentFilesBySource('local')` on dialog open |
+| Google open | Two paths: picker (`handlePickerSelect`) or direct by id (`handleOpenById`) → both navigate to `/v/g/<fileId>` |
+| GitHub recents | `loadRecentFilesBySource('github')` on dialog open |
+| GitHub browse | Shows `GitHubFileBrowser` via `showGithubBrowser` slide transition |
+| Recent persistence | `addRecentFileEntry` on every successful open; keyed by source |
+
+### Google Drive flow
+
+1. `SourcesTab` calls `onPickerReady(token, connection)` → dialog hides,
+   `GoogleDrivePickerDialog` activates (modal outside the dialog stack).
+2. User picks a file → `handlePickerSelect` navigates to `/v/g/<fileId>`.
+3. Alternatively, user clicks a recent file → `handleOpenById` navigates
+   directly without re-authenticating.
+
+On page reload the OAuth token is restored from `sessionStorage`
+(`gdrive_token_<connectionId>`) so re-authentication is not required.
+
+## `GitHubFileBrowser`
+
+Cascading async selectors: Org → Repo → Branch → Folder → File.
+
+- Each selection triggers a GitHub API fetch that populates the next level.
+- **Selector** supports an optional `validate` prop that adds an
+  "Enter name..." escape hatch for typed input (debounced, shows
+  Found/No match feedback).
+- **SelectorSeparator** is a variant that shows the accumulated `currentPath`
+  as its display value and emits `<No subfolders>` when the folder list is
+  empty.
+- "Open" is disabled until a supported file extension is selected
+  (`pathSuffixSupported`).
+
+## `Selector` / `SelectorSeparator`
+
+Reusable controlled dropdowns.
+
+| Prop | Purpose |
+|---|---|
+| `list` | Options array |
+| `selected` | Controlled index (number) or typed string |
+| `setSelected` | Called with index from dropdown or string from Other… mode |
+| `validate` | `async (string) => boolean` — enables Other… text entry |
+| `emptyText` | Shown at full opacity when `list` is empty (default `<None>`) |
+
+`SelectorSeparator` additionally accepts `displayValue` to show an arbitrary
+string (e.g. current folder path) regardless of the selected index.
+
+## `SampleModels`
+
+Static chip grid of public reference models hosted on GitHub. Navigates
+immediately on click; no authentication required. Always quota-free (see
+below).
+
+## `hashState`
+
+`HASH_PREFIX_OPEN_MODEL = 'open'` — the dialog is opened by appending
+`#open:` to the URL, and `isVisibleInitially()` reads this on first render.
+
+---
+
+## Usage Quotas
+
+Private-model loads (local, Drive, private GitHub) are metered per tier to
+create a sign-up / upgrade moment; public and sample content is never counted.
+**The full design — tiers and limits, the 30-day rolling window, the
+server-authoritative `record-load` gate, GitHub public/private detection, the
+OPFS local fallback, and the `quotas` feature flag — lives in
+[design/new/quotas.md](../../../design/new/quotas.md).** This section covers
+only how the Open dialog surfaces and wires it.
+
+### UI surfaces
+
+The check fires when a private load is *initiated* (before navigation), never
+mid-session on an already-loaded model.
+
+| Usage level | UI behaviour |
+|---|---|
+| 0 % used | Silent — no quota UI |
+| ≥ 50 % | Subtle badge on the Open toolbar button ("N of M used") |
+| ≥ 75 % | Same badge, amber |
+| Over limit | `QuotaLimitDialog` (value prop + sign-up / upgrade CTA) instead of navigating |
+
+`QuotaBadge` wraps the `OpenModelControl` toolbar button so the dialog stays
+uncluttered; it hides whenever `limit === Infinity` (paid tier, or the `quotas`
+flag off). `QuotaLimitDialog` links to `/share/quotas`.
+
+### Gating wiring
+
+`useQuota()` exposes `{used, limit, tier, hasCapacity, record}`. Every load site
+— Drive picker + recents, local file + recents, GitHub recents + browser, sample
+chips, drag-and-drop — gates in this order:
+
+1. **`hasCapacity`** — cheap client check; if already over, open
+   `QuotaLimitDialog` and stop (no consent popup, no server round-trip).
+2. **`provider.getAccessToken`** (Drive / GitHub only) — token preflight
+   *inside* the click handler, before any other `await`, so a GIS consent popup
+   keeps its user-gesture activation. Navigating or awaiting `record()` first
+   loses the gesture → `popup_failed_to_open`. See the comment in
+   `handleOpenById`.
+3. **`record(key)`** — the authoritative gate; on `403` open `QuotaLimitDialog`
+   instead of navigating, otherwise add the recent and navigate.
+
+When the `quotas` flag is off (the default) `useQuota` reports unlimited
+capacity and `record()` is a no-op, so every load site above is inert.
+
+### Files (this subsystem)
+
+| File | Role |
+|---|---|
+| `QuotaBadge.jsx` | Usage badge overlaying `OpenModelControl` |
+| `QuotaLimitDialog.jsx` | Over-limit value-prop modal |
+| `src/hooks/useQuota.js` | Hook over the lib + `record-load` |
+| `src/quota/quota.js` | Core lib — see [design/new/quotas.md](../../../design/new/quotas.md) |

--- a/src/Components/Open/README.md
+++ b/src/Components/Open/README.md
@@ -132,12 +132,17 @@ flag off). `QuotaLimitDialog` links to `/share/quotas`.
 
 ### Gating wiring
 
-`useQuota()` exposes `{used, limit, tier, hasCapacity, record}`. Every load site
-— Drive picker + recents, local file + recents, GitHub recents + browser, sample
-chips, drag-and-drop — gates in this order:
+`useQuota()` exposes `{used, limit, tier, hasCapacity, check, record}`. Every
+load site — Drive picker + recents, local file + recents, GitHub recents +
+browser, sample chips, drag-and-drop (viewport and onboarding overlay) — gates
+in this order:
 
-1. **`hasCapacity`** — cheap client check; if already over, open
+1. **Cheap client check** — `check(key)` when the share path is known up front
+   (recents), `hasCapacity` when it isn't yet (new local file). If denied, open
    `QuotaLimitDialog` and stop (no consent popup, no server round-trip).
+   `check` only denies a *known-new, known-private* load: already-counted keys
+   stay openable at limit (mirroring the server's idempotency), and `/v/gh/`
+   paths pass through because only the server can tell public from private.
 2. **`provider.getAccessToken`** (Drive / GitHub only) — token preflight
    *inside* the click handler, before any other `await`, so a GIS consent popup
    keeps its user-gesture activation. Navigating or awaiting `record()` first

--- a/src/Components/Open/SampleModelFileSelector.jsx
+++ b/src/Components/Open/SampleModelFileSelector.jsx
@@ -1,5 +1,6 @@
 import React, {ReactElement, useState} from 'react'
 import {MenuItem, TextField} from '@mui/material'
+import useQuota from '../../hooks/useQuota'
 import {disablePageReloadApprovalCheck} from '../../utils/event'
 import {navigateToModel} from '../../utils/navigate'
 
@@ -10,8 +11,9 @@ import {navigateToModel} from '../../utils/navigate'
  */
 export default function SampleModelFileSelector({navigate, setIsDialogDisplayed}) {
   const [selected, setSelected] = useState('')
+  const {record} = useQuota()
 
-  const handleSelect = (e, closeDialog) => {
+  const handleSelect = async (e, closeDialog) => {
     setSelected(e.target.value)
     const modelPath = {
       0: '/share/v/gh/bldrs-ai/test-models/main/ifc/Schependomlaan.ifc#c:60.45,-4.32,60.59,1.17,5.93,-3.77',
@@ -22,8 +24,12 @@ export default function SampleModelFileSelector({navigate, setIsDialogDisplayed}
       5: '/share/v/gh/OlegMoshkovich/Bldrs_Plaza/main/IFC_STUDY.ifc#c:220.607,-9.595,191.198,12.582,27.007,-21.842',
       6: '/share/v/gh/bldrs-ai/test-models/main/fbx/samba-dancing.fbx#c:-1.016,129.356,253.729,0,90.107,2.409',
     }
+    const path = modelPath[e.target.value]
+    if (path) {
+      await record(path.split('#')[0])
+    }
     disablePageReloadApprovalCheck()
-    navigateToModel({pathname: modelPath[e.target.value]}, navigate)
+    navigateToModel({pathname: path}, navigate)
     closeDialog()
   }
 

--- a/src/Components/Open/SampleModelFileSelector.jsx
+++ b/src/Components/Open/SampleModelFileSelector.jsx
@@ -22,11 +22,12 @@ export default function SampleModelFileSelector({navigate, setIsDialogDisplayed}
   const [selected, setSelected] = useState('')
   const {record} = useQuota()
 
-  const handleSelect = async (e, closeDialog) => {
+  const handleSelect = (e, closeDialog) => {
     setSelected(e.target.value)
     const path = SAMPLE_MODELS[e.target.value].path
-    // Public sample — record() resolves it as free; see SampleModels.handleSelect.
-    await record(path.split('#')[0])
+    // Public sample — record() resolves it as free and we don't gate on it;
+    // fire-and-forget so the click isn't delayed. See SampleModels.handleSelect.
+    record(path.split('#')[0])
     disablePageReloadApprovalCheck()
     navigateToModel({pathname: path}, navigate)
     closeDialog()

--- a/src/Components/Open/SampleModels.jsx
+++ b/src/Components/Open/SampleModels.jsx
@@ -1,6 +1,7 @@
 import React, {ReactElement, useState} from 'react'
 import {Grid, Chip, Typography} from '@mui/material'
 import {AccessibilityOutlined as AccessibilityIcon} from '@mui/icons-material'
+import useQuota from '../../hooks/useQuota'
 import Bplaza from '../../assets/icons/Bplaza.svg'
 import Gear from '../../assets/icons/Gear.svg'
 import Momentum from '../../assets/icons/Momentum.svg'
@@ -19,6 +20,7 @@ export default function SampleModels({navigate, setIsDialogDisplayed}) {
   // Lazy import to avoid circulars in tests
   const {navigateToModel} = require('../../utils/navigate')
   const [, setSelected] = useState('')
+  const {record} = useQuota()
   const iconsStyle = {height: '1.6em'}
   const modelPath = {
     Momentum: '/share/v/gh/Swiss-Property-AG/Momentum-Public/main/Momentum.ifc#c:-38.64,12.52,35.4,-5.29,0.94,0.86',
@@ -42,8 +44,11 @@ export default function SampleModels({navigate, setIsDialogDisplayed}) {
     Gear: <Gear style={iconsStyle}/>,
   }
 
-  const handleSelect = (modelName, closeDialog) => {
+  const handleSelect = async (modelName, closeDialog) => {
     setSelected(modelName)
+    // Sample models are public; the server resolves them as such and the
+    // call is a free no-op. Anonymous users skip the round-trip via record().
+    await record(modelPath[modelName].split('#')[0])
     navigateToModel({pathname: modelPath[modelName]}, navigate)
     closeDialog()
   }

--- a/src/Components/Open/SampleModels.jsx
+++ b/src/Components/Open/SampleModels.jsx
@@ -15,11 +15,13 @@ export default function SampleModels({navigate, setIsDialogDisplayed}) {
   const [, setSelected] = useState('')
   const {record} = useQuota()
 
-  const handleSelect = async (model, closeDialog) => {
+  const handleSelect = (model, closeDialog) => {
     setSelected(model.name)
     // Sample models are public; the server resolves them as such and the
-    // call is a free no-op. Anonymous users skip the round-trip via record().
-    await record(model.path.split('#')[0])
+    // call is a free no-op whose result we don't gate on — fire-and-forget
+    // so the click navigates immediately instead of waiting out a token
+    // fetch + record-load round-trip. record() never rejects.
+    record(model.path.split('#')[0])
     navigateToModel({pathname: model.path}, navigate)
     closeDialog()
   }

--- a/src/Containers/ViewerContainer.jsx
+++ b/src/Containers/ViewerContainer.jsx
@@ -4,6 +4,8 @@ import {Box} from '@mui/material'
 import {useIsMobile} from '../Components/Hooks'
 import {PlacemarkHandlers as placemarkHandlers} from '../Components/Markers/MarkerControl'
 import useStore from '../store/useStore'
+import useQuota from '../hooks/useQuota'
+import QuotaLimitDialog from '../Components/Open/QuotaLimitDialog'
 import {handleFileDrop, handleDragOverOrEnter, handleDragLeave} from '../utils/dragAndDrop'
 
 
@@ -18,8 +20,10 @@ export default function ViewerContainer() {
   const isMobile = useIsMobile()
 
   const [, setIsDragActive] = useState(false)
+  const [showQuotaDialog, setShowQuotaDialog] = useState(false)
 
   const navigate = useNavigate()
+  const {tier, hasCapacity, record} = useQuota()
 
   /**
    * Handles file drop into drag-n-drop area
@@ -28,31 +32,42 @@ export default function ViewerContainer() {
    */
   async function onDrop(event) {
     setIsDragActive(false)
-    await handleFileDrop(event, navigate, appPrefix, isOpfsAvailable, setAlert)
+    await handleFileDrop(event, navigate, appPrefix, isOpfsAvailable, setAlert, undefined, undefined, {
+      hasCapacity,
+      record,
+      onExceeded: () => setShowQuotaDialog(true),
+    })
   }
 
 
   return (
-    <Box
-      id='viewer-container'
-      sx={{
-        position: 'absolute',
-        top: 0,
-        left: 0,
-        width: '100vw',
-        height: isMobile ? `${vh}px` : '100vh',
-        margin: 0,
-        padding: 0,
-        textAlign: 'center',
-      }}
-      onMouseDown={async (event) => await onSceneSingleTap(event)}
-      onDoubleClick={async (event) => await onSceneDoubleTap(event)}
-      onDragOver={(event) => handleDragOverOrEnter(event, setIsDragActive)}
-      onDragEnter={(event) => handleDragOverOrEnter(event, setIsDragActive)}
-      onDragLeave={(event) => handleDragLeave(event, setIsDragActive)}
-      onDrop={onDrop}
-      data-testid='cadview-dropzone'
-      data-model-ready={isModelReady}
-    />
+    <>
+      <Box
+        id='viewer-container'
+        sx={{
+          position: 'absolute',
+          top: 0,
+          left: 0,
+          width: '100vw',
+          height: isMobile ? `${vh}px` : '100vh',
+          margin: 0,
+          padding: 0,
+          textAlign: 'center',
+        }}
+        onMouseDown={async (event) => await onSceneSingleTap(event)}
+        onDoubleClick={async (event) => await onSceneDoubleTap(event)}
+        onDragOver={(event) => handleDragOverOrEnter(event, setIsDragActive)}
+        onDragEnter={(event) => handleDragOverOrEnter(event, setIsDragActive)}
+        onDragLeave={(event) => handleDragLeave(event, setIsDragActive)}
+        onDrop={onDrop}
+        data-testid='cadview-dropzone'
+        data-model-ready={isModelReady}
+      />
+      <QuotaLimitDialog
+        tier={tier}
+        isOpen={showQuotaDialog}
+        onClose={() => setShowQuotaDialog(false)}
+      />
+    </>
   )
 }

--- a/src/FeatureFlags.js
+++ b/src/FeatureFlags.js
@@ -14,6 +14,15 @@ export const flags = [
   // land in identity-decoupling PR2.
   // See design/new/identity-decoupling-decisions.md.
   {name: 'githubAsSource', isActive: false},
+  // Usage quotas. The quota lib (src/quota), the record-load Netlify
+  // function, the useQuota hook and QuotaLimitDialog all ship
+  // unconditionally; this flag gates ENFORCEMENT. When off, useQuota
+  // reports unlimited capacity and record() is a no-op, so no load is
+  // ever counted or blocked and the QuotaBadge stays hidden. Off by
+  // default while quotas are validated against real Auth0 + public/private
+  // repos; enable per-session with `?feature=quotas`. Flip isActive to true
+  // to roll the limits out to everyone.
+  {name: 'quotas', isActive: false},
   // GLB runtime artifact pipeline (design/new/glb-model-sharing.md).
   // `glb` enables both the writer (post-IFC-parse cache warm-up) and the
   // reader (skip-IFC-when-GLB-cached fast path in Loader.js).

--- a/src/ShareRoutes.jsx
+++ b/src/ShareRoutes.jsx
@@ -10,6 +10,7 @@ import debug from './utils/debug'
 import {disablePageReloadApprovalCheck} from './utils/event'
 import About from './pages/share/About'
 import Conway from './pages/share/Conway'
+import Quotas from './pages/share/Quotas'
 import Share from './Share'
 
 
@@ -45,6 +46,7 @@ export default function ShareRoutes({installPrefix, appPrefix}) {
       <Route path='/' element={<Forward appPrefix={appPrefix}/>}>
         <Route path='about' element={<About/>}/>
         <Route path='about/conway' element={<Conway/>}/>
+        <Route path='quotas' element={<Quotas/>}/>
         <Route
           path='v/new/*'
           element={

--- a/src/__mocks__/api-handlers.js
+++ b/src/__mocks__/api-handlers.js
@@ -2,6 +2,8 @@ import {http, passthrough} from 'msw'
 import {
   HTTP_AUTHORIZATION_REQUIRED,
   HTTP_BAD_REQUEST,
+  HTTP_FORBIDDEN,
+  HTTP_INTERNAL_SERVER_ERROR,
   HTTP_OK,
 } from '../net/http'
 import apiHandlersGithub from './api-handlers-github'
@@ -104,6 +106,8 @@ function workersAndWasmPassthrough() {
 }
 
 
+const FREE_LIMIT_MOCK = 4
+
 /**
  * Handlers for Netlify functions
  *
@@ -133,6 +137,100 @@ function netlifyHandlers() {
           status: HTTP_OK,
           headers: {'Content-Type': 'application/json'},
         },
+      )
+    }),
+
+    http.post('/.netlify/functions/record-load', async ({request}) => {
+      // Tests can flip window.__mockQuotaForce5xx to exercise the
+      // fallback-to-OPFS path. Reset between tests.
+      if (typeof window !== 'undefined' && window.__mockQuotaForce5xx) {
+        return new Response('', {status: HTTP_INTERNAL_SERVER_ERROR})
+      }
+
+      const auth = request.headers.get('authorization') || ''
+      if (!/^Bearer\s+.+/i.test(auth)) {
+        return new Response(
+          JSON.stringify({error: 'Missing Authorization'}),
+          {status: HTTP_AUTHORIZATION_REQUIRED, headers: {'Content-Type': 'application/json'}},
+        )
+      }
+
+      const body = await request.json().catch(() => ({}))
+      const key = body && typeof body.key === 'string' ? body.key : null
+      if (!key) {
+        return new Response(
+          JSON.stringify({error: 'Missing key'}),
+          {status: HTTP_BAD_REQUEST, headers: {'Content-Type': 'application/json'},
+          })
+      }
+
+      // Tier from the Zustand store (mirrors what the real function reads
+      // from Auth0 app_metadata; tests inject metadata via setAppMetadata).
+      let tier = 'free'
+      try {
+        const subscriptionStatus =
+          window?.store?.getState?.()?.appMetadata?.subscriptionStatus
+        if (subscriptionStatus === 'sharePro') {
+          tier = 'paid'
+        }
+      } catch {
+        // store not exposed in this test build — default to free
+      }
+
+      // Quotability — same path classification as the real handler.
+      const isLocallyQuotable = key.includes('/v/new/') || key.includes('/v/g/')
+      const ghMatch = key.match(/\/v\/gh\/([^/]+)\/([^/]+)\//)
+      let quotable = isLocallyQuotable
+      if (ghMatch) {
+        // Heuristic: repo names containing "Public" (matching our sample
+        // models like Momentum-Public) are treated as public; everything
+        // else under /v/gh/ is private.
+        const repoName = ghMatch[2]
+        const isPublic = /Public/i.test(repoName)
+        quotable = !isPublic
+      }
+
+      if (typeof window !== 'undefined') {
+        window.__mockQuotaLoads = window.__mockQuotaLoads || []
+      }
+      const loads = (typeof window !== 'undefined' && window.__mockQuotaLoads) || []
+      const limit = tier === 'paid' ? null : FREE_LIMIT_MOCK
+
+      if (tier === 'paid') {
+        return new Response(
+          JSON.stringify({allowed: true, used: loads.length, limit, tier, alreadyCounted: false}),
+          {status: HTTP_OK, headers: {'Content-Type': 'application/json'}},
+        )
+      }
+
+      if (!quotable) {
+        return new Response(
+          JSON.stringify({allowed: true, used: loads.length, limit, tier, alreadyCounted: false}),
+          {status: HTTP_OK, headers: {'Content-Type': 'application/json'}},
+        )
+      }
+
+      if (loads.some((l) => l.key === key)) {
+        return new Response(
+          JSON.stringify({allowed: true, used: loads.length, limit, tier, alreadyCounted: true, loads}),
+          {status: HTTP_OK, headers: {'Content-Type': 'application/json'}},
+        )
+      }
+
+      if (loads.length >= FREE_LIMIT_MOCK) {
+        return new Response(
+          JSON.stringify({allowed: false, used: loads.length, limit, tier, alreadyCounted: false, loads}),
+          {status: HTTP_FORBIDDEN, headers: {'Content-Type': 'application/json'}},
+        )
+      }
+
+      const newLoads = [...loads, {key, loadedAt: new Date().toISOString()}]
+      if (typeof window !== 'undefined') {
+        window.__mockQuotaLoads = newLoads
+      }
+      return new Response(
+        JSON.stringify({allowed: true, used: newLoads.length, limit, tier, alreadyCounted: false, loads: newLoads}),
+        {status: HTTP_OK, headers: {'Content-Type': 'application/json'}},
       )
     }),
   ]

--- a/src/hooks/useQuota.js
+++ b/src/hooks/useQuota.js
@@ -1,0 +1,272 @@
+import {useState, useEffect, useCallback} from 'react'
+import {captureException} from '@sentry/react'
+import {useAuth0} from '../Auth0/Auth0Proxy'
+import useStore from '../store/useStore'
+import {isFeatureEnabled} from '../FeatureFlags'
+import {
+  TIERS,
+  LIMITS,
+  isQuotablePath,
+  isLocallyQuotable,
+  getTier,
+  pruneLoads,
+  loadQuota,
+  saveQuota,
+  recordLoad,
+  subscribeToQuota,
+} from '../quota/quota'
+
+
+const RECORD_LOAD_ENDPOINT = '/.netlify/functions/record-load'
+const HTTP_FORBIDDEN = 403
+
+
+// Stable no-ops returned when the `quotas` feature flag is off, so the hook's
+// shape is unchanged but every gate passes. Module-level keeps their identity
+// stable across renders. Not async (avoids require-await); callers `await`
+// the returned Promise.
+const passthroughCheck = () => ({allowed: true, used: 0, limit: Infinity, alreadyCounted: false})
+const passthroughRecord = () => Promise.resolve({allowed: true, used: 0, limit: Infinity, tier: TIERS.PAID, alreadyCounted: false})
+
+
+/**
+ * React hook for usage quota state.
+ *
+ * For authenticated users the server (record-load Netlify function) is the
+ * source of truth: every quotable load POSTs to it, the response is mirrored
+ * into OPFS, and the JWT is force-refreshed so other readers (BaseRoutes)
+ * see the same app_metadata.
+ *
+ * For anonymous users there is no server backstop — the hook relies on
+ * OPFS only, which is the explicit "lossy nudge to sign in" v1 trade-off.
+ *
+ * If the Netlify function is unreachable, the hook falls back to OPFS-only
+ * for that load and reports to Sentry. We degrade open rather than block
+ * legitimate users on an outage.
+ *
+ * @return {{
+ *   used: number,
+ *   limit: number,
+ *   tier: string,
+ *   hasCapacity: boolean,
+ *   check: Function,
+ *   record: Function,
+ * }}
+ */
+export default function useQuota() {
+  // isFeatureEnabled (not the useExistInFeature hook) reads window.location
+  // directly, so useQuota imposes no Router context on its consumers — it is
+  // rendered in containers that some tests mount without a router.
+  const quotasEnabled = isFeatureEnabled('quotas')
+  const {isAuthenticated, getAccessTokenSilently} = useAuth0()
+  const appMetadata = useStore((state) => state.appMetadata)
+  const tier = getTier(appMetadata, isAuthenticated)
+  const [quota, setQuota] = useState(null)
+
+  useEffect(() => {
+    let cancelled = false
+    loadQuota().then((raw) => {
+      if (cancelled) {
+        return
+      }
+      const next = {...raw, tier, loads: pruneLoads(raw.loads, tier)}
+      setQuota(next)
+      if (next.tier !== raw.tier || next.loads.length !== raw.loads.length) {
+        saveQuota(next)
+      }
+    })
+    const unsub = subscribeToQuota((q) => {
+      if (cancelled) {
+        return
+      }
+      setQuota({...q, tier})
+    })
+    return () => {
+      cancelled = true
+      unsub()
+    }
+  }, [tier])
+
+  const used = quota?.loads.length ?? 0
+  const limit = LIMITS[tier] !== undefined ? LIMITS[tier] : LIMITS[TIERS.FREE]
+
+  const check = useCallback((key) => {
+    if (!quota) {
+      return {allowed: true, used: 0, limit: Infinity, alreadyCounted: false}
+    }
+    if (tier === TIERS.PAID) {
+      return {allowed: true, used, limit, alreadyCounted: false}
+    }
+    if (key === null || !isQuotablePath(key)) {
+      return {allowed: true, used, limit, alreadyCounted: false}
+    }
+    const alreadyCounted = quota.loads.some((l) => l.key === key)
+    return {
+      allowed: alreadyCounted || used < limit,
+      used,
+      limit,
+      alreadyCounted,
+    }
+  }, [quota, used, limit, tier])
+
+  const record = useCallback(async (key) => {
+    if (!isQuotablePath(key)) {
+      return {allowed: true, used, limit, tier, alreadyCounted: false}
+    }
+
+    // Anonymous: OPFS only.
+    if (tier === TIERS.ANONYMOUS) {
+      if (!isLocallyQuotable(key)) {
+        return {allowed: true, used, limit, tier, alreadyCounted: false}
+      }
+      const updated = await recordLoad(key)
+      if (updated) {
+        setQuota((prev) => ({...(prev || updated), loads: updated.loads}))
+      }
+      const newUsed = updated?.loads.length ?? used
+      return {
+        allowed: newUsed <= limit,
+        used: newUsed,
+        limit,
+        tier,
+        alreadyCounted: false,
+      }
+    }
+
+    // Authenticated: server is authoritative.
+    let token
+    try {
+      token = await getAccessTokenSilently({
+        authorizationParams: {
+          audience: 'https://api.github.com/',
+          scope: 'openid profile email offline_access',
+        },
+      })
+    } catch (err) {
+      captureException(err)
+      return fallbackRecord(key, tier, limit, used, setQuota)
+    }
+
+    let response
+    try {
+      response = await fetch(RECORD_LOAD_ENDPOINT, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${token}`,
+        },
+        body: JSON.stringify({key}),
+      })
+    } catch (err) {
+      captureException(err)
+      return fallbackRecord(key, tier, limit, used, setQuota)
+    }
+
+    let data
+    try {
+      data = await response.json()
+    } catch {
+      data = {}
+    }
+
+    if (response.status === HTTP_FORBIDDEN) {
+      // Server denied — surface the limit dialog via the returned payload.
+      return {
+        allowed: false,
+        used: data.used ?? used,
+        limit: data.limit ?? limit,
+        tier: data.tier ?? tier,
+        alreadyCounted: false,
+      }
+    }
+
+    if (!response.ok) {
+      captureException(new Error(`record-load returned ${response.status}`))
+      return fallbackRecord(key, tier, limit, used, setQuota)
+    }
+
+    // Mirror server response into OPFS so the next mount has fresh state
+    // even if the server is briefly unreachable later.
+    if (Array.isArray(data.loads)) {
+      const updated = {tier: data.tier ?? tier, loads: data.loads}
+      saveQuota(updated)
+      setQuota(updated)
+    }
+
+    // Force-refresh the JWT so app_metadata readers (BaseRoutes etc.)
+    // see the bumped count on next read. Failure here is non-fatal —
+    // the hook's own state is already authoritative for the badge / dialog.
+    getAccessTokenSilently({
+      authorizationParams: {
+        audience: 'https://api.github.com/',
+        scope: 'openid profile email offline_access',
+      },
+      cacheMode: 'off',
+      useRefreshTokens: true,
+    }).catch((err) => captureException(err))
+
+    return {
+      allowed: data.allowed !== false,
+      used: data.used ?? used,
+      limit: data.limit ?? limit,
+      tier: data.tier ?? tier,
+      alreadyCounted: data.alreadyCounted === true,
+    }
+  }, [tier, limit, used, getAccessTokenSilently])
+
+  // Feature-gated: with the `quotas` flag off (the default) the hook reports
+  // unlimited capacity and record()/check() are no-ops, so every load site
+  // bypasses gating and the QuotaBadge (hidden when limit === Infinity) never
+  // shows. Enforcement is enabled per-session via `?feature=quotas`, or for
+  // everyone by flipping the flag's isActive in FeatureFlags.js. All hooks
+  // above run unconditionally, so this early return respects the rules of hooks.
+  if (!quotasEnabled) {
+    return {
+      used: 0,
+      limit: Infinity,
+      tier,
+      hasCapacity: true,
+      check: passthroughCheck,
+      record: passthroughRecord,
+    }
+  }
+
+  return {
+    used,
+    limit,
+    tier,
+    hasCapacity: tier === TIERS.PAID || used < limit,
+    check,
+    record,
+  }
+}
+
+
+/**
+ * Server unreachable — fall back to OPFS-only counting. Mirrors the
+ * anonymous code path but keeps the user's authenticated tier.
+ *
+ * @param {string} key Share path being loaded
+ * @param {string} tier User's quota tier
+ * @param {number} limit Per-tier load limit
+ * @param {number} used Current observed usage
+ * @param {Function} setQuota State setter for the hook's quota cache
+ * @return {Promise<{allowed:boolean,used:number,limit:number,tier:string,alreadyCounted:boolean}>}
+ */
+async function fallbackRecord(key, tier, limit, used, setQuota) {
+  if (!isLocallyQuotable(key)) {
+    return {allowed: true, used, limit, tier, alreadyCounted: false}
+  }
+  const updated = await recordLoad(key)
+  if (updated) {
+    setQuota((prev) => ({...(prev || updated), loads: updated.loads, tier}))
+  }
+  const newUsed = updated?.loads.length ?? used
+  return {
+    allowed: newUsed <= limit,
+    used: newUsed,
+    limit,
+    tier,
+    alreadyCounted: false,
+  }
+}

--- a/src/hooks/useQuota.js
+++ b/src/hooks/useQuota.js
@@ -3,6 +3,7 @@ import {captureException} from '@sentry/react'
 import {useAuth0} from '../Auth0/Auth0Proxy'
 import useStore from '../store/useStore'
 import {isFeatureEnabled} from '../FeatureFlags'
+import {HTTP_FORBIDDEN} from '../net/http'
 import {
   TIERS,
   LIMITS,
@@ -18,7 +19,6 @@ import {
 
 
 const RECORD_LOAD_ENDPOINT = '/.netlify/functions/record-load'
-const HTTP_FORBIDDEN = 403
 
 
 // Stable no-ops returned when the `quotas` feature flag is off, so the hook's
@@ -64,6 +64,14 @@ export default function useQuota() {
   const [quota, setQuota] = useState(null)
 
   useEffect(() => {
+    // With the flag off the hook returns the passthrough shape below, so
+    // loading OPFS state would be wasted work — and its post-mount setQuota
+    // is exactly the kind of unsettled async update that litters every
+    // consumer's tests with act() warnings (PLAYBOOK §"Keep the test
+    // console clean").
+    if (!quotasEnabled) {
+      return undefined
+    }
     let cancelled = false
     loadQuota().then((raw) => {
       if (cancelled) {
@@ -85,7 +93,7 @@ export default function useQuota() {
       cancelled = true
       unsub()
     }
-  }, [tier])
+  }, [tier, quotasEnabled])
 
   const used = quota?.loads.length ?? 0
   const limit = LIMITS[tier] !== undefined ? LIMITS[tier] : LIMITS[TIERS.FREE]
@@ -97,12 +105,16 @@ export default function useQuota() {
     if (tier === TIERS.PAID) {
       return {allowed: true, used, limit, alreadyCounted: false}
     }
-    if (key === null || !isQuotablePath(key)) {
+    if (key === null || key === undefined || !isQuotablePath(key)) {
       return {allowed: true, used, limit, alreadyCounted: false}
     }
     const alreadyCounted = quota.loads.some((l) => l.key === key)
+    // Only deny what the client KNOWS is a new private load: /v/gh/ paths
+    // may be public (the server resolves that), so they pass the cheap gate
+    // and record() makes the authoritative call. Already-counted keys stay
+    // openable at limit (server idempotency).
     return {
-      allowed: alreadyCounted || used < limit,
+      allowed: alreadyCounted || !isLocallyQuotable(key) || used < limit,
       used,
       limit,
       alreadyCounted,
@@ -114,23 +126,10 @@ export default function useQuota() {
       return {allowed: true, used, limit, tier, alreadyCounted: false}
     }
 
-    // Anonymous: OPFS only.
+    // Anonymous: OPFS only — same local flow as the server-unreachable
+    // fallback, just with the anonymous tier.
     if (tier === TIERS.ANONYMOUS) {
-      if (!isLocallyQuotable(key)) {
-        return {allowed: true, used, limit, tier, alreadyCounted: false}
-      }
-      const updated = await recordLoad(key)
-      if (updated) {
-        setQuota((prev) => ({...(prev || updated), loads: updated.loads}))
-      }
-      const newUsed = updated?.loads.length ?? used
-      return {
-        allowed: newUsed <= limit,
-        used: newUsed,
-        limit,
-        tier,
-        alreadyCounted: false,
-      }
+      return recordLocally(key, tier, limit, setQuota)
     }
 
     // Authenticated: server is authoritative.
@@ -144,7 +143,7 @@ export default function useQuota() {
       })
     } catch (err) {
       captureException(err)
-      return fallbackRecord(key, tier, limit, used, setQuota)
+      return recordLocally(key, tier, limit, setQuota)
     }
 
     let response
@@ -159,7 +158,7 @@ export default function useQuota() {
       })
     } catch (err) {
       captureException(err)
-      return fallbackRecord(key, tier, limit, used, setQuota)
+      return recordLocally(key, tier, limit, setQuota)
     }
 
     let data
@@ -167,6 +166,15 @@ export default function useQuota() {
       data = await response.json()
     } catch {
       data = {}
+    }
+
+    // Mirror the server's authoritative loads into OPFS whenever it sends
+    // them (both allow and deny responses) so the badge and the next mount
+    // agree with the server even if it's briefly unreachable later.
+    if (Array.isArray(data.loads)) {
+      const updated = {tier: data.tier ?? tier, loads: data.loads}
+      saveQuota(updated)
+      setQuota(updated)
     }
 
     if (response.status === HTTP_FORBIDDEN) {
@@ -182,28 +190,26 @@ export default function useQuota() {
 
     if (!response.ok) {
       captureException(new Error(`record-load returned ${response.status}`))
-      return fallbackRecord(key, tier, limit, used, setQuota)
+      return recordLocally(key, tier, limit, setQuota)
     }
 
-    // Mirror server response into OPFS so the next mount has fresh state
-    // even if the server is briefly unreachable later.
-    if (Array.isArray(data.loads)) {
-      const updated = {tier: data.tier ?? tier, loads: data.loads}
-      saveQuota(updated)
-      setQuota(updated)
+    // A new load was persisted server-side (loads present and not a dedup
+    // hit): force-refresh the JWT so app_metadata readers (BaseRoutes etc.)
+    // see the bumped count on next read. Skipped for not-quotable / paid /
+    // alreadyCounted responses, where app_metadata didn't change and the
+    // cacheMode:'off' refresh would be a wasted Auth0 round-trip. Failure
+    // here is non-fatal — the hook's own state is already authoritative
+    // for the badge / dialog.
+    if (Array.isArray(data.loads) && data.alreadyCounted !== true) {
+      getAccessTokenSilently({
+        authorizationParams: {
+          audience: 'https://api.github.com/',
+          scope: 'openid profile email offline_access',
+        },
+        cacheMode: 'off',
+        useRefreshTokens: true,
+      }).catch((err) => captureException(err))
     }
-
-    // Force-refresh the JWT so app_metadata readers (BaseRoutes etc.)
-    // see the bumped count on next read. Failure here is non-fatal —
-    // the hook's own state is already authoritative for the badge / dialog.
-    getAccessTokenSilently({
-      authorizationParams: {
-        audience: 'https://api.github.com/',
-        scope: 'openid profile email offline_access',
-      },
-      cacheMode: 'off',
-      useRefreshTokens: true,
-    }).catch((err) => captureException(err))
 
     return {
       allowed: data.allowed !== false,
@@ -243,27 +249,35 @@ export default function useQuota() {
 
 
 /**
- * Server unreachable — fall back to OPFS-only counting. Mirrors the
- * anonymous code path but keeps the user's authenticated tier.
+ * OPFS-only record: the anonymous path, and the fallback when the server
+ * is unreachable for an authenticated user (whose tier is kept). Applies
+ * the same order of operations as the server — dedup, then capacity gate,
+ * then persist — so a denied load is never written (writing it would
+ * over-report `used` and make the key read as alreadyCounted later).
  *
  * @param {string} key Share path being loaded
  * @param {string} tier User's quota tier
  * @param {number} limit Per-tier load limit
- * @param {number} used Current observed usage
  * @param {Function} setQuota State setter for the hook's quota cache
  * @return {Promise<{allowed:boolean,used:number,limit:number,tier:string,alreadyCounted:boolean}>}
  */
-async function fallbackRecord(key, tier, limit, used, setQuota) {
-  if (!isLocallyQuotable(key)) {
-    return {allowed: true, used, limit, tier, alreadyCounted: false}
+async function recordLocally(key, tier, limit, setQuota) {
+  const current = await loadQuota()
+  const pruned = pruneLoads(current.loads, tier)
+  const alreadyCounted = pruned.some((l) => l.key === key)
+  if (!isLocallyQuotable(key) || alreadyCounted) {
+    return {allowed: true, used: pruned.length, limit, tier, alreadyCounted}
+  }
+  if (pruned.length >= limit) {
+    return {allowed: false, used: pruned.length, limit, tier, alreadyCounted: false}
   }
   const updated = await recordLoad(key)
   if (updated) {
     setQuota((prev) => ({...(prev || updated), loads: updated.loads, tier}))
   }
-  const newUsed = updated?.loads.length ?? used
+  const newUsed = updated?.loads.length ?? pruned.length
   return {
-    allowed: newUsed <= limit,
+    allowed: true,
     used: newUsed,
     limit,
     tier,

--- a/src/hooks/useQuota.test.js
+++ b/src/hooks/useQuota.test.js
@@ -1,0 +1,48 @@
+import {renderHook, waitFor} from '@testing-library/react'
+import {mockedUseAuth0, mockedUserLoggedOut} from '../__mocks__/authentication'
+import {isFeatureEnabled} from '../FeatureFlags'
+import useQuota from './useQuota'
+
+
+// Keep the real `flags` table; only stub the enforcement gate so each test
+// drives the flag directly.
+jest.mock('../FeatureFlags', () => ({
+  ...jest.requireActual('../FeatureFlags'),
+  isFeatureEnabled: jest.fn(),
+}))
+
+
+/**
+ * The `quotas` feature flag gates enforcement. These cover the gate itself;
+ * the per-tier / rolling-window correctness lives in src/quota/quota.test.js.
+ */
+describe('useQuota — quotas feature flag', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockedUseAuth0.mockReturnValue(mockedUserLoggedOut)
+  })
+
+  it('reports unlimited capacity and makes record() a no-op when the flag is off', async () => {
+    isFeatureEnabled.mockReturnValue(false)
+
+    const {result} = renderHook(() => useQuota())
+
+    expect(result.current.hasCapacity).toBe(true)
+    expect(result.current.limit).toBe(Infinity)
+    expect(result.current.used).toBe(0)
+
+    // A private GitHub path would normally be counted and could be blocked;
+    // with the flag off, record() resolves allowed without a server round-trip.
+    await expect(result.current.record('/share/v/gh/owner/repo/main/private.ifc'))
+      .resolves.toMatchObject({allowed: true})
+  })
+
+  it('enforces a finite per-tier limit when the flag is on', async () => {
+    isFeatureEnabled.mockReturnValue(true)
+
+    const {result} = renderHook(() => useQuota())
+
+    // Anonymous (logged-out) tier has a finite cap, so the gate is live.
+    await waitFor(() => expect(Number.isFinite(result.current.limit)).toBe(true))
+  })
+})

--- a/src/hooks/useQuota.test.js
+++ b/src/hooks/useQuota.test.js
@@ -1,4 +1,4 @@
-import {renderHook, waitFor} from '@testing-library/react'
+import {act, renderHook} from '@testing-library/react'
 import {mockedUseAuth0, mockedUserLoggedOut} from '../__mocks__/authentication'
 import {isFeatureEnabled} from '../FeatureFlags'
 import useQuota from './useQuota'
@@ -42,7 +42,11 @@ describe('useQuota — quotas feature flag', () => {
 
     const {result} = renderHook(() => useQuota())
 
+    // Settle the mount cascade (loadQuota → setQuota) inside act so the
+    // async state update doesn't land outside act() and warn.
+    await act(async () => {})
+
     // Anonymous (logged-out) tier has a finite cap, so the gate is live.
-    await waitFor(() => expect(Number.isFinite(result.current.limit)).toBe(true))
+    expect(Number.isFinite(result.current.limit)).toBe(true)
   })
 })

--- a/src/net/http.js
+++ b/src/net/http.js
@@ -8,6 +8,7 @@ export const HTTP_NOT_MODIFIED = 304
 
 export const HTTP_BAD_REQUEST = 400
 export const HTTP_AUTHORIZATION_REQUIRED = 401
+export const HTTP_FORBIDDEN = 403
 export const HTTP_NOT_FOUND = 404
 
 export const HTTP_INTERNAL_SERVER_ERROR = 500

--- a/src/pages/share/Quotas.jsx
+++ b/src/pages/share/Quotas.jsx
@@ -1,0 +1,67 @@
+import React, {ReactElement} from 'react'
+import {Box, Link, Table, TableBody, TableCell, TableHead, TableRow, Typography} from '@mui/material'
+import TitledLayout from '../../layouts/TitledLayout'
+
+
+/** @return {ReactElement} */
+export default function Quotas() {
+  return (
+    <TitledLayout title='Bldrs Share: Usage limits'>
+      <Box sx={{maxWidth: 720, margin: '0 auto', padding: '1em'}}>
+        <Typography variant='h4' gutterBottom>Usage limits</Typography>
+        <Typography paragraph>
+          Bldrs Share counts loads of <em>private</em> models — files in
+          your local browser storage, files from your Google Drive, and
+          private GitHub repositories. Public GitHub samples and shared
+          public-repo models do not count.
+        </Typography>
+
+        <Table sx={{marginTop: '1em'}}>
+          <TableHead>
+            <TableRow>
+              <TableCell><strong>Tier</strong></TableCell>
+              <TableCell><strong>Private model loads</strong></TableCell>
+              <TableCell><strong>Window</strong></TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            <TableRow>
+              <TableCell>Anonymous</TableCell>
+              <TableCell>2</TableCell>
+              <TableCell>Lifetime — sign in to reset</TableCell>
+            </TableRow>
+            <TableRow>
+              <TableCell>Free (signed in)</TableCell>
+              <TableCell>4</TableCell>
+              <TableCell>Rolling 30 days</TableCell>
+            </TableRow>
+            <TableRow>
+              <TableCell>Pro</TableCell>
+              <TableCell>Unlimited</TableCell>
+              <TableCell>—</TableCell>
+            </TableRow>
+          </TableBody>
+        </Table>
+
+        <Typography variant='h6' sx={{marginTop: '2em'}}>What counts as a load?</Typography>
+        <Typography paragraph>
+          Each unique private model URL counts once. Reloading the same
+          model — via the browser back button, your recently-used list,
+          or a fresh tab — does not consume additional quota.
+        </Typography>
+
+        <Typography variant='h6' sx={{marginTop: '1.5em'}}>What does <em>not</em> count?</Typography>
+        <Typography component='ul'>
+          <li>Public GitHub repositories (including all sample models)</li>
+          <li>Browsing the model viewer itself, navigation, search, etc.</li>
+          <li>Loads while offline (they will sync when you reconnect)</li>
+        </Typography>
+
+        <Typography sx={{marginTop: '2em'}}>
+          Need more? <Link href='/subscribe'>Upgrade to Pro</Link> for
+          unlimited private model loads.
+        </Typography>
+      </Box>
+    </TitledLayout>
+  )
+}

--- a/src/pages/share/Quotas.jsx
+++ b/src/pages/share/Quotas.jsx
@@ -54,7 +54,6 @@ export default function Quotas() {
         <Typography component='ul'>
           <li>Public GitHub repositories (including all sample models)</li>
           <li>Browsing the model viewer itself, navigation, search, etc.</li>
-          <li>Loads while offline (they will sync when you reconnect)</li>
         </Typography>
 
         <Typography sx={{marginTop: '2em'}}>

--- a/src/tests/e2e/utils.ts
+++ b/src/tests/e2e/utils.ts
@@ -223,17 +223,23 @@ export async function returningUserVisitsHomepage(page: Page) {
 
 /**
  * Same as returningUserVisitsHomepage, but wait for model too
+ *
+ * @param search Optional query string (e.g. '?feature=quotas') appended to the
+ *   model URL so the SPA boots with feature flags active.
  */
-export async function returningUserVisitsHomepageWaitForModel(page: Page) {
+export async function returningUserVisitsHomepageWaitForModel(page: Page, search = '') {
   await setIsReturningUser(page.context())
-  await visitHomepageWaitForModel(page)
+  await visitHomepageWaitForModel(page, search)
 }
 
 
 /**
  * Assumes other setup, then visit homepage and wait for model
+ *
+ * @param search Optional query string (e.g. '?feature=quotas') appended to the
+ *   model URL so the SPA boots with feature flags active.
  */
-export async function visitHomepageWaitForModel(page: Page) {
+export async function visitHomepageWaitForModel(page: Page, search = '') {
   await Promise.all([
     // await page.waitForURL('/index.ifc', {timeout: 10_000}), // ensure the bounce happened
     page.waitForResponse(async (response: Response) => {
@@ -244,7 +250,7 @@ export async function visitHomepageWaitForModel(page: Page) {
       }
       return false
     }),
-    page.goto('/share/v/p/index.ifc', {waitUntil: 'domcontentloaded'}),
+    page.goto(`/share/v/p/index.ifc${search}`, {waitUntil: 'domcontentloaded'}),
   ])
   // MSW registers and activates its service worker during the first
   // navigation. Wait for it to be the page's active controller before

--- a/src/utils/dragAndDrop.js
+++ b/src/utils/dragAndDrop.js
@@ -18,8 +18,11 @@ import debug from './debug'
  * @param {Function} setAlert Function to set alert messages
  * @param {Function} [onSuccess] Optional callback when file is successfully processed
  * @param {Function} [onError] Optional callback when an error occurs
+ * @param {{hasCapacity: boolean, record: Function, onExceeded: Function}} [quotaOptions]
+ *   Optional quota integration. When provided, blocks the drop if hasCapacity is false
+ *   and records the load key via record() on success.
  */
-export async function handleFileDrop(event, navigate, appPrefix, isOpfsAvailable, setAlert, onSuccess, onError) {
+export async function handleFileDrop(event, navigate, appPrefix, isOpfsAvailable, setAlert, onSuccess, onError, quotaOptions) {
   event.preventDefault()
   const files = event.dataTransfer.files
 
@@ -41,6 +44,12 @@ export async function handleFileDrop(event, navigate, appPrefix, isOpfsAvailable
     }
     return
   }
+
+  if (quotaOptions && !quotaOptions.hasCapacity) {
+    quotaOptions.onExceeded()
+    return
+  }
+
   const uploadedFile = files[0]
 
   debug().log('handleFileDrop: uploadedFile', uploadedFile)
@@ -56,10 +65,18 @@ export async function handleFileDrop(event, navigate, appPrefix, isOpfsAvailable
   }
 
   /** @param {string} fileName The filename the upload was given */
-  function onWritten(fileName) {
+  async function onWritten(fileName) {
+    const key = `${appPrefix}/v/new/${fileName}`
+    if (quotaOptions) {
+      const result = await quotaOptions.record(key)
+      if (result && result.allowed === false) {
+        quotaOptions.onExceeded()
+        return
+      }
+    }
     disablePageReloadApprovalCheck()
     debug().log('handleFileDrop: navigate to:', fileName)
-    navigateToModel(`${appPrefix}/v/new/${fileName}`, navigate)
+    navigateToModel(key, navigate)
     addRecentFileEntry({
       id: fileName,
       source: 'local',


### PR DESCRIPTION
## Summary

Implements a complete usage-quota system for private-model loads (local, Google Drive, private GitHub). Free-tier users are limited to 4 loads per rolling 30-day window; Pro subscribers have unlimited access. The system is server-authoritative via a new `record-load` Netlify function, with OPFS-based fallback when the server is unreachable. Enforcement is gated behind the `quotas` feature flag (off by default).

## Key Changes

**Backend (Netlify Function)**
- `netlify/functions/record-load.js` — authoritative gate for quota counting
  - Validates access tokens via Auth0 `/userinfo`
  - Reads user tier from Auth0 `app_metadata.subscriptionStatus`
  - Derives quotability: `/v/new/` and `/v/g/` always count; `/v/gh/` repos are checked against GitHub API (cached 15 min per repo)
  - Prunes loads outside the rolling 30-day window
  - Idempotent: returns current state if key already counted
  - Returns 403 when FREE tier hits limit; client surfaces limit dialog
  - Persists new loads to Auth0 `app_metadata.usageQuota.loads`

**Frontend (React Hook & UI)**
- `src/hooks/useQuota.js` — React hook managing quota state
  - For authenticated users: POSTs to `record-load` on each quotable load; mirrors server response into OPFS
  - For anonymous users: OPFS-only counting (lossy, nudges sign-in)
  - Falls back to OPFS-only if server unreachable; reports to Sentry
  - Force-refreshes JWT after recording so other readers see bumped count
  - Feature-gated: with `quotas` flag off, all gates pass and `record()`/`check()` are no-ops

- `src/Components/Open/QuotaLimitDialog.jsx` — modal shown when user hits limit
  - Anonymous: offers both "Sign up" and "Subscribe" buttons
  - Free tier: offers "Subscribe" button
  - Links to `/share/quotas` for limit explanation

- `src/Components/Open/QuotaBadge.jsx` — usage badge on Open toolbar button
  - Shows `used/limit` once ≥50% consumed; turns amber at ≥75%
  - Hidden for paid tier or unlimited capacity

**Integration Points**
- `src/Components/Open/OpenModelDialog.jsx` — gates private-model opens via `record()` before navigation; surfaces limit dialog on 403
- `src/Containers/ViewerContainer.jsx` — gates drag-and-drop file loads via quota integration
- `src/Components/Open/GitHubFileBrowser.jsx` — accepts optional `checkQuota` gate (wired by parent)
- `src/utils/dragAndDrop.js` — accepts optional `quotaOptions` to gate and record local file drops
- `src/__mocks__/api-handlers.js` — MSW mock for `record-load` endpoint (tests can inject tier via Zustand, flip 5xx flag)

**Documentation & Tests**
- `src/Components/Open/README.md` — component design doc with quota section
- `src/pages/share/Quotas.jsx` — public-facing limits table and FAQ
- `src/Components/Open/Quota.spec.ts` — E2E test for Pro-tier enforcement
- `src/hooks/useQuota.test.js` — unit test for feature-flag gating
- `src/Components/Open/OpenModelDialog.test.jsx` — updated to await quota `record()` gate

**Feature Flag & Constants**
- `src/FeatureFlags.js` — added `quotas` flag (default off)
- `src/quota/quota.js` (pre-existing) — tier/limit constants, rolling-window pruning, quotability classification

## Notable Implementation Details

- **Server-authoritative with graceful degradation:** The `record-load` function is the source of truth for authenticated users, but if it's unreachable, the hook falls back to OP

https://claude.ai/code/session_01Pm2xv1QpFJQVEdM3bM6iL3