### PR TITLE
Add real_model_open GA event, guard against demo-model noise

### DIFF
--- a/design/new/ads.md
+++ b/design/new/ads.md
@@ -32,7 +32,7 @@ There is no "verification-only" build of the script. The snippet for verificatio
   - Because the safeguard lives outside the repo, the repo's only reliable defense is **not loading the script on routes that must stay ad-free**. Treat the dashboard toggle as a second layer, not the first.
 - **Viewer routes never carry `<ins>` slots.** Specifically `/`, `/share/*`, and any model-editing UI. Slots are limited to text-heavy routes (`/about`, `/privacy`, `/tos`, `/blog/*`).
 - **Tests stay hermetic.** No live ad traffic during Jest or Playwright runs. See "Test hermeticity" below.
-- **Consent matches GTM today.** The script loads unconditionally on every page, same as `googletagmanager.com/gtag/js`. The existing `isAnalyticsAllowed` cookie (`src/privacy/analytics.js:6`) gates *gtag event calls*, not script loading — mirror that for ads. A future iteration can gate the script itself if EU consent rules force it; `isAnalyticsAllowed` is the foothold.
+- **Consent matches GTM today.** The AdSense script loads unconditionally on every page. (`googletagmanager.com/gtag/js` used to as well, but is now injected only on prod hosts by `src/index/ga.js` — analytics hygiene, not consent.) The existing `isAnalyticsAllowed` cookie (`src/privacy/analytics.js:6`) gates *gtag event calls*, not script loading — mirror that for ads. A future iteration can gate the script itself if EU consent rules force it; `isAnalyticsAllowed` is the foothold.
 
 
 ## Incident: unintended Auto ads (2026-05 → 2026-07)

--- a/design/roadmap.md
+++ b/design/roadmap.md
@@ -695,8 +695,10 @@ which channel *reaches* that audience is the open GTM question owned bizdev-side
 **Epic `grow-120`: Funnel instrumentation + analytics hygiene** ⬜ (NEW)
 - Instrument the funnel stages the growth doc defines (§3 there):
   `share_link_created`, `share_link_opened`, `model_interacted` events in Share;
-  the derived `real_model_open` key event (built on `select_content` +
-  `stats_preprocessorVersion`) is GA4 config, not code.
+  `real_model_open` is sent directly by Share (CadView#loadModel, guarded by
+  `analytics#isRealModelOpen` so the homepage's auto-loaded demo model doesn't
+  fire it — it replaced `select_content`, whose counts were conflated with
+  homepage visits); marking it a key event + the Ads import stay GA4 config.
 - Hygiene: skip GA init when `navigator.webdriver === true` or when
   `location.hostname !== 'bldrs.ai'` — one guard cleans CI/e2e, localhost, and
   preview-deploy pollution out of prod analytics. (Also: confirm whether scheduled
@@ -1051,7 +1053,7 @@ landing page — before the MVP launch needs any of it.
   hostname check on GA init) — cleans CI/e2e/preview pollution out of prod data.
 - `grow-120` events: `share_link_created`, `share_link_opened`,
   `model_interacted` wired into the share flow + viewer; `real_model_open`
-  derived key event configured GA4-side.
+  fires from Share on non-demo model opens (✅), key-event marking GA4-side.
 - `grow-100`: `/viewer/ifc` + `/viewer/step` landing pages on the marketing SSG
   build (then `/viewer/stl`, `/viewer/obj`, …). Unblocks the acquisition-campaign
   landing targets.

--- a/design/roadmap.md
+++ b/design/roadmap.md
@@ -700,10 +700,14 @@ which channel *reaches* that audience is the open GTM question owned bizdev-side
   nor opens on `*.netlify.app` deploy-preview/dev hosts fire it — it replaced
   `select_content`, whose counts were conflated with homepage visits); marking
   it a key event + the Ads import stay GA4 config.
-- Hygiene: skip GA init when `navigator.webdriver === true` or when
-  `location.hostname !== 'bldrs.ai'` — one guard cleans CI/e2e, localhost, and
-  preview-deploy pollution out of prod analytics. (Also: confirm whether scheduled
-  e2e runs ship the prod measurement ID.)
+- Hygiene: GA only initializes in prod (✅) — index.html keeps the inline
+  dataLayer/gtag stub (event buffering + E2E assertions), while
+  `src/index/ga.js#setupGa` injects the external gtag/js loader only on
+  bldrs.ai/www.bldrs.ai with `navigator.webdriver` false, cleaning CI/e2e,
+  localhost, and preview-deploy pollution out of prod analytics. Init failures
+  go to Sentry tagged `subsystem:ga_init`; ad-blocked clients will dominate
+  that stream — add a sentry.js filter (cf. `netlify_rum_blocked`) when it
+  gets noisy.
 - Channel-grouping + dashboard slices are bizdev-side config; the Share-side
   deliverable is the events existing and firing.
 - v0.4 addition: capture **model size/complexity** (bucketed — bytes, element
@@ -1051,7 +1055,8 @@ into a funnel with no earned channels wastes the launch.
 **Goal:** the funnel is measurable, share links unfurl, and search intent has a
 landing page — before the MVP launch needs any of it.
 - `grow-120` first slice: GA hygiene guard (`navigator.webdriver` +
-  hostname check on GA init) — cleans CI/e2e/preview pollution out of prod data.
+  hostname check on GA init) — cleans CI/e2e/preview pollution out of prod
+  data (✅ `src/index/ga.js`).
 - `grow-120` events: `share_link_created`, `share_link_opened`,
   `model_interacted` wired into the share flow + viewer; `real_model_open`
   fires from Share on non-demo model opens (✅), key-event marking GA4-side.

--- a/design/roadmap.md
+++ b/design/roadmap.md
@@ -696,9 +696,10 @@ which channel *reaches* that audience is the open GTM question owned bizdev-side
 - Instrument the funnel stages the growth doc defines (§3 there):
   `share_link_created`, `share_link_opened`, `model_interacted` events in Share;
   `real_model_open` is sent directly by Share (CadView#loadModel, guarded by
-  `analytics#isRealModelOpen` so the homepage's auto-loaded demo model doesn't
-  fire it — it replaced `select_content`, whose counts were conflated with
-  homepage visits); marking it a key event + the Ads import stay GA4 config.
+  `analytics#isRealModelOpen` so neither the homepage's auto-loaded demo model
+  nor opens on `*.netlify.app` deploy-preview/dev hosts fire it — it replaced
+  `select_content`, whose counts were conflated with homepage visits); marking
+  it a key event + the Ads import stay GA4 config.
 - Hygiene: skip GA init when `navigator.webdriver === true` or when
   `location.hostname !== 'bldrs.ai'` — one guard cleans CI/e2e, localhost, and
   preview-deploy pollution out of prod analytics. (Also: confirm whether scheduled

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bldrs",
-  "version": "1.1550.215ad37",
+  "version": "1.1722.d41cd27",
   "main": "src/index.jsx",
   "license": "AGPL-3.0",
   "homepage": "https://github.com/bldrs-ai/Share",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bldrs",
-  "version": "1.1722.d41cd27",
+  "version": "1.1550.215ad37",
   "main": "src/index.jsx",
   "license": "AGPL-3.0",
   "homepage": "https://github.com/bldrs-ai/Share",

--- a/public/index.html
+++ b/public/index.html
@@ -48,7 +48,8 @@
     <!-- gtag stub only: buffers events into dataLayer everywhere (gtagEvent
          calls + E2E assertions rely on it). The external gtag/js loader is
          injected by src/index/ga.js, and only on prod hosts outside
-         automation — keeps preview/dev/CI traffic out of prod analytics. -->
+         automation — keeps preview/dev/CI traffic out of prod analytics.
+         The config ID below must match ga.js#GA_MEASUREMENT_ID. -->
     <script type="application/javascript">
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}

--- a/public/index.html
+++ b/public/index.html
@@ -45,15 +45,17 @@
       loader.setAttribute('src', pathPrefix + '/index.js')
       document.body.appendChild(loader)
     </script>
-    <!-- gtags after app bundle; helps race with MSW in dev server and testing -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-GRLNVMZRGW" type="application/javascript"></script>
+    <!-- gtag stub only: buffers events into dataLayer everywhere (gtagEvent
+         calls + E2E assertions rely on it). The external gtag/js loader is
+         injected by src/index/ga.js, and only on prod hosts outside
+         automation — keeps preview/dev/CI traffic out of prod analytics. -->
     <script type="application/javascript">
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
       gtag('config', 'G-GRLNVMZRGW');
     </script>
-    <!-- AdSense site verification. Same body-after-bundle placement as gtag above so MSW takes control before the script's network requests fire in dev/test. design/new/ads.md captures why Auto ads stay OFF and which routes may carry ad slots. -->
+    <!-- AdSense site verification. Body-after-bundle placement so MSW takes control before the script's network requests fire in dev/test. design/new/ads.md captures why Auto ads stay OFF and which routes may carry ad slots. -->
     <script async
             src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-2372655610709687"
             crossorigin="anonymous"></script>

--- a/src/Containers/CadView.jsx
+++ b/src/Containers/CadView.jsx
@@ -7,7 +7,7 @@ import {captureException} from '@sentry/react'
 import {fileSuffixBoundaryRegex} from '../Filetype'
 import {useAuth0} from '../Auth0/Auth0Proxy'
 import {onHash} from '../Components/Camera/CameraControl'
-import {gtagEvent} from '../privacy/analytics'
+import {gtagEvent, isRealModelOpen} from '../privacy/analytics'
 import {getRenderMode} from '../privacy/preferences'
 import {resetState as resetCutPlaneState} from '../Components/CutPlane/CutPlaneMenu'
 import {useIsMobile} from '../Components/Hooks'
@@ -558,15 +558,21 @@ export default function CadView({
       console.warn('CadView#loadedModel: model without manager:', loadedModel)
     }
 
-    const selectContentObj = {
-      content_type: loadedModel.type || 'undefined',
-      content_id: filepath,
+    // Replaces the retired `select_content` event, whose counts were
+    // conflated with homepage visits because the demo model fired it
+    // too. The isRealModelOpen guard keeps that from recurring — see
+    // its doc for why the demo must stay out of this event.
+    if (isRealModelOpen(routeResult)) {
+      const eventParams = {
+        content_type: loadedModel.type || 'undefined',
+        content_id: filepath,
+      }
+      // TODO(pablo): currently only IFC/STEP are populated with stats.
+      if (loadedModel.loadStats) {
+        addProperties(eventParams, loadedModel.loadStats, 'stats_')
+      }
+      gtagEvent('real_model_open', eventParams)
     }
-    // TODO(pablo): currently only IFC/STEP are populated with stats.
-    if (loadedModel.loadStats) {
-      addProperties(selectContentObj, loadedModel.loadStats, 'stats_')
-    }
-    gtagEvent('select_content', selectContentObj)
 
     return loadedModel
   }

--- a/src/Containers/realModelOpen.spec.ts
+++ b/src/Containers/realModelOpen.spec.ts
@@ -1,4 +1,5 @@
 import {Page, expect, test} from '@playwright/test'
+import {describeMobileAndDesktop} from '../tests/e2e/formFactor'
 import {
   homepageSetup,
   setIsReturningUser,
@@ -41,7 +42,7 @@ async function realModelOpenEvents(page: Page): Promise<{name: string, contentId
  * conversion bidding — hence the guarded, separately-named event
  * (CadView#loadModel + analytics#isRealModelOpen).
  */
-test.describe('real_model_open GA event', () => {
+describeMobileAndDesktop('real_model_open GA event', () => {
   test.beforeEach(async ({page}) => {
     await homepageSetup(page)
     await setIsReturningUser(page.context())

--- a/src/Containers/realModelOpen.spec.ts
+++ b/src/Containers/realModelOpen.spec.ts
@@ -1,0 +1,69 @@
+import {Page, expect, test} from '@playwright/test'
+import {
+  homepageSetup,
+  setIsReturningUser,
+  visitHomepageWaitForModel,
+} from '../tests/e2e/utils'
+import {setupVirtualPathIntercept, waitForModelReady} from '../tests/e2e/models'
+
+
+// Any remote-sourced model qualifies as a "real" open; this one rides the
+// bldrs-ai/test-models fixture path that the dev server serves natively.
+const REAL_MODEL = '/share/v/gh/bldrs-ai/test-models/main/ifc/misc/box.ifc'
+
+
+/**
+ * Collect `real_model_open` gtag events from the page's dataLayer.
+ *
+ * index.html declares `gtag(){dataLayer.push(arguments)}` inline, so
+ * even with the googletagmanager script blocked in tests every
+ * `gtagEvent` call lands in `window.dataLayer` — no stub needed.
+ * Entries are `arguments` objects; map to plain serializable data
+ * before they cross the evaluate boundary.
+ *
+ * @param page Playwright page object
+ * @return Array of {name, contentId} for each real_model_open event
+ */
+async function realModelOpenEvents(page: Page): Promise<{name: string, contentId: string}[]> {
+  return await page.evaluate(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const dataLayer: any[] = (window as any).dataLayer || []
+    return dataLayer
+      .filter((entry) => entry?.[0] === 'event' && entry?.[1] === 'real_model_open')
+      .map((entry) => ({name: String(entry[1]), contentId: String(entry[2]?.content_id ?? '')}))
+  })
+}
+
+
+/**
+ * The homepage auto-loads the bundled demo model, and counting that as a
+ * model open once polluted the metric this event feeds into Google Ads
+ * conversion bidding — hence the guarded, separately-named event
+ * (CadView#loadModel + analytics#isRealModelOpen).
+ */
+test.describe('real_model_open GA event', () => {
+  test.beforeEach(async ({page}) => {
+    await homepageSetup(page)
+    await setIsReturningUser(page.context())
+  })
+
+  test('does not fire for the homepage demo model', async ({page}) => {
+    await visitHomepageWaitForModel(page)
+    // Guard against a vacuous pass: the inline gtag bootstrap must have
+    // run, or the absence below would only prove gtag was missing.
+    const hasGtag = await page.evaluate(() =>
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      typeof (window as any).gtag === 'function' && Array.isArray((window as any).dataLayer))
+    expect(hasGtag).toBe(true)
+    expect(await realModelOpenEvents(page)).toHaveLength(0)
+  })
+
+  test('fires once for a GitHub-hosted model open', async ({page}) => {
+    await setupVirtualPathIntercept(page, REAL_MODEL, 'box.ifc')
+    await page.goto(REAL_MODEL, {waitUntil: 'domcontentloaded'})
+    await waitForModelReady(page)
+    const events = await realModelOpenEvents(page)
+    expect(events).toHaveLength(1)
+    expect(events[0].contentId).toContain('box.ifc')
+  })
+})

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -11,6 +11,7 @@ import Auth0BridgeRegistrar from './connections/Auth0BridgeRegistrar'
 import {flags} from './FeatureFlags'
 import './compat'
 import setupEsbuildWatch from './index/esbuild'
+import setupGa from './index/ga'
 import setupMSW from './index/msw'
 import setupSentry from './index/sentry'
 import './index.css'
@@ -21,6 +22,8 @@ import '@fontsource/roboto/latin-700.css'
 
 
 setupSentry()
+// After setupSentry: ga.js reports init failures via captureException.
+setupGa()
 setupMSW()
 setupEsbuildWatch()
 

--- a/src/index/ga.js
+++ b/src/index/ga.js
@@ -1,6 +1,9 @@
 import {captureException} from '@sentry/react'
 
 
+// Must match the ID in public/index.html's inline gtag('config') stub —
+// the stub routes buffered events to the property, this constant only
+// fetches the loader. A property migration has to update both.
 export const GA_MEASUREMENT_ID = 'G-GRLNVMZRGW'
 
 // Apex is canonical; www is included in case a client renders before

--- a/src/index/ga.js
+++ b/src/index/ga.js
@@ -1,0 +1,70 @@
+import {captureException} from '@sentry/react'
+
+
+export const GA_MEASUREMENT_ID = 'G-GRLNVMZRGW'
+
+// Apex is canonical; www is included in case a client renders before
+// any redirect settles. Everything else — localhost, *.netlify.app
+// previews/dev, GitHub Pages installs — must not feed prod analytics.
+const PROD_HOSTNAMES = ['bldrs.ai', 'www.bldrs.ai']
+
+
+/**
+ * True when this page should load Google Analytics: production host
+ * only, and never under automation (Playwright/Selenium/Puppeteer set
+ * navigator.webdriver). Off-prod and automated traffic polluted the
+ * metrics Google Ads bids on — see design/roadmap.md grow-120 and the
+ * matching event-level guard in privacy/analytics#isRealModelOpen.
+ *
+ * @param {object} [env] overrides for tests
+ * @param {string} [env.hostname]
+ * @param {boolean} [env.isWebdriver]
+ * @return {boolean}
+ */
+export function shouldInitGa({
+  hostname = window.location.hostname,
+  isWebdriver = navigator.webdriver === true,
+} = {}) {
+  return PROD_HOSTNAMES.includes(hostname) && !isWebdriver
+}
+
+
+/**
+ * Inject the gtag/js loader when shouldInitGa allows. index.html keeps
+ * the inline dataLayer/gtag stub unconditionally (gtagEvent calls
+ * buffer there, and the E2E suite asserts against that buffer on
+ * localhost), so off-prod the app behaves identically minus the
+ * network beacon.
+ *
+ * Any init failure is reported to Sentry tagged subsystem:ga_init so
+ * we can see when prod loses its Ads-conversion signal. The expected
+ * steady-state noise here is ad-blocker users failing the script load;
+ * keep the tag stable so a future sentry.js filter (or a GA-side
+ * blocked-client event, cf. netlify_rum_blocked) can key off it.
+ *
+ * @param {object} [env] overrides for tests, forwarded to shouldInitGa
+ */
+export default function setupGa(env = undefined) {
+  if (!shouldInitGa(env)) {
+    return
+  }
+  try {
+    // The stub is declared inline in index.html before the bundle
+    // loads; its absence means the bootstrap contract broke.
+    if (typeof window.gtag !== 'function' || !Array.isArray(window.dataLayer)) {
+      throw new Error('ga_init: gtag bootstrap missing — index.html inline stub did not run')
+    }
+    const script = document.createElement('script')
+    script.async = true
+    script.src = `https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`
+    script.onerror = () => {
+      captureException(
+        new Error('ga_init: gtag/js failed to load (blocked client or network failure)'),
+        {tags: {subsystem: 'ga_init'}},
+      )
+    }
+    document.head.appendChild(script)
+  } catch (err) {
+    captureException(err, {tags: {subsystem: 'ga_init'}})
+  }
+}

--- a/src/index/ga.test.js
+++ b/src/index/ga.test.js
@@ -1,0 +1,75 @@
+import {captureException} from '@sentry/react'
+import setupGa, {GA_MEASUREMENT_ID, shouldInitGa} from './ga'
+
+
+jest.mock('@sentry/react', () => ({captureException: jest.fn()}))
+
+
+/** @return {HTMLScriptElement|null} the injected gtag/js tag, if any */
+function findGtagScript() {
+  return document.head.querySelector(`script[src*="${GA_MEASUREMENT_ID}"]`)
+}
+
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  document.head.querySelectorAll('script').forEach((s) => s.remove())
+  // Mirror the inline bootstrap index.html declares before the bundle.
+  window.dataLayer = []
+  window.gtag = function gtag() {
+    window.dataLayer.push(arguments)
+  }
+})
+
+
+describe('shouldInitGa', () => {
+  test('true only on prod hosts', () => {
+    expect(shouldInitGa({hostname: 'bldrs.ai', isWebdriver: false})).toBe(true)
+    expect(shouldInitGa({hostname: 'www.bldrs.ai', isWebdriver: false})).toBe(true)
+    expect(shouldInitGa({hostname: 'localhost', isWebdriver: false})).toBe(false)
+    expect(shouldInitGa({hostname: 'bldrs-share-dev.netlify.app', isWebdriver: false})).toBe(false)
+    expect(shouldInitGa({hostname: 'deploy-preview-1741--bldrs-share-prod.netlify.app', isWebdriver: false})).toBe(false)
+    expect(shouldInitGa({hostname: 'bldrs-ai.github.io', isWebdriver: false})).toBe(false)
+  })
+
+  test('false under automation even on prod', () => {
+    expect(shouldInitGa({hostname: 'bldrs.ai', isWebdriver: true})).toBe(false)
+  })
+})
+
+
+describe('setupGa', () => {
+  test('does not inject the loader off-prod', () => {
+    setupGa({hostname: 'localhost', isWebdriver: false})
+    expect(findGtagScript()).toBeNull()
+    expect(captureException).not.toHaveBeenCalled()
+  })
+
+  test('injects the async gtag/js loader on prod', () => {
+    setupGa({hostname: 'bldrs.ai', isWebdriver: false})
+    const script = findGtagScript()
+    expect(script).not.toBeNull()
+    expect(script.async).toBe(true)
+    expect(script.src).toBe(`https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`)
+    expect(captureException).not.toHaveBeenCalled()
+  })
+
+  test('reports a load failure to Sentry, tagged ga_init', () => {
+    setupGa({hostname: 'bldrs.ai', isWebdriver: false})
+    findGtagScript().onerror()
+    expect(captureException).toHaveBeenCalledWith(
+      expect.objectContaining({message: expect.stringContaining('ga_init: gtag/js failed to load')}),
+      {tags: {subsystem: 'ga_init'}},
+    )
+  })
+
+  test('reports a missing inline bootstrap to Sentry without throwing', () => {
+    delete window.gtag
+    expect(() => setupGa({hostname: 'bldrs.ai', isWebdriver: false})).not.toThrow()
+    expect(findGtagScript()).toBeNull()
+    expect(captureException).toHaveBeenCalledWith(
+      expect.objectContaining({message: expect.stringContaining('ga_init: gtag bootstrap missing')}),
+      {tags: {subsystem: 'ga_init'}},
+    )
+  })
+})

--- a/src/privacy/analytics.js
+++ b/src/privacy/analytics.js
@@ -51,13 +51,15 @@ export function gtagEvent(eventName, parameters) {
  * and isUploadedFile comes back false — upload filepaths are
  * UUID-derived, never 'index.ifc'.
  *
- * Also false on Netlify deploy hosts (*.netlify.app): deploy previews,
- * branch deploys and the bldrs-share-dev site all serve the production
- * index.html with the prod GA tag baked in, so team review sessions on
- * a PR preview would otherwise register as conversions. Production is
- * bldrs.ai; localhost stays included because the Playwright E2E suite
- * (realModelOpen.spec.ts) asserts against dataLayer on localhost and
- * the googletagmanager script is blocked there anyway.
+ * Also false on Netlify deploy hosts (*.netlify.app), so team review
+ * sessions on a PR preview don't register as conversions. This is
+ * deliberate defense-in-depth behind index/ga.js#shouldInitGa, whose
+ * prod-hostname allowlist already keeps gtag/js from loading off-prod
+ * at all. The two predicates differ on purpose and can't be merged:
+ * localhost must stay *included* here because the Playwright E2E suite
+ * (realModelOpen.spec.ts) asserts this event lands in the dataLayer
+ * buffer on localhost, while shouldInitGa excludes localhost from
+ * loading GA entirely.
  *
  * @param {object} routeResult from routes.ts#handleRoute
  * @param {string} hostname current page host; parameterized for tests

--- a/src/privacy/analytics.js
+++ b/src/privacy/analytics.js
@@ -51,10 +51,22 @@ export function gtagEvent(eventName, parameters) {
  * and isUploadedFile comes back false — upload filepaths are
  * UUID-derived, never 'index.ifc'.
  *
+ * Also false on Netlify deploy hosts (*.netlify.app): deploy previews,
+ * branch deploys and the bldrs-share-dev site all serve the production
+ * index.html with the prod GA tag baked in, so team review sessions on
+ * a PR preview would otherwise register as conversions. Production is
+ * bldrs.ai; localhost stays included because the Playwright E2E suite
+ * (realModelOpen.spec.ts) asserts against dataLayer on localhost and
+ * the googletagmanager script is blocked there anyway.
+ *
  * @param {object} routeResult from routes.ts#handleRoute
+ * @param {string} hostname current page host; parameterized for tests
  * @return {boolean}
  */
-export function isRealModelOpen(routeResult) {
+export function isRealModelOpen(routeResult, hostname = window.location.hostname) {
+  if (hostname.endsWith('.netlify.app')) {
+    return false
+  }
   const isBundledDemo = routeResult?.kind === 'file' &&
     !routeResult.isUploadedFile &&
     routeResult.filepath === 'index.ifc'

--- a/src/privacy/analytics.js
+++ b/src/privacy/analytics.js
@@ -32,3 +32,31 @@ export function gtagEvent(eventName, parameters) {
     window.gtag('event', eventName, parameters)
   }
 }
+
+
+/**
+ * True for model loads worth counting as the `real_model_open` GA event:
+ * any remote source (GitHub, Google Drive, generic URL) or an uploaded
+ * file. False for the bundled demo model the homepage auto-loads
+ * (navToDefault → /share/v/p/index.ifc) — counting it would fire on
+ * every homepage visit. real_model_open is a GA4 key event imported
+ * into Google Ads as the search campaigns' conversion, so
+ * pageview-shaped noise here would poison bidding (bizdev
+ * ads-campaign-build §1, growth-strategy §3).
+ *
+ * Demo detection matches routes.ts#processFile output for hosted
+ * project files: {kind: 'file', isUploadedFile: false, filepath}. The
+ * filepath check covers uploads on GitHub Pages installs, where
+ * processFile's '/share/v/new' prefix test misses ('/Share/share/v/new')
+ * and isUploadedFile comes back false — upload filepaths are
+ * UUID-derived, never 'index.ifc'.
+ *
+ * @param {object} routeResult from routes.ts#handleRoute
+ * @return {boolean}
+ */
+export function isRealModelOpen(routeResult) {
+  const isBundledDemo = routeResult?.kind === 'file' &&
+    !routeResult.isUploadedFile &&
+    routeResult.filepath === 'index.ifc'
+  return !isBundledDemo
+}

--- a/src/privacy/analytics.test.js
+++ b/src/privacy/analytics.test.js
@@ -69,5 +69,30 @@ describe('Analytics', () => {
       expect(Analytics.isRealModelOpen({kind: 'provider', provider: 'google', fileId: 'abc123'})).toBe(true)
       expect(Analytics.isRealModelOpen({kind: 'url'})).toBe(true)
     })
+
+    // All *.netlify.app hosts (deploy previews, branch deploys, the dev
+    // site) serve the prod GA tag — opens there are team/CI traffic,
+    // not conversions.
+    test('false on Netlify deploy hosts, even for real sources', () => {
+      const githubOpen = {
+        kind: 'provider',
+        provider: 'github',
+        gitpath: 'https://github.com/bldrs-ai/test-models/blob/main/ifc/misc/box.ifc',
+      }
+      expect(Analytics.isRealModelOpen(githubOpen, 'deploy-preview-1741--bldrs-share-prod.netlify.app')).toBe(false)
+      expect(Analytics.isRealModelOpen(githubOpen, 'bldrs-share-dev.netlify.app')).toBe(false)
+    })
+
+    test('true on production and localhost hosts for real sources', () => {
+      const githubOpen = {
+        kind: 'provider',
+        provider: 'github',
+        gitpath: 'https://github.com/bldrs-ai/test-models/blob/main/ifc/misc/box.ifc',
+      }
+      expect(Analytics.isRealModelOpen(githubOpen, 'bldrs.ai')).toBe(true)
+      // localhost must stay true: realModelOpen.spec.ts asserts the
+      // event fires in the E2E harness, which serves on localhost.
+      expect(Analytics.isRealModelOpen(githubOpen, 'localhost')).toBe(true)
+    })
   })
 })

--- a/src/privacy/analytics.test.js
+++ b/src/privacy/analytics.test.js
@@ -14,4 +14,60 @@ describe('Analytics', () => {
     Analytics.setIsAllowed(true)
     expect(Analytics.isAllowed()).toBe(true)
   })
+
+
+  // Route-result shapes mirror routes.ts#handleRoute output. The one
+  // excluded shape is the homepage's bundled demo — everything else is
+  // a real open.
+  describe('isRealModelOpen', () => {
+    test('false for the bundled homepage demo (/share/v/p/index.ifc)', () => {
+      expect(Analytics.isRealModelOpen({
+        kind: 'file',
+        isUploadedFile: false,
+        filepath: 'index.ifc',
+      })).toBe(false)
+    })
+
+    test('false for a demo permalink with an element subpath', () => {
+      // processFile strips the eltPath, so the demo shape is identical.
+      expect(Analytics.isRealModelOpen({
+        kind: 'file',
+        isUploadedFile: false,
+        filepath: 'index.ifc',
+        eltPath: '/81/621',
+      })).toBe(false)
+    })
+
+    test('true for an uploaded file', () => {
+      expect(Analytics.isRealModelOpen({
+        kind: 'file',
+        isUploadedFile: true,
+        filepath: '6f5a9c22-0330-4f4a-a2f0-d295c07d9a3c.ifc',
+      })).toBe(true)
+    })
+
+    test('true for an upload even when isUploadedFile is misdetected', () => {
+      // GitHub Pages installs prefix routes with /Share, defeating
+      // processFile's '/share/v/new' test — the UUID filepath still
+      // distinguishes the upload from the demo.
+      expect(Analytics.isRealModelOpen({
+        kind: 'file',
+        isUploadedFile: false,
+        filepath: '6f5a9c22-0330-4f4a-a2f0-d295c07d9a3c.ifc',
+      })).toBe(true)
+    })
+
+    test('true for GitHub-hosted models', () => {
+      expect(Analytics.isRealModelOpen({
+        kind: 'provider',
+        provider: 'github',
+        gitpath: 'https://github.com/bldrs-ai/test-models/blob/main/ifc/misc/box.ifc',
+      })).toBe(true)
+    })
+
+    test('true for Google Drive and generic URL sources', () => {
+      expect(Analytics.isRealModelOpen({kind: 'provider', provider: 'google', fileId: 'abc123'})).toBe(true)
+      expect(Analytics.isRealModelOpen({kind: 'url'})).toBe(true)
+    })
+  })
 })


### PR DESCRIPTION
Cleans Google Ads' conversion signal two ways: a new `real_model_open` GA4 event that fires only for genuine model opens, and a prod-only gate on GA initialization itself so preview/dev/CI traffic never reaches prod analytics at all.

## Changes

### `real_model_open` event (replaces `select_content`)

- **`src/privacy/analytics.js`**: Added `isRealModelOpen(routeResult, hostname)` — returns `false` for the bundled demo the homepage auto-loads (`/share/v/p/index.ifc`) and for any `*.netlify.app` host (deploy previews, branch deploys, dev site), `true` for genuine opens (uploads, GitHub, Google Drive, generic URLs). Docs cover the GitHub Pages prefix-routing edge case and why the netlify blocklist stays as defense-in-depth behind the GA init gate.

- **`src/Containers/CadView.jsx`**: `loadedModel` callback fires `real_model_open` only when `isRealModelOpen(routeResult)` is true, replacing the unconditional `select_content`. Event parameters unchanged (content_type, content_id, load stats).

- **`src/privacy/analytics.test.js`**: Unit suite covering demo detection (± element subpath), uploads (including misdetected `isUploadedFile` on GitHub Pages), GitHub/Drive/URL sources, netlify-host exclusion, and prod/localhost inclusion.

- **`src/Containers/realModelOpen.spec.ts`**: E2E suite via `describeMobileAndDesktop` (desktop + mobile): demo does not fire on homepage load; GitHub-hosted model fires exactly once with the right content_id; includes a gtag-bootstrap assertion to guard against vacuous passes.

### GA only initializes in prod (`grow-120` hygiene slice)

- **`src/index/ga.js`** (new): `setupGa` injects the external `gtag/js` loader only when the hostname is `bldrs.ai`/`www.bldrs.ai` and `navigator.webdriver` is false. Any init failure — missing bootstrap stub or failed script load — is reported to Sentry tagged `subsystem:ga_init`, so we notice if prod loses its conversion signal. Ad-blocked clients will surface in that stream; the stable tag is the hook for filtering them later (cf. the `netlify_rum_blocked` pattern in `index/sentry.js`).

- **`public/index.html`**: The static `googletagmanager.com/gtag/js` script tag is removed; the inline `dataLayer`/`gtag` stub stays unconditionally so `gtagEvent` calls buffer everywhere (the E2E suite asserts against that buffer on localhost). Off-prod the buffer is simply never consumed.

- **`src/index.jsx`**: Calls `setupGa()` after `setupSentry()` so init failures are capturable.

- **`src/index/ga.test.js`** (new): Covers the host allowlist, the webdriver gate, loader injection on prod, and Sentry reporting for both failure modes.

- **`design/roadmap.md`, `design/new/ads.md`**: `grow-120` updated (event guard + hygiene slice ✅); ads.md's "loads unconditionally, same as gtag" consent note corrected.

## Implementation notes

The `isRealModelOpen` guard is applied at the point of event firing (CadView#loadModel), keeping analytics logic co-located in the privacy module. Demo detection matches the exact shape `routes.ts#processFile` produces, with a UUID-filepath check for GitHub Pages deployments where `isUploadedFile` detection can fail. Both `isRealModelOpen` and `shouldInitGa` take injectable host/webdriver parameters so unit tests exercise both sides without stubbing globals. The two host predicates are deliberately separate: localhost must stay *countable* (E2E asserts events land in the dataLayer buffer) while being excluded from *loading* GA.

https://claude.ai/code/session_01EULm3yasgtCeQr8cDZaKri