### PR TITLE
Derive the camera near plane from model bounds, not an absolute floor

### DIFF
--- a/.github/workflows/test-flows.yml
+++ b/.github/workflows/test-flows.yml
@@ -23,8 +23,11 @@ jobs:
     # is chosen so screenshot baselines regenerated in the dev/sandbox env
     # (also noble + chromium 1194) match CI's renders pixel-for-pixel.
     container: mcr.microsoft.com/playwright:v1.56.1-noble
-    # Headroom for the reduced worker count below: the suite took 12.8m at 3
-    # workers on this runner, so 20 left no margin at 2.
+    # Headroom, not a fitted bound: a clean run at the worker count below
+    # measured 11.7m on this runner. The margin is for the degraded case --
+    # a starved run burns far longer than a healthy one because each failure
+    # drags a 30s timeout plus a retry behind it (the 3-worker run with 4
+    # failures took 12.8m, and main's 53-failure run took 14.4m).
     timeout-minutes: 35
     steps:
       - uses: actions/checkout@v4
@@ -57,8 +60,8 @@ jobs:
       # `#viewer-container` never mounting at all — not as honest assertion
       # failures — so it reads like flake. Measured on this runner:
       # 6 workers => 53 failed / 81 passed (the state main landed in at
-      # 6df8de7), 3 workers => 4 failed / 134 passed. 2 is the next step
-      # down, and matches Playwright's own default heuristic of vCPU/2.
+      # 6df8de7), 3 workers => 4 failed / 134 passed, 2 workers => green in
+      # 11.7m. 2 also matches Playwright's own default heuristic of vCPU/2.
       - name: Run Playwright tests
         run: yarn test-flows --reporter=github,list,html --workers=2
 

--- a/.github/workflows/test-flows.yml
+++ b/.github/workflows/test-flows.yml
@@ -44,8 +44,15 @@ jobs:
       - name: Playwright Info
         run: npx playwright --version
 
+      # Worker count is tied to `runs-on` above, and overrides the local
+      # default in tools/playwright.config.js. Keep it at or below the
+      # runner's vCPU count minus one: each worker drives its own Chromium
+      # alongside the shared static server, and oversubscribing shows up as
+      # timing flake in click/visibility waits rather than as honest
+      # failures. 6 workers on this 4-vCPU runner did exactly that — update
+      # this number whenever the runner size changes.
       - name: Run Playwright tests
-        run: yarn test-flows --reporter=github,list,html --workers=6
+        run: yarn test-flows --reporter=github,list,html --workers=3
 
       # Always upload the HTML report (handy to debug failures)
       - name: Upload Playwright HTML report

--- a/.github/workflows/test-flows.yml
+++ b/.github/workflows/test-flows.yml
@@ -23,7 +23,9 @@ jobs:
     # is chosen so screenshot baselines regenerated in the dev/sandbox env
     # (also noble + chromium 1194) match CI's renders pixel-for-pixel.
     container: mcr.microsoft.com/playwright:v1.56.1-noble
-    timeout-minutes: 20
+    # Headroom for the reduced worker count below: the suite took 12.8m at 3
+    # workers on this runner, so 20 left no margin at 2.
+    timeout-minutes: 35
     steps:
       - uses: actions/checkout@v4
 
@@ -45,14 +47,20 @@ jobs:
         run: npx playwright --version
 
       # Worker count is tied to `runs-on` above, and overrides the local
-      # default in tools/playwright.config.js. Keep it at or below the
-      # runner's vCPU count minus one: each worker drives its own Chromium
-      # alongside the shared static server, and oversubscribing shows up as
-      # timing flake in click/visibility waits rather than as honest
-      # failures. 6 workers on this 4-vCPU runner did exactly that — update
-      # this number whenever the runner size changes.
+      # default in tools/playwright.config.js. Update it whenever the runner
+      # changes size.
+      #
+      # RAM is the binding constraint here, not vCPU: this runner has 8GB
+      # against the previous runner's 32GB, and every worker holds a whole
+      # Chromium rendering a WebGL scene with the conway wasm heap resident.
+      # Starvation shows up as click/visibility timeouts and as
+      # `#viewer-container` never mounting at all — not as honest assertion
+      # failures — so it reads like flake. Measured on this runner:
+      # 6 workers => 53 failed / 81 passed (the state main landed in at
+      # 6df8de7), 3 workers => 4 failed / 134 passed. 2 is the next step
+      # down, and matches Playwright's own default heuristic of vCPU/2.
       - name: Run Playwright tests
-        run: yarn test-flows --reporter=github,list,html --workers=3
+        run: yarn test-flows --reporter=github,list,html --workers=2
 
       # Always upload the HTML report (handy to debug failures)
       - name: Upload Playwright HTML report

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bldrs",
-  "version": "1.1722.d41cd27",
+  "version": "1.1743.6caa6b3",
   "main": "src/index.jsx",
   "license": "AGPL-3.0",
   "homepage": "https://github.com/bldrs-ai/Share",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bldrs",
-  "version": "1.1741.4a1cba9",
+  "version": "1.1722.d41cd27",
   "main": "src/index.jsx",
   "license": "AGPL-3.0",
   "homepage": "https://github.com/bldrs-ai/Share",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@babel/plugin-syntax-import-assertions": "7.18.6",
     "@babel/preset-env": "7.18.10",
     "@babel/preset-react": "7.18.6",
-    "@bldrs-ai/conway": "1.460.1363",
+    "@bldrs-ai/conway": "1.465.1375",
     "@bldrs-ai/ifclib": "5.3.3",
     "@emotion/react": "11.10.0",
     "@emotion/styled": "11.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bldrs",
-  "version": "1.1722.d41cd27",
+  "version": "1.1741.4a1cba9",
   "main": "src/index.jsx",
   "license": "AGPL-3.0",
   "homepage": "https://github.com/bldrs-ai/Share",
@@ -75,7 +75,7 @@
     "@babel/plugin-syntax-import-assertions": "7.18.6",
     "@babel/preset-env": "7.18.10",
     "@babel/preset-react": "7.18.6",
-    "@bldrs-ai/conway": "1.450.1353",
+    "@bldrs-ai/conway": "1.460.1363",
     "@bldrs-ai/ifclib": "5.3.3",
     "@emotion/react": "11.10.0",
     "@emotion/styled": "11.10.0",

--- a/src/Components/Camera/CameraControl.jsx
+++ b/src/Components/Camera/CameraControl.jsx
@@ -9,7 +9,6 @@ import {
   removeHashListener,
 } from '../../utils/location'
 import {roundCoord} from '../../utils/math'
-import {floatStrTrim} from '../../utils/strings'
 import {
   HASH_PREFIX_CAMERA,
   removeCameraUrlParams,
@@ -140,7 +139,13 @@ export function setCameraFromParams(encodedParams, cameraControls) {
 }
 
 
-const floatPattern = '(-?\\d+(?:\\.\\d+)?)'
+// The exponent group is load-bearing, not decoration. Camera coords are
+// serialized with `String(number)`, which switches to exponential below
+// 1e-6 -- reachable on a sub-millimetre part now that coords are rounded
+// relative to scale rather than to 3 decimals. Without it such a link
+// fails to match and restores no camera at all. Superset of the old
+// grammar, so existing permalinks still parse.
+const floatPattern = '(-?\\d+(?:\\.\\d+)?(?:[eE][-+]?\\d+)?)'
 const coordPattern = `${floatPattern},${floatPattern},${floatPattern}`
 const paramPattern = `${HASH_PREFIX_CAMERA}:${coordPattern}(?:,${coordPattern})?`
 const paramRegex = new RegExp(paramPattern)
@@ -157,13 +162,17 @@ export function parseHashParams(encodedParams) {
   debug().log('CameraControl#onHash: match: ', match)
 
   if (match && match[1] !== undefined && match[2] !== undefined && match[3] !== undefined) {
-    const x = floatStrTrim(match[1])
-    const y = floatStrTrim(match[2])
-    const z = floatStrTrim(match[3])
+    // parseFloat, not floatStrTrim: re-rounding to 3 decimals on read
+    // would undo the scale-aware rounding done on write, collapsing a
+    // millimetre part's camera back to the origin. The regex has already
+    // established each group is a well-formed number.
+    const x = parseFloat(match[1])
+    const y = parseFloat(match[2])
+    const z = parseFloat(match[3])
     if (match[4] === undefined && match[5] === undefined && match[6] === undefined) {
       return [x, y, z]
     } else {
-      return [x, y, z, floatStrTrim(match[4]), floatStrTrim(match[5]), floatStrTrim(match[6])]
+      return [x, y, z, parseFloat(match[4]), parseFloat(match[5]), parseFloat(match[6])]
     }
   } else {
     debug().warn('CameraControl#onHash, no camera coordinate present in hash: ', location.hash)

--- a/src/Components/Camera/CameraControl.test.jsx
+++ b/src/Components/Camera/CameraControl.test.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-magic-numbers */
 import React from 'react'
 import {__getShareViewerMockSingleton} from '../../../__mocks__/shareViewerTestHarness'
 import {act, render, renderHook, screen} from '@testing-library/react'
@@ -23,6 +24,21 @@ describe('CameraControl', () => {
 
   it('parseHashParams, 6 params', () => {
     expect(parseHashParams(`${HASH_PREFIX_CAMERA}:1,2,3,4,5,6`)).toStrictEqual([1, 2, 3, 4, 5, 6])
+  })
+
+  it('parseHashParams keeps sub-millimetre precision', () => {
+    // Read used to re-round to 3 decimals via floatStrTrim, which undid
+    // the write-side precision and parsed a small part's camera back to
+    // the origin however carefully it had been serialized.
+    expect(parseHashParams(`${HASH_PREFIX_CAMERA}:0.00042,0.00013,0.00021`))
+      .toStrictEqual([0.00042, 0.00013, 0.00021])
+  })
+
+  it('parseHashParams accepts exponential notation', () => {
+    // String(1e-7) is '1e-7' -- reachable on a sub-millimetre part, and
+    // rejected outright by the pre-fix grammar.
+    expect(parseHashParams(`${HASH_PREFIX_CAMERA}:1e-7,-2.5e-8,3E+2`))
+      .toStrictEqual([1e-7, -2.5e-8, 300])
   })
 
   it('CameraControl', async () => {

--- a/src/Components/Camera/smallPartNearPlane.spec.ts
+++ b/src/Components/Camera/smallPartNearPlane.spec.ts
@@ -1,0 +1,146 @@
+import {Page, expect, test} from '@playwright/test'
+import {setupVirtualPathIntercept, waitForModelReady} from '../../tests/e2e/models'
+import {homepageSetup, setIsReturningUser} from '../../tests/e2e/utils'
+import {describeMobileAndDesktop} from '../../tests/e2e/formFactor'
+
+
+/**
+ * Guards #1742: `orbit-control.js` floored the camera near plane at an
+ * absolute 0.1 scene units while every other camera limit was derived from
+ * the model's bounds. For a part smaller than a couple of metres that floor
+ * sits *inside* the part — zooming in clipped it, and past 0.1 it vanished.
+ *
+ * `gear.step` is a millimetre file (`SI_UNIT(.MILLI.,.METRE.)`) whose raw
+ * coordinates span 3.3, so at true scale it is a 3.3 mm gear — about 30x
+ * under the old floor.
+ *
+ * It only became a #1742 fixture with conway >= 1.460.1363. Before
+ * bldrs-ai/conway#460 the unit factor was applied as its reciprocal, so the
+ * same file landed 1e6x too large: measured against conway 1.450.1353 this
+ * model framed with `minDistance` 92 and `near` 46, where a 0.1 floor is
+ * irrelevant. That conway pin is therefore load-bearing for this test rather
+ * than incidental, which is why the model's world size is asserted *before*
+ * the near-plane invariant — a unit regression then fails as itself instead
+ * of quietly softening the real assertion into a tautology.
+ *
+ * Asserts camera state rather than pixels, matching permalinkCamera.spec.ts:
+ * "is the model still lit up" is inherently flaky, whereas the frustum
+ * invariant that keeps it visible is exact.
+ */
+
+const GEAR_PATH = '/share/v/gh/bldrs-ai/test-models/main/step/gear.step'
+// STEP parse + BREP tessellation is heavier than the IFC smoke models.
+const TEST_TIMEOUT_MS = 90_000
+const SETTLE_TIMEOUT_MS = 15_000
+/** The absolute near-plane floor #1742 removed, in scene units. */
+const OLD_MIN_NEAR = 0.1
+
+
+type CameraLimits = {
+  /** Camera near plane, scene units. */
+  near: number
+  /** Closest dolly camera-controls will allow, scene units. */
+  minDistance: number
+  /** Longest edge of the model's world-space bounding box, scene units. */
+  extent: number
+}
+
+
+/**
+ * Read the settled near plane, the closest dolly distance, and the model's
+ * world-space extent off the live viewer via `window.store`.
+ *
+ * Returns null while any of it is missing so `expect.poll` keeps waiting on
+ * a half-built scene rather than asserting against it.
+ *
+ * @param page Playwright page
+ * @return the three limits, or null if the viewer isn't ready yet
+ */
+async function readCameraLimits(page: Page): Promise<CameraLimits | null> {
+  return await page.evaluate(() => {
+    /* eslint-disable @typescript-eslint/no-explicit-any */
+    const context = (window as any).store?.getState()?.viewer?.context
+    const camera = context?.getCamera?.()
+    const controls = context?.getCameraControls?.()
+    const models = context?.getLoadedModels?.()
+    if (!camera || !controls || !models?.length) {
+      return null
+    }
+
+    // Measure the loaded models, not the scene: the `?feature=look` ground
+    // plane is a real mesh sized to a multiple of the model, so a whole-scene
+    // walk reads several times too large.
+    //
+    // Box3.expandByObject is what does the work — conway emits STEP geometry
+    // as an InstancedMesh whose per-instance matrices carry both the part
+    // placements and the root unit scale that conway#460 corrected. A hand
+    // walk over `geometry.boundingBox` misses those matrices entirely and
+    // reports the raw file coordinates (3.3, not 0.0033), which would defeat
+    // the point of measuring in world space. Box3 is borrowed by cloning a
+    // geometry's own rather than importing three — the spec must not pull a
+    // second copy of three into the page.
+    let box: any = null
+    const borrowBox = (obj: any) => {
+      if (box || !obj.isMesh || !obj.geometry) {
+        return
+      }
+      if (!obj.geometry.boundingBox) {
+        obj.geometry.computeBoundingBox()
+      }
+      box = obj.geometry.boundingBox?.clone() ?? null
+    }
+    for (const model of models) {
+      model.updateMatrixWorld(true)
+      model.traverse(borrowBox)
+    }
+    if (!box) {
+      return null
+    }
+    box.makeEmpty()
+    for (const model of models) {
+      box.expandByObject(model)
+    }
+    if (box.isEmpty()) {
+      return null
+    }
+    const extent = Math.max(
+      box.max.x - box.min.x, box.max.y - box.min.y, box.max.z - box.min.z)
+    return {near: camera.near, minDistance: controls.minDistance, extent}
+    /* eslint-enable @typescript-eslint/no-explicit-any */
+  })
+}
+
+
+describeMobileAndDesktop('Small-part near plane', () => {
+  test('a millimetre STEP part stays inside the near plane at full zoom-in', async ({page}) => {
+    test.setTimeout(TEST_TIMEOUT_MS)
+    page.on('pageerror', (err) => console.warn(`[pageerror] ${err.message}`))
+
+    await homepageSetup(page)
+    await setIsReturningUser(page.context())
+
+    const {navigateAndWaitForModel} = await setupVirtualPathIntercept(page, GEAR_PATH, '')
+    await navigateAndWaitForModel()
+    await waitForModelReady(page)
+
+    await expect.poll(
+      () => readCameraLimits(page),
+      {timeout: SETTLE_TIMEOUT_MS, message: 'viewer never exposed settled camera limits'},
+    ).not.toBeNull()
+
+    const limits = await readCameraLimits(page) as CameraLimits
+
+    // Precondition, not the assertion under test: this fixture is only a
+    // #1742 case while conway loads it at true millimetre scale (~0.0033).
+    expect(limits.extent).toBeGreaterThan(0)
+    expect(limits.extent).toBeLessThan(OLD_MIN_NEAR)
+
+    // The regression itself, stated two ways. The near plane has to sit
+    // inside the part rather than in front of it, and inside the closest
+    // dolly the user can reach — under the old floor it was 0.1 against a
+    // 0.0033 part and a minDistance of ~9e-5, so zooming in ate the model.
+    expect(limits.near).toBeGreaterThan(0)
+    expect(limits.near).toBeLessThan(limits.extent)
+    expect(limits.near).toBeLessThan(limits.minDistance)
+  })
+})

--- a/src/Components/Connections/GitHubTab.test.jsx
+++ b/src/Components/Connections/GitHubTab.test.jsx
@@ -61,7 +61,7 @@ beforeEach(() => {
  */
 async function flushStatusEffect() {
   await act(async () => {
-    await new Promise((resolve) => setTimeout(resolve, 0))
+    await Promise.resolve()
   })
 }
 

--- a/src/Components/Connections/GoogleDriveTab.test.jsx
+++ b/src/Components/Connections/GoogleDriveTab.test.jsx
@@ -36,7 +36,7 @@ async function flushValidateEffect() {
   // number of Promise.resolve hops — and doing it inside act keeps the
   // trailing setStatuses from logging an un-acted-on update warning.
   await act(async () => {
-    await new Promise((resolve) => setTimeout(resolve, 0))
+    await Promise.resolve()
   })
 }
 

--- a/src/Components/CutPlane/CutPlaneMenu.jsx
+++ b/src/Components/CutPlane/CutPlaneMenu.jsx
@@ -5,7 +5,8 @@ import {Menu, MenuItem, SvgIcon, Typography} from '@mui/material'
 import useStore from '../../store/useStore'
 import debug from '../../utils/debug'
 import {addHashParams, getHashParams, getObjectParams, removeParams} from '../../utils/location'
-import {floatStrTrim, isNumeric} from '../../utils/strings'
+import {roundCoordComponent} from '../../utils/math'
+import {isNumeric} from '../../utils/strings'
 import {TooltipIconButton} from '../Buttons'
 import {HASH_PREFIX_CUT_PLANE} from './hashState'
 import {Close as CloseIcon, CropOutlined as CropOutlinedIcon} from '@mui/icons-material'
@@ -285,7 +286,10 @@ export function getPlanesOffset(viewer, ifcModel) {
           planeNormal = key
           planeAxisCenter = modelCenter[planeNormal]
           planeOffsetFromCenter = planeOffsetFromModelBoundary - planeAxisCenter
-          planesOffset[planeNormal] = floatStrTrim(planeOffsetFromCenter)
+          // Scale-relative, not 3 fixed decimals: a millimetre part's
+          // offsets all sit inside the old absolute quantum, so every
+          // plane in a shared #cp: link snapped to the model centre.
+          planesOffset[planeNormal] = roundCoordComponent(planeOffsetFromCenter)
         }
       }
     })
@@ -336,7 +340,9 @@ export function getPlanes(planeHash) {
     } else {
       planes.push({
         direction: key,
-        offset: floatStrTrim(value),
+        // parseFloat, not floatStrTrim: re-rounding on read would undo
+        // the write-side precision from getPlanesOffset.
+        offset: parseFloat(value),
       })
     }
     if (removableParamKeys.length) {
@@ -367,7 +373,12 @@ export function getPlaneSceneInfo({modelCenter, direction, offset = 0}) {
   let planeOffsetX = 0
   let planeOffsetY = 0
   let planeOffsetZ = 0
-  const finiteOffset = floatStrTrim(offset)
+  // Coerce to finite without rounding. This is scene placement rather
+  // than serialization, so quantizing here would re-apply the absolute
+  // step that getPlanesOffset and getPlanes just stopped applying, and
+  // a millimetre part's planes would still land on the centre.
+  const parsedOffset = typeof offset === 'string' ? parseFloat(offset) : offset
+  const finiteOffset = Number.isFinite(parsedOffset) ? parsedOffset : 0
 
   switch (direction) {
     case 'x':

--- a/src/Components/CutPlane/CutPlaneMenu.test.jsx
+++ b/src/Components/CutPlane/CutPlaneMenu.test.jsx
@@ -151,7 +151,13 @@ describe('CutPlaneMenu', () => {
     check(getPlanesFromHash(`${pfx}:x=1,y=4`), [['x', 1], ['y', 4]])
     check(getPlanesFromHash(`${pfx}:x=2,z=5`), [['x', 2], ['z', 5]])
     check(getPlanesFromHash(`${pfx}:y=3,z=6`), [['y', 3], ['z', 6]])
-    check(getPlanesFromHash(`${pfx}:x=0,y=1.11111,z=2.22222`), [['x', 0], ['y', 1.111], ['z', 2.222]])
+    // Offsets are no longer re-rounded on read; the hash value is the
+    // value. 3 decimals here used to send a millimetre part's planes to
+    // the model centre.
+    check(getPlanesFromHash(`${pfx}:x=0,y=1.11111,z=2.22222`), [['x', 0], ['y', 1.11111], ['z', 2.22222]])
+    check(
+      getPlanesFromHash(`${pfx}:x=0.00042,y=-0.00013`),
+      [['x', 0.00042], ['y', -0.00013]])
     /* eslint-enable no-magic-numbers */
   })
 })

--- a/src/Components/CutPlane/hashState.js
+++ b/src/Components/CutPlane/hashState.js
@@ -5,7 +5,7 @@ import {
   getHashParams as utilsGetHashParams,
   removeHashParams as utilsRemoveHashParams,
 } from '../../utils/location'
-import {floatStrTrim, isNumeric} from '../../utils/strings'
+import {isNumeric} from '../../utils/strings'
 import {getPlanesOffset} from './CutPlaneMenu'
 
 
@@ -68,7 +68,11 @@ export function getPlanesFromHash(planeHash) {
     } else {
       planes.push({
         direction: key,
-        offset: floatStrTrim(value),
+        // parseFloat, not floatStrTrim: 3-decimal rounding on read
+        // collapses a millimetre part's offsets to 0. Kept in step with
+        // the near-identical CutPlaneMenu#getPlanes, which is the copy
+        // the app actually calls -- these two want deduplicating.
+        offset: parseFloat(value),
       })
     }
     if (removableParamKeys.length) {

--- a/src/Components/LoadingBackdrop.jsx
+++ b/src/Components/LoadingBackdrop.jsx
@@ -1,6 +1,7 @@
 import React, {ReactElement} from 'react'
 import {Backdrop, CircularProgress} from '@mui/material'
 import {useTheme} from '@mui/material/styles'
+import useExistInFeature from '../hooks/useExistInFeature'
 import useStore from '../store/useStore'
 
 
@@ -10,15 +11,22 @@ import useStore from '../store/useStore'
  * (AlertDialogAndSnackbar), which shows the same normalized load-log lines the JS
  * console gets (design/new/load-log-format.md).
  *
+ * Because it sits above the canvas it also swallows pointer events for the
+ * whole load, so `?feature=disableLoadOverlay` suppresses it to make a
+ * progressive load inspectable — orbit/zoom while geometry streams in. See
+ * FeatureFlags.js for the caveat about the camera follow stopping on first
+ * interaction.
+ *
  * @return {ReactElement}
  */
 export default function LoadingBackdrop() {
   const isModelLoading = useStore((state) => state.isModelLoading)
+  const isOverlayDisabled = useExistInFeature('disableLoadOverlay')
   const theme = useTheme()
   return (
     theme &&
       <Backdrop
-        open={isModelLoading}
+        open={isModelLoading && !isOverlayDisabled}
         sx={{color: theme.palette.primary.sceneHighlight, zIndex: 1000}}
         data-testid='LoadingBackdrop'
       >

--- a/src/Components/Open/GitHubFileBrowser.test.jsx
+++ b/src/Components/Open/GitHubFileBrowser.test.jsx
@@ -50,7 +50,7 @@ const GH_BROWSER_STATE_KEY = 'bldrs.openDialog.github'
  */
 async function flushCascade() {
   await act(async () => {
-    await new Promise((resolve) => setTimeout(resolve, 0))
+    await Promise.resolve()
   })
 }
 

--- a/src/Containers/ViewerContainer.test.jsx
+++ b/src/Containers/ViewerContainer.test.jsx
@@ -73,7 +73,7 @@ describe('ViewerContainer', () => {
     // CadView mounts async work (viewer setup) that sets state after this sync
     // assertion; settle it inside act so the trailing update doesn't warn.
     await act(async () => {
-      await new Promise((resolve) => setTimeout(resolve, 0))
+      await Promise.resolve()
     })
   })
 

--- a/src/FeatureFlags.js
+++ b/src/FeatureFlags.js
@@ -123,6 +123,25 @@ export const flags = [
   // only changes models that had zero color to begin with.
   // See src/viewer/ifc/productPalette.js.
   {name: 'autoColorParts', isActive: true},
+  // Diagnostic OFF-switch for the full-screen loading overlay
+  // (Components/LoadingBackdrop.jsx). The overlay is a dimmer that sits
+  // above the canvas, so it also swallows pointer events for the whole
+  // load — which makes anything that goes wrong *during* a progressive
+  // load unobservable: you cannot orbit or zoom out to tell "the model
+  // shifted offscreen" apart from "the model isn't there".
+  // `?feature=disableLoadOverlay` leaves the canvas live so a load can be
+  // inspected while it streams.
+  //
+  // Note when using it: taking the camera fires `controlstart`, which
+  // stops ProgressiveLoadSession's camera follow permanently (by design
+  // — the user outranks the follow). So the first interaction freezes
+  // the camera for the rest of the load. That is what makes the flag
+  // useful for "where did it go", and also why the follow's own framing
+  // can't be observed in the same run.
+  //
+  // Inverted semantics on purpose: `?feature=` can only turn flags ON,
+  // so an off-switch for default-on behavior has to be an off-flag.
+  {name: 'disableLoadOverlay', isActive: false},
 ]
 
 

--- a/src/Filetype.js
+++ b/src/Filetype.js
@@ -1,4 +1,7 @@
 import axios from 'axios'
+// three's vendored fflate — already shipped for its EXR/other loaders,
+// so this adds no bundle weight beyond what the app carries.
+import {Gunzip} from 'three/examples/jsm/libs/fflate.module.js'
 import {assertDefined} from './utils/assert'
 import debug from './utils/debug'
 
@@ -187,7 +190,12 @@ export function analyzeHeader(headerBuffer) {
   }
   if (headerBuffer.byteLength >= 2 &&
       new DataView(headerBuffer).getUint16(0, true) === GZIP_MAGIC_NUMBER) {
-    return 'spz'
+    // The gzip signature is shared by SPZ splats and every ordinary
+    // gzipped upload (.tar.gz, gzipped logs/JSON) — same trap as the
+    // zip branch below. Decompress the head and require SPZ's own
+    // magic; anything else stays unrecognized so it fails sniffing
+    // cleanly instead of dying inside the splat decoder.
+    return looksLikeSpzStream(headerBuffer) ? 'spz' : null
   }
   if (matchesMagic(headerBuffer, ZIP_MAGIC)) {
     // The zip signature is shared by USDZ packages, SOG splat bundles,
@@ -239,6 +247,40 @@ function matchesMagic(headerBuffer, magicBytes) {
  */
 function looksLikeUsdzArchive(headerBuffer) {
   return /\.usd[ac]?$/i.test(firstZipEntryName(headerBuffer))
+}
+
+
+// SPZ header magic 0x5053474e, little-endian on disk: 'NGSP' as the
+// first four DECOMPRESSED bytes of every .spz file (Niantic spz spec).
+const SPZ_MAGIC = Array.from('NGSP', (c) => c.charCodeAt(0))
+
+
+/**
+ * Distinguish an SPZ splat from any other gzip stream by inflating the
+ * head and checking SPZ's own magic. The header buffer is a truncated
+ * prefix of the file, so this streams through fflate's `Gunzip` (which
+ * emits the decompressed prefix of a partial member) rather than
+ * `gunzipSync` (which would throw on the missing tail).
+ *
+ * @param {ArrayBuffer} headerBuffer
+ * @return {boolean}
+ */
+function looksLikeSpzStream(headerBuffer) {
+  try {
+    /** @type {Array<Uint8Array>} */
+    const chunks = []
+    const gunzip = new Gunzip()
+    gunzip.ondata = (chunk) => {
+      chunks.push(chunk)
+    }
+    gunzip.push(new Uint8Array(headerBuffer), false)
+    const decoded = chunks[0]
+    return decoded !== undefined && decoded.length >= SPZ_MAGIC.length &&
+      SPZ_MAGIC.every((byte, index) => decoded[index] === byte)
+  } catch {
+    // Truncated-at-an-awkward-boundary or corrupt gzip: not sniffable.
+    return false
+  }
 }
 
 

--- a/src/Filetype.test.js
+++ b/src/Filetype.test.js
@@ -1,3 +1,4 @@
+import {gzipSync} from 'three/examples/jsm/libs/fflate.module.js'
 import {
   FilenameParseError,
   analyzeHeader,
@@ -236,11 +237,26 @@ describe('Filetype', () => {
       expect(analyzeHeader(buffer)).toBe(null)
     })
 
-    it('detects SPZ (gzip magic) binary format', () => {
+    it('detects SPZ by its decompressed magic, not by gzip alone', () => {
+      // A real .spz is a gzip stream whose DECOMPRESSED bytes begin with
+      // SPZ's magic 'NGSP'. Gzip alone must not classify: every
+      // .tar.gz / gzipped log shares that signature, and routing those
+      // to the splat decoder turns a clean "unknown type" alert into a
+      // parse failure deep inside wasm (adding-model-formats.md).
+      const spzHead = new Uint8Array([...Array.from('NGSP', (c) => c.charCodeAt(0)), 2, 0, 0, 0])
+      expect(analyzeHeader(gzipSync(spzHead).buffer)).toBe('spz')
+    })
+
+    it('leaves a non-SPZ gzip stream unrecognized', () => {
+      const tarball = new TextEncoder().encode('not a splat, just gzipped text content')
+      expect(analyzeHeader(gzipSync(tarball).buffer)).toBe(null)
+    })
+
+    it('leaves a gzip header with no decodable payload unrecognized', () => {
       const GZIP_MAGIC_NUMBER = 0x8B1F // gzip magic 1f 8b, little-endian
       const buffer = new ArrayBuffer(GLB_MIN_SIZE)
       new DataView(buffer).setUint16(0, GZIP_MAGIC_NUMBER, true)
-      expect(analyzeHeader(buffer)).toBe('spz')
+      expect(analyzeHeader(buffer)).toBe(null)
     })
 
     it('detects USDC crate binary format', () => {

--- a/src/loader/Loader.js
+++ b/src/loader/Loader.js
@@ -397,7 +397,15 @@ export async function load(
         } catch (evictError) {
           debug().warn('Loader#load: could not evict stale LFS pointer entry:', evictError)
         }
-        // Falls through to the direct-fetch block below.
+        // Falls through to the direct-fetch block below. Two lines above
+        // already told a different story — undo both: the store's
+        // opfsFile still points at the (now deleted) pointer entry, so a
+        // later "Save" would write the 130-byte pointer instead of the
+        // rendered model, and the report's Source line claims a cache
+        // hit for bytes that are about to come from the network.
+        setOpfsFile(null)
+        reportSourceInfo(
+          'Source: OPFS entry was a stale Git LFS pointer — evicted, re-fetching from network')
         modelData = undefined
         glbExportContext = null
         cameFromGlbCache = false

--- a/src/loader/glbCacheKey.js
+++ b/src/loader/glbCacheKey.js
@@ -15,6 +15,20 @@
 /**
  * Current Bldrs GLB artifact schema version. Bumped on any backwards-
  * incompatible change to the BLDRS_* extension contract or cache-key shape.
+ * 0.15.0 — retires STEP artifacts baked at the wrong world scale. conway
+ *         1.460.1363 (bldrs-ai/conway#458, PR conway#460) stopped applying a
+ *         STEP file's length-unit factor as its RECIPROCAL, so a millimetre
+ *         model that used to arrive 1e6x too large now arrives at true size.
+ *         Geometry is baked into the GLB in world coordinates and nothing in
+ *         the cache key identifies the engine, so without this bump a user
+ *         holding a pre-1.460 artifact would keep loading the oversized
+ *         geometry indefinitely — never picking up the fix, and disagreeing
+ *         with cache-miss users on every shared camera / cut-plane link.
+ *         Older 0.14.0 artifacts read as miss; next miss rewrites at true
+ *         scale. IFC artifacts are unaffected (the IFC path folds
+ *         `linearScalingFactor` into its coordination matrix and never had
+ *         the defect), but the key is format-blind so they rewrite too.
+ *         Precedent for pairing an engine bump with a schema bump: d1a74ea.
  * 0.14.0 — fixed the batched writer dropping STEP per-occurrence data. The
  *         default render path is now the demandGeometry BatchedMesh, which
  *         has no `instanceMap`; the writer had read `occurrencePaths` /
@@ -123,7 +137,7 @@
  * 0.2.0 — generalised cache key from GitHub-only (owner/repo/branch) to a
  *         per-source-kind 3-level namespace (ns1/ns2/ns3).
  */
-export const BLDRS_GLB_SCHEMA_VERSION = '0.14.0'
+export const BLDRS_GLB_SCHEMA_VERSION = '0.15.0'
 
 
 /**

--- a/src/loader/splats.js
+++ b/src/loader/splats.js
@@ -36,6 +36,13 @@ function loadSpark() {
     sparkModulePromise = import('@sparkjsdev/spark').then((module) => {
       spark = module
       return module
+    }).catch((importError) => {
+      // Never cache a rejected import: the ~5MB chunk failing once on a
+      // flaky network would otherwise fail every later splat open in the
+      // session with the same stale error. Clearing the slot lets the
+      // next open retry the fetch.
+      sparkModulePromise = null
+      throw importError
     })
   }
   return sparkModulePromise

--- a/src/utils/math.js
+++ b/src/utils/math.js
@@ -1,5 +1,3 @@
-import {floatStrTrim} from './strings'
-
 /**
  * @param {number|string} num Number to round
  * @param {number} numDigits Number of digits to round to, default = 0
@@ -17,13 +15,59 @@ export function round(num, numDigits = 0) {
 }
 
 
+// Decimal places kept at building scale, and significant figures kept
+// once a coordinate falls below that quantum. See roundCoordComponent.
+export const COORD_DECIMALS = 3
+export const COORD_SIG_DIGITS = 6
+
+
+/**
+ * Round one coordinate for URL serialization, at any model scale.
+ *
+ * Fixed-decimal rounding is an *absolute* quantization, and so is wrong
+ * for the same reason an absolute camera near plane was (#1742): conway
+ * emits true-scale geometry, so on a millimetre part every coordinate
+ * sits inside the 3-decimal quantum. Camera position and target both
+ * round to (0,0,0) and the permalink restores a degenerate camera;
+ * cut-plane offsets all round to ~0 and the planes snap to the centre.
+ *
+ * Significant-digit rounding is scale-invariant, but on its own it
+ * coarsens large site coordinates that fixed decimals used to keep
+ * (12345.6789 -> 12345.7). So compute both and keep whichever landed
+ * closer to the input: fixed decimals win at building scale — which
+ * also keeps URLs short — and significant digits take over exactly
+ * where fixed decimals would have collapsed the value.
+ *
+ * Degenerate inputs keep floatStrTrim's old contract (0/NaN/'' -> 0,
+ * non-finite throws) so this stays a drop-in for the callers it
+ * replaces.
+ *
+ * @param {number|string} num Coordinate to round
+ * @param {number} numDigits Decimal places, default = COORD_DECIMALS
+ * @param {number} sigDigits Significant figures, default = COORD_SIG_DIGITS
+ * @return {number} The rounded coordinate
+ */
+export function roundCoordComponent(num, numDigits = COORD_DECIMALS, sigDigits = COORD_SIG_DIGITS) {
+  const n = typeof num === 'string' ? parseFloat(num) : num
+  if (!n) {
+    return 0
+  }
+  if (!isFinite(n)) {
+    throw new Error('Parameter is invalid.')
+  }
+  const fixed = Number(n.toFixed(numDigits))
+  const significant = Number(n.toPrecision(sigDigits))
+  return Math.abs(n - fixed) <= Math.abs(n - significant) ? fixed : significant
+}
+
+
 /**
  * @param {number} x X coordinate
  * @param {number} y y coordinate
  * @param {number} z Z coordinate
- * @param {number} numDigits Number of digits to round to, default = 0
+ * @param {number} numDigits Number of digits to round to, default = 3
  * @return {Array<number>} Array of [x, y, z]
  */
-export function roundCoord(x, y, z, numDigits = 3) {
-  return [x, y, z].map((n) => floatStrTrim(n, numDigits))
+export function roundCoord(x, y, z, numDigits = COORD_DECIMALS) {
+  return [x, y, z].map((n) => roundCoordComponent(n, numDigits))
 }

--- a/src/utils/math.test.js
+++ b/src/utils/math.test.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-magic-numbers */
-import {round, roundCoord} from './math'
+import {round, roundCoord, roundCoordComponent} from './math'
 
 
 // τ = 2π, τ >> π.  Excelsior!
@@ -16,4 +16,35 @@ test('round', () => {
 
 test('roundCoord', () => {
   expect(roundCoord(1.1, 2.2, 3.3)).toStrictEqual([1.1, 2.2, 3.3])
+})
+
+describe('roundCoordComponent', () => {
+  it('does not collapse a millimetre-scale coordinate to zero', () => {
+    // This is the whole bug: 3-decimal rounding returned 0 here, so a
+    // small part's camera position, target and cut-plane offsets all
+    // serialized to the origin (#1742).
+    expect(roundCoordComponent(0.00042)).toBe(0.00042)
+    expect(roundCoordComponent(0.0000012345678)).toBeCloseTo(0.0000012345678, 10)
+  })
+
+  it('keeps fixed decimals where they beat significant digits', () => {
+    // 6 significant figures alone would coarsen this to 12345.7, losing
+    // precision that large-site coordinates used to keep.
+    expect(roundCoordComponent(12345.6789)).toBe(12345.679)
+  })
+
+  it('takes significant digits where they beat fixed decimals', () => {
+    expect(roundCoordComponent(12.3456789)).toBe(12.3457)
+  })
+
+  it('keeps the floatStrTrim contract for degenerate input', () => {
+    expect(roundCoordComponent(0)).toBe(0)
+    expect(roundCoordComponent(NaN)).toBe(0)
+    expect(roundCoordComponent('')).toBe(0)
+    expect(() => roundCoordComponent(Infinity)).toThrow()
+  })
+
+  it('accepts numeric strings', () => {
+    expect(roundCoordComponent('0.00042')).toBe(0.00042)
+  })
 })

--- a/src/viewer/ProgressiveLoadSession.js
+++ b/src/viewer/ProgressiveLoadSession.js
@@ -1,6 +1,7 @@
-import {Box3, Group, MathUtils, Sphere, Vector3} from 'three'
+import {Box3, Group, Sphere, Vector3} from 'three'
 import {setLoadSummary} from '../loader/loadProgress'
 import debug, {WARN} from '../utils/debug'
+import {FRAMING_MARGIN, applyCameraLimits, cameraLimitsForSphere} from './three/cameraLimits'
 import {ElementBoxes, robustBoundsFromElements} from './three/robustBounds'
 
 
@@ -14,19 +15,12 @@ export const SessionState = Object.freeze({
 })
 
 
-/** Bounding-sphere margin applied when framing the preview. */
-const FRAMING_MARGIN = 1.5
 /** Minimum gap between two follow refits (also the starting cadence). */
 const CAMERA_FOLLOW_MIN_MS = 250
 /** The cadence cap the exponential growth converges to. */
 const CAMERA_FOLLOW_MAX_MS = 1000
 /** Per-refit cadence growth factor. */
 const CAMERA_FOLLOW_GROWTH = 1.5
-const HALF = 0.5
-/** Far plane must clear the whole zoom-out range plus the model. */
-const FAR_PLANE_SLACK = 1.5
-/** Zoom-out headroom over the fit distance (mirrors fitModelToFrame). */
-const MAX_DISTANCE_HEADROOM = 10
 /** Box corner count for the sphere-containment test. */
 const BOX_CORNERS = 8
 /**
@@ -476,28 +470,25 @@ export default class ProgressiveLoadSession {
       this.lastFitMs = Date.now()
       return
     }
-    const vFov = MathUtils.degToRad(camera.fov)
-    const hFov = Math.atan(Math.tan(vFov * HALF) * camera.aspect) * 2
-    const limitingFov = camera.aspect > 1 ? vFov : hFov
-    const fitDistance = sphere.radius / Math.sin(limitingFov * HALF)
     // camera-controls clamps every dolly to [minDistance, maxDistance],
-    // and the activation default is maxDistance = 300 scene units — on
-    // any model whose fit distance exceeds that, fitToSphere silently
-    // parks the camera at the clamp and the model overflows the window.
-    // Scale the zoom-out range with the growing union exactly like the
-    // final fitModelToFrame does (10x headroom), only ever outward —
-    // the union is monotonic, so the range never needs to shrink
-    // mid-follow and the final fit re-derives it anyway.
-    const wantMaxDistance = fitDistance * MAX_DISTANCE_HEADROOM
-    if (typeof controls.maxDistance === 'number' &&
-        controls.maxDistance < wantMaxDistance) {
-      controls.maxDistance = wantMaxDistance
-    }
-    const wantFar = (wantMaxDistance + sphere.radius) * FAR_PLANE_SLACK
-    if (camera.far < wantFar) {
-      camera.far = wantFar
-      camera.updateProjectionMatrix()
-    }
+    // and the OrbitControl activation defaults are minDistance 1 /
+    // maxDistance 300 with near 1. Both ends bite, in opposite
+    // directions and at opposite scales:
+    //
+    //  - large model: fit distance exceeds maxDistance 300, so
+    //    fitToSphere parks at the clamp and the model overflows;
+    //  - sub-metre model: fit distance is under minDistance 1, so
+    //    fitToSphere parks *too far out* and the model is a speck, while
+    //    near = 1 sits beyond it entirely and clips it in half.
+    //
+    // The follow used to grow only maxDistance and far, so the second
+    // case went unhandled until the end-of-load fit corrected it — read
+    // as the model "resizing during load". Derive the whole set from the
+    // same place the final fit does; growOnly keeps the outward range
+    // monotonic (the union only grows, and a shrinking range would pop
+    // the projection between refits) while letting minDistance and near
+    // come down off the defaults.
+    applyCameraLimits(camera, controls, cameraLimitsForSphere(camera, sphere), true)
     controls.fitToSphere(sphere, withTransition)
     this.fittedSphere = sphere
     this.overflowPending = false

--- a/src/viewer/ProgressiveLoadSession.js
+++ b/src/viewer/ProgressiveLoadSession.js
@@ -96,6 +96,11 @@ export default class ProgressiveLoadSession {
     this.streamedBoxes = new ElementBoxes()
     this.fittedSphere = null
     this.overflowPending = false
+    // Diagnostic counters for the always-on [progressive] lifecycle log.
+    // "Geometry shows briefly then vanishes mid-load" is invisible in the
+    // current log: preview install, the coordination stamp that can move
+    // the whole preview group, and teardown are all silent.
+    this.previewMeshCount = 0
     this.onControlStart = () => this.stopFollow_()
   }
 
@@ -143,9 +148,12 @@ export default class ProgressiveLoadSession {
     }
     try {
       this.previewGroup.add(mesh)
+      this.previewMeshCount++
       if (!this.previewInstalled) {
         this.previewInstalled = true
         this.scene.add(this.previewGroup)
+        // eslint-disable-next-line no-console
+        console.info('[progressive] preview installed (first mesh)')
       }
       if (this.state === SessionState.IDLE) {
         this.state = SessionState.PREVIEWING
@@ -212,6 +220,15 @@ export default class ProgressiveLoadSession {
     try {
       group.matrix.fromArray(matrixArr)
       group.matrixAutoUpdate = false
+      // Prime suspect when the preview shows and then vanishes: a
+      // non-identity stamp moves the ENTIRE preview group in one go. The
+      // union is rebuilt and a refit requested right after, but
+      // maybeRefit_ is behind a cadence gate, so the camera can lag the
+      // jump by up to CAMERA_FOLLOW_MAX_MS with the preview offscreen.
+      // eslint-disable-next-line no-console
+      console.info(
+        `[progressive] coordination stamp: translation=(${matrixArr[12]}, ` +
+        `${matrixArr[13]}, ${matrixArr[14]}) meshes=${this.previewMeshCount}`)
       this.rebuildUnion_()
       this.overflowPending = true
       this.maybeRefit_()
@@ -489,6 +506,15 @@ export default class ProgressiveLoadSession {
     // the projection between refits) while letting minDistance and near
     // come down off the defaults.
     applyCameraLimits(camera, controls, cameraLimitsForSphere(camera, sphere), true)
+    // One line per actual camera move (throttled 250ms -> 1s, so a
+    // handful per load). A centre that jumps between fits is the preview
+    // group being relocated under the camera; a radius that explodes is
+    // a stray dragging the frame out.
+    // eslint-disable-next-line no-console
+    console.info(
+      `[progressive] fit: centre=(${sphere.center.x.toFixed(2)}, ` +
+      `${sphere.center.y.toFixed(2)}, ${sphere.center.z.toFixed(2)}) ` +
+      `radius=${sphere.radius.toFixed(3)} previewMeshes=${this.previewMeshCount}`)
     controls.fitToSphere(sphere, withTransition)
     this.fittedSphere = sphere
     this.overflowPending = false
@@ -519,6 +545,11 @@ export default class ProgressiveLoadSession {
     if (this.previewGroup === null || !this.previewInstalled) {
       return
     }
+    // The other way geometry vanishes: the preview is disposed here and
+    // the durable model has to be on screen by now, or there is a gap.
+    // eslint-disable-next-line no-console
+    console.info(
+      `[progressive] preview teardown: meshes=${this.previewMeshCount} state=${this.state}`)
     try {
       this.scene.remove(this.previewGroup)
       for (const child of this.previewGroup.children) {

--- a/src/viewer/ProgressiveLoadSession.js
+++ b/src/viewer/ProgressiveLoadSession.js
@@ -34,6 +34,15 @@ const REFIT_EPSILON_FRACTION = 0.01
  * stray that inflated the frame, not to track ordinary growth.
  */
 const OVERFRAME_FACTOR = 4
+/**
+ * Preview placements this many times the accumulated preview radius away
+ * from its centre are dropped. See isPreviewOutlier_ — this defends the
+ * camera follow against a preview channel that mis-places geometry, and
+ * the multiple is enormous so that only a broken placement trips it.
+ */
+const PREVIEW_OUTLIER_FACTOR = 100
+/** Accepted previews required before the test has anything to measure. */
+const PREVIEW_OUTLIER_WARMUP = 32
 
 
 /**
@@ -107,6 +116,11 @@ export default class ProgressiveLoadSession {
     // current log: preview install, the coordination stamp that can move
     // the whole preview group, and teardown are all silent.
     this.previewMeshCount = 0
+    this.previewOutliers = 0
+    // Running union of ACCEPTED preview boxes, for the outlier test.
+    // Cheap to maintain (one box expand per mesh) unlike re-deriving
+    // robust bounds, which is why the test lives here and not in the fit.
+    this.previewUnion = new Box3()
     this.onControlStart = () => this.stopFollow_()
   }
 
@@ -153,6 +167,18 @@ export default class ProgressiveLoadSession {
       return
     }
     try {
+      const box = this.meshWorldBox_(mesh)
+      if (this.isPreviewOutlier_(box)) {
+        this.previewOutliers++
+        if (this.previewOutliers === 1) {
+          const centre = box.getCenter(new Vector3())
+          console.warn(
+            '[progressive] dropping mis-placed preview geometry at ' +
+            `(${centre.x.toFixed(1)}, ${centre.y.toFixed(1)}, ${centre.z.toFixed(1)}) — ` +
+            'the durable model does not place geometry there')
+        }
+        return
+      }
       this.previewGroup.add(mesh)
       this.previewMeshCount++
       if (!this.previewInstalled) {
@@ -274,6 +300,45 @@ export default class ProgressiveLoadSession {
 
 
   /**
+   * Is this preview placed somewhere the model plainly is not?
+   *
+   * conway's parse-time preview channel can emit a placement with the
+   * origin-coordination transform applied to geometry that is already
+   * local, so the site offset is subtracted twice instead of cancelling.
+   * On Snowdon (site at 417622, 78714, 238) that put 88 previews ~425km
+   * out while the durable stream placed none of them there. The camera
+   * follow frames the union, so it chased them and rendered the building
+   * as a speck for the whole load.
+   *
+   * The stray filter in robustBounds cannot help: it is tuned for
+   * "model + a few strays" and gives up past MAX_EXCLUDED_FRACTION (2%),
+   * which 88 displaced elements exceed — that is why it reported
+   * excluded=0 while framing a 318km sphere.
+   *
+   * Deliberately crude. Real geometry is never 100x the model's own
+   * radius from its centre, so this cannot fire on a legitimate outlying
+   * wing, crane or antenna; it only catches a placement that is wrong.
+   * Durable bounds are never tested — that stream is authoritative.
+   *
+   * @param {Box3|null} box the candidate's world bounds
+   * @return {boolean}
+   */
+  isPreviewOutlier_(box) {
+    if (box === null || this.previewMeshCount < PREVIEW_OUTLIER_WARMUP ||
+        this.previewUnion.isEmpty()) {
+      return false
+    }
+    const sphere = new Sphere()
+    this.previewUnion.getBoundingSphere(sphere)
+    if (!(sphere.radius > 0) || !Number.isFinite(sphere.radius)) {
+      return false
+    }
+    return box.getCenter(new Vector3()).distanceTo(sphere.center) >
+      sphere.radius * PREVIEW_OUTLIER_FACTOR
+  }
+
+
+  /**
    * Record one preview mesh's world bounds and flag an overflow when it
    * escapes the currently framed sphere.
    *
@@ -284,6 +349,7 @@ export default class ProgressiveLoadSession {
     if (box === null) {
       return
     }
+    this.previewUnion.union(box)
     this.previewBoxes.push(box)
     if (this.fittedSphere !== null && !this.sphereContainsBox_(this.fittedSphere, box)) {
       this.overflowPending = true
@@ -298,6 +364,10 @@ export default class ProgressiveLoadSession {
    */
   rebuildUnion_() {
     this.previewBoxes.clear()
+    // The outlier test measures against the same transform the boxes are
+    // in, so this has to be rebuilt with them or a coordination stamp
+    // would leave it comparing across frames.
+    this.previewUnion.makeEmpty()
     if (this.previewGroup === null) {
       return
     }
@@ -305,6 +375,7 @@ export default class ProgressiveLoadSession {
       const box = this.meshWorldBox_(child)
       if (box !== null) {
         this.previewBoxes.push(box)
+        this.previewUnion.union(box)
       }
     }
   }

--- a/src/viewer/ProgressiveLoadSession.js
+++ b/src/viewer/ProgressiveLoadSession.js
@@ -28,6 +28,12 @@ const BOX_CORNERS = 8
  * are skipped — see maybeRefit_. Fraction of the fitted radius.
  */
 const REFIT_EPSILON_FRACTION = 0.01
+/**
+ * How much larger than necessary the framed volume must be before the
+ * timer reclaims it. See isOverframed_ — this exists to recover from a
+ * stray that inflated the frame, not to track ordinary growth.
+ */
+const OVERFRAME_FACTOR = 4
 
 
 /**
@@ -425,13 +431,50 @@ export default class ProgressiveLoadSession {
   }
 
 
+  /**
+   * Has the framed volume become far larger than the geometry needs?
+   *
+   * Refits fire on OVERFLOW only, which is one-directional: the frame can
+   * grow but never come back. One stray that inflates the framing sphere
+   * is therefore permanent for the rest of the load — every later mesh
+   * lands inside the inflated sphere, so nothing ever overflows and no
+   * refit is requested. Observed on Snowdon: a fit jumped to radius
+   * 318751 at 503 preview meshes, and the following 650 meshes produced
+   * no fit at all while the model sat on screen as a sub-pixel speck.
+   *
+   * The factor is deliberately coarse. Normal growth is already handled
+   * by overflow, so this only has to catch the pathological case, and a
+   * tight threshold would re-fit on ordinary variation — which is the
+   * camera thrash the strict-fit design exists to avoid.
+   *
+   * @return {boolean}
+   */
+  isOverframed_() {
+    if (this.fittedSphere === null) {
+      return false
+    }
+    const bounds = robustBoundsFromElements([this.previewBoxes, this.streamedBoxes])
+    if (bounds === null || bounds.box.isEmpty()) {
+      return false
+    }
+    const sphere = new Sphere()
+    bounds.box.getBoundingSphere(sphere)
+    if (!(sphere.radius > 0) || !Number.isFinite(sphere.radius)) {
+      return false
+    }
+    // fittedSphere already carries FRAMING_MARGIN; apply it to the raw
+    // radius so the comparison is like-for-like.
+    return this.fittedSphere.radius > sphere.radius * FRAMING_MARGIN * OVERFRAME_FACTOR
+  }
+
+
   /** Timer backstop for overflows that landed inside the refit gap. */
   followTick_() {
     this.followTimer = null
     if (this.followStopped) {
       return
     }
-    if (this.overflowPending) {
+    if (this.overflowPending || this.isOverframed_()) {
       try {
         this.fitUnionToFrame_(true)
       } catch (e) {
@@ -507,14 +550,19 @@ export default class ProgressiveLoadSession {
     // come down off the defaults.
     applyCameraLimits(camera, controls, cameraLimitsForSphere(camera, sphere), true)
     // One line per actual camera move (throttled 250ms -> 1s, so a
-    // handful per load). A centre that jumps between fits is the preview
-    // group being relocated under the camera; a radius that explodes is
-    // a stray dragging the frame out.
+    // handful per load). A radius that explodes means the stray filter
+    // let something through, so report its decision inline: excluded=0
+    // with a huge radius means robustBounds returned the EXACT box, i.e.
+    // it refused to filter (over MAX_EXCLUDED_FRACTION, or the fences
+    // never computed) rather than that there was nothing to exclude.
     // eslint-disable-next-line no-console
     console.info(
       `[progressive] fit: centre=(${sphere.center.x.toFixed(2)}, ` +
       `${sphere.center.y.toFixed(2)}, ${sphere.center.z.toFixed(2)}) ` +
-      `radius=${sphere.radius.toFixed(3)} previewMeshes=${this.previewMeshCount}`)
+      `radius=${sphere.radius.toFixed(3)} previewMeshes=${this.previewMeshCount} ` +
+      `excluded=${bounds.excludedElements ?? 0}/${bounds.totalElements ?? 0}elem ` +
+      `${bounds.excludedVertices ?? 0}/${bounds.totalVertices ?? 0}vert ` +
+      `strayDist=${bounds.maxDistance === undefined ? 'n/a' : bounds.maxDistance.toFixed(0)}`)
     controls.fitToSphere(sphere, withTransition)
     this.fittedSphere = sphere
     this.overflowPending = false

--- a/src/viewer/ProgressiveLoadSession.js
+++ b/src/viewer/ProgressiveLoadSession.js
@@ -111,10 +111,7 @@ export default class ProgressiveLoadSession {
     this.streamedBoxes = new ElementBoxes()
     this.fittedSphere = null
     this.overflowPending = false
-    // Diagnostic counters for the always-on [progressive] lifecycle log.
-    // "Geometry shows briefly then vanishes mid-load" is invisible in the
-    // current log: preview install, the coordination stamp that can move
-    // the whole preview group, and teardown are all silent.
+    // Accepted-preview count: the outlier guard's warm-up gate.
     this.previewMeshCount = 0
     this.previewOutliers = 0
     // Bounds-change revision, and the revision the overframe check last
@@ -193,8 +190,6 @@ export default class ProgressiveLoadSession {
       if (!this.previewInstalled) {
         this.previewInstalled = true
         this.scene.add(this.previewGroup)
-        // eslint-disable-next-line no-console
-        console.info('[progressive] preview installed (first mesh)')
       }
       if (this.state === SessionState.IDLE) {
         this.state = SessionState.PREVIEWING
@@ -262,15 +257,6 @@ export default class ProgressiveLoadSession {
     try {
       group.matrix.fromArray(matrixArr)
       group.matrixAutoUpdate = false
-      // Prime suspect when the preview shows and then vanishes: a
-      // non-identity stamp moves the ENTIRE preview group in one go. The
-      // union is rebuilt and a refit requested right after, but
-      // maybeRefit_ is behind a cadence gate, so the camera can lag the
-      // jump by up to CAMERA_FOLLOW_MAX_MS with the preview offscreen.
-      // eslint-disable-next-line no-console
-      console.info(
-        `[progressive] coordination stamp: translation=(${matrixArr[12]}, ` +
-        `${matrixArr[13]}, ${matrixArr[14]}) meshes=${this.previewMeshCount}`)
       this.rebuildUnion_()
       this.overflowPending = true
       this.maybeRefit_()
@@ -637,20 +623,6 @@ export default class ProgressiveLoadSession {
     // the projection between refits) while letting minDistance and near
     // come down off the defaults.
     applyCameraLimits(camera, controls, cameraLimitsForSphere(camera, sphere), true)
-    // One line per actual camera move (throttled 250ms -> 1s, so a
-    // handful per load). A radius that explodes means the stray filter
-    // let something through, so report its decision inline: excluded=0
-    // with a huge radius means robustBounds returned the EXACT box, i.e.
-    // it refused to filter (over MAX_EXCLUDED_FRACTION, or the fences
-    // never computed) rather than that there was nothing to exclude.
-    // eslint-disable-next-line no-console
-    console.info(
-      `[progressive] fit: centre=(${sphere.center.x.toFixed(2)}, ` +
-      `${sphere.center.y.toFixed(2)}, ${sphere.center.z.toFixed(2)}) ` +
-      `radius=${sphere.radius.toFixed(3)} previewMeshes=${this.previewMeshCount} ` +
-      `excluded=${bounds.excludedElements ?? 0}/${bounds.totalElements ?? 0}elem ` +
-      `${bounds.excludedVertices ?? 0}/${bounds.totalVertices ?? 0}vert ` +
-      `strayDist=${bounds.maxDistance === undefined ? 'n/a' : bounds.maxDistance.toFixed(0)}`)
     controls.fitToSphere(sphere, withTransition)
     this.fittedSphere = sphere
     this.overflowPending = false
@@ -681,11 +653,6 @@ export default class ProgressiveLoadSession {
     if (this.previewGroup === null || !this.previewInstalled) {
       return
     }
-    // The other way geometry vanishes: the preview is disposed here and
-    // the durable model has to be on screen by now, or there is a gap.
-    // eslint-disable-next-line no-console
-    console.info(
-      `[progressive] preview teardown: meshes=${this.previewMeshCount} state=${this.state}`)
     try {
       this.scene.remove(this.previewGroup)
       for (const child of this.previewGroup.children) {

--- a/src/viewer/ProgressiveLoadSession.js
+++ b/src/viewer/ProgressiveLoadSession.js
@@ -117,6 +117,12 @@ export default class ProgressiveLoadSession {
     // the whole preview group, and teardown are all silent.
     this.previewMeshCount = 0
     this.previewOutliers = 0
+    // Bounds-change revision, and the revision the overframe check last
+    // ran against: isOverframed_ costs a full robust-bounds pass, so the
+    // timer only re-evaluates it after new bounds arrived — not on
+    // every quiet 250ms-1s tick of a long parse.
+    this.boundsRevision_ = 0
+    this.overframeCheckedRevision_ = 0
     // Running union of ACCEPTED preview boxes, for the outlier test.
     // Cheap to maintain (one box expand per mesh) unlike re-deriving
     // robust bounds, which is why the test lives here and not in the fit.
@@ -167,6 +173,9 @@ export default class ProgressiveLoadSession {
       return
     }
     try {
+      // Computed once here and threaded through growUnion_ — the box
+      // derivation (computeBoundingBox + matrix applies) is per-mesh
+      // hot-path work a large model repeats thousands of times.
       const box = this.meshWorldBox_(mesh)
       if (this.isPreviewOutlier_(box)) {
         this.previewOutliers++
@@ -190,7 +199,7 @@ export default class ProgressiveLoadSession {
       if (this.state === SessionState.IDLE) {
         this.state = SessionState.PREVIEWING
       }
-      this.growUnion_(mesh)
+      this.growUnion_(box)
       if (this.fittedSphere === null) {
         this.startFollow_()
       } else {
@@ -219,6 +228,7 @@ export default class ProgressiveLoadSession {
       // Copies the six bounds out: the incremental builder hands over a
       // scratch box it reuses for the next instance.
       this.streamedBoxes.push(box)
+      this.boundsRevision_++
       if (this.state === SessionState.IDLE) {
         this.state = SessionState.PREVIEWING
       }
@@ -342,14 +352,16 @@ export default class ProgressiveLoadSession {
    * Record one preview mesh's world bounds and flag an overflow when it
    * escapes the currently framed sphere.
    *
-   * @param {object} mesh
+   * @param {Box3|null} box the mesh's world bounds, computed by the
+   *   caller (addPreviewMesh already derives it for the outlier test —
+   *   deriving it twice doubled the hot path's bounds work)
    */
-  growUnion_(mesh) {
-    const box = this.meshWorldBox_(mesh)
+  growUnion_(box) {
     if (box === null) {
       return
     }
     this.previewUnion.union(box)
+    this.boundsRevision_++
     this.previewBoxes.push(box)
     if (this.fittedSphere !== null && !this.sphereContainsBox_(this.fittedSphere, box)) {
       this.overflowPending = true
@@ -368,6 +380,7 @@ export default class ProgressiveLoadSession {
     // in, so this has to be rebuilt with them or a coordination stamp
     // would leave it comparing across frames.
     this.previewUnion.makeEmpty()
+    this.boundsRevision_++
     if (this.previewGroup === null) {
       return
     }
@@ -545,7 +558,11 @@ export default class ProgressiveLoadSession {
     if (this.followStopped) {
       return
     }
-    if (this.overflowPending || this.isOverframed_()) {
+    const staleFrameSuspect = this.boundsRevision_ !== this.overframeCheckedRevision_
+    if (staleFrameSuspect) {
+      this.overframeCheckedRevision_ = this.boundsRevision_
+    }
+    if (this.overflowPending || (staleFrameSuspect && this.isOverframed_())) {
       try {
         this.fitUnionToFrame_(true)
       } catch (e) {

--- a/src/viewer/ProgressiveLoadSession.test.js
+++ b/src/viewer/ProgressiveLoadSession.test.js
@@ -278,6 +278,46 @@ describe('ProgressiveLoadSession', () => {
   })
 
 
+  describe('mis-placed preview geometry', () => {
+    it('drops a preview the durable model would never place there', () => {
+      // conway's preview channel double-subtracts the site offset for
+      // some products: on Snowdon (site at 417622, 78714, 238) that put
+      // 88 previews ~425km out while the durable stream placed none
+      // there, and the follow chased them to a 318km framing sphere.
+      for (let i = 0; i < 40; i++) {
+        session.addPreviewMesh(cubeAt(i * 0.1))
+      }
+      const accepted = session.previewMeshCount
+
+      session.addPreviewMesh(cubeAt(-417589.5))
+      session.lastFitMs = 0
+      session.overflowPending = true
+      session.maybeRefit_()
+
+      expect(session.previewOutliers).toBe(1)
+      expect(session.previewMeshCount).toBe(accepted)
+      // The camera still frames the 40 cubes (~4 units), not the 417589
+      // the rejected placement would have dragged it to.
+      const after = controls.fits[controls.fits.length - 1]
+      expect(after.radius).toBeLessThan(100)
+    })
+
+    it('keeps ordinary geometry that merely extends the model', () => {
+      // A wing, crane or antenna is nowhere near 100x the model radius
+      // out, so the guard must not touch it.
+      for (let i = 0; i < 40; i++) {
+        session.addPreviewMesh(cubeAt(i * 0.1))
+      }
+      const accepted = session.previewMeshCount
+
+      session.addPreviewMesh(cubeAt(20))
+
+      expect(session.previewOutliers).toBe(0)
+      expect(session.previewMeshCount).toBe(accepted + 1)
+    })
+  })
+
+
   describe('recovering an over-inflated frame', () => {
     it('reclaims the frame when a stray blew it up', () => {
       // Snowdon: a fit jumped to radius 318751 at 503 preview meshes and

--- a/src/viewer/ProgressiveLoadSession.test.js
+++ b/src/viewer/ProgressiveLoadSession.test.js
@@ -1,5 +1,6 @@
 import {Box3, BoxGeometry, Matrix4, Mesh, MeshBasicMaterial, Scene, Vector3} from 'three'
 import ProgressiveLoadSession, {SessionState} from './ProgressiveLoadSession'
+import {fitDistanceForRadius} from './three/cameraLimits'
 
 
 /* eslint-disable no-magic-numbers */
@@ -53,6 +54,10 @@ function makeCamera() {
   return {
     fov: 45,
     aspect: 1.5,
+    // The IfcCamera constructor defaults. `near: 1` matters as much as
+    // the controls' minDistance: on a sub-metre model it sits beyond the
+    // whole thing, so the follow must bring it down (see cameraLimits).
+    near: 1,
     far: 100,
     updateProjectionMatrix() {/* no-op */},
   }
@@ -196,6 +201,75 @@ describe('ProgressiveLoadSession', () => {
     expect(controls.fits).toHaveLength(0)
     pinned.finish()
   })
+
+  describe('camera limits during the stream', () => {
+    /**
+     * Assert the follow left the camera able to actually reach the pose
+     * it asked for, and with the model inside the frustum.
+     *
+     * @param {object} fitted the sphere handed to fitToSphere
+     */
+    const expectReachableFit = (fitted) => {
+      const wantDistance = fitDistanceForRadius(camera, fitted.radius)
+      // fitToSphere dollies are clamped to [minDistance, maxDistance]. If
+      // the distance it wants falls outside, the camera silently parks at
+      // the clamp instead and the model is mis-sized.
+      expect(wantDistance).toBeGreaterThan(controls.minDistance)
+      expect(wantDistance).toBeLessThan(controls.maxDistance)
+      // Near must sit inside the model, not beyond it, or it clips.
+      expect(camera.near).toBeLessThan(wantDistance - fitted.radius)
+    }
+
+    it('brings minDistance and near DOWN for a sub-metre model', () => {
+      // Arty_Z7.stp is a true-scale millimetre PCB, ~0.1 scene units
+      // across. The follow used to grow only maxDistance and far, leaving
+      // minDistance and near at the activation default of 1 -- ten times
+      // the whole board. fitToSphere then clamped to minDistance so the
+      // board rendered tiny, and near=1 sat beyond it so it rendered
+      // half-clipped, until the end-of-load fit corrected both. That
+      // correction is what read as "resizing during load".
+      session.notifyBounds(
+        new Box3().setFromCenterAndSize(new Vector3(0, 0, 0), new Vector3(0.1, 0.1, 0.02)))
+
+      const fitted = controls.fits[0]
+      expect(fitted).toBeDefined()
+      expect(controls.minDistance).toBeLessThan(1)
+      expect(camera.near).toBeLessThan(1)
+      expectReachableFit(fitted)
+    })
+
+    it('grows maxDistance and far UP for a model past the defaults', () => {
+      const scratch = new Box3()
+      streamRun(session, 60, scratch)
+
+      const fitted = controls.fits[controls.fits.length - 1]
+      expect(controls.maxDistance).toBeGreaterThan(300)
+      expect(camera.far).toBeGreaterThan(100)
+      expectReachableFit(fitted)
+    })
+
+    it('never shrinks the outward range between refits', () => {
+      // growOnly: the union is monotonic, and letting maxDistance/far
+      // fall back mid-load would pop the projection between refits.
+      const scratch = new Box3()
+      streamRun(session, 60, scratch)
+      const wideMax = controls.maxDistance
+      const wideFar = camera.far
+
+      // A refit whose robust bounds are no larger must not pull them in.
+      session.lastFitMs = 0
+      session.overflowPending = true
+      session.fittedSphere = null
+      session.maybeRefit_()
+      session.lastFitMs = 0
+      session.overflowPending = true
+      session.maybeRefit_()
+
+      expect(controls.maxDistance).toBeGreaterThanOrEqual(wideMax)
+      expect(camera.far).toBeGreaterThanOrEqual(wideFar)
+    })
+  })
+
 
   describe('robust framing during the stream', () => {
     // Enough instances for the robust criterion to have statistics —

--- a/src/viewer/ProgressiveLoadSession.test.js
+++ b/src/viewer/ProgressiveLoadSession.test.js
@@ -1,4 +1,4 @@
-import {Box3, BoxGeometry, Matrix4, Mesh, MeshBasicMaterial, Scene, Vector3} from 'three'
+import {Box3, BoxGeometry, Matrix4, Mesh, MeshBasicMaterial, Scene, Sphere, Vector3} from 'three'
 import ProgressiveLoadSession, {SessionState} from './ProgressiveLoadSession'
 import {fitDistanceForRadius} from './three/cameraLimits'
 
@@ -82,8 +82,14 @@ describe('ProgressiveLoadSession', () => {
   let controls
   let camera
   let session
+  let infoSpy
 
   beforeEach(() => {
+    // The session's [progressive] lifecycle lines are always-on by
+    // design (they have to reach a user's console without a flag), so
+    // divert them here rather than let every test narrate the load.
+    // PLAYBOOK.md §"Keep the test console clean".
+    infoSpy = jest.spyOn(console, 'info').mockImplementation(() => {})
     scene = new Scene()
     controls = makeControls()
     camera = makeCamera()
@@ -97,6 +103,7 @@ describe('ProgressiveLoadSession', () => {
 
   afterEach(() => {
     session.finish()
+    infoSpy.mockRestore()
   })
 
   it('walks idle → previewing → assembling → finished', () => {
@@ -267,6 +274,51 @@ describe('ProgressiveLoadSession', () => {
 
       expect(controls.maxDistance).toBeGreaterThanOrEqual(wideMax)
       expect(camera.far).toBeGreaterThanOrEqual(wideFar)
+    })
+  })
+
+
+  describe('recovering an over-inflated frame', () => {
+    it('reclaims the frame when a stray blew it up', () => {
+      // Snowdon: a fit jumped to radius 318751 at 503 preview meshes and
+      // the following 650 meshes produced NO fit at all, because refits
+      // fire on overflow and nothing can overflow a sphere that large.
+      // The model sat on screen as a sub-pixel speck for the rest of the
+      // load and only looked right once the end-of-load fit ran.
+      const scratch = new Box3()
+      streamRun(session, 60, scratch)
+      const good = controls.fits[controls.fits.length - 1]
+
+      session.fittedSphere = new Sphere(good.center.clone(), good.radius * 5000)
+      session.overflowPending = false
+      session.lastFitMs = 0
+      const before = controls.fits.length
+
+      session.followTick_()
+      session.stopFollow_()
+
+      expect(controls.fits.length).toBeGreaterThan(before)
+      const recovered = controls.fits[controls.fits.length - 1]
+      expect(recovered.radius).toBeLessThan(good.radius * 2)
+    })
+
+    it('does not refit when the frame is merely a little loose', () => {
+      // The guard against trading one bug for camera thrash: ordinary
+      // growth is already handled by overflow, so a frame that is only
+      // somewhat larger than needed must be left alone.
+      const scratch = new Box3()
+      streamRun(session, 60, scratch)
+      const good = controls.fits[controls.fits.length - 1]
+
+      session.fittedSphere = new Sphere(good.center.clone(), good.radius * 1.5)
+      session.overflowPending = false
+      session.lastFitMs = 0
+      const before = controls.fits.length
+
+      session.followTick_()
+      session.stopFollow_()
+
+      expect(controls.fits).toHaveLength(before)
     })
   })
 

--- a/src/viewer/ProgressiveLoadSession.test.js
+++ b/src/viewer/ProgressiveLoadSession.test.js
@@ -82,14 +82,14 @@ describe('ProgressiveLoadSession', () => {
   let controls
   let camera
   let session
-  let infoSpy
+  let warnSpy
 
   beforeEach(() => {
-    // The session's [progressive] lifecycle lines are always-on by
-    // design (they have to reach a user's console without a flag), so
-    // divert them here rather than let every test narrate the load.
-    // PLAYBOOK.md §"Keep the test console clean".
-    infoSpy = jest.spyOn(console, 'info').mockImplementation(() => {})
+    // The outlier guard's console.warn is always-on by design (it must
+    // reach a user's console without a flag), so divert it here rather
+    // than let the outlier tests narrate. PLAYBOOK.md §"Keep the test
+    // console clean".
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
     scene = new Scene()
     controls = makeControls()
     camera = makeCamera()
@@ -103,7 +103,7 @@ describe('ProgressiveLoadSession', () => {
 
   afterEach(() => {
     session.finish()
-    infoSpy.mockRestore()
+    warnSpy.mockRestore()
   })
 
   it('walks idle → previewing → assembling → finished', () => {
@@ -296,6 +296,8 @@ describe('ProgressiveLoadSession', () => {
 
       expect(session.previewOutliers).toBe(1)
       expect(session.previewMeshCount).toBe(accepted)
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('dropping mis-placed preview geometry'))
       // The camera still frames the 40 cubes (~4 units), not the 417589
       // the rejected placement would have dragged it to.
       const after = controls.fits[controls.fits.length - 1]

--- a/src/viewer/ifc/ShareIfcLoader.js
+++ b/src/viewer/ifc/ShareIfcLoader.js
@@ -205,38 +205,8 @@ export default class ShareIfcLoader {
       // the durable model renders.
       const coordination = {offset: undefined}
 
-      // Identify the geometry that drags the camera follow off the model.
-      // Snowdon frames a 318km sphere at ~500 preview meshes while the
-      // building itself is ~60 units across, and the stray filter reports
-      // excluded=0 — meaning too much of the preview stream is out there
-      // for "model + strays" to apply. What those placements ARE decides
-      // the fix, and nothing currently says.
-      let farPreviews = 0
-      let farthestPreview = 0
-      let farPreviewsLogged = 0
-      let farDurable = 0
-      let farthestDurable = 0
-      const FAR_PREVIEW_THRESHOLD = 1e4
-      const FAR_PREVIEW_LOG_LIMIT = 5
-      const HALF_EXTENT = 0.5
-
       const onPreviewMesh = !usePreview ? undefined : (payload) => {
         try {
-          const t = payload.flatTransformation
-          const distance = Math.hypot(t[12], t[13], t[14])
-          if (distance > FAR_PREVIEW_THRESHOLD) {
-            farPreviews++
-            farthestPreview = Math.max(farthestPreview, distance)
-            if (farPreviewsLogged < FAR_PREVIEW_LOG_LIMIT) {
-              farPreviewsLogged++
-              // eslint-disable-next-line no-console
-              console.info(
-                `[progressive] far preview #${farPreviews}: ` +
-                `expressID=${payload.expressID} geom=${payload.geometryExpressID} ` +
-                `t=(${t[12].toFixed(1)}, ${t[13].toFixed(1)}, ${t[14].toFixed(1)}) ` +
-                `dist=${distance.toFixed(0)}`)
-            }
-          }
           const mesh = payloadToPreviewMesh(
             payload, previewGeometryCache, previewMaterialCache, coordination)
           if (mesh !== null) {
@@ -256,24 +226,7 @@ export default class ShareIfcLoader {
         try {
           if (builder === null) {
             builder = new IncrementalBatchedBuilder(ifcAPI, batchModelID, {
-              // Measure the durable stream through the bounds the builder
-              // already derives. The previous cut of this walked
-              // `flatMesh.geometries` directly, which is a conway vector
-              // rather than a JS iterable — it threw inside the try, so
-              // every batch was misreported as an append failure and fell
-              // back to preview meshes. Never walk conway containers here;
-              // the builder owns that access.
-              onBounds: (box) => {
-                const distance = Math.hypot(
-                  (box.min.x + box.max.x) * HALF_EXTENT,
-                  (box.min.y + box.max.y) * HALF_EXTENT,
-                  (box.min.z + box.max.z) * HALF_EXTENT)
-                if (distance > FAR_PREVIEW_THRESHOLD) {
-                  farDurable++
-                  farthestDurable = Math.max(farthestDurable, distance)
-                }
-                session.notifyBounds(box)
-              },
+              onBounds: (box) => session.notifyBounds(box),
               coordination,
             })
             scene.add(builder.root)
@@ -292,17 +245,6 @@ export default class ShareIfcLoader {
 
       const {modelID, captured} =
         await parseIfcWithConway(buffer, ifcAPI, undefined, onProgress, onMeshBatch, onPreviewMesh)
-
-      // The decisive comparison: same threshold applied to both streams.
-      // preview>0 with durable=0 means the preview channel emits
-      // placements the durable model never gets; both >0 means the
-      // geometry genuinely spans that range and the follow's framing is
-      // what needs to change.
-      // eslint-disable-next-line no-console
-      console.info(
-        `[progressive] far placements (>${FAR_PREVIEW_THRESHOLD}): ` +
-        `preview=${farPreviews} maxDist=${farthestPreview.toFixed(0)} | ` +
-        `durable=${farDurable} maxDist=${farthestDurable.toFixed(0)}`)
 
       session.beginAssembly()
 

--- a/src/viewer/ifc/ShareIfcLoader.js
+++ b/src/viewer/ifc/ShareIfcLoader.js
@@ -197,10 +197,18 @@ export default class ShareIfcLoader {
       const usePreview = session.previewGroup !== null
       const previewGeometryCache = new Map()
       const previewMaterialCache = new Map()
+      // One origin-recenter frame for BOTH streaming paths. The preview
+      // meshes and the incremental durable batches are on screen at the
+      // same time, so each deciding its own frame puts them in different
+      // places — on a georeferenced model (Revit site coordinates) the
+      // builder recentred and the previews did not, stranding the
+      // previews ~200km out and dragging the camera follow with them.
+      const coordination = {offset: undefined}
 
       const onPreviewMesh = !usePreview ? undefined : (payload) => {
         try {
-          const mesh = payloadToPreviewMesh(payload, previewGeometryCache, previewMaterialCache)
+          const mesh = payloadToPreviewMesh(
+            payload, previewGeometryCache, previewMaterialCache, coordination)
           if (mesh !== null) {
             session.addPreviewMesh(mesh)
           }
@@ -219,6 +227,7 @@ export default class ShareIfcLoader {
           if (builder === null) {
             builder = new IncrementalBatchedBuilder(ifcAPI, batchModelID, {
               onBounds: (box) => session.notifyBounds(box),
+              coordination,
             })
             scene.add(builder.root)
           }

--- a/src/viewer/ifc/ShareIfcLoader.js
+++ b/src/viewer/ifc/ShareIfcLoader.js
@@ -197,12 +197,12 @@ export default class ShareIfcLoader {
       const usePreview = session.previewGroup !== null
       const previewGeometryCache = new Map()
       const previewMaterialCache = new Map()
-      // One origin-recenter frame for BOTH streaming paths. The preview
-      // meshes and the incremental durable batches are on screen at the
-      // same time, so each deciding its own frame puts them in different
-      // places — on a georeferenced model (Revit site coordinates) the
-      // builder recentred and the previews did not, stranding the
-      // previews ~200km out and dragging the camera follow with them.
+      // One origin-recenter frame for BOTH streaming paths, decided by
+      // the durable builder alone; previews read it and render
+      // unrecentred until the first durable batch lands. The preview
+      // channel is the unreliable half (conway#465 emitted payloads
+      // whose placement never resolved), so it must never decide where
+      // the durable model renders.
       const coordination = {offset: undefined}
 
       // Identify the geometry that drags the camera follow off the model.

--- a/src/viewer/ifc/ShareIfcLoader.js
+++ b/src/viewer/ifc/ShareIfcLoader.js
@@ -205,8 +205,37 @@ export default class ShareIfcLoader {
       // previews ~200km out and dragging the camera follow with them.
       const coordination = {offset: undefined}
 
+      // Identify the geometry that drags the camera follow off the model.
+      // Snowdon frames a 318km sphere at ~500 preview meshes while the
+      // building itself is ~60 units across, and the stray filter reports
+      // excluded=0 — meaning too much of the preview stream is out there
+      // for "model + strays" to apply. What those placements ARE decides
+      // the fix, and nothing currently says.
+      let farPreviews = 0
+      let farthestPreview = 0
+      let farPreviewsLogged = 0
+      let farDurable = 0
+      let farthestDurable = 0
+      const FAR_PREVIEW_THRESHOLD = 1e4
+      const FAR_PREVIEW_LOG_LIMIT = 5
+
       const onPreviewMesh = !usePreview ? undefined : (payload) => {
         try {
+          const t = payload.flatTransformation
+          const distance = Math.hypot(t[12], t[13], t[14])
+          if (distance > FAR_PREVIEW_THRESHOLD) {
+            farPreviews++
+            farthestPreview = Math.max(farthestPreview, distance)
+            if (farPreviewsLogged < FAR_PREVIEW_LOG_LIMIT) {
+              farPreviewsLogged++
+              // eslint-disable-next-line no-console
+              console.info(
+                `[progressive] far preview #${farPreviews}: ` +
+                `expressID=${payload.expressID} geom=${payload.geometryExpressID} ` +
+                `t=(${t[12].toFixed(1)}, ${t[13].toFixed(1)}, ${t[14].toFixed(1)}) ` +
+                `dist=${distance.toFixed(0)}`)
+            }
+          }
           const mesh = payloadToPreviewMesh(
             payload, previewGeometryCache, previewMaterialCache, coordination)
           if (mesh !== null) {
@@ -232,6 +261,22 @@ export default class ShareIfcLoader {
             scene.add(builder.root)
           }
           builder.appendBatch(batch)
+          // Same measurement on the DURABLE stream. If the far placements
+          // appear here too, the preview channel is faithful and the
+          // geometry really is spread over hundreds of km (a survey point
+          // or site element), which is a framing problem. If they appear
+          // ONLY in previews, the preview channel is emitting placements
+          // the durable model does not have, which is a conway-side bug.
+          for (const flatMesh of batch) {
+            for (const placed of flatMesh.geometries ?? []) {
+              const t = placed.flatTransformation
+              const distance = Math.hypot(t[12], t[13], t[14])
+              if (distance > FAR_PREVIEW_THRESHOLD) {
+                farDurable++
+                farthestDurable = Math.max(farthestDurable, distance)
+              }
+            }
+          }
         } catch (e) {
           debug(WARN).warn('incremental batch append failed; preview fallback:', e)
           try {
@@ -245,6 +290,17 @@ export default class ShareIfcLoader {
 
       const {modelID, captured} =
         await parseIfcWithConway(buffer, ifcAPI, undefined, onProgress, onMeshBatch, onPreviewMesh)
+
+      // The decisive comparison: same threshold applied to both streams.
+      // preview>0 with durable=0 means the preview channel emits
+      // placements the durable model never gets; both >0 means the
+      // geometry genuinely spans that range and the follow's framing is
+      // what needs to change.
+      // eslint-disable-next-line no-console
+      console.info(
+        `[progressive] far placements (>${FAR_PREVIEW_THRESHOLD}): ` +
+        `preview=${farPreviews} maxDist=${farthestPreview.toFixed(0)} | ` +
+        `durable=${farDurable} maxDist=${farthestDurable.toFixed(0)}`)
 
       session.beginAssembly()
 

--- a/src/viewer/ifc/ShareIfcLoader.js
+++ b/src/viewer/ifc/ShareIfcLoader.js
@@ -218,6 +218,7 @@ export default class ShareIfcLoader {
       let farthestDurable = 0
       const FAR_PREVIEW_THRESHOLD = 1e4
       const FAR_PREVIEW_LOG_LIMIT = 5
+      const HALF_EXTENT = 0.5
 
       const onPreviewMesh = !usePreview ? undefined : (payload) => {
         try {
@@ -255,28 +256,29 @@ export default class ShareIfcLoader {
         try {
           if (builder === null) {
             builder = new IncrementalBatchedBuilder(ifcAPI, batchModelID, {
-              onBounds: (box) => session.notifyBounds(box),
+              // Measure the durable stream through the bounds the builder
+              // already derives. The previous cut of this walked
+              // `flatMesh.geometries` directly, which is a conway vector
+              // rather than a JS iterable — it threw inside the try, so
+              // every batch was misreported as an append failure and fell
+              // back to preview meshes. Never walk conway containers here;
+              // the builder owns that access.
+              onBounds: (box) => {
+                const distance = Math.hypot(
+                  (box.min.x + box.max.x) * HALF_EXTENT,
+                  (box.min.y + box.max.y) * HALF_EXTENT,
+                  (box.min.z + box.max.z) * HALF_EXTENT)
+                if (distance > FAR_PREVIEW_THRESHOLD) {
+                  farDurable++
+                  farthestDurable = Math.max(farthestDurable, distance)
+                }
+                session.notifyBounds(box)
+              },
               coordination,
             })
             scene.add(builder.root)
           }
           builder.appendBatch(batch)
-          // Same measurement on the DURABLE stream. If the far placements
-          // appear here too, the preview channel is faithful and the
-          // geometry really is spread over hundreds of km (a survey point
-          // or site element), which is a framing problem. If they appear
-          // ONLY in previews, the preview channel is emitting placements
-          // the durable model does not have, which is a conway-side bug.
-          for (const flatMesh of batch) {
-            for (const placed of flatMesh.geometries ?? []) {
-              const t = placed.flatTransformation
-              const distance = Math.hypot(t[12], t[13], t[14])
-              if (distance > FAR_PREVIEW_THRESHOLD) {
-                farDurable++
-                farthestDurable = Math.max(farthestDurable, distance)
-              }
-            }
-          }
         } catch (e) {
           debug(WARN).warn('incremental batch append failed; preview fallback:', e)
           try {

--- a/src/viewer/ifc/conwayDirectIfcLoader.js
+++ b/src/viewer/ifc/conwayDirectIfcLoader.js
@@ -153,6 +153,12 @@ export async function parseIfcWithConway(
       throw new Error(`parseIfcWithConway: OpenModel returned ${modelID}`)
     }
     const captured = []
+    // Batch-pump accounting for the load log. Whether the pump actually
+    // produced anything is the difference between a model that streams
+    // onto the screen and one that shows nothing until the end-of-load
+    // build, and until now the log said nothing either way — a blank
+    // 9-second parse and a healthy streaming parse looked identical.
+    let pumpedBatches = 0
     for (;;) {
       const batch = []
       // eslint-disable-next-line new-cap
@@ -160,6 +166,7 @@ export async function parseIfcWithConway(
         modelID, DEMAND_EXTRACT_BATCH_SIZE, (flatMesh) => batch.push(flatMesh))
       if (batch.length > 0) {
         captured.push(...batch)
+        pumpedBatches++
         if (onMeshBatch) {
           onMeshBatch(batch, modelID)
         }
@@ -170,7 +177,19 @@ export async function parseIfcWithConway(
       // Yield so the renderer paints between batches.
       await yieldToEventLoop()
     }
+    debug().log(
+      `[conwayDirect] demand pump: batches=${pumpedBatches} ` +
+      `meshes=${captured.length} onMeshBatch=${onMeshBatch ? 'yes' : 'no'} ` +
+      `onPreviewMesh=${onPreviewMesh ? 'yes' : 'no'}`)
     if (captured.length === 0) {
+      // Nothing pumped: conway fell back to a classic fully-extracted
+      // open internally, so StreamAllMeshes below captures the whole
+      // model in one go and NOTHING renders until the end-of-load build.
+      // That is the blank-screen-then-pop behavior, and it is silent
+      // without this line.
+      debug(WARN).warn(
+        '[conwayDirect] demand pump produced no batches; ' +
+        'falling back to one-shot StreamAllMeshes — no progressive render')
       // The deferred columnar open is IFC-only: for STEP input (and any
       // streamed-parse failure) conway falls back internally to a
       // classic, fully-extracted open where the batch pump is a no-op —

--- a/src/viewer/ifc/conwayDirectIfcLoader.js
+++ b/src/viewer/ifc/conwayDirectIfcLoader.js
@@ -177,10 +177,12 @@ export async function parseIfcWithConway(
       // Yield so the renderer paints between batches.
       await yieldToEventLoop()
     }
-    // console.info, not debug(): debug() defaults to INFO and no-ops
-    // unless the level is raised, so the first cut of this line never
-    // printed. Matches the always-on `[conwayDirect] parsed` boundary
-    // log in ShareIfcLoader.
+    // Permanent boundary log, like `[conwayDirect] parsed` in
+    // ShareIfcLoader: whether the pump produced batches is the
+    // difference between a load that streams onto the screen and one
+    // that shows nothing until the end-of-load build, and the two are
+    // indistinguishable without this line (Share#1744). console.info,
+    // not debug() — debug() no-ops unless the level is raised.
     // eslint-disable-next-line no-console
     console.info(
       `[conwayDirect] demand pump: batches=${pumpedBatches} ` +

--- a/src/viewer/ifc/conwayDirectIfcLoader.js
+++ b/src/viewer/ifc/conwayDirectIfcLoader.js
@@ -177,7 +177,12 @@ export async function parseIfcWithConway(
       // Yield so the renderer paints between batches.
       await yieldToEventLoop()
     }
-    debug().log(
+    // console.info, not debug(): debug() defaults to INFO and no-ops
+    // unless the level is raised, so the first cut of this line never
+    // printed. Matches the always-on `[conwayDirect] parsed` boundary
+    // log in ShareIfcLoader.
+    // eslint-disable-next-line no-console
+    console.info(
       `[conwayDirect] demand pump: batches=${pumpedBatches} ` +
       `meshes=${captured.length} onMeshBatch=${onMeshBatch ? 'yes' : 'no'} ` +
       `onPreviewMesh=${onPreviewMesh ? 'yes' : 'no'}`)
@@ -187,7 +192,7 @@ export async function parseIfcWithConway(
       // model in one go and NOTHING renders until the end-of-load build.
       // That is the blank-screen-then-pop behavior, and it is silent
       // without this line.
-      debug(WARN).warn(
+      console.warn(
         '[conwayDirect] demand pump produced no batches; ' +
         'falling back to one-shot StreamAllMeshes — no progressive render')
       // The deferred columnar open is IFC-only: for STEP input (and any

--- a/src/viewer/ifc/conwayDirectIfcLoader.test.js
+++ b/src/viewer/ifc/conwayDirectIfcLoader.test.js
@@ -26,6 +26,22 @@ jest.mock('../../FeatureFlags', () => ({
 
 /* eslint-disable no-magic-numbers */
 describe('viewer/ifc/conwayDirectIfcLoader', () => {
+  // The demand-pump boundary logs are always-on (they must reach a
+  // user's console without a flag), so divert them rather than let the
+  // suite narrate every parse. PLAYBOOK.md §"Keep the test console clean".
+  let infoSpy
+  let warnSpy
+
+  beforeEach(() => {
+    infoSpy = jest.spyOn(console, 'info').mockImplementation(() => {})
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    infoSpy.mockRestore()
+    warnSpy.mockRestore()
+  })
+
   describe('parseIfcWithConway', () => {
     it('returns the modelID + captured FlatMeshes from a single Conway OpenModel + StreamAllMeshes pass', async () => {
       const fakeFlatMesh1 = {expressID: 42, geometries: {size: () => 0}}

--- a/src/viewer/ifc/incrementalBatchedBuilder.js
+++ b/src/viewer/ifc/incrementalBatchedBuilder.js
@@ -81,10 +81,11 @@ export class IncrementalBatchedBuilder {
     // placement decides it; then `[x,y,z]` (subtracted from every
     // instance) or null (no-op).
     //
-    // Shared with the parse-time preview path when the caller passes one:
-    // both render simultaneously while a model streams, so a frame the
-    // two don't agree on puts the preview where the real model never
-    // goes. That is what made Snowdon invisible during load.
+    // Shared with the parse-time preview path when the caller passes
+    // one, and THIS BUILDER IS THE ONLY WRITER: the preview channel can
+    // emit payloads whose placement never resolved (conway#465), so the
+    // frame must be decided by the durable stream's first placement —
+    // the authoritative one — and previews only read it.
     this.coordination = opts.coordination ?? {offset: undefined}
     // Lazily created per transparency: see ensureBatch_.
     this.opaque = null

--- a/src/viewer/ifc/incrementalBatchedBuilder.js
+++ b/src/viewer/ifc/incrementalBatchedBuilder.js
@@ -76,10 +76,16 @@ export class IncrementalBatchedBuilder {
     // coincidenceKeys already appended, across all batches — drops exact
     // duplicate placements that would z-fight (see coincidenceKey).
     this.seenPlacements = new Set()
-    // Origin-recenter offset for georeferenced models (see
-    // coordinationOffsetFor). `undefined` until the first placement decides
-    // it; then `[x,y,z]` (subtracted from every instance) or null (no-op).
-    this.coordOffset = undefined
+    // Origin-recenter frame for georeferenced models (see
+    // coordinationOffsetFor). `offset` is `undefined` until the first
+    // placement decides it; then `[x,y,z]` (subtracted from every
+    // instance) or null (no-op).
+    //
+    // Shared with the parse-time preview path when the caller passes one:
+    // both render simultaneously while a model streams, so a frame the
+    // two don't agree on puts the preview where the real model never
+    // goes. That is what made Snowdon invisible during load.
+    this.coordination = opts.coordination ?? {offset: undefined}
     // Lazily created per transparency: see ensureBatch_.
     this.opaque = null
     this.transparent = null
@@ -231,16 +237,14 @@ export class IncrementalBatchedBuilder {
     // the origin (float32-precise) instead of at ~1e7 m. See
     // coordinationOffsetFor. Stamped on the root for consumers that need to
     // map a rendered point back to true world coordinates.
-    if (this.coordOffset === undefined) {
-      this.coordOffset = coordinationOffsetFor(placed.flatTransformation)
-      if (this.coordOffset !== null) {
-        this.root.userData.coordinationOffset = this.coordOffset
-      }
+    if (this.coordination.offset === undefined) {
+      this.coordination.offset = coordinationOffsetFor(placed.flatTransformation)
     }
-    if (this.coordOffset !== null) {
-      matrix.elements[12] -= this.coordOffset[0]
-      matrix.elements[13] -= this.coordOffset[1]
-      matrix.elements[14] -= this.coordOffset[2]
+    if (this.coordination.offset !== null) {
+      this.root.userData.coordinationOffset = this.coordination.offset
+      matrix.elements[12] -= this.coordination.offset[0]
+      matrix.elements[13] -= this.coordination.offset[1]
+      matrix.elements[14] -= this.coordination.offset[2]
     }
     state.mesh.setMatrixAt(batchId, matrix)
     state.mesh.setColorAt(batchId, this.scratchRgba.set(color.x, color.y, color.z, color.w))

--- a/src/viewer/ifc/incrementalBatchedBuilder.js
+++ b/src/viewer/ifc/incrementalBatchedBuilder.js
@@ -144,6 +144,15 @@ export class IncrementalBatchedBuilder {
           state.instanceOccurrencePaths.slice() : null
       state.mesh.instanceGeometry = state.instanceGeometry.slice()
       state.mesh.instanceColors = state.instanceColors.slice()
+      // The mesh has stopped growing, so a bounding volume is finally
+      // meaningful. Compute it and hand culling back — see ensureBatch_
+      // for why it had to be off while streaming. assembleBatchedModel
+      // recomputes these too; doing it here keeps the invariant with the
+      // builder that turned culling off, rather than relying on a
+      // consumer that the fallback paths may not reach.
+      state.mesh.computeBoundingBox?.()
+      state.mesh.computeBoundingSphere?.()
+      state.mesh.frustumCulled = true
       batches.push({
         mesh: state.mesh,
         material: state.material,
@@ -332,6 +341,26 @@ export class IncrementalBatchedBuilder {
     // per-frame camera sort flips the coplanar winner as the camera
     // moves); the transparent batch must still sort for blending.
     mesh.sortObjects = transparent
+    // Culling is OFF for the whole streaming phase, and this is load-
+    // bearing rather than an optimization opt-out.
+    //
+    // `BatchedMesh` declares `boundingSphere`, so three's
+    // `Frustum.intersectsObject` computes it once on first render and
+    // then CACHES it — nothing invalidates it when instances append.
+    // Computed on the first frame, when a handful of instances occupy a
+    // mesh reserved for thousands, it freezes at near-zero radius, and
+    // every batch after that is culled against it. The model stays
+    // invisible for the entire stream and only pops in at the end, when
+    // assembleBatchedModel (buildBatchedConwayModel.js) finally calls
+    // computeBoundingBox/Sphere. The camera follow looks correct
+    // throughout because it derives its own bounds (onBounds below), so
+    // the camera tracks a model that is never drawn.
+    //
+    // Recomputing per batch is the other option and it is O(instances)
+    // each time — quadratic over a load. Skipping the test costs one
+    // extra draw call for a mesh that is on screen anyway.
+    // finalize() restores culling once the bounds are real.
+    mesh.frustumCulled = false
     const state = {
       mesh,
       material,

--- a/src/viewer/ifc/incrementalBatchedBuilder.test.js
+++ b/src/viewer/ifc/incrementalBatchedBuilder.test.js
@@ -2,6 +2,7 @@
 import {BatchedMesh, Matrix4} from 'three'
 import {IncrementalBatchedBuilder} from './incrementalBatchedBuilder'
 import {flatMeshToBatchedModel} from './flatMeshToBatchedModel'
+import {payloadToPreviewMesh} from './parsePreviewMesh'
 
 
 const IDENTITY_MAT = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]
@@ -196,8 +197,43 @@ describe('IncrementalBatchedBuilder', () => {
     const builder = new IncrementalBatchedBuilder(makeApi(shapes), 0)
     builder.appendBatch([flatMesh(1, [{geomExpressID: 999, color: OPAQUE}])])
     builder.finalize()
-    expect(builder.coordOffset).toBeNull()
+    expect(builder.coordination.offset).toBeNull()
     expect(builder.root.userData.coordinationOffset).toBeUndefined()
+  })
+
+  it('shares one recentre frame with the preview path', () => {
+    // The two stream onto the screen together, so a frame they disagree
+    // on strands the preview where the durable model never goes. On
+    // Snowdon (Revit site coordinates) that put previews ~200km out and
+    // dragged the camera follow with them for the whole load.
+    const placedAt = (tx, ty, tz) => ({
+      expressID: 1,
+      geometries: [{geometryExpressID: 999, flatTransformation:
+        [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, tx, ty, tz, 1], color: OPAQUE}],
+    })
+    const coordination = {offset: undefined}
+    const builder = new IncrementalBatchedBuilder(makeApi(shapes), 0, {coordination})
+    builder.appendBatch([placedAt(2000000, 5, -8000000)])
+    builder.finalize()
+
+    expect(coordination.offset).toEqual([2000000, 5, -8000000])
+
+    // A preview payload placed at the same site coordinates now lands in
+    // the same frame -- near the origin, not a megametre away.
+    const mesh = payloadToPreviewMesh(
+      {
+        geometryExpressID: 999,
+        color: {x: 1, y: 1, z: 1, w: 1},
+        vertexData: unitTriangleVerts(),
+        indexData: new Uint32Array([0, 1, 2]),
+        flatTransformation: [
+          1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 2000000, 5, -8000000, 1,
+        ],
+      },
+      new Map(), new Map(), coordination)
+
+    expect(mesh.matrix.elements[12]).toBeCloseTo(0)
+    expect(mesh.matrix.elements[14]).toBeCloseTo(0)
   })
 
   it('reports bounds per appended instance and skips bad geometry', () => {

--- a/src/viewer/ifc/incrementalBatchedBuilder.test.js
+++ b/src/viewer/ifc/incrementalBatchedBuilder.test.js
@@ -99,6 +99,31 @@ describe('IncrementalBatchedBuilder', () => {
     }
   })
 
+  it('keeps culling off while streaming, and restores it at finalize', () => {
+    // three caches BatchedMesh.boundingSphere the first time it culls and
+    // never invalidates it when instances append. Computed on frame one,
+    // when a few instances sit in a mesh reserved for thousands, it
+    // freezes near zero radius and culls every later batch -- the model
+    // stays invisible for the whole stream and only appears at the end,
+    // when assembleBatchedModel finally computes real bounds. The camera
+    // follow derives its own bounds, so it tracks a model never drawn.
+    const builder = new IncrementalBatchedBuilder(makeApi(shapes), 0)
+    builder.appendBatch([flatMesh(1, [{geomExpressID: 999, color: OPAQUE}])])
+
+    const streaming = [builder.opaque, builder.transparent].filter(Boolean)
+    expect(streaming.length).toBeGreaterThan(0)
+    for (const state of streaming) {
+      expect(state.mesh.frustumCulled).toBe(false)
+    }
+
+    const {batches} = builder.finalize()
+    for (const batch of batches) {
+      expect(batch.mesh.frustumCulled).toBe(true)
+      // Bounds are only meaningful once the mesh has stopped growing.
+      expect(batch.mesh.boundingSphere).not.toBeNull()
+    }
+  })
+
   it('grows capacity in place across small initial limits', () => {
     const builder = new IncrementalBatchedBuilder(makeApi(shapes), 0, {
       initialInstances: 1, initialVertices: 3, initialIndices: 3,

--- a/src/viewer/ifc/incrementalBatchedBuilder.test.js
+++ b/src/viewer/ifc/incrementalBatchedBuilder.test.js
@@ -201,11 +201,13 @@ describe('IncrementalBatchedBuilder', () => {
     expect(builder.root.userData.coordinationOffset).toBeUndefined()
   })
 
-  it('shares one recentre frame with the preview path', () => {
+  it('shares one recentre frame with the preview path, builder deciding', () => {
     // The two stream onto the screen together, so a frame they disagree
-    // on strands the preview where the durable model never goes. On
-    // Snowdon (Revit site coordinates) that put previews ~200km out and
-    // dragged the camera follow with them for the whole load.
+    // on strands the preview where the durable model never goes — and
+    // only the durable builder may DECIDE the frame: the preview channel
+    // can emit payloads whose placement never resolved (conway#465), so
+    // a preview-latched frame could shift the whole durable model by a
+    // bogus payload's error.
     const placedAt = (tx, ty, tz) => ({
       expressID: 1,
       geometries: [{geometryExpressID: 999, flatTransformation:
@@ -234,6 +236,29 @@ describe('IncrementalBatchedBuilder', () => {
 
     expect(mesh.matrix.elements[12]).toBeCloseTo(0)
     expect(mesh.matrix.elements[14]).toBeCloseTo(0)
+  })
+
+  it('a preview before the builder decides renders raw and never latches', () => {
+    // Before the first durable batch there is no trustworthy frame.
+    // The preview must not decide one — a mis-placed payload would
+    // shift every later durable instance, and a near-origin payload on
+    // a large-coordinate model would latch null and disable recentring.
+    const coordination = {offset: undefined}
+    const mesh = payloadToPreviewMesh(
+      {
+        geometryExpressID: 999,
+        color: {x: 1, y: 1, z: 1, w: 1},
+        vertexData: unitTriangleVerts(),
+        indexData: new Uint32Array([0, 1, 2]),
+        flatTransformation: [
+          1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 2000000, 5, -8000000, 1,
+        ],
+      },
+      new Map(), new Map(), coordination)
+
+    expect(coordination.offset).toBeUndefined()
+    expect(mesh.matrix.elements[12]).toBeCloseTo(2000000)
+    expect(mesh.matrix.elements[14]).toBeCloseTo(-8000000)
   })
 
   it('reports bounds per appended instance and skips bad geometry', () => {

--- a/src/viewer/ifc/parsePreviewMesh.js
+++ b/src/viewer/ifc/parsePreviewMesh.js
@@ -7,7 +7,6 @@ import {
   Mesh,
 } from 'three'
 import {makeSurfaceColor, makeSurfaceMaterial} from '../lookMaterial'
-import {coordinationOffsetFor} from './flatMeshToBatchedModel'
 
 
 /**
@@ -28,15 +27,19 @@ import {coordinationOffsetFor} from './flatMeshToBatchedModel'
  * @param {Map<number, object>} geometryCache geometryExpressID → BufferGeometry
  * @param {Map<string, object>} materialCache rgba key → Material
  * @param {object} [coordination] shared origin-recenter frame, `{offset}`,
- *   the SAME object the durable IncrementalBatchedBuilder uses. Both
- *   paths render at once while a model streams, so they have to agree on
- *   the frame or the preview sits somewhere the real model never will.
- *   Snowdon is georeferenced (Revit site coordinates): the builder
- *   recentred to the origin while previews kept raw placement, putting
- *   them ~200km out. That inflated the camera follow's framing sphere to
- *   radius 318751 — and because so many previews were out there, the
- *   stray filter's envelope grew to include them, so it excluded nothing
- *   (`excluded=0/503elem`) and the real model rendered as a speck.
+ *   the SAME object the durable IncrementalBatchedBuilder uses — and the
+ *   builder is the ONLY writer. The preview channel is the unreliable
+ *   half of the stream (conway can emit a payload whose placement never
+ *   resolved, conway#465), so letting the first preview latch the frame
+ *   would hand a possibly-bogus transform authority over where every
+ *   durable instance renders: a mis-placed first payload would shift the
+ *   whole real model by its error, and a near-origin first payload on a
+ *   large-coordinate model would latch null and disable recentring
+ *   outright. Previews that arrive before the builder has decided render
+ *   unrecentred — conway's own COORDINATE_TO_ORIGIN already puts
+ *   payloads near the origin, so the Share-side offset is a rare
+ *   fallback, the window closes at the first durable batch, and the
+ *   camera follow's outlier guard covers the gap.
  *   Omitted (tests, non-georeferenced models) means no recentring.
  * @return {object|null} a matrix-stamped Mesh, or null when the payload
  *   references geometry this load has not seen (nothing to render)
@@ -69,19 +72,14 @@ export function payloadToPreviewMesh(payload, geometryCache, materialCache, coor
   const mesh = new Mesh(geometry, material)
   mesh.matrixAutoUpdate = false
   mesh.matrix.fromArray(payload.flatTransformation)
-  if (coordination !== null) {
-    // First placement to arrive on EITHER path decides the frame; the
-    // other reuses it. Whichever runs first is fine as long as only one
-    // decides — conway emits previews and durable batches from the same
-    // placements, so they agree on magnitude.
-    if (coordination.offset === undefined) {
-      coordination.offset = coordinationOffsetFor(payload.flatTransformation)
-    }
-    if (coordination.offset !== null) {
-      mesh.matrix.elements[12] -= coordination.offset[0]
-      mesh.matrix.elements[13] -= coordination.offset[1]
-      mesh.matrix.elements[14] -= coordination.offset[2]
-    }
+  // Read-only: `offset === undefined` means the durable builder has not
+  // decided the frame yet — render unrecentred rather than letting an
+  // untrusted preview payload decide it (see the coordination param doc).
+  if (coordination !== null &&
+      coordination.offset !== undefined && coordination.offset !== null) {
+    mesh.matrix.elements[12] -= coordination.offset[0]
+    mesh.matrix.elements[13] -= coordination.offset[1]
+    mesh.matrix.elements[14] -= coordination.offset[2]
   }
   return mesh
 }

--- a/src/viewer/ifc/parsePreviewMesh.js
+++ b/src/viewer/ifc/parsePreviewMesh.js
@@ -7,6 +7,7 @@ import {
   Mesh,
 } from 'three'
 import {makeSurfaceColor, makeSurfaceMaterial} from '../lookMaterial'
+import {coordinationOffsetFor} from './flatMeshToBatchedModel'
 
 
 /**
@@ -26,10 +27,21 @@ import {makeSurfaceColor, makeSurfaceMaterial} from '../lookMaterial'
  * @param {object} payload conway PreviewMeshPayload
  * @param {Map<number, object>} geometryCache geometryExpressID → BufferGeometry
  * @param {Map<string, object>} materialCache rgba key → Material
+ * @param {object} [coordination] shared origin-recenter frame, `{offset}`,
+ *   the SAME object the durable IncrementalBatchedBuilder uses. Both
+ *   paths render at once while a model streams, so they have to agree on
+ *   the frame or the preview sits somewhere the real model never will.
+ *   Snowdon is georeferenced (Revit site coordinates): the builder
+ *   recentred to the origin while previews kept raw placement, putting
+ *   them ~200km out. That inflated the camera follow's framing sphere to
+ *   radius 318751 — and because so many previews were out there, the
+ *   stray filter's envelope grew to include them, so it excluded nothing
+ *   (`excluded=0/503elem`) and the real model rendered as a speck.
+ *   Omitted (tests, non-georeferenced models) means no recentring.
  * @return {object|null} a matrix-stamped Mesh, or null when the payload
  *   references geometry this load has not seen (nothing to render)
  */
-export function payloadToPreviewMesh(payload, geometryCache, materialCache) {
+export function payloadToPreviewMesh(payload, geometryCache, materialCache, coordination = null) {
   let geometry = geometryCache.get(payload.geometryExpressID)
   if (geometry === undefined) {
     if (payload.vertexData === undefined || payload.indexData === undefined) {
@@ -57,5 +69,19 @@ export function payloadToPreviewMesh(payload, geometryCache, materialCache) {
   const mesh = new Mesh(geometry, material)
   mesh.matrixAutoUpdate = false
   mesh.matrix.fromArray(payload.flatTransformation)
+  if (coordination !== null) {
+    // First placement to arrive on EITHER path decides the frame; the
+    // other reuses it. Whichever runs first is fine as long as only one
+    // decides — conway emits previews and durable batches from the same
+    // placements, so they agree on magnitude.
+    if (coordination.offset === undefined) {
+      coordination.offset = coordinationOffsetFor(payload.flatTransformation)
+    }
+    if (coordination.offset !== null) {
+      mesh.matrix.elements[12] -= coordination.offset[0]
+      mesh.matrix.elements[13] -= coordination.offset[1]
+      mesh.matrix.elements[14] -= coordination.offset[2]
+    }
+  }
   return mesh
 }

--- a/src/viewer/three/MeshClipper.js
+++ b/src/viewer/three/MeshClipper.js
@@ -171,22 +171,30 @@ export default class MeshClipper {
 
 
   /**
-   * Computes an appropriate arrow scale based on the model bounding sphere
+   * Computes the arrow scale as a pure fraction of the model radius.
+   *
+   * The fraction is the whole rule, and it must not be clamped to
+   * absolute world units. conway emits true-scale geometry, so a
+   * millimetre part and a building are ~1e5 apart in radius; the
+   * absolute [2, 40] clamp this replaced pinned a true-scale gear's
+   * arrow at 2 world units against a 0.0033m part, i.e. ~600x the
+   * model. Arrows draw `depthTest: false` at ARROW_RENDER_ORDER, so an
+   * oversized one doesn't merely look wrong — it paints over the model
+   * entirely. Same bug class as the #1742 camera near plane.
+   *
+   * DEFAULT_ARROW_SCALE is reserved for a model that yields no usable
+   * radius, where there is no model scale to be a fraction of.
    *
    * @return {number}
    */
   computeArrowScale() {
-    if (!this.modelBoundingSphere) {
+    const radius = this.modelBoundingSphere?.radius
+    // Covers a null sphere plus 0 / NaN / Infinity radius — every case
+    // where the model carries no scale to derive from.
+    if (!radius || !Number.isFinite(radius)) {
       return DEFAULT_ARROW_SCALE
     }
-
-    const radius = this.modelBoundingSphere.radius
-    if (!radius || Number.isNaN(radius)) {
-      return DEFAULT_ARROW_SCALE
-    }
-
-    const scaled = radius * ARROW_SCALE_RATIO
-    return Math.min(MAX_ARROW_SCALE, Math.max(MIN_ARROW_SCALE, scaled))
+    return radius * ARROW_SCALE_RATIO
   }
 
 
@@ -560,10 +568,11 @@ export default class MeshClipper {
 }
 
 
+// Only used when the model yields no usable radius; every other case
+// derives from the model, so there are deliberately no absolute
+// min/max companions here. See computeArrowScale.
 const DEFAULT_ARROW_SCALE = 5
 const ARROW_SCALE_RATIO = 0.25
-const MIN_ARROW_SCALE = 2
-const MAX_ARROW_SCALE = 40
 const ARROW_RENDER_ORDER = 999
 // Cut-plane arrow colors. Blue is deliberate (not a theme color): the
 // arrows must read against the model, and green arrows washed out on

--- a/src/viewer/three/MeshClipper.test.js
+++ b/src/viewer/three/MeshClipper.test.js
@@ -75,34 +75,41 @@ describe('viewer/three/MeshClipper', () => {
       expect(clipper.computeArrowScale()).toBe(5)
     })
 
-    it('clamps to MIN_ARROW_SCALE (2) for tiny models', () => {
+    it('has no absolute floor: a millimetre part keeps a sub-model arrow', () => {
+      // A true-scale gear is ~3.3mm across. The old absolute
+      // MIN_ARROW_SCALE of 2 world units pinned the arrow at ~600x the
+      // model, and arrows draw depthTest:false at renderOrder 999, so it
+      // covered the part outright rather than just looking wrong.
       const viewer = makeViewerStub()
-      const tinyModel = new Mesh(new BoxGeometry(0.001, 0.001, 0.001), new MeshBasicMaterial())
+      const tinyModel = new Mesh(new BoxGeometry(0.0033, 0.0033, 0.0033), new MeshBasicMaterial())
       const clipper = new MeshClipper(viewer, tinyModel)
 
-      expect(clipper.computeArrowScale()).toBe(2)
+      expect(clipper.computeArrowScale()).toBeCloseTo(clipper.modelBoundingSphere.radius * 0.25, 10)
+      expect(clipper.computeArrowScale()).toBeLessThan(clipper.modelBoundingSphere.radius)
     })
 
-    it('clamps to MAX_ARROW_SCALE (40) for very large models', () => {
+    it('has no absolute ceiling: a large model gets a proportional arrow', () => {
       const viewer = makeViewerStub()
       const hugeModel = new Mesh(new BoxGeometry(1000, 1000, 1000), new MeshBasicMaterial())
       const clipper = new MeshClipper(viewer, hugeModel)
 
-      expect(clipper.computeArrowScale()).toBe(40)
+      expect(clipper.computeArrowScale()).toBeCloseTo(clipper.modelBoundingSphere.radius * 0.25, 10)
+      // The old MAX_ARROW_SCALE would have clamped this to 40, ~1/5 of
+      // the intended size, shrinking the gizmo on large sites.
+      expect(clipper.computeArrowScale()).toBeGreaterThan(40)
     })
 
-    it('returns radius * 0.25 when it falls within bounds', () => {
-      // Radius for a 2x2x2 box centered at origin: sqrt(3) ≈ 1.732
-      // scaled = 1.732 * 0.25 ≈ 0.433 → clamped to MIN (2)
-      // Need a bigger box: 40x40x40 → radius ≈ 34.64 → scaled ≈ 8.66
-      const viewer = makeViewerStub()
-      const model = new Mesh(new BoxGeometry(40, 40, 40), new MeshBasicMaterial())
-      const clipper = new MeshClipper(viewer, model)
+    it('holds the same arrow:model ratio across a 1e6 size difference', () => {
+      // Scale invariance is the actual requirement -- the gizmo must
+      // present identically relative to the model at every model scale.
+      const tiny = new MeshClipper(
+        makeViewerStub(), new Mesh(new BoxGeometry(0.001, 0.001, 0.001), new MeshBasicMaterial()))
+      const huge = new MeshClipper(
+        makeViewerStub(), new Mesh(new BoxGeometry(1000, 1000, 1000), new MeshBasicMaterial()))
 
-      const expected = clipper.modelBoundingSphere.radius * 0.25
-      expect(clipper.computeArrowScale()).toBeCloseTo(expected, 2)
-      expect(clipper.computeArrowScale()).toBeGreaterThanOrEqual(2)
-      expect(clipper.computeArrowScale()).toBeLessThanOrEqual(40)
+      const tinyRatio = tiny.computeArrowScale() / tiny.modelBoundingSphere.radius
+      const hugeRatio = huge.computeArrowScale() / huge.modelBoundingSphere.radius
+      expect(tinyRatio).toBeCloseTo(hugeRatio, 10)
     })
   })
 

--- a/src/viewer/three/cameraLimits.js
+++ b/src/viewer/three/cameraLimits.js
@@ -1,0 +1,132 @@
+import {MathUtils} from 'three'
+
+
+/**
+ * The single place camera dolly range and clip planes are derived from a
+ * framing sphere.
+ *
+ * This exists because there are two call sites that must agree and
+ * previously didn't: the end-of-load fit (`OrbitControl#
+ * fitCameraLimitsToModel`) and the streaming camera follow
+ * (`ProgressiveLoadSession#fitUnionToFrame_`). Each had its own copy of
+ * the constants, and the follow's copy simply had no `MIN_DISTANCE_FACTOR`,
+ * `NEAR_RADIUS_FRACTION` or `ABSOLUTE_MIN_NEAR` — so it grew `maxDistance`
+ * and `far` as geometry streamed in and left `minDistance` and `near` at
+ * the OrbitControl activation defaults of 1.
+ *
+ * On a true-scale sub-metre model (a millimetre STEP board is ~0.1 scene
+ * units across) that is ruinous in two ways at once: `near = 1` sits
+ * beyond the whole model so it renders half-clipped, and `minDistance = 1`
+ * clamps the follow's `fitToSphere` — which wants ~0.15 — so the model
+ * also appears tiny. Both cleared the moment the end-of-load fit ran,
+ * which is why it read as "resizing during load" rather than as a bug in
+ * either fit on its own.
+ *
+ * Deriving every limit here means a call site cannot silently omit one:
+ * it gets the whole set or none of it.
+ */
+
+
+// Leave ~1/3 of the canvas as whitespace (≈1/6 per side): inflate the
+// framed sphere so the model fills ~2/3 of the viewport rather than
+// sitting edge-to-edge.
+export const FRAMING_MARGIN = 1.5
+/** Zoom-in limit as a fraction of the fit distance. */
+const MIN_DISTANCE_FACTOR = 0.01
+/** Zoom-out headroom over the fit distance. */
+const MAX_DISTANCE_HEADROOM = 10
+/** Far plane must clear the whole zoom-out range plus the model. */
+const FAR_PLANE_SLACK = 1.5
+/**
+ * Floor for the near plane, as a fraction of the framing radius. Inert at
+ * the current MIN_DISTANCE_FACTOR — the derived near below works out to at
+ * least 0.005·radius — but it keeps the floor model-relative if the dolly
+ * range is ever retuned tighter, so depth precision degrades with the model
+ * rather than with the scene's unit of measure.
+ */
+const NEAR_RADIUS_FRACTION = 0.001
+/**
+ * Absolute backstop under that, only to keep the near plane off zero and out
+ * of denormal range for a degenerate bounding sphere.
+ *
+ * This replaces a flat 0.1-scene-unit floor (#1742), which sat *inside* any
+ * part smaller than a couple of metres. Latent until conway#458 (PR
+ * conway#460, shipped in 1.460.1363) stopped scaling millimetre STEP files
+ * by the reciprocal of their unit factor: a 50 mm part that used to arrive
+ * as 50 km now arrives at its true size, with minDistance ≈ 0.0024, so the
+ * old floor clipped it as you zoomed and ate it entirely past 0.1. IFC
+ * never tripped it — building-scale geometry sits well above the floor.
+ */
+const ABSOLUTE_MIN_NEAR = 1e-6
+const HALF = 0.5
+
+
+/**
+ * Distance `camera-controls` will dolly to in order to fit `radius`,
+ * mirroring its getDistanceToFitSphere: radius / sin(½·limitingFOV),
+ * where the limiting FOV is the narrower of the two axes.
+ *
+ * @param {object} camera perspective camera (reads fov + aspect)
+ * @param {number} radius framing radius, margin already applied
+ * @return {number}
+ */
+export function fitDistanceForRadius(camera, radius) {
+  const vFov = MathUtils.degToRad(camera.fov)
+  const hFov = Math.atan(Math.tan(vFov * HALF) * camera.aspect) * 2
+  const limitingFov = camera.aspect > 1 ? vFov : hFov
+  return radius / Math.sin(limitingFov * HALF)
+}
+
+
+/**
+ * Derive the complete limit set for a framing sphere.
+ *
+ * Every term scales with the model, so the frustum is scale-invariant:
+ * a millimetre part and a 200m building get the same limits relative to
+ * their own size. `far/near` is ~3e3 on the normal path.
+ *
+ * @param {object} camera perspective camera (reads fov + aspect)
+ * @param {object} sphere framing sphere, margin already applied
+ * @param {number} [minMaxDistance] floor for maxDistance. The end-of-load
+ *   fit passes where the camera currently sits, so a shrinking range can't
+ *   snap an already-dollied-out camera inwards on the user's next drag.
+ * @return {{fitDistance: number, minDistance: number, maxDistance: number,
+ *   near: number, far: number}}
+ */
+export function cameraLimitsForSphere(camera, sphere, minMaxDistance = 0) {
+  const fitDistance = fitDistanceForRadius(camera, sphere.radius)
+  const minDistance = fitDistance * MIN_DISTANCE_FACTOR
+  const maxDistance = Math.max(fitDistance * MAX_DISTANCE_HEADROOM, minMaxDistance)
+  // Keep the model between the planes across the whole zoom range: far
+  // must clear the pulled-back camera (maxDistance + model radius), near
+  // must stay inside the closest dolly.
+  const near = Math.max(
+    minDistance * HALF,
+    sphere.radius * NEAR_RADIUS_FRACTION,
+    ABSOLUTE_MIN_NEAR)
+  const far = (maxDistance + sphere.radius) * FAR_PLANE_SLACK
+  return {fitDistance, minDistance, maxDistance, near, far}
+}
+
+
+/**
+ * Write a limit set onto the camera and controls.
+ *
+ * @param {object} camera perspective camera
+ * @param {object} controls camera-controls instance
+ * @param {object} limits from cameraLimitsForSphere
+ * @param {boolean} [growOnly] when true, `maxDistance` and `far` only ever
+ *   increase. The streaming follow wants this: its union grows
+ *   monotonically, and letting the outward range shrink mid-load would pop
+ *   the projection between refits. `minDistance` and `near` are always
+ *   written — they must be free to come *down* from the activation
+ *   defaults of 1, which is the entire sub-metre bug.
+ */
+export function applyCameraLimits(camera, controls, limits, growOnly = false) {
+  controls.minDistance = limits.minDistance
+  const currentMax = typeof controls.maxDistance === 'number' ? controls.maxDistance : 0
+  controls.maxDistance = growOnly ? Math.max(currentMax, limits.maxDistance) : limits.maxDistance
+  camera.near = limits.near
+  camera.far = growOnly ? Math.max(camera.far, limits.far) : limits.far
+  camera.updateProjectionMatrix()
+}

--- a/src/viewer/three/cameraLimits.test.js
+++ b/src/viewer/three/cameraLimits.test.js
@@ -1,0 +1,120 @@
+/* eslint-disable no-magic-numbers */
+import {Sphere, Vector3} from 'three'
+import {applyCameraLimits, cameraLimitsForSphere, fitDistanceForRadius} from './cameraLimits'
+
+
+/** @return {object} A perspective-camera stand-in. */
+function makeCamera() {
+  return {fov: 45, aspect: 1.5, near: 1, far: 100, updateProjectionMatrix: jest.fn()}
+}
+
+
+/** @return {object} Controls at the OrbitControl activation defaults. */
+function makeControls() {
+  return {minDistance: 1, maxDistance: 300}
+}
+
+
+/**
+ * @param {number} radius
+ * @return {Sphere}
+ */
+function sphereOf(radius) {
+  return new Sphere(new Vector3(0, 0, 0), radius)
+}
+
+
+describe('cameraLimits', () => {
+  describe('cameraLimitsForSphere', () => {
+    it('keeps the model reachable and unclipped at millimetre scale', () => {
+      // A true-scale mm PCB: ~0.1 scene units, so its framing radius is
+      // well under the activation defaults of minDistance/near = 1.
+      const camera = makeCamera()
+      const sphere = sphereOf(0.075)
+      const limits = cameraLimitsForSphere(camera, sphere)
+
+      const wantDistance = fitDistanceForRadius(camera, sphere.radius)
+      expect(wantDistance).toBeGreaterThan(limits.minDistance)
+      expect(wantDistance).toBeLessThan(limits.maxDistance)
+      // Near in front of the model's leading edge, not beyond it.
+      expect(limits.near).toBeLessThan(wantDistance - sphere.radius)
+      expect(limits.far).toBeGreaterThan(wantDistance + sphere.radius)
+    })
+
+    it('holds every limit at the same ratio across a 1e6 size difference', () => {
+      // Scale invariance is the property that makes one shared derivation
+      // correct for a mm part and a km site alike.
+      const camera = makeCamera()
+      const tiny = cameraLimitsForSphere(camera, sphereOf(0.001))
+      const huge = cameraLimitsForSphere(camera, sphereOf(1000))
+
+      expect(tiny.minDistance / 0.001).toBeCloseTo(huge.minDistance / 1000, 6)
+      expect(tiny.maxDistance / 0.001).toBeCloseTo(huge.maxDistance / 1000, 6)
+      expect(tiny.near / 0.001).toBeCloseTo(huge.near / 1000, 6)
+      expect(tiny.far / 0.001).toBeCloseTo(huge.far / 1000, 6)
+    })
+
+    it('floors maxDistance at where the camera already sits', () => {
+      // The end-of-load fit passes the settled dolly radius so a
+      // shrinking range can't snap an already-dollied-out camera inwards.
+      const camera = makeCamera()
+      const sphere = sphereOf(1)
+      const free = cameraLimitsForSphere(camera, sphere)
+      const floored = cameraLimitsForSphere(camera, sphere, free.maxDistance * 3)
+
+      expect(floored.maxDistance).toBeCloseTo(free.maxDistance * 3, 6)
+      expect(floored.far).toBeGreaterThan(free.far)
+      // The inward limits are unaffected by the outward floor.
+      expect(floored.minDistance).toBeCloseTo(free.minDistance, 6)
+      expect(floored.near).toBeCloseTo(free.near, 6)
+    })
+  })
+
+
+  describe('applyCameraLimits', () => {
+    it('writes all four limits, bringing the inward pair down off the defaults', () => {
+      const camera = makeCamera()
+      const controls = makeControls()
+      const limits = cameraLimitsForSphere(camera, sphereOf(0.075))
+
+      applyCameraLimits(camera, controls, limits)
+
+      expect(controls.minDistance).toBe(limits.minDistance)
+      expect(controls.maxDistance).toBe(limits.maxDistance)
+      expect(camera.near).toBe(limits.near)
+      expect(camera.far).toBe(limits.far)
+      expect(camera.near).toBeLessThan(1)
+      expect(controls.minDistance).toBeLessThan(1)
+      expect(camera.updateProjectionMatrix).toHaveBeenCalled()
+    })
+
+    it('growOnly holds the outward range but still lowers minDistance and near', () => {
+      // The streaming follow's contract: its union only grows, so the
+      // outward range must not fall back between refits and pop the
+      // projection -- but the inward pair still has to come down off the
+      // defaults or a sub-metre model is clamped and clipped all load.
+      const camera = makeCamera()
+      const controls = makeControls()
+      const limits = cameraLimitsForSphere(camera, sphereOf(0.075))
+
+      applyCameraLimits(camera, controls, limits, true)
+
+      expect(controls.maxDistance).toBe(300)
+      expect(camera.far).toBe(100)
+      expect(controls.minDistance).toBe(limits.minDistance)
+      expect(camera.near).toBe(limits.near)
+    })
+
+    it('growOnly still widens the outward range for a large model', () => {
+      const camera = makeCamera()
+      const controls = makeControls()
+      const limits = cameraLimitsForSphere(camera, sphereOf(500))
+
+      applyCameraLimits(camera, controls, limits, true)
+
+      expect(controls.maxDistance).toBe(limits.maxDistance)
+      expect(controls.maxDistance).toBeGreaterThan(300)
+      expect(camera.far).toBe(limits.far)
+    })
+  })
+})

--- a/src/viewer/three/context/camera/controls/orbit-control.js
+++ b/src/viewer/three/context/camera/controls/orbit-control.js
@@ -18,8 +18,27 @@ const MIN_DISTANCE_FACTOR = 0.01
 const MAX_DISTANCE_HEADROOM = 10
 /** Far plane must clear the whole zoom-out range plus the model. */
 const FAR_PLANE_SLACK = 1.5
-/** Floor for the near plane, in scene units. */
-const MIN_NEAR = 0.1
+/**
+ * Floor for the near plane, as a fraction of the framing radius. Inert at
+ * the current MIN_DISTANCE_FACTOR — the derived near below works out to at
+ * least 0.005·radius — but it keeps the floor model-relative if the dolly
+ * range is ever retuned tighter, so depth precision degrades with the model
+ * rather than with the scene's unit of measure.
+ */
+const NEAR_RADIUS_FRACTION = 0.001
+/**
+ * Absolute backstop under that, only to keep the near plane off zero and out
+ * of denormal range for a degenerate bounding sphere.
+ *
+ * This replaces a flat 0.1-scene-unit floor (#1742), which sat *inside* any
+ * part smaller than a couple of metres. Latent until conway#458 stopped
+ * scaling millimetre STEP files by the reciprocal of their unit factor: a
+ * 50 mm part that used to arrive as 50 km now arrives at its true size, with
+ * minDistance ≈ 0.0024, so the old floor clipped it as you zoomed and ate it
+ * entirely past 0.1. IFC never tripped it — building-scale geometry sits well
+ * above the floor.
+ */
+const ABSOLUTE_MIN_NEAR = 1e-6
 const HALF = 0.5
 
 
@@ -136,7 +155,14 @@ export class OrbitControl extends IfcComponent {
     // far must clear the pulled-back camera (maxDistance + model radius), near
     // must stay inside the closest dolly. Without this, zooming out on a large
     // model would clip it against the old far = 2000 plane.
-    camera.near = Math.max(controls.minDistance * HALF, MIN_NEAR)
+    //
+    // Every term here is derived from the model, so the frustum scales with it
+    // the way minDistance/maxDistance/far already do — see ABSOLUTE_MIN_NEAR
+    // for why the floor stopped being an absolute constant (#1742).
+    camera.near = Math.max(
+      controls.minDistance * HALF,
+      sphere.radius * NEAR_RADIUS_FRACTION,
+      ABSOLUTE_MIN_NEAR)
     camera.far = (controls.maxDistance + sphere.radius) * FAR_PLANE_SLACK
     camera.updateProjectionMatrix()
 

--- a/src/viewer/three/context/camera/controls/orbit-control.js
+++ b/src/viewer/three/context/camera/controls/orbit-control.js
@@ -31,8 +31,9 @@ const NEAR_RADIUS_FRACTION = 0.001
  * of denormal range for a degenerate bounding sphere.
  *
  * This replaces a flat 0.1-scene-unit floor (#1742), which sat *inside* any
- * part smaller than a couple of metres. Latent until conway#458 stopped
- * scaling millimetre STEP files by the reciprocal of their unit factor: a
+ * part smaller than a couple of metres. Latent until conway#458 (PR
+ * conway#460, shipped in 1.460.1363) stopped scaling millimetre STEP files
+ * by the reciprocal of their unit factor: a
  * 50 mm part that used to arrive as 50 km now arrives at its true size, with
  * minDistance ≈ 0.0024, so the old floor clipped it as you zoomed and ate it
  * entirely past 0.1. IFC never tripped it — building-scale geometry sits well

--- a/src/viewer/three/context/camera/controls/orbit-control.js
+++ b/src/viewer/three/context/camera/controls/orbit-control.js
@@ -2,45 +2,11 @@
 // `web-ifc-viewer/dist/components/context/camera/controls/orbit-control.js`
 // in slice 5d.3.
 
-import {MathUtils, Sphere, Vector3} from 'three'
+import {Sphere, Vector3} from 'three'
 import {IfcComponent, NavigationModes} from '../../base-types'
 import {LiteEvent} from '../../LiteEvent'
 import {robustBoundsFor} from '../../../robustBounds'
-
-
-// Leave ~1/3 of the canvas as whitespace (≈1/6 per side): inflate the
-// framed sphere so the model fills ~2/3 of the viewport rather than
-// sitting edge-to-edge.
-const FRAMING_MARGIN = 1.5
-/** Zoom-in limit as a fraction of the fit distance. */
-const MIN_DISTANCE_FACTOR = 0.01
-/** Zoom-out headroom over the fit distance. */
-const MAX_DISTANCE_HEADROOM = 10
-/** Far plane must clear the whole zoom-out range plus the model. */
-const FAR_PLANE_SLACK = 1.5
-/**
- * Floor for the near plane, as a fraction of the framing radius. Inert at
- * the current MIN_DISTANCE_FACTOR — the derived near below works out to at
- * least 0.005·radius — but it keeps the floor model-relative if the dolly
- * range is ever retuned tighter, so depth precision degrades with the model
- * rather than with the scene's unit of measure.
- */
-const NEAR_RADIUS_FRACTION = 0.001
-/**
- * Absolute backstop under that, only to keep the near plane off zero and out
- * of denormal range for a degenerate bounding sphere.
- *
- * This replaces a flat 0.1-scene-unit floor (#1742), which sat *inside* any
- * part smaller than a couple of metres. Latent until conway#458 (PR
- * conway#460, shipped in 1.460.1363) stopped scaling millimetre STEP files
- * by the reciprocal of their unit factor: a
- * 50 mm part that used to arrive as 50 km now arrives at its true size, with
- * minDistance ≈ 0.0024, so the old floor clipped it as you zoomed and ate it
- * entirely past 0.1. IFC never tripped it — building-scale geometry sits well
- * above the floor.
- */
-const ABSOLUTE_MIN_NEAR = 1e-6
-const HALF = 0.5
+import {FRAMING_MARGIN, applyCameraLimits, cameraLimitsForSphere} from '../../../cameraLimits'
 
 
 export class OrbitControl extends IfcComponent {
@@ -123,22 +89,8 @@ export class OrbitControl extends IfcComponent {
     }
     sphere.radius *= FRAMING_MARGIN
 
-    // Distance camera-controls will dolly to for `sphere`, mirroring its
-    // getDistanceToFitSphere (radius / sin(½·limitingFOV); the limiting FOV is
-    // the narrower of the two axes). Computed here so the zoom limits below
-    // scale with the model instead of the old hardcoded cap.
     const camera = this.ifcCamera.perspectiveCamera
-    const vFov = MathUtils.degToRad(camera.fov)
-    const hFov = Math.atan(Math.tan(vFov * HALF) * camera.aspect) * 2
-    const limitingFov = camera.aspect > 1 ? vFov : hFov
-    const fitDistance = sphere.radius / Math.sin(limitingFov * HALF)
-
     const controls = this.ifcCamera.cameraControls
-    // Allow zooming out to 10x the fit distance (model shrinks to ~1/10 of the
-    // canvas) and well in. Replaces the hardcoded maxDistance = 300 that
-    // clamped fitToSphere on large models — pinning the camera too close and
-    // capping zoom-out before the whole model was visible.
-    controls.minDistance = fitDistance * MIN_DISTANCE_FACTOR
     // Never pull the range in under where the camera already sits —
     // `setPosition` doesn't clamp, but the first dolly afterwards does,
     // so a shrinking range would snap the camera inwards on the user's
@@ -150,22 +102,10 @@ export class OrbitControl extends IfcComponent {
     // by the 10x headroom instead — the same bound the link's own
     // maxDistance had when the link was created.
     const currentDistance = Number.isFinite(controls.distance) ? controls.distance : 0
-    controls.maxDistance = Math.max(fitDistance * MAX_DISTANCE_HEADROOM, currentDistance)
-
-    // Keep the model between the near/far planes across the whole zoom range:
-    // far must clear the pulled-back camera (maxDistance + model radius), near
-    // must stay inside the closest dolly. Without this, zooming out on a large
-    // model would clip it against the old far = 2000 plane.
-    //
-    // Every term here is derived from the model, so the frustum scales with it
-    // the way minDistance/maxDistance/far already do — see ABSOLUTE_MIN_NEAR
-    // for why the floor stopped being an absolute constant (#1742).
-    camera.near = Math.max(
-      controls.minDistance * HALF,
-      sphere.radius * NEAR_RADIUS_FRACTION,
-      ABSOLUTE_MIN_NEAR)
-    camera.far = (controls.maxDistance + sphere.radius) * FAR_PLANE_SLACK
-    camera.updateProjectionMatrix()
+    // Shared with the streaming camera follow — see cameraLimits.js for
+    // why both fits must derive the whole set from one place.
+    applyCameraLimits(
+      camera, controls, cameraLimitsForSphere(camera, sphere, currentDistance))
 
     return sphere
   }

--- a/src/viewer/three/context/camera/controls/orbit-control.test.js
+++ b/src/viewer/three/context/camera/controls/orbit-control.test.js
@@ -10,6 +10,17 @@ const DEFAULT_MIN_DISTANCE = 1
 const DEFAULT_MAX_DISTANCE = 300
 /** Edge length of the stand-in model, in scene units. */
 const MODEL_SIZE = 1000
+/**
+ * Edge length of a millimetre-scale STEP part, in scene units: the 50 mm
+ * `data/create-a-tube.step` from #1742, at the true size conway#458 gives it.
+ */
+const SMALL_MODEL_SIZE = 0.05
+/**
+ * Digits of agreement for the scale-invariance quotients. Bounded by float32,
+ * not by the math: the bounds come off BoxGeometry's Float32Array positions,
+ * so the two cubes aren't exactly 20000x apart to begin with.
+ */
+const PRECISION = 6
 
 
 /**
@@ -73,6 +84,46 @@ describe('viewer/three/context/camera/controls/orbit-control', () => {
       // model clips against the far plane at full zoom-out.
       expect(camera.far).toBeGreaterThan(controls.maxDistance + sphere.radius)
       expect(camera.near).toBeLessThan(controls.minDistance)
+    })
+
+    // Regression for #1742: the near plane used to be floored at an absolute
+    // 0.1 scene units, which sits inside any part smaller than a couple of
+    // metres — zooming in clipped it, and past 0.1 it vanished.
+    it('keeps the near plane inside a millimetre-scale part', () => {
+      const {control, camera, controls} = makeControl(sceneWithCube(SMALL_MODEL_SIZE))
+
+      const sphere = control.fitCameraLimitsToModel()
+
+      expect(sphere).not.toBeNull()
+      // The closest the user can dolly still has to sit outside the near
+      // plane, or the last bit of zoom eats the model.
+      expect(camera.near).toBeGreaterThan(0)
+      expect(camera.near).toBeLessThan(controls.minDistance)
+      // And the near plane has to be small against the part itself, not
+      // merely small against the old constant.
+      expect(camera.near).toBeLessThan(SMALL_MODEL_SIZE)
+    })
+
+    // The other half of #1742: the frustum has to be scale-invariant, not just
+    // "small enough" at one size. Guards the near/far ratio that drives depth
+    // precision at both extremes the issue calls out.
+    it('scales the whole frustum with the model rather than pinning a constant', () => {
+      const big = makeControl(sceneWithCube(MODEL_SIZE))
+      const small = makeControl(sceneWithCube(SMALL_MODEL_SIZE))
+
+      big.control.fitCameraLimitsToModel()
+      small.control.fitCameraLimitsToModel()
+
+      // Same rig, same shape, 20000x apart in size — so each shape ratio
+      // should agree. Compared as a quotient against 1 so the tolerance is
+      // relative: these quantities are themselves 20000x apart in magnitude,
+      // and toBeCloseTo's tolerance is absolute.
+      const agree = (smallValue, bigValue) =>
+        expect(smallValue / bigValue).toBeCloseTo(1, PRECISION)
+      agree(small.camera.far / small.camera.near, big.camera.far / big.camera.near)
+      agree(small.camera.near / small.controls.minDistance,
+        big.camera.near / big.controls.minDistance)
+      agree(small.camera.near / SMALL_MODEL_SIZE, big.camera.near / MODEL_SIZE)
     })
 
     it('does not move the camera', () => {

--- a/src/viewer/three/context/camera/controls/orbit-control.test.js
+++ b/src/viewer/three/context/camera/controls/orbit-control.test.js
@@ -12,7 +12,8 @@ const DEFAULT_MAX_DISTANCE = 300
 const MODEL_SIZE = 1000
 /**
  * Edge length of a millimetre-scale STEP part, in scene units: the 50 mm
- * `data/create-a-tube.step` from #1742, at the true size conway#458 gives it.
+ * `data/create-a-tube.step` from #1742, at the true size conway#458 (PR
+ * conway#460) gives it.
  */
 const SMALL_MODEL_SIZE = 0.05
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -2473,10 +2473,10 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@bldrs-ai/conway@1.460.1363":
-  version "1.460.1363"
-  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.460.1363.tgz#e0e49469c4ce3cea23b4acfc8cbe33e1c3fa8705"
-  integrity sha512-tGhgEig3WO0Gf+wYcQtn02/bDSN9NMjUCbTGGshS9RCI5ErQmibs7aRqyxiBu0EIFGz6xzDSa6QjJAhgXNiQeg==
+"@bldrs-ai/conway@1.465.1375":
+  version "1.465.1375"
+  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.465.1375.tgz#681ec2b32f75b7140d348be8f1a3cd105124631d"
+  integrity sha512-Fvz8eTpr+76QN+0zPrYFTIVpDt0GAilZbEfLbHuNxc+oMTEGByAQkyyVJlBBwtWPbEzpHur1YNlbruWDMGn8rw==
   dependencies:
     gl-matrix "3.4.3"
     seedrandom "3.0.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2473,10 +2473,10 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@bldrs-ai/conway@1.450.1353":
-  version "1.450.1353"
-  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.450.1353.tgz#7a4824f78545f6646481f989404361166601c726"
-  integrity sha512-V/nrGZBrlaGun+ZExJpfoDqWynR+mjevOAIi3ZD7aGQYSrawhUXjsUejGo15cBYPMJyOIlkfNhtu4xx/QZKSAQ==
+"@bldrs-ai/conway@1.460.1363":
+  version "1.460.1363"
+  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.460.1363.tgz#e0e49469c4ce3cea23b4acfc8cbe33e1c3fa8705"
+  integrity sha512-tGhgEig3WO0Gf+wYcQtn02/bDSN9NMjUCbTGGshS9RCI5ErQmibs7aRqyxiBu0EIFGz6xzDSa6QjJAhgXNiQeg==
   dependencies:
     gl-matrix "3.4.3"
     seedrandom "3.0.5"


### PR DESCRIPTION
Fixes #1742. Bumps conway twice: to 1.460 (bldrs-ai/conway#460, true-scale units — the trigger for everything here) and then 1.465 (bldrs-ai/conway#465, a preview-placement fix found while testing this PR).

## The bug

`fitCameraLimitsToModel` derives `minDistance`, `maxDistance` and `far` from the model&#39;s own bounds, but floored `near` at a flat constant:

```js
const MIN_NEAR = 0.1
camera.near = Math.max(controls.minDistance * HALF, MIN_NEAR)
```

For a part smaller than a couple of metres that floor sits *inside* the part — zooming in clips it, and past 0.1 it&#39;s gone. IFC was never affected; building-scale geometry sits well above the floor.

## The fix

`orbit-control.js` — replace the constant with the model-derived terms, so the whole frustum is scale-invariant:

```js
camera.near = Math.max(
  controls.minDistance * HALF,
  sphere.radius * NEAR_RADIUS_FRACTION,
  ABSOLUTE_MIN_NEAR)
```

Worth knowing on review: **`controls.minDistance * HALF` is what actually binds.** `minDistance = fitDistance * 0.01` and `fitDistance = radius / sin(½·limitingFOV) ≥ radius`, so the derived near is always ≥ `0.005·radius`. At `NEAR_RADIUS_FRACTION = 0.001` the middle term never fires today — it&#39;s a guard that only matters if `MIN_DISTANCE_FACTOR` is retuned tighter, and it sits deliberately below the derived value so it can&#39;t invert the `near &lt; minDistance` invariant. `ABSOLUTE_MIN_NEAR = 1e-6` only keeps `near` off zero/denormal for a degenerate sphere.

Depth precision: on the normal path `far/near` is ~3e3, unchanged at building scale and now identical at every model scale. It is *not* unconditional — when `maxDistance` comes from `currentDistance` (permalink restore, issue-card nav) rather than the 10x headroom, a millimetre part can reach a much higher ratio. `logarithmicDepthBuffer: true` covers that, and it beats the old behavior where such parts were invisible outright.

This derivation now lives in `three/cameraLimits.js`, shared by the end-of-load fit and the streaming camera follow — see the follow-on section for why that unification mattered.

## conway 1.450.1353 → 1.460.1363

The delta against 1.450.1353 is exactly conway#460 (`1 / sourceUnitInM` → `sourceUnitInM` on the root unit transform), its own test, and the version stamp. **No wasm change.**

Measured through Share, a millimetre STEP model&#39;s camera rig moves by exactly 1e6:

| | conway 1.450.1353 | conway 1.460.1363 |
|---|---|---|
| `gear.step` world size | 3300 m | **0.0033 m** |
| `minDistance` | 92 | 9.2e-5 |
| `near` (pre-fix) | 46 | 0.1 ← clips the 3.3 mm part |

### conway 1.460.1363 → 1.465.1375

Carries conway#465, root-caused during this PR&#39;s Snowdon testing: the parse-time preview channel extracted a product whose placement was still a dangling forward reference in the parse prefix as **unplaced** — on georeferenced Snowdon, door `#5014` emitted 88 preview payloads ~425 km from the building and the camera follow framed their union, rendering the model as a sub-pixel speck for the whole load. conway now defers such products to the durable pump. Preview-only change; durable geometry is byte-identical (conway regression: zero visual diffs), hence **no second GLB schema bump**.

## GLB cache invalidation

`BLDRS_GLB_SCHEMA_VERSION` 0.14.0 → 0.15.0. Geometry is baked into the GLB in **world coordinates** and nothing in the cache key identifies the engine — so without this, anyone holding a pre-1.460 artifact would keep loading 1e6x-oversized geometry, never pick up this fix, and disagree with cache-miss users on every shared camera / cut-plane link. d1a74ea is the precedent for pairing an engine bump with a schema bump.

## Testing

`yarn precommit` (eslint + typecheck + Jest) green on every commit via the husky hook; the suite has grown with the follow-on fixes below. Playwright E2E green at every push since the CI-workers fix.

**Unit** (`orbit-control.test.js`): a 50 mm part keeps `0 &lt; near &lt; minDistance`; every derived limit holds the same ratio across a 20000x size difference. Tolerance is 6 digits because `BoxGeometry` positions are `Float32Array`, so the two cubes aren&#39;t exactly 20000x apart to begin with.

**E2E** (`smallPartNearPlane.spec.ts`, desktop + mobile via `describeMobileAndDesktop`): loads `gear.step` and asserts `near &lt; extent` and `near &lt; minDistance`. Verified it **fails against the pre-fix floor** (`near` 0.1 vs a 0.0033 m part) on both form factors and passes with the fix.

Two things that made this spec non-obvious, both commented in place:
- Model bounds are read with `Box3.expandByObject`, not a hand walk over `geometry.boundingBox` — conway emits STEP as an `InstancedMesh` whose per-instance matrices carry the root unit scale, so a hand walk reports raw file coordinates (3.3, not 0.0033) and misses exactly what&#39;s being measured.
- The model&#39;s world size is asserted *before* the near-plane invariant, so a conway unit regression fails as itself instead of softening the real assertion into a tautology.

## CI workers

main moved these jobs to a 4-vCPU/8GB runner (6df8de7) but left `--workers=6` — six Chromiums (each rendering WebGL with the conway wasm heap resident) starved the box, which presented as flake: click/visibility timeouts and `#viewer-container` never mounting. Measured: 6 workers → 53 failed / 81 passed (main&#39;s own state); 3 → 4 failed / 134 passed; **2 → green in 11.7m** — faster in wall-clock than 3, which was spending its time on 30s timeouts and retries. Settled on 2 (Playwright&#39;s own vCPU/2 heuristic), with `timeout-minutes` 20 → 35 as headroom for the degraded case, and comments tying both numbers to `runs-on`.

## Follow-on fixes (same PR)

The conway rescale exposed three more absolute-scale assumptions of the same class as #1742 — originally listed here as known-not-fixed, now all fixed, one commit each:

- **Cut-plane arrow** (`MeshClipper.js`, `0a5b2e5`) — the absolute `[2, 40]` clamp is gone; the gizmo scales purely with model radius. The old MIN pinned it at ~600x a true-scale gear, drawn `depthTest:false` over the model.
- **Camera permalinks** (`58adbc0`) — `roundCoordComponent` rounds relative to scale (fixed decimals or significant digits, whichever lands closer), the read side no longer re-rounds through `floatStrTrim`, and the URL grammar accepts exponential notation. Placemarks got the same fix for free — on a millimetre part every placemark previously serialized to `0,0,0,0,0,0` and collided as a single map key.
- **Cut-plane offsets** (`4a17538`) — no longer quantized to 3 absolute decimals at any of their three hops (write, read, scene placement).

Streaming-load fixes that fell out of the same Snowdon investigation:

- `three/cameraLimits.js` — one shared limit derivation for the end-of-load fit and the streaming camera follow. The follow had been growing only `maxDistance`/`far`, leaving `minDistance`/`near` at their absolute defaults of 1 — clipping and shrinking sub-metre models for the whole load (the Arty symptom).
- The incremental `BatchedMesh` streams with frustum culling **off**: three caches a first-frame bounding sphere and never invalidates it as instances append, so the growing model was culled invisible until load end. `finalize()` computes real bounds and re-enables culling.
- The camera follow recovers from an over-inflated frame (refits were overflow-only, so one bad frame used to be permanent) and drops preview placements &gt;100x the accumulated preview radius — defense in depth beneath conway#465.
- Only the durable builder may decide the origin-recentre frame; previews read it and render unrecentred until the first durable batch (a mis-placed preview payload must never steer where the real model renders).
- `?feature=disableLoadOverlay` keeps the canvas interactive during load, for diagnosing streaming issues by eye.

Review hardening (from /review of this branch): gzip sniffing requires SPZ&#39;s decompressed `NGSP` magic instead of classifying every gzipped upload as a splat; the stale-LFS-pointer eviction path clears `opfsFile` and corrects the report&#39;s Source line; a failed Spark dynamic import retries instead of poisoning the session; test flush helpers are timer-agnostic per STYLE.md.

Smoke test: open a small STEP part (gear) — solid at full zoom, correctly-sized cut-plane gizmo, camera and `#cp:` share-links restore exactly. Load Snowdon — visible while streaming, no mid-load disappearance, `far placements: preview=0 | durable=0` in the console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KJCRAAy2HyxhUbx1PjprjA