### PR TITLE
Tag open_cid value so GA4 stores it as text, not a number

### DIFF
--- a/design/roadmap.md
+++ b/design/roadmap.md
@@ -718,9 +718,15 @@ which channel *reaches* that audience is the open GTM question owned bizdev-side
   originally specced: GA4 reserves the `ga_`/`google_`/`firebase_`/`gtag.`
   prefixes and silently disables matching params, so that name would have
   ingested as nothing and left the dimension permanently empty.
+  The value is sent prefix-tagged (`cid.<client id>`) because gtag types
+  numeric-looking params as numbers (`epn.` in the beacon): a raw id landed
+  in GA4's numeric slot, rendering as `1.87152e+09` — float64 truncates the
+  id's 20 digits, colliding distinct clients, and a text dimension won't
+  populate from a numeric param.
   **Remaining GA4-side config:** Admin → Custom definitions → new
-  event-scoped dimension `open_cid` from event parameter `open_cid`; then
-  query `customEvent:open_cid × eventCount` and bucket client-side
+  event-scoped dimension `open_cid` from event parameter `open_cid` (a
+  *dimension*, not a metric); then query `customEvent:open_cid × eventCount`
+  and bucket client-side
   (1 / 2 / 3–5 / 6+ opens, fixtures excluded). No backfill — the dimension
   accrues from ship time, so land it early in a campaign window for a clean
   baseline. At larger scale GA4 rolls high-cardinality values into "(other)";

--- a/src/Containers/CadView.jsx
+++ b/src/Containers/CadView.jsx
@@ -7,7 +7,7 @@ import {captureException} from '@sentry/react'
 import {fileSuffixBoundaryRegex} from '../Filetype'
 import {useAuth0} from '../Auth0/Auth0Proxy'
 import {onHash} from '../Components/Camera/CameraControl'
-import {OPEN_CID_PARAM, getGaClientId, gtagEvent, isRealModelOpen} from '../privacy/analytics'
+import {OPEN_CID_PARAM, getOpenCid, gtagEvent, isRealModelOpen} from '../privacy/analytics'
 import {getRenderMode} from '../privacy/preferences'
 import {resetState as resetCutPlaneState} from '../Components/CutPlane/CutPlaneMenu'
 import {useIsMobile} from '../Components/Hooks'
@@ -572,9 +572,10 @@ export default function CadView({
         addProperties(eventParams, loadedModel.loadStats, 'stats_')
       }
       // Per-user open depth: GA4 has no user-id dimension, so the
-      // client id rides along as an event-scoped custom dimension.
+      // client id rides along as an event-scoped custom dimension,
+      // prefix-tagged by getOpenCid so GA4 can't type it as a number.
       // Absent whenever GA didn't initialize — see analytics#gaClientId.
-      const openCid = getGaClientId()
+      const openCid = getOpenCid()
       if (openCid) {
         eventParams[OPEN_CID_PARAM] = openCid
       }

--- a/src/Containers/realModelOpen.spec.ts
+++ b/src/Containers/realModelOpen.spec.ts
@@ -23,9 +23,11 @@ const REAL_MODEL = '/share/v/gh/bldrs-ai/test-models/main/ifc/misc/box.ifc'
  * before they cross the evaluate boundary.
  *
  * @param page Playwright page object
- * @return Array of {name, contentId, hasOpenCid} for each real_model_open event
+ * @return Array of {name, contentId, hasOpenCid, openCid} per real_model_open event
  */
-async function realModelOpenEvents(page: Page): Promise<{name: string, contentId: string, hasOpenCid: boolean}[]> {
+async function realModelOpenEvents(
+  page: Page,
+): Promise<{name: string, contentId: string, hasOpenCid: boolean, openCid?: unknown}[]> {
   return await page.evaluate(() => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const dataLayer: any[] = (window as any).dataLayer || []
@@ -35,9 +37,15 @@ async function realModelOpenEvents(page: Page): Promise<{name: string, contentId
         name: String(entry[1]),
         contentId: String(entry[2]?.content_id ?? ''),
         hasOpenCid: entry[2]?.open_cid !== undefined,
+        openCid: entry[2]?.open_cid,
       }))
   })
 }
+
+
+// A real GA client id: two dot-joined numbers, so the whole value
+// parses as a float unless something makes it non-numeric.
+const FAKE_CLIENT_ID = '1871520000.1754700000'
 
 
 /**
@@ -76,5 +84,29 @@ describeMobileAndDesktop('real_model_open GA event', () => {
     // param must be absent rather than empty, so it can't form its own
     // bucket in GA4.
     expect(events[0].hasOpenCid).toBe(false)
+  })
+
+  /*
+   * Pins the wire format through the real call site, not just
+   * getOpenCid in isolation: a bare client id is numeric-looking, and
+   * gtag beacons numeric-looking params as `epn.` (number), which
+   * truncates the id in float64 and leaves the text custom dimension
+   * empty. Seeding the `_ga` cookie exercises analytics#getGaClientId's
+   * fallback, the one client-id path that works with GA unloaded.
+   */
+  test('sends a non-numeric open_cid when a client id is available', async ({page}) => {
+    await page.context().addCookies([
+      {name: '_ga', value: `GA1.1.${FAKE_CLIENT_ID}`, domain: 'localhost', path: '/'},
+    ])
+    await setupVirtualPathIntercept(page, REAL_MODEL, 'box.ifc')
+    await page.goto(REAL_MODEL, {waitUntil: 'domcontentloaded'})
+    await waitForModelReady(page)
+    const events = await realModelOpenEvents(page)
+    expect(events).toHaveLength(1)
+    expect(events[0].openCid).toBe(`cid.${FAKE_CLIENT_ID}`)
+    // The point of the prefix: unparseable as a number, so gtag keeps
+    // it in the text slot with all its digits intact.
+    expect(Number(events[0].openCid)).toBeNaN()
+    expect(String(events[0].openCid)).toContain(FAKE_CLIENT_ID)
   })
 })

--- a/src/privacy/analytics.js
+++ b/src/privacy/analytics.js
@@ -105,6 +105,47 @@ export function getGaClientId() {
 }
 
 
+/*
+ * Tag prefixing the client id in the OPEN_CID_PARAM value, so the value
+ * can never be read as a number.
+ *
+ * A raw client id is numeric-looking by construction
+ * ("1871520000.1754700000"), and gtag classifies each event param as
+ * text or numeric when it builds the collect beacon — numeric-looking
+ * values go out as `epn.` (number) instead of `ep.` (text). Landing in
+ * the numeric slot has two consequences, both observed in the GA4 UI as
+ * a value rendered "1.87152e+09":
+ *
+ *   1. float64 holds ~15-17 significant digits against the id's 20, so
+ *      "1871520000.1754700000" truncates to 1871520000.17547 and
+ *      distinct clients silently collide — fatal for a per-user count.
+ *   2. An event-scoped custom *dimension* (text) doesn't populate from
+ *      a numeric param at all.
+ *
+ * The same coercion bites downstream of GA4 too: any CSV/Sheets export
+ * of a bare id re-parses it to a float on open.
+ *
+ * A non-digit prefix removes the ambiguity everywhere at once. It makes
+ * the value opaque rather than joinable against a raw client id, which
+ * this metric doesn't need — it only ever counts events per distinct
+ * value.
+ */
+const OPEN_CID_PREFIX = 'cid.'
+
+
+/**
+ * The OPEN_CID_PARAM value for the current client: the client id
+ * tagged so GA4 stores it as text. Null when no id is available, in
+ * which case callers must omit the param rather than send a blank.
+ *
+ * @return {string|null}
+ */
+export function getOpenCid() {
+  const cid = getGaClientId()
+  return cid === null ? null : `${OPEN_CID_PREFIX}${cid}`
+}
+
+
 /** @return {string|null} client id parsed from the `_ga` cookie */
 function gaClientIdFromCookie() {
   const raw = Cookies.get(GA_COOKIE_NAME)

--- a/src/privacy/analytics.test.js
+++ b/src/privacy/analytics.test.js
@@ -69,6 +69,46 @@ describe('Analytics', () => {
   })
 
 
+  /*
+   * The param VALUE must be un-parseable as a number. A bare client id
+   * is numeric-looking, and gtag sends numeric-looking params as `epn.`
+   * (number): float64 truncates the id's 20 digits to ~16, colliding
+   * distinct clients, and a text custom dimension won't populate from a
+   * numeric param at all.
+   */
+  describe('getOpenCid', () => {
+    beforeEach(() => {
+      Analytics._resetGaClientIdForTests()
+      Cookies.remove('_ga')
+    })
+
+    test('null when no client id is available, so the param is omitted', () => {
+      expect(Analytics.getOpenCid()).toBeNull()
+    })
+
+    test('tags the id so it cannot be parsed as a number', () => {
+      Analytics.setGaClientId('1871520000.1754700000')
+      const value = Analytics.getOpenCid()
+      expect(value).toBe('cid.1871520000.1754700000')
+      expect(Number.isNaN(Number(value))).toBe(true)
+    })
+
+    test('preserves the full id, which float64 would truncate', () => {
+      const cid = '1871520000.1754700000'
+      Analytics.setGaClientId(cid)
+      expect(Analytics.getOpenCid()).toContain(cid)
+      // The bug this guards: Number() drops 5 digits, so two clients
+      // differing only in the tail would collapse to one value.
+      expect(String(Number(cid))).not.toBe(cid)
+    })
+
+    test('tags the cookie-derived id too', () => {
+      Cookies.set('_ga', 'GA1.1.1871520000.1754700000')
+      expect(Analytics.getOpenCid()).toBe('cid.1871520000.1754700000')
+    })
+  })
+
+
   // Route-result shapes mirror routes.ts#handleRoute output. The one
   // excluded shape is the homepage's bundled demo — everything else is
   // a real open.


### PR DESCRIPTION
Fixes `open_cid` landing in GA4's numeric slot, observed in the console as values rendered `1.87152e+09`.

Follow-up to #1743.

## The bug

A GA client id is numeric-looking by construction (`1871520000.1754700000`). We send it as a JS string, but gtag classifies each event param as text or numeric when it builds the collect beacon, and numeric-looking values go out as `epn.` (number) rather than `ep.` (text). Two consequences, both of which the scientific-notation rendering is a symptom of:

1. **Distinct clients collide.** float64 carries ~15–17 significant digits against the id's 20, so `1871520000.1754700000` truncates to `1871520000.17547`. Two clients differing only in the tail collapse to one value — fatal for a metric whose entire purpose is counting events per distinct client.
2. **The dimension stays empty.** An event-scoped custom *dimension* is text and doesn't populate from a numeric param at all.

The same coercion bites downstream of GA4: any CSV/Sheets export of a bare id re-parses it to a float on open.

## The fix

`getOpenCid()` prefixes the id with a non-digit tag before it goes on the event, so the value is `cid.1871520000.1754700000`. A leading non-digit makes it un-parseable as a number, so it takes the `ep.` text path, keeps all 20 digits, and lands in the dimension.

The value becomes opaque rather than joinable against a raw client id, which this metric doesn't need — it only ever counts events per distinct value.

## Changes

- **`src/privacy/analytics.js`**: new `getOpenCid()` returning the tagged value (or null, so callers omit the param rather than send a blank). `getGaClientId()` keeps returning the raw id. The `OPEN_CID_PREFIX` doc records the coercion mechanism and both consequences.
- **`src/Containers/CadView.jsx`**: sends `getOpenCid()` instead of the raw id.
- **`src/privacy/analytics.test.js`**: asserts `Number(value)` is NaN, that the full untruncated id round-trips, that `Number(rawId)` provably differs from the raw id (pinning the collision this guards against), and that the cookie-derived path is tagged too.
- **`src/Containers/realModelOpen.spec.ts`**: E2E now pins the wire format through the real call site — seeds a `_ga` cookie (the one client-id path that works with GA unloaded), then asserts the emitted `open_cid` is the prefixed form and unparseable as a number. Without this, reverting CadView to the raw id kept the whole suite green; verified the new test fails against that revert.
- **`design/roadmap.md`**: `grow-120` records the value format and why, and notes the GA4 definition must be a *dimension*, not a metric.

## Operational notes

- **Values collected before this ships are lossy** — they were truncated at ~16 digits, so that window can't be merged with post-fix data for distinct counts. The dimension is only days old, so the loss is small.
- **Worth confirming the GA4 definition is a dimension, not a metric.** A custom metric would coerce to number regardless of what we send, showing the same scientific notation after this fix. Decisive check either way: load a prod page, filter network for `collect`, and look for `ep.open_cid` (correct) vs `epn.open_cid` (still numeric).

https://claude.ai/code/session_01EULm3yasgtCeQr8cDZaKri