### PR TITLE
Gate build and test-flows on PR draft state

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,9 +16,11 @@ on:
     #
     # converted_to_draft is the other half of that gate, and it works by
     # cancellation rather than by starting anything: pushing a PR back to
-    # draft fires an event in the job's concurrency group, so
+    # draft fires an event in the run-level concurrency group below, so
     # cancel-in-progress kills the build that is mid-flight and the run it
-    # schedules in its place skips (the PR is a draft again).
+    # schedules in its place skips (the PR is a draft again). Run-level, not
+    # job-level, for the reason given there — a skipped job never enters its
+    # own group, so a job-level group could not cancel anything here.
     types: [ opened, synchronize, reopened, ready_for_review, converted_to_draft ]
     paths-ignore:
       - '**/*.md'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,10 +51,9 @@ on:
 # `cancel-in-progress: false` does not mean "never cancel" — GitHub cancels a
 # run still PENDING in a group when a newer one joins — so three merges inside
 # one build window drop the middle commit's build. That is the accepted cost:
-# keying on github.sha instead would run them in parallel against the 4-job cap
-# and would collide across event types (a workflow_dispatch re-run on a main
-# commit joining that commit's push run). Same choice as test-flows.yml, and as
-# conway, which has an npm release riding on the ordering (conway#468).
+# keying on github.sha instead would run them in parallel against the 4-job
+# cap. Same choice as test-flows.yml, and as conway, which has an npm release
+# riding on the ordering (conway#468).
 concurrency:
   group: build-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,6 +22,14 @@ on:
     # job-level, for the reason given there — a skipped job never enters its
     # own group, so a job-level group could not cancel anything here.
     types: [ opened, synchronize, reopened, ready_for_review, converted_to_draft ]
+    # NOTE: this is a workflow-level skip, and it interacts badly with the
+    # job-level draft gate below in one specific way. A skipped-by-`if` job
+    # still reports a `skipped` conclusion, which satisfies a required status
+    # check; a path-skipped workflow reports NOTHING. So if `build` is ever
+    # made a required check in branch protection, a docs-only PR will have no
+    # check to satisfy it and will sit unmergeable forever. Convert this to a
+    # per-job `if` gate at that point. conway's build.yml carries the same
+    # note for the same reason.
     paths-ignore:
       - '**/*.md'
       - 'design/**'
@@ -39,14 +47,16 @@ on:
 # branch (the original static `build-group` cancelled across every branch in
 # the repo, so any push anywhere aborted running PR builds).
 #
-# Per-COMMIT for everything else. Every push to main shares one ref, and
-# `cancel-in-progress: false` does not mean "never cancel" — GitHub cancels any
-# run still PENDING in a group when a newer one joins it. A ref-keyed group
-# would therefore queue main's builds and drop the middle one whenever three
-# merges landed inside a single build window. github.sha gives each commit its
-# own group.
+# Ref-keyed for non-PR events too, which serializes main's builds. Note that
+# `cancel-in-progress: false` does not mean "never cancel" — GitHub cancels a
+# run still PENDING in a group when a newer one joins — so three merges inside
+# one build window drop the middle commit's build. That is the accepted cost:
+# keying on github.sha instead would run them in parallel against the 4-job cap
+# and would collide across event types (a workflow_dispatch re-run on a main
+# commit joining that commit's push run). Same choice as test-flows.yml, and as
+# conway, which has an npm release riding on the ordering (conway#468).
 concurrency:
-  group: build-${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
+  group: build-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,6 +26,27 @@ on:
       - 'notes/**'
   workflow_dispatch:
 
+# Hoisted here from the `build` job, which is where this used to live. A job
+# skipped by `if:` never enters its own concurrency group, so with the draft
+# gate in place a job-level group could not do the one thing converted_to_draft
+# needs it to do — have the replacement run's skipped job cancel the build the
+# withdrawn PR left in flight. At workflow level the group is claimed by the
+# run itself, so the cancellation happens regardless of what the jobs decide.
+#
+# Per-ref for PRs, so a push to one branch only cancels builds for that same
+# branch (the original static `build-group` cancelled across every branch in
+# the repo, so any push anywhere aborted running PR builds).
+#
+# Per-COMMIT for everything else. Every push to main shares one ref, and
+# `cancel-in-progress: false` does not mean "never cancel" — GitHub cancels any
+# run still PENDING in a group when a newer one joins it. A ref-keyed group
+# would therefore queue main's builds and drop the middle one whenever three
+# merges landed inside a single build window. github.sha gives each commit its
+# own group.
+concurrency:
+  group: build-${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   build:
     # Draft PRs don't build. Several PRs are typically in flight at once and
@@ -48,13 +69,6 @@ jobs:
     # of the expression language. The clause states the intent instead.
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     timeout-minutes: 10
-    # Per-ref group so a push to one branch only cancels in-progress builds
-    # for that same branch. The previous static `build-group` cancelled
-    # across every branch in the repo, so any push anywhere aborted PR
-    # builds that happened to be running.
-    concurrency:
-      group: build-${{ github.workflow }}-${{ github.ref }}
-      cancel-in-progress: true
     env:
       SHARE_CONFIG: dev
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,13 @@ on:
     # flipping a draft to ready fires no event and the PR would sit with no
     # build until the next push. opened/synchronize/reopened are the Actions
     # default set, restated because naming `types` at all replaces it.
-    types: [ opened, synchronize, reopened, ready_for_review ]
+    #
+    # converted_to_draft is the other half of that gate, and it works by
+    # cancellation rather than by starting anything: pushing a PR back to
+    # draft fires an event in the job's concurrency group, so
+    # cancel-in-progress kills the build that is mid-flight and the run it
+    # schedules in its place skips (the PR is a draft again).
+    types: [ opened, synchronize, reopened, ready_for_review, converted_to_draft ]
     paths-ignore:
       - '**/*.md'
       - 'design/**'
@@ -33,6 +39,13 @@ jobs:
     # keeps this compatible with required status checks: a skipped-by-if job
     # reports a conclusion, a workflow that never triggers reports nothing and
     # leaves the PR waiting forever.
+    #
+    # The event_name clause is defensive, not load-bearing. On push and
+    # workflow_dispatch `github.event.pull_request` is null, and Actions
+    # coerces both sides of `==` to a number when the types differ, so a bare
+    # `draft == false` would evaluate `0 == 0` and run anyway. Relying on that
+    # coercion would make CI on main hinge on a documented-but-obscure corner
+    # of the expression language. The clause states the intent instead.
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     timeout-minutes: 10
     # Per-ref group so a push to one branch only cancels in-progress builds

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,16 +47,22 @@ on:
 # branch (the original static `build-group` cancelled across every branch in
 # the repo, so any push anywhere aborted running PR builds).
 #
-# Ref-keyed for non-PR events too, which serializes main's builds. Note that
-# `cancel-in-progress: false` does not mean "never cancel" — GitHub cancels a
-# run still PENDING in a group when a newer one joins — so three merges inside
-# one build window drop the middle commit's build. That is the accepted cost:
-# keying on github.sha instead would run them in parallel against the 4-job
-# cap. Same choice as test-flows.yml, and as conway, which has an npm release
-# riding on the ordering (conway#468).
+# Ref-keyed and cancel-always, which is what this was before the hoist —
+# superseded builds die rather than queue, on main as much as on a PR. Nothing
+# ships from a build here (Netlify deploys separately, and there is no publish
+# step), so only the newest commit's result is worth a runner.
+#
+# Do NOT narrow this to `${{ github.event_name == 'pull_request' }}`. Leaving
+# main uncancelled makes its runs queue in this group, and `cancel-in-progress:
+# false` does not mean "never cancel" — GitHub drops a run still PENDING in a
+# group when a newer one joins — so three quick merges would leave commit 3
+# waiting behind commit 1's already-superseded build and lose commit 2's
+# entirely. conway does scope its cancellation that way, but only because an
+# npm publish rides on the ordering there (conway#468); that reason does not
+# exist here.
 concurrency:
   group: build-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: true
 
 jobs:
   build:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,11 @@ on:
       - 'notes/**'
   pull_request:
     branches: [ main ]
+    # ready_for_review is what makes the draft gate below usable: without it,
+    # flipping a draft to ready fires no event and the PR would sit with no
+    # build until the next push. opened/synchronize/reopened are the Actions
+    # default set, restated because naming `types` at all replaces it.
+    types: [ opened, synchronize, reopened, ready_for_review ]
     paths-ignore:
       - '**/*.md'
       - 'design/**'
@@ -17,6 +22,18 @@ on:
 
 jobs:
   build:
+    # Draft PRs don't build. Several PRs are typically in flight at once and
+    # each draft push would otherwise burn a full build+lint+test slot on the
+    # shared runners while the change is still being reviewed and reworked.
+    # Netlify deploy previews are NOT affected — they come from Netlify's own
+    # GitHub integration, not from Actions — so a draft still gets a preview
+    # URL to look at. See AGENTS.md "PR lifecycle".
+    #
+    # A job-level `if` (rather than a workflow-level trigger filter) is what
+    # keeps this compatible with required status checks: a skipped-by-if job
+    # reports a conclusion, a workflow that never triggers reports nothing and
+    # leaves the PR waiting forever.
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     timeout-minutes: 10
     # Per-ref group so a push to one branch only cancels in-progress builds
     # for that same branch. The previous static `build-group` cancelled

--- a/.github/workflows/test-flows.yml
+++ b/.github/workflows/test-flows.yml
@@ -27,36 +27,26 @@ on:
   workflow_dispatch:
 
 # The draft gate defers this workflow's cost; this bounds it. These are the two
-# longest jobs in the repo (~12m and ~25m ceilings), so without cancellation
-# three quick pushes to one ready PR leave six of them running to completion
-# against a 4-job cap -- which is the exact starvation the draft gate exists to
-# prevent, just relocated from drafts to rework pushes.
+# longest jobs in the repo (35m and 25m ceilings, ~12m for a healthy
+# playwright-run), so without cancellation three quick pushes to one ready PR
+# leave six of them running against a 4-job cap -- the exact starvation the
+# draft gate exists to prevent, just relocated from drafts to rework pushes.
 #
-# Grouped per ref for PRs, so PRs never cancel each other (refs/pull/<n>/merge
-# is unique per PR). cancel-in-progress is scoped to pull_request: a push to
-# main should run to completion, since its result is the record of what main is
-# in rather than feedback on a diff still being edited.
+# Grouped per ref, so PRs never cancel each other (refs/pull/<n>/merge is
+# unique per PR). Cancel-always, matching main.yml: superseded runs die rather
+# than queue, on main as much as on a PR, because nothing ships from a flows
+# run and only the newest commit's result is worth a runner.
 #
-# That guarantee is not absolute, and the ref key is a deliberate choice about
-# which way to fail. All main pushes share one ref, so they land in one group
-# and run one at a time — and `cancel-in-progress: false` does not mean "never
-# cancel": GitHub cancels a run still PENDING in a group when a newer one
-# joins. Three merges inside one flows window (12-25m, so not rare) therefore
-# drop the middle commit's run before it starts.
-#
-# Keying non-PR events on github.sha would avoid that, and it is the wrong
-# trade here: it lets those three merges run six large-runner jobs at once
-# against the 4-job cap, relocating onto main exactly the starvation the draft
-# gate removes from drafts. What serializing costs is one main commit's flow
-# run, and nothing ships from those runs. conway keys on the ref for a
-# stronger reason — an npm publish rides on the ordering there (conway#468).
-#
-# (This repo has no tag triggers, so push and workflow_dispatch on main share
-# `refs/heads/main` and land in one group either way. Don't carry conway's
-# extra event-type argument over here; it turns on its `rc-*` tag trigger.)
+# Do NOT narrow this to `${{ github.event_name == 'pull_request' }}`. Leaving
+# main uncancelled makes its runs queue in this group, and `cancel-in-progress:
+# false` does not mean "never cancel" -- GitHub drops a run still PENDING in a
+# group when a newer one joins -- so three merges inside one flows window would
+# lose the middle commit's run anyway, while the others serialized. conway does
+# scope its cancellation that way, but only because an npm publish rides on the
+# ordering there (conway#468); that reason does not exist here.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: true
 
 jobs:
   playwright-run:

--- a/.github/workflows/test-flows.yml
+++ b/.github/workflows/test-flows.yml
@@ -45,13 +45,15 @@ on:
 # drop the middle commit's run before it starts.
 #
 # Keying non-PR events on github.sha would avoid that, and it is the wrong
-# trade here. It lets those three merges run six large-runner jobs at once
-# against the 4-job cap — relocating onto main exactly the starvation the draft
-# gate removes from drafts — and it collides across event types the ref keeps
-# apart, so a workflow_dispatch re-run on a main commit would queue behind that
-# commit's push run. What is lost by serializing is one main commit's flow run,
-# which ships nothing; conway keys on the ref for the same reason with more at
-# stake (see conway#468).
+# trade here: it lets those three merges run six large-runner jobs at once
+# against the 4-job cap, relocating onto main exactly the starvation the draft
+# gate removes from drafts. What serializing costs is one main commit's flow
+# run, and nothing ships from those runs. conway keys on the ref for a
+# stronger reason — an npm publish rides on the ordering there (conway#468).
+#
+# (This repo has no tag triggers, so push and workflow_dispatch on main share
+# `refs/heads/main` and land in one group either way. Don't carry conway's
+# extra event-type argument over here; it turns on its `rc-*` tag trigger.)
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/test-flows.yml
+++ b/.github/workflows/test-flows.yml
@@ -9,6 +9,11 @@ on:
       - 'notes/**'
   pull_request:
     branches: [ main ]
+    # ready_for_review is what makes the draft gate below usable: without it,
+    # flipping a draft to ready fires no event and the PR would sit with no
+    # flow run until the next push. opened/synchronize/reopened are the
+    # Actions default set, restated because naming `types` at all replaces it.
+    types: [ opened, synchronize, reopened, ready_for_review ]
     paths-ignore:
       - '**/*.md'
       - 'design/**'
@@ -17,6 +22,19 @@ on:
 
 jobs:
   playwright-run:
+    # Draft PRs don't run flows. This is the most expensive thing CI does per
+    # PR (~12m on a large runner, two jobs' worth), and with several PRs in
+    # flight the draft pushes alone can saturate the 4-job concurrency cap and
+    # starve the PRs that are actually ready. Netlify deploy previews are NOT
+    # affected — they come from Netlify's own GitHub integration, not from
+    # Actions — so a draft still gets a preview URL to click through by hand.
+    # See AGENTS.md "PR lifecycle".
+    #
+    # A job-level `if` (rather than a workflow-level trigger filter) is what
+    # keeps this compatible with required status checks: a skipped-by-if job
+    # reports a conclusion, a workflow that never triggers reports nothing and
+    # leaves the PR waiting forever.
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-24.04-4vcpu-8gb-150gbssd
     # Image must match @playwright/test in package.json (Playwright caches
     # by version + matches browser APIs). The -noble (Ubuntu 24.04) variant
@@ -102,6 +120,8 @@ jobs:
   # console so any isolated-runtime failure is legible without a local
   # browser (see design/new/viewer-replacement.md §5f).
   playwright-webifc-run:
+    # Draft-gated for the same reason as playwright-run above.
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-24.04-4vcpu-8gb-150gbssd
     container: mcr.microsoft.com/playwright:v1.56.1-noble
     timeout-minutes: 25

--- a/.github/workflows/test-flows.yml
+++ b/.github/workflows/test-flows.yml
@@ -32,12 +32,20 @@ on:
 # against a 4-job cap -- which is the exact starvation the draft gate exists to
 # prevent, just relocated from drafts to rework pushes.
 #
-# Grouped per ref, so PRs never cancel each other (refs/pull/<n>/merge is
-# unique per PR). cancel-in-progress is scoped to pull_request: a push to main
-# should run to completion, since its result is the record of what main is in
-# rather than feedback on a diff still being edited.
+# Grouped per ref for PRs, so PRs never cancel each other (refs/pull/<n>/merge
+# is unique per PR). cancel-in-progress is scoped to pull_request: a push to
+# main should run to completion, since its result is the record of what main is
+# in rather than feedback on a diff still being edited.
+#
+# Keyed per COMMIT for everything else, which is what actually delivers that
+# guarantee. Every push to main shares one ref, and `cancel-in-progress: false`
+# does not mean "never cancel" — GitHub cancels any run still PENDING in a
+# group when a newer one joins it. With a ref-keyed group, three merges inside
+# one flows window (12-25m, so not rare) would queue behind each other and the
+# middle commit's run would be cancelled before it started, leaving that commit
+# with no flow coverage at all. github.sha gives each commit its own group.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:

--- a/.github/workflows/test-flows.yml
+++ b/.github/workflows/test-flows.yml
@@ -37,15 +37,23 @@ on:
 # main should run to completion, since its result is the record of what main is
 # in rather than feedback on a diff still being edited.
 #
-# Keyed per COMMIT for everything else, which is what actually delivers that
-# guarantee. Every push to main shares one ref, and `cancel-in-progress: false`
-# does not mean "never cancel" — GitHub cancels any run still PENDING in a
-# group when a newer one joins it. With a ref-keyed group, three merges inside
-# one flows window (12-25m, so not rare) would queue behind each other and the
-# middle commit's run would be cancelled before it started, leaving that commit
-# with no flow coverage at all. github.sha gives each commit its own group.
+# That guarantee is not absolute, and the ref key is a deliberate choice about
+# which way to fail. All main pushes share one ref, so they land in one group
+# and run one at a time — and `cancel-in-progress: false` does not mean "never
+# cancel": GitHub cancels a run still PENDING in a group when a newer one
+# joins. Three merges inside one flows window (12-25m, so not rare) therefore
+# drop the middle commit's run before it starts.
+#
+# Keying non-PR events on github.sha would avoid that, and it is the wrong
+# trade here. It lets those three merges run six large-runner jobs at once
+# against the 4-job cap — relocating onto main exactly the starvation the draft
+# gate removes from drafts — and it collides across event types the ref keeps
+# apart, so a workflow_dispatch re-run on a main commit would queue behind that
+# commit's push run. What is lost by serializing is one main commit's flow run,
+# which ships nothing; conway keys on the ref for the same reason with more at
+# stake (see conway#468).
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:

--- a/.github/workflows/test-flows.yml
+++ b/.github/workflows/test-flows.yml
@@ -20,6 +20,12 @@ on:
     # cancel-in-progress kills the flows that are mid-flight and the run it
     # schedules in their place skips (the PR is a draft again).
     types: [ opened, synchronize, reopened, ready_for_review, converted_to_draft ]
+    # NOTE: same caveat as main.yml and conway's build.yml — this is a
+    # workflow-level skip, so a docs-only PR produces NO check run at all,
+    # whereas the job-level draft gate below produces a `skipped` conclusion
+    # that satisfies a required status check. If either job here is ever made
+    # required in branch protection, convert this to a per-job `if` gate or
+    # docs-only PRs will sit unmergeable forever.
     paths-ignore:
       - '**/*.md'
       - 'design/**'

--- a/.github/workflows/test-flows.yml
+++ b/.github/workflows/test-flows.yml
@@ -13,12 +13,32 @@ on:
     # flipping a draft to ready fires no event and the PR would sit with no
     # flow run until the next push. opened/synchronize/reopened are the
     # Actions default set, restated because naming `types` at all replaces it.
-    types: [ opened, synchronize, reopened, ready_for_review ]
+    #
+    # converted_to_draft is the other half of that gate, and it works by
+    # cancellation rather than by starting anything: pushing a PR back to
+    # draft fires an event in the concurrency group below, so
+    # cancel-in-progress kills the flows that are mid-flight and the run it
+    # schedules in their place skips (the PR is a draft again).
+    types: [ opened, synchronize, reopened, ready_for_review, converted_to_draft ]
     paths-ignore:
       - '**/*.md'
       - 'design/**'
       - 'notes/**'
   workflow_dispatch:
+
+# The draft gate defers this workflow's cost; this bounds it. These are the two
+# longest jobs in the repo (~12m and ~25m ceilings), so without cancellation
+# three quick pushes to one ready PR leave six of them running to completion
+# against a 4-job cap -- which is the exact starvation the draft gate exists to
+# prevent, just relocated from drafts to rework pushes.
+#
+# Grouped per ref, so PRs never cancel each other (refs/pull/<n>/merge is
+# unique per PR). cancel-in-progress is scoped to pull_request: a push to main
+# should run to completion, since its result is the record of what main is in
+# rather than feedback on a diff still being edited.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   playwright-run:
@@ -34,6 +54,13 @@ jobs:
     # keeps this compatible with required status checks: a skipped-by-if job
     # reports a conclusion, a workflow that never triggers reports nothing and
     # leaves the PR waiting forever.
+    #
+    # The event_name clause is defensive, not load-bearing. On push and
+    # workflow_dispatch `github.event.pull_request` is null, and Actions
+    # coerces both sides of `==` to a number when the types differ, so a bare
+    # `draft == false` would evaluate `0 == 0` and run anyway. Relying on that
+    # coercion would make CI on main hinge on a documented-but-obscure corner
+    # of the expression language. The clause states the intent instead.
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-24.04-4vcpu-8gb-150gbssd
     # Image must match @playwright/test in package.json (Playwright caches

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,10 @@ This file is the router for AI assistants working in this repo. Keep it small. T
   **What the gate covers:** `build` (main.yml) and both `test-flows`
   jobs are skipped on drafts. **Netlify deploy previews still run** —
   they come from Netlify's GitHub integration, not Actions — so a draft
-  always has a preview URL to click through. Before editing those
+  normally has a preview URL to click through. (Not for a docs-only PR:
+  `tools/netlify/ignore-build.sh` skips the deploy when every changed
+  file matches `.md` / `design/` / `notes/`. Marketing posts are `.mdx`,
+  so they still build.) Before editing those
   workflows: the gate is a job-level `if:` (a skipped-by-if job
   satisfies a required check; a workflow that never triggers leaves the
   PR waiting forever); `ready_for_review` and `converted_to_draft` must

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,11 +50,15 @@ This file is the router for AI assistants working in this repo. Keep it small. T
   mismatched `==` operands to numbers, so `null == false` is already
   true on push) — keep it so CI on main doesn't hinge on that.
   **Consequence to be aware of:** because `build` is gated here, a draft
-  gets no lint/typecheck/unit-test signal from CI at all — the husky
-  pre-commit hook is what covers that phase, which is why the rule above
-  about never skipping it matters more than it looks. If you push a
-  draft from a sandbox where the hook isn't installed, run `yarn install`
-  before you rely on anything being checked.
+  gets no CI signal at all. The husky pre-commit hook covers most of
+  that phase — but only most: it runs eslint + typecheck + jest, while
+  CI's `build` job *also* runs `yarn build-prod`. So an esbuild-only
+  breakage (a missing asset loader, a plugin misconfig) survives every
+  draft commit and first surfaces at step 3, after `/review` has already
+  signed off — exactly the step-4 re-review this lifecycle is trying to
+  avoid. Run `yarn build-prod` once before flipping to ready. And if
+  you're in a sandbox where the hook isn't installed, `yarn install`
+  first; nothing is being checked otherwise.
   conway uses the same lifecycle, gating `run-ifc-regression` and
   `visual-diff` while leaving its `build` job ungated.
 - **PRs: auto-subscribe to CI / review activity.** Immediately after `create_pull_request` succeeds, call `subscribe_pr_activity` for that PR without asking. The default-prompt asks first — for this repo, skip that question and just subscribe. Babysitting is the expected mode here: watch CI, autofix tractable failures, respond to review comments per the system-prompt rules (small + confident → push the fix; ambiguous or architecturally significant → `AskUserQuestion` first; no-op-able → skip silently). Only `unsubscribe_pr_activity` when the user explicitly says to stop.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,14 +52,20 @@ This file is the router for AI assistants working in this repo. Keep it small. T
   clause is defensive rather than load-bearing (Actions coerces
   mismatched `==` operands to numbers, so `null == false` is already
   true on push) — keep it so CI on main doesn't hinge on that.
-  **Consequence to be aware of:** because `build` is gated here, a draft
-  gets no CI signal at all. The husky pre-commit hook covers most of
-  that phase — but only most: it runs eslint + typecheck + jest, while
-  CI's `build` job *also* runs `yarn build-prod`. So an esbuild-only
-  breakage (a missing asset loader, a plugin misconfig) survives every
-  draft commit and first surfaces at step 3, after `/review` has already
-  signed off — exactly the step-4 re-review this lifecycle is trying to
-  avoid. Run `yarn build-prod` once before flipping to ready — then undo
+  **Consequence to be aware of:** because every job is gated here, a
+  draft gets no CI signal at all, and the husky pre-commit hook covers
+  only part of the gap. Three things it does not run, each of which will
+  otherwise first fail at step 3 — after `/review` has signed off, which
+  is exactly the step-4 re-review this lifecycle is trying to avoid:
+  (a) `yarn build-prod`, so an esbuild-only breakage (missing asset
+  loader, plugin misconfig) survives every draft commit; (b) coverage —
+  the hook's `yarn test` runs `test-src`, while CI runs `test-ci` →
+  `test-coverage` with thresholds enforced (`tools/jest/jest.config.js`);
+  (c) **Playwright**, the big one — E2E specs never execute before step
+  3, so `/review` is reading specs that have never run, against this
+  file's own mandatory desktop+mobile E2E rule. Before flipping to ready,
+  run `yarn build-prod`, `yarn test-ci`, and
+  `yarn test-flows-build-and-serve` + `yarn test-flows [spec]` — then undo
   what it did to `package.json`, because `tools/updateVersion.mjs` stamps
   a local version into that tracked file on every build and the stamp
   must never reach a commit (#1747). `git checkout -- package.json` if

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,29 @@ This file is the router for AI assistants working in this repo. Keep it small. T
 - **Run tests; don't ask first.** Use `--config tools/jest/jest.config.js` when invoking Jest directly.
 - **The husky `.husky/pre-commit` hook runs `yarn precommit` (eslint + typecheck + jest) automatically on every commit.** Trust it — don't run `yarn precommit` yourself before `git commit` / `git push`. The hook is the gate; running it explicitly too is just doing the same multi-minute pass twice. It enforces the same checks CI's `build` job runs (`eslint src netlify tools --max-warnings 0 && yarn typecheck && yarn test`). If the hook isn't installed (fresh sandbox, `yarn install --ignore-scripts`, etc.), run `yarn install` to wire it in; don't paper over a missing hook by running the gate manually. Running a piece of the gate in isolation while iterating (e.g. one Jest file, `yarn eslint <path>`) is fine — that's a development inner loop, not the commit gate.
 - **UI work: "if it's not doc'd, it doesn't exist; if it's not tested, it doesn't work."** Two standing requirements for any PR implementing UI epic/story/task work: (1) **doc** — the work is tracked as an epic-labeled issue with native sub-issues per story/task, all titles sharing the epic's name so the family is greppable; (2) **test** — an issue isn't done until each task/sub-issue has a happy-path E2E test on desktop *and* mobile, via `describeMobileAndDesktop` (`src/tests/e2e/formFactor.ts`). Cross-link the PR ↔ issues, and close the story/task sub-issues when the implementing PR is submitted. Full rule + worked example: [design/new/conversational-cad.md](design/new/conversational-cad.md) §7.1.
+- **PRs: open in draft, land in five steps.** Several PRs are usually
+  in flight and CI runners are capped at 4 concurrent jobs, so a PR that
+  runs the full suite on every rework push starves the PRs that are
+  ready. (1) Open it with `draft: true` — not opened-then-marked.
+  (2) Keep it in draft until `/review` has run and every finding is
+  fixed or answered in the thread. (3) Flip to ready
+  (`update_pull_request`, `draft: false`); that fires
+  `ready_for_review`, which is what starts the gated jobs. (4) Drive CI
+  green, and `/review` again if the fixes changed the diff beyond a
+  trivial revert — otherwise the reviewed diff isn't the merged diff.
+  (5) Update the PR description to match what the change became, merge,
+  then close or narrow its issues (partly-addressed → a comment saying
+  what's left, not a close).
+  **What the gate covers:** `build` (main.yml) and both `test-flows`
+  jobs are skipped on drafts. **Netlify deploy previews still run** —
+  they come from Netlify's GitHub integration, not Actions — so a draft
+  always has a preview URL to click through. Before editing those
+  workflows: the gate is a job-level `if:` (a skipped-by-if job
+  satisfies a required check; a workflow that never triggers leaves the
+  PR waiting forever), and `ready_for_review` must stay in the
+  `pull_request` `types:` list or step 3 silently does nothing.
+  conway uses the same lifecycle, gating `run-ifc-regression` and
+  `visual-diff` while leaving its `build` job ungated.
 - **PRs: auto-subscribe to CI / review activity.** Immediately after `create_pull_request` succeeds, call `subscribe_pr_activity` for that PR without asking. The default-prompt asks first — for this repo, skip that question and just subscribe. Babysitting is the expected mode here: watch CI, autofix tractable failures, respond to review comments per the system-prompt rules (small + confident → push the fix; ambiguous or architecturally significant → `AskUserQuestion` first; no-op-able → skip silently). Only `unsubscribe_pr_activity` when the user explicitly says to stop.
 
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,9 +56,11 @@ This file is the router for AI assistants working in this repo. Keep it small. T
   breakage (a missing asset loader, a plugin misconfig) survives every
   draft commit and first surfaces at step 3, after `/review` has already
   signed off — exactly the step-4 re-review this lifecycle is trying to
-  avoid. Run `yarn build-prod` once before flipping to ready. And if
-  you're in a sandbox where the hook isn't installed, `yarn install`
-  first; nothing is being checked otherwise.
+  avoid. Run `yarn build-prod` once before flipping to ready — then
+  `git checkout -- package.json`, because `tools/updateVersion.mjs`
+  stamps a local version into it on every build and that stamp must
+  never reach a commit. And if you're in a sandbox where the hook isn't
+  installed, `yarn install` first; nothing is being checked otherwise.
   conway uses the same lifecycle, gating `run-ifc-regression` and
   `visual-diff` while leaving its `build` job ungated.
 - **PRs: auto-subscribe to CI / review activity.** Immediately after `create_pull_request` succeeds, call `subscribe_pr_activity` for that PR without asking. The default-prompt asks first — for this repo, skip that question and just subscribe. Babysitting is the expected mode here: watch CI, autofix tractable failures, respond to review comments per the system-prompt rules (small + confident → push the fix; ambiguous or architecturally significant → `AskUserQuestion` first; no-op-able → skip silently). Only `unsubscribe_pr_activity` when the user explicitly says to stop.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,8 +42,19 @@ This file is the router for AI assistants working in this repo. Keep it small. T
   always has a preview URL to click through. Before editing those
   workflows: the gate is a job-level `if:` (a skipped-by-if job
   satisfies a required check; a workflow that never triggers leaves the
-  PR waiting forever), and `ready_for_review` must stay in the
-  `pull_request` `types:` list or step 3 silently does nothing.
+  PR waiting forever); `ready_for_review` and `converted_to_draft` must
+  stay in the `pull_request` `types:` list (the first starts the gated
+  jobs at step 3, the second lets pulling a PR back to draft *cancel* a
+  run already in flight); and the `github.event_name != 'pull_request'`
+  clause is defensive rather than load-bearing (Actions coerces
+  mismatched `==` operands to numbers, so `null == false` is already
+  true on push) — keep it so CI on main doesn't hinge on that.
+  **Consequence to be aware of:** because `build` is gated here, a draft
+  gets no lint/typecheck/unit-test signal from CI at all — the husky
+  pre-commit hook is what covers that phase, which is why the rule above
+  about never skipping it matters more than it looks. If you push a
+  draft from a sandbox where the hook isn't installed, run `yarn install`
+  before you rely on anything being checked.
   conway uses the same lifecycle, gating `run-ifc-regression` and
   `visual-diff` while leaving its `build` job ungated.
 - **PRs: auto-subscribe to CI / review activity.** Immediately after `create_pull_request` succeeds, call `subscribe_pr_activity` for that PR without asking. The default-prompt asks first — for this repo, skip that question and just subscribe. Babysitting is the expected mode here: watch CI, autofix tractable failures, respond to review comments per the system-prompt rules (small + confident → push the fix; ambiguous or architecturally significant → `AskUserQuestion` first; no-op-able → skip silently). Only `unsubscribe_pr_activity` when the user explicitly says to stop.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,10 +56,14 @@ This file is the router for AI assistants working in this repo. Keep it small. T
   breakage (a missing asset loader, a plugin misconfig) survives every
   draft commit and first surfaces at step 3, after `/review` has already
   signed off — exactly the step-4 re-review this lifecycle is trying to
-  avoid. Run `yarn build-prod` once before flipping to ready — then
-  `git checkout -- package.json`, because `tools/updateVersion.mjs`
-  stamps a local version into it on every build and that stamp must
-  never reach a commit. And if you're in a sandbox where the hook isn't
+  avoid. Run `yarn build-prod` once before flipping to ready — then undo
+  what it did to `package.json`, because `tools/updateVersion.mjs` stamps
+  a local version into that tracked file on every build and the stamp
+  must never reach a commit (#1747). `git checkout -- package.json` if
+  the version is the only change in it; if you also edited it — added a
+  dependency, changed a script — restore just the `version` field by
+  hand, since the checkout would silently drop the rest while
+  `yarn.lock` kept it. And if you're in a sandbox where the hook isn't
   installed, `yarn install` first; nothing is being checked otherwise.
   conway uses the same lifecycle, gating `run-ifc-regression` and
   `visual-diff` while leaving its `build` job ungated.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bldrs",
-  "version": "1.1743.6caa6b3",
+  "version": "1.1745.198f7d4",
   "main": "src/index.jsx",
   "license": "AGPL-3.0",
   "homepage": "https://github.com/bldrs-ai/Share",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bldrs",
-  "version": "1.1745.198f7d4",
+  "version": "1.1743.6caa6b3",
   "main": "src/index.jsx",
   "license": "AGPL-3.0",
   "homepage": "https://github.com/bldrs-ai/Share",


### PR DESCRIPTION
Implements the Share half of the multi-PR CI policy, and documents the surrounding lifecycle in `AGENTS.md`.

## Why

Several PRs are usually in flight at once against a runner pool capped at 4 concurrent jobs. The Playwright flows are the most expensive thing CI does per PR — two jobs, 35m and 25m ceilings — so draft pushes on a PR that is still being reworked can saturate the cap and starve the PRs that are actually ready for review.

## What changes

| Job | Draft PR | Ready PR |
|---|---|---|
| `build` (`main.yml`: build-prod + lint + test-ci) | **skipped** | runs |
| `playwright-run` (`test-flows.yml`) | **skipped** | runs |
| `playwright-webifc-run` (`test-flows.yml`) | **skipped** | runs |
| **Netlify deploy preview** | **runs** | runs |

Deploy previews are untouched because they don't come from Actions at all — they're Netlify's own GitHub integration. So a draft still gets a preview URL while its checks are held back, which is exactly the split asked for. (One exception, now documented: `tools/netlify/ignore-build.sh` skips the deploy on docs-only PRs.)

Trigger `types:` gains `ready_for_review` and `converted_to_draft`. Naming `types` at all *replaces* the Actions default set, so `opened` / `synchronize` / `reopened` are restated alongside them — dropping those would have quietly stopped CI on ordinary pushes.

`test-flows.yml` also gains a `concurrency` group, which it had none of. The draft gate defers this workflow's cost; nothing bounded it, so three quick pushes on one ready PR could leave six long jobs running against the 4-job cap — the same starvation the gate removes from drafts, relocated onto rework pushes.

## Mechanics, for reviewers

- **Job-level `if:`, not a trigger filter.** A skipped-by-if job reports a conclusion and satisfies a required status check; a workflow that never triggers reports nothing and leaves the PR waiting forever. Both workflows now carry that NOTE against their `paths-ignore`, matching conway.
- **`main.yml`'s concurrency moved from the job to the workflow.** Required, not cosmetic: a job skipped by `if:` never claims a job-level group, so `converted_to_draft` could not have cancelled anything.
- **The `github.event_name != 'pull_request' ||` clause is defensive, not load-bearing** — `null == false` is already true under Actions' numeric coercion. Kept so CI on main doesn't hinge on it.

## What review changed

Six rounds. Worth calling out, since two were self-inflicted:

- **A stray `package.json` version stamp** got committed and reverted. `yarn build-prod` runs `tools/updateVersion.mjs`, which rewrites that tracked file — so following this PR's own new "run build-prod before flipping to ready" advice reproduces the problem. Filed as #1747; the doc now carries the cleanup step, with a warning that a blanket `git checkout` would also drop an unrelated `package.json` edit.
- **Hoisting `main.yml`'s concurrency accidentally narrowed `cancel-in-progress` from `true` to PR-only**, so main's builds would have queued where they used to be cancelled — and a queued run isn't a safe run, since GitHub drops a *pending* run when a newer one joins. Restored to cancel-always, and `test-flows.yml` now matches. Nothing ships from either workflow, so only the newest commit's result is worth a runner. (conway scopes its cancellation to PRs, but only because an npm publish rides on the ordering there — conway#468. Copying that shape without the reason is what caused this.)
- An event-type argument was copied from conway that doesn't hold here — Share has no tag triggers, so push and `workflow_dispatch` on main share a ref either way. Removed, with a note not to carry it back.

## The lifecycle it documents

`AGENTS.md` §Always gains **PRs: open in draft, land in five steps**: open with `draft: true` → keep it there until `/review` findings are handled → flip to ready (which triggers the gated jobs) → drive CI green, re-reviewing if the fixes changed the diff → update the description, merge, close or narrow its issues.

It also names the gap the gate creates, which is bigger than it first looks: with every job gated, a draft gets **no** CI signal, and the husky hook covers only part of it. It doesn't run `build-prod`, doesn't run coverage (`test-ci` → `test-coverage` with enforced thresholds, vs the hook's `test-src`), and doesn't run Playwright at all — so `/review` at step 2 reads E2E specs that have never executed, against this repo's own mandatory desktop+mobile E2E rule. The doc lists the local commands that close each gap before flipping to ready.

## Verification

Both workflows parse and the gate resolves per job as intended. `yarn precommit` (eslint + typecheck + jest) passed on every commit via the husky hook, plus a manual `yarn build-prod`.

**Verified live on this PR.** As a draft it showed the Netlify preview building and all three Actions jobs `skipped`. Flipping it to ready fired `ready_for_review` and queued all three — the step-3 mechanic working end to end.

Companion PR in conway: bldrs-ai/conway#467.