### PR TITLE
Send GA client id as open_cid on real_model_open

### DIFF
--- a/design/roadmap.md
+++ b/design/roadmap.md
@@ -710,16 +710,21 @@ which channel *reaches* that audience is the open GTM question owned bizdev-side
   gets noisy.
 - Per-user open depth (decided 2026-08-08): the GA4 Data API has no user-id
   dimension, so "X users opened Y models" can't be derived — only the
-  eventCount ÷ totalUsers average. Share now sends GA4's client id as a
-  `ga_cid` param on `real_model_open` (✅ `index/ga.js` requests it via
-  `gtag('get', …, 'client_id', …)`, `analytics#getGaClientId` holds it,
-  CadView attaches it when present). **Remaining GA4-side config:** Admin →
-  Custom definitions → new event-scoped dimension `ga_cid` from event
-  parameter `ga_cid`; then query `customEvent:ga_cid × eventCount` and bucket
-  client-side (1 / 2 / 3–5 / 6+ opens, fixtures excluded). No backfill — the
-  dimension accrues from ship time, so land it early in a campaign window for
-  a clean baseline. At larger scale GA4 rolls high-cardinality values into
-  "(other)"; that's the cue to move the query to the BigQuery export.
+  eventCount ÷ totalUsers average. Share now sends GA4's client id as an
+  `open_cid` param on `real_model_open` (✅ `index/ga.js` requests it via
+  `gtag('get', …, 'client_id', …)`, `analytics#getGaClientId` holds it and
+  falls back to the `_ga` cookie for events that fire before that async
+  callback lands, CadView attaches it when present). **Not `ga_cid`** as
+  originally specced: GA4 reserves the `ga_`/`google_`/`firebase_`/`gtag.`
+  prefixes and silently disables matching params, so that name would have
+  ingested as nothing and left the dimension permanently empty.
+  **Remaining GA4-side config:** Admin → Custom definitions → new
+  event-scoped dimension `open_cid` from event parameter `open_cid`; then
+  query `customEvent:open_cid × eventCount` and bucket client-side
+  (1 / 2 / 3–5 / 6+ opens, fixtures excluded). No backfill — the dimension
+  accrues from ship time, so land it early in a campaign window for a clean
+  baseline. At larger scale GA4 rolls high-cardinality values into "(other)";
+  that's the cue to move the query to the BigQuery export.
 - Channel-grouping + dashboard slices are bizdev-side config; the Share-side
   deliverable is the events existing and firing.
 - v0.4 addition: capture **model size/complexity** (bucketed — bytes, element

--- a/design/roadmap.md
+++ b/design/roadmap.md
@@ -708,6 +708,18 @@ which channel *reaches* that audience is the open GTM question owned bizdev-side
   go to Sentry tagged `subsystem:ga_init`; ad-blocked clients will dominate
   that stream — add a sentry.js filter (cf. `netlify_rum_blocked`) when it
   gets noisy.
+- Per-user open depth (decided 2026-08-08): the GA4 Data API has no user-id
+  dimension, so "X users opened Y models" can't be derived — only the
+  eventCount ÷ totalUsers average. Share now sends GA4's client id as a
+  `ga_cid` param on `real_model_open` (✅ `index/ga.js` requests it via
+  `gtag('get', …, 'client_id', …)`, `analytics#getGaClientId` holds it,
+  CadView attaches it when present). **Remaining GA4-side config:** Admin →
+  Custom definitions → new event-scoped dimension `ga_cid` from event
+  parameter `ga_cid`; then query `customEvent:ga_cid × eventCount` and bucket
+  client-side (1 / 2 / 3–5 / 6+ opens, fixtures excluded). No backfill — the
+  dimension accrues from ship time, so land it early in a campaign window for
+  a clean baseline. At larger scale GA4 rolls high-cardinality values into
+  "(other)"; that's the cue to move the query to the BigQuery export.
 - Channel-grouping + dashboard slices are bizdev-side config; the Share-side
   deliverable is the events existing and firing.
 - v0.4 addition: capture **model size/complexity** (bucketed — bytes, element

--- a/src/Containers/CadView.jsx
+++ b/src/Containers/CadView.jsx
@@ -7,7 +7,7 @@ import {captureException} from '@sentry/react'
 import {fileSuffixBoundaryRegex} from '../Filetype'
 import {useAuth0} from '../Auth0/Auth0Proxy'
 import {onHash} from '../Components/Camera/CameraControl'
-import {gtagEvent, isRealModelOpen} from '../privacy/analytics'
+import {getGaClientId, gtagEvent, isRealModelOpen} from '../privacy/analytics'
 import {getRenderMode} from '../privacy/preferences'
 import {resetState as resetCutPlaneState} from '../Components/CutPlane/CutPlaneMenu'
 import {useIsMobile} from '../Components/Hooks'
@@ -570,6 +570,13 @@ export default function CadView({
       // TODO(pablo): currently only IFC/STEP are populated with stats.
       if (loadedModel.loadStats) {
         addProperties(eventParams, loadedModel.loadStats, 'stats_')
+      }
+      // Per-user open depth: GA4 has no user-id dimension, so the
+      // client id rides along as an event-scoped custom dimension.
+      // Absent whenever GA didn't initialize — see analytics#gaClientId.
+      const gaCid = getGaClientId()
+      if (gaCid) {
+        eventParams.ga_cid = gaCid
       }
       gtagEvent('real_model_open', eventParams)
     }

--- a/src/Containers/CadView.jsx
+++ b/src/Containers/CadView.jsx
@@ -7,7 +7,7 @@ import {captureException} from '@sentry/react'
 import {fileSuffixBoundaryRegex} from '../Filetype'
 import {useAuth0} from '../Auth0/Auth0Proxy'
 import {onHash} from '../Components/Camera/CameraControl'
-import {getGaClientId, gtagEvent, isRealModelOpen} from '../privacy/analytics'
+import {OPEN_CID_PARAM, getGaClientId, gtagEvent, isRealModelOpen} from '../privacy/analytics'
 import {getRenderMode} from '../privacy/preferences'
 import {resetState as resetCutPlaneState} from '../Components/CutPlane/CutPlaneMenu'
 import {useIsMobile} from '../Components/Hooks'
@@ -574,9 +574,9 @@ export default function CadView({
       // Per-user open depth: GA4 has no user-id dimension, so the
       // client id rides along as an event-scoped custom dimension.
       // Absent whenever GA didn't initialize — see analytics#gaClientId.
-      const gaCid = getGaClientId()
-      if (gaCid) {
-        eventParams.ga_cid = gaCid
+      const openCid = getGaClientId()
+      if (openCid) {
+        eventParams[OPEN_CID_PARAM] = openCid
       }
       gtagEvent('real_model_open', eventParams)
     }

--- a/src/Containers/realModelOpen.spec.ts
+++ b/src/Containers/realModelOpen.spec.ts
@@ -23,9 +23,9 @@ const REAL_MODEL = '/share/v/gh/bldrs-ai/test-models/main/ifc/misc/box.ifc'
  * before they cross the evaluate boundary.
  *
  * @param page Playwright page object
- * @return Array of {name, contentId, hasGaCid} for each real_model_open event
+ * @return Array of {name, contentId, hasOpenCid} for each real_model_open event
  */
-async function realModelOpenEvents(page: Page): Promise<{name: string, contentId: string, hasGaCid: boolean}[]> {
+async function realModelOpenEvents(page: Page): Promise<{name: string, contentId: string, hasOpenCid: boolean}[]> {
   return await page.evaluate(() => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const dataLayer: any[] = (window as any).dataLayer || []
@@ -34,7 +34,7 @@ async function realModelOpenEvents(page: Page): Promise<{name: string, contentId
       .map((entry) => ({
         name: String(entry[1]),
         contentId: String(entry[2]?.content_id ?? ''),
-        hasGaCid: entry[2]?.ga_cid !== undefined,
+        hasOpenCid: entry[2]?.open_cid !== undefined,
       }))
   })
 }
@@ -70,10 +70,11 @@ describeMobileAndDesktop('real_model_open GA event', () => {
     const events = await realModelOpenEvents(page)
     expect(events).toHaveLength(1)
     expect(events[0].contentId).toContain('box.ifc')
-    // ga_cid comes from gtag's client_id callback, which only resolves
-    // once gtag/js loads — never here, since index/ga.js skips the
-    // loader off-prod and under automation. The param must be absent
-    // rather than empty, so it can't form its own bucket in GA4.
-    expect(events[0].hasGaCid).toBe(false)
+    // open_cid comes from gtag's client_id callback or the _ga cookie,
+    // neither of which exists here: index/ga.js skips the loader
+    // off-prod and under automation, so nothing ever writes them. The
+    // param must be absent rather than empty, so it can't form its own
+    // bucket in GA4.
+    expect(events[0].hasOpenCid).toBe(false)
   })
 })

--- a/src/Containers/realModelOpen.spec.ts
+++ b/src/Containers/realModelOpen.spec.ts
@@ -23,15 +23,19 @@ const REAL_MODEL = '/share/v/gh/bldrs-ai/test-models/main/ifc/misc/box.ifc'
  * before they cross the evaluate boundary.
  *
  * @param page Playwright page object
- * @return Array of {name, contentId} for each real_model_open event
+ * @return Array of {name, contentId, hasGaCid} for each real_model_open event
  */
-async function realModelOpenEvents(page: Page): Promise<{name: string, contentId: string}[]> {
+async function realModelOpenEvents(page: Page): Promise<{name: string, contentId: string, hasGaCid: boolean}[]> {
   return await page.evaluate(() => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const dataLayer: any[] = (window as any).dataLayer || []
     return dataLayer
       .filter((entry) => entry?.[0] === 'event' && entry?.[1] === 'real_model_open')
-      .map((entry) => ({name: String(entry[1]), contentId: String(entry[2]?.content_id ?? '')}))
+      .map((entry) => ({
+        name: String(entry[1]),
+        contentId: String(entry[2]?.content_id ?? ''),
+        hasGaCid: entry[2]?.ga_cid !== undefined,
+      }))
   })
 }
 
@@ -66,5 +70,10 @@ describeMobileAndDesktop('real_model_open GA event', () => {
     const events = await realModelOpenEvents(page)
     expect(events).toHaveLength(1)
     expect(events[0].contentId).toContain('box.ifc')
+    // ga_cid comes from gtag's client_id callback, which only resolves
+    // once gtag/js loads — never here, since index/ga.js skips the
+    // loader off-prod and under automation. The param must be absent
+    // rather than empty, so it can't form its own bucket in GA4.
+    expect(events[0].hasGaCid).toBe(false)
   })
 })

--- a/src/index/ga.js
+++ b/src/index/ga.js
@@ -1,4 +1,5 @@
 import {captureException} from '@sentry/react'
+import {setGaClientId} from '../privacy/analytics'
 
 
 // Must match the ID in public/index.html's inline gtag('config') stub —
@@ -67,6 +68,12 @@ export default function setupGa(env = undefined) {
       )
     }
     document.head.appendChild(script)
+    // Ask GA for this browser's client id so model-open events can
+    // carry it as ga_cid (see privacy/analytics#setGaClientId for why).
+    // The call buffers in dataLayer like any other gtag call and the
+    // callback fires once gtag/js has loaded and resolved the id — so
+    // it never fires on a blocked client, and events just omit ga_cid.
+    window.gtag('get', GA_MEASUREMENT_ID, 'client_id', setGaClientId)
   } catch (err) {
     captureException(err, {tags: {subsystem: 'ga_init'}})
   }

--- a/src/index/ga.js
+++ b/src/index/ga.js
@@ -69,10 +69,11 @@ export default function setupGa(env = undefined) {
     }
     document.head.appendChild(script)
     // Ask GA for this browser's client id so model-open events can
-    // carry it as ga_cid (see privacy/analytics#setGaClientId for why).
-    // The call buffers in dataLayer like any other gtag call and the
-    // callback fires once gtag/js has loaded and resolved the id — so
-    // it never fires on a blocked client, and events just omit ga_cid.
+    // carry it as open_cid (see privacy/analytics#setGaClientId for
+    // why). The call buffers in dataLayer like any other gtag call and
+    // the callback fires once gtag/js has loaded and resolved the id —
+    // so it never fires on a blocked client. Events fired before it
+    // lands fall back to the _ga cookie in analytics#getGaClientId.
     window.gtag('get', GA_MEASUREMENT_ID, 'client_id', setGaClientId)
   } catch (err) {
     captureException(err, {tags: {subsystem: 'ga_init'}})

--- a/src/index/ga.test.js
+++ b/src/index/ga.test.js
@@ -1,5 +1,6 @@
+import Cookies from 'js-cookie'
 import {captureException} from '@sentry/react'
-import {getGaClientId} from '../privacy/analytics'
+import {_resetGaClientIdForTests, getGaClientId} from '../privacy/analytics'
 import setupGa, {GA_MEASUREMENT_ID, shouldInitGa} from './ga'
 
 
@@ -14,6 +15,10 @@ function findGtagScript() {
 
 beforeEach(() => {
   jest.clearAllMocks()
+  _resetGaClientIdForTests()
+  // getGaClientId falls back to this cookie; clear it so the assertions
+  // below see only what setupGa's callback provides.
+  Cookies.remove('_ga')
   document.head.querySelectorAll('script').forEach((s) => s.remove())
   // Mirror the inline bootstrap index.html declares before the bundle.
   window.dataLayer = []

--- a/src/index/ga.test.js
+++ b/src/index/ga.test.js
@@ -1,4 +1,5 @@
 import {captureException} from '@sentry/react'
+import {getGaClientId} from '../privacy/analytics'
 import setupGa, {GA_MEASUREMENT_ID, shouldInitGa} from './ga'
 
 
@@ -61,6 +62,24 @@ describe('setupGa', () => {
       expect.objectContaining({message: expect.stringContaining('ga_init: gtag/js failed to load')}),
       {tags: {subsystem: 'ga_init'}},
     )
+  })
+
+  // GA4 has no user-id dimension, so the client id ships as an event
+  // param; the callback only resolves once gtag/js actually loads.
+  test('requests the GA client id and records it for model-open events', () => {
+    setupGa({hostname: 'bldrs.ai', isWebdriver: false})
+    const getCall = window.dataLayer.find((entry) => entry?.[0] === 'get')
+    expect(getCall).toBeDefined()
+    expect(getCall[1]).toBe(GA_MEASUREMENT_ID)
+    expect(getCall[2]).toBe('client_id')
+    expect(getGaClientId()).toBeNull()
+    getCall[3]('1234567890.0987654321')
+    expect(getGaClientId()).toBe('1234567890.0987654321')
+  })
+
+  test('does not request a client id off-prod', () => {
+    setupGa({hostname: 'localhost', isWebdriver: false})
+    expect(window.dataLayer.find((entry) => entry?.[0] === 'get')).toBeUndefined()
   })
 
   test('reports a missing inline bootstrap to Sentry without throwing', () => {

--- a/src/privacy/analytics.js
+++ b/src/privacy/analytics.js
@@ -40,15 +40,14 @@ export function gtagEvent(eventName, parameters) {
  * The GA4 Data API exposes no user-id dimension, so per-user open
  * depth ("how many people opened exactly one model vs six or more")
  * can't be derived — only the eventCount ÷ totalUsers average. Sending
- * the client id as a `ga_cid` event param, with a matching
- * event-scoped custom dimension registered GA4-side (Admin → Custom
- * definitions → event parameter `ga_cid`), makes the distribution
- * queryable: customEvent:ga_cid × eventCount, bucketed client-side.
+ * the client id as the OPEN_CID_PARAM event param, with a matching
+ * event-scoped custom dimension registered GA4-side, makes the
+ * distribution queryable: customEvent:open_cid × eventCount, bucketed
+ * client-side.
  *
- * Null until gtag's async callback lands, and permanently null
- * wherever GA never initializes — off-prod, under automation, or on
- * blocked clients — so events simply omit the param there rather than
- * carrying a placeholder that would form its own bogus bucket. No
+ * Null wherever GA never initializes — off-prod, under automation, or
+ * on blocked clients — so events simply omit the param there rather
+ * than carrying a placeholder that would form its own bogus bucket. No
  * backfill: the dimension only accrues data from ship time forward.
  *
  * At much larger scale GA4 rolls high-cardinality dimension values
@@ -56,6 +55,22 @@ export function gtagEvent(eventName, parameters) {
  * BigQuery export.
  */
 let gaClientId = null
+
+
+/*
+ * NOT `ga_cid`: GA4 reserves the `ga_`, `google_`, `firebase_` and
+ * `gtag.` prefixes (plus a leading underscore) for event and parameter
+ * names, and silently disables anything that matches — the param would
+ * be dropped at ingestion with no error, leaving the custom dimension
+ * permanently empty.
+ */
+export const OPEN_CID_PARAM = 'open_cid'
+
+
+// Cookie GA writes the client id into, as `GA<version>.<domain depth>.<id>`
+// where the id itself contains a dot (GA1.1.1234567890.0987654321).
+const GA_COOKIE_NAME = '_ga'
+const GA_COOKIE_ID_OFFSET = 2
 
 
 /**
@@ -72,9 +87,42 @@ export function setGaClientId(cid) {
 }
 
 
-/** @return {string|null} GA4 client id, or null if unavailable */
+/**
+ * The client id from gtag's async `get` callback, falling back to the
+ * `_ga` cookie gtag/js writes synchronously on config.
+ *
+ * The fallback matters more than it looks: the callback only resolves
+ * after gtag/js loads, and any event fired before then still reaches
+ * GA4 (gtagEvent buffers into dataLayer, which gtag/js drains on load)
+ * — just without the param. That window sits at session start, so the
+ * losses would concentrate on each visitor's *first* open, which is
+ * exactly the "1 open" cohort this instrumentation exists to size.
+ *
+ * @return {string|null} GA4 client id, or null if unavailable
+ */
 export function getGaClientId() {
-  return gaClientId
+  return gaClientId ?? gaClientIdFromCookie()
+}
+
+
+/** @return {string|null} client id parsed from the `_ga` cookie */
+function gaClientIdFromCookie() {
+  const raw = Cookies.get(GA_COOKIE_NAME)
+  if (!raw) {
+    return null
+  }
+  const parts = raw.split('.')
+  if (parts.length <= GA_COOKIE_ID_OFFSET) {
+    return null
+  }
+  const cid = parts.slice(GA_COOKIE_ID_OFFSET).join('.')
+  return cid.length > 0 ? cid : null
+}
+
+
+/** Test-only reset for the captured client id. */
+export function _resetGaClientIdForTests() {
+  gaClientId = null
 }
 
 

--- a/src/privacy/analytics.js
+++ b/src/privacy/analytics.js
@@ -34,6 +34,50 @@ export function gtagEvent(eventName, parameters) {
 }
 
 
+/*
+ * GA4's client id, captured at init by index/ga.js.
+ *
+ * The GA4 Data API exposes no user-id dimension, so per-user open
+ * depth ("how many people opened exactly one model vs six or more")
+ * can't be derived — only the eventCount ÷ totalUsers average. Sending
+ * the client id as a `ga_cid` event param, with a matching
+ * event-scoped custom dimension registered GA4-side (Admin → Custom
+ * definitions → event parameter `ga_cid`), makes the distribution
+ * queryable: customEvent:ga_cid × eventCount, bucketed client-side.
+ *
+ * Null until gtag's async callback lands, and permanently null
+ * wherever GA never initializes — off-prod, under automation, or on
+ * blocked clients — so events simply omit the param there rather than
+ * carrying a placeholder that would form its own bogus bucket. No
+ * backfill: the dimension only accrues data from ship time forward.
+ *
+ * At much larger scale GA4 rolls high-cardinality dimension values
+ * into "(other)"; that's the signal to graduate this query to the
+ * BigQuery export.
+ */
+let gaClientId = null
+
+
+/**
+ * Record the GA4 client id. Ignores anything but a non-empty string —
+ * gtag's `get` callback yields undefined when the property isn't
+ * loaded yet, and a falsy id is worse than none.
+ *
+ * @param {string} cid
+ */
+export function setGaClientId(cid) {
+  if (typeof cid === 'string' && cid.length > 0) {
+    gaClientId = cid
+  }
+}
+
+
+/** @return {string|null} GA4 client id, or null if unavailable */
+export function getGaClientId() {
+  return gaClientId
+}
+
+
 /**
  * True for model loads worth counting as the `real_model_open` GA event:
  * any remote source (GitHub, Google Drive, generic URL) or an uploaded

--- a/src/privacy/analytics.test.js
+++ b/src/privacy/analytics.test.js
@@ -16,6 +16,28 @@ describe('Analytics', () => {
   })
 
 
+  // ga_cid carries GA4's client id on model-open events so per-user
+  // open depth is queryable; see the module doc for why the param is
+  // simply absent when GA never initialized.
+  describe('GA client id', () => {
+    test('null until set', () => {
+      expect(Analytics.getGaClientId()).toBeNull()
+    })
+
+    test('records a non-empty string id', () => {
+      Analytics.setGaClientId('1234567890.0987654321')
+      expect(Analytics.getGaClientId()).toBe('1234567890.0987654321')
+    })
+
+    test('ignores the empty/undefined ids gtag yields before the property loads', () => {
+      Analytics.setGaClientId('1234567890.0987654321')
+      Analytics.setGaClientId(undefined)
+      Analytics.setGaClientId('')
+      expect(Analytics.getGaClientId()).toBe('1234567890.0987654321')
+    })
+  })
+
+
   // Route-result shapes mirror routes.ts#handleRoute output. The one
   // excluded shape is the homepage's bundled demo — everything else is
   // a real open.

--- a/src/privacy/analytics.test.js
+++ b/src/privacy/analytics.test.js
@@ -1,3 +1,4 @@
+import Cookies from 'js-cookie'
 import * as Analytics from './analytics'
 
 
@@ -16,11 +17,16 @@ describe('Analytics', () => {
   })
 
 
-  // ga_cid carries GA4's client id on model-open events so per-user
+  // open_cid carries GA4's client id on model-open events so per-user
   // open depth is queryable; see the module doc for why the param is
   // simply absent when GA never initialized.
   describe('GA client id', () => {
-    test('null until set', () => {
+    beforeEach(() => {
+      Analytics._resetGaClientIdForTests()
+      Cookies.remove('_ga')
+    })
+
+    test('null when neither the gtag callback nor the cookie has an id', () => {
       expect(Analytics.getGaClientId()).toBeNull()
     })
 
@@ -34,6 +40,31 @@ describe('Analytics', () => {
       Analytics.setGaClientId(undefined)
       Analytics.setGaClientId('')
       expect(Analytics.getGaClientId()).toBe('1234567890.0987654321')
+    })
+
+    // Events fired before gtag's async callback resolves still reach
+    // GA4; without this fallback they'd lose the param exactly on a
+    // visitor's first open.
+    test('falls back to the _ga cookie, whose id keeps its embedded dot', () => {
+      Cookies.set('_ga', 'GA1.1.1234567890.0987654321')
+      expect(Analytics.getGaClientId()).toBe('1234567890.0987654321')
+    })
+
+    test('prefers the gtag callback id over the cookie', () => {
+      Cookies.set('_ga', 'GA1.1.1111111111.2222222222')
+      Analytics.setGaClientId('3333333333.4444444444')
+      expect(Analytics.getGaClientId()).toBe('3333333333.4444444444')
+    })
+
+    test('null for a malformed cookie rather than a junk id', () => {
+      Cookies.set('_ga', 'GA1.1')
+      expect(Analytics.getGaClientId()).toBeNull()
+    })
+
+    // GA4 reserves the ga_ prefix and silently drops matching params.
+    test('param name avoids GA4 reserved prefixes', () => {
+      expect(Analytics.OPEN_CID_PARAM).toBe('open_cid')
+      expect(Analytics.OPEN_CID_PARAM).not.toMatch(/^(_|ga_|google_|firebase_|gtag\.)/)
     })
   })
 


### PR DESCRIPTION
Makes per-user open depth queryable. GA4's Data API exposes no user-id dimension, so "how many people opened exactly one model vs six or more" can't be derived — only the `eventCount ÷ totalUsers` average. This ships GA4's client id as an `open_cid` param on `real_model_open`, which pairs with an event-scoped custom dimension registered GA4-side to make the distribution queryable.

Follow-up to #1741.

## Changes

- **`src/index/ga.js`**: after injecting the gtag loader, request the client id via `gtag('get', GA_MEASUREMENT_ID, 'client_id', setGaClientId)`. This sits inside the existing prod-only gate, so the request only happens where GA actually initializes.

- **`src/privacy/analytics.js`**: `setGaClientId` / `getGaClientId` hold the id, with `OPEN_CID_PARAM` as its single name definition. `getGaClientId` falls back to the `_ga` cookie (see below). The setter ignores non-string and empty values — that's what gtag's callback yields before the property loads.

- **`src/Containers/CadView.jsx`**: attaches `open_cid` to the `real_model_open` params when an id is present.

- **`src/privacy/analytics.test.js`, `src/index/ga.test.js`**: unit coverage for the getter/setter contract, cookie fallback and precedence, malformed-cookie handling, the reserved-prefix constraint, the `get` request shape and callback wiring, and that no client id is requested off-prod.

- **`src/Containers/realModelOpen.spec.ts`**: E2E asserts `open_cid` is *absent* on localhost, which doubles as a live check that the prod-only GA gate still holds.

- **`design/roadmap.md`**: `grow-120` records the decision, the remaining GA4-side config, and the caveats.

## Two corrections to the original spec

**The param is `open_cid`, not `ga_cid`.** GA4 reserves the `ga_`, `google_`, `firebase_` and `gtag.` prefixes (plus a leading underscore) for event and parameter names, and silently disables anything matching. `ga_cid` would have been dropped at ingestion with no error, leaving the registered custom dimension permanently empty — the failure mode would only surface as "the dashboard query returns nothing" days later. **The GA4 Admin dimension must therefore be created as `open_cid`.**

**It attaches to `real_model_open`, not `select_content`** — the latter was retired in #1741 because the homepage demo model fired it too.

## Implementation notes

The id is read from gtag's async `get` callback, falling back to the `_ga` cookie that gtag/js writes synchronously on config. The fallback is load-bearing: `gtagEvent` buffers into `dataLayer` and gtag/js drains that queue on load, so an event fired before the callback resolves is still transmitted — just without the param. That window sits at session start, so the losses would concentrate on each visitor's *first* open, which is exactly the "1 open" cohort the bucketing exists to size.

The param is **omitted rather than blank** wherever no id is available — off-prod, under automation, or on blocked clients. An empty-string id would otherwise collect into its own large bucket that reads as a real cohort of one-off users.

## Remaining GA4-side config (not code)

1. Admin → Custom definitions → new event-scoped dimension `open_cid` from event parameter `open_cid`. Until this exists the param ships but isn't queryable.
2. Query `customEvent:open_cid × eventCount`, bucketed client-side (1 / 2 / 3–5 / 6+ opens, fixtures excluded).

Caveats: no backfill — the dimension accrues from ship time forward, so landing it early in a campaign window keeps the baseline clean. At much larger scale GA4 rolls high-cardinality values into `(other)`, which is the cue to move this query to the BigQuery export.

https://claude.ai/code/session_01EULm3yasgtCeQr8cDZaKri