### PR TITLE
Publish the GA client id as a user property, and send local_hour

### DIFF
--- a/design/roadmap.md
+++ b/design/roadmap.md
@@ -731,6 +731,30 @@ which channel *reaches* that audience is the open GTM question owned bizdev-side
   accrues from ship time, so land it early in a campaign window for a clean
   baseline. At larger scale GA4 rolls high-cardinality values into "(other)";
   that's the cue to move the query to the BigQuery export.
+- Per-user *behaviour* beyond open depth (2026-08-13): an event-scoped
+  dimension exists only on the events carrying it, so session count,
+  engagement duration, landing page and new-vs-returning are unreachable per
+  user however the query is written — filtering to `real_model_open` yields no
+  engagement, not filtering yields `(not set)` everywhere else. Share now also
+  publishes the same id as a **user property** (`analytics#setUserCidProperty`,
+  called from `index/ga.js` both at setup and from the `client_id` callback,
+  since user properties only attach to events sent after they are set).
+  **Remaining GA4-side config:** a second custom definition, scope **User**,
+  from user property `open_cid` — the event- and user-scoped dimensions
+  coexist because GA4 namespaces event parameters separately from user
+  properties. Query it as `customUser:<name>`.
+- Local time of day (2026-08-13): GA4's `hour` dimension is in the *property's*
+  timezone, which says nothing about when a Europe/Brazil-heavy audience
+  actually works. `real_model_open` now carries `local_hour`, the browser's own
+  hour, zero-padded to a string for the same typing reason `open_cid` is
+  prefixed. **Remaining GA4-side config:** an event-scoped dimension from event
+  parameter `local_hour`.
+- Model *name* was considered and deliberately not sent. For remote models the
+  name is already derivable from `content_id`; the only case it would add
+  information is local uploads, which route by OPFS blob id — so sending it
+  would newly disclose user-chosen filenames to Google for exactly the files
+  that never leave the browser today. Left as a product decision rather than
+  slipped in with the rest.
 - Channel-grouping + dashboard slices are bizdev-side config; the Share-side
   deliverable is the events existing and firing.
 - v0.4 addition: capture **model size/complexity** (bucketed — bytes, element

--- a/design/roadmap.md
+++ b/design/roadmap.md
@@ -742,13 +742,18 @@ which channel *reaches* that audience is the open GTM question owned bizdev-side
   **Remaining GA4-side config:** a second custom definition, scope **User**,
   from user property `open_cid` — the event- and user-scoped dimensions
   coexist because GA4 namespaces event parameters separately from user
-  properties. Query it as `customUser:<name>`.
+  properties. Query it as `customUser:<name>`. Withdrawing analytics consent
+  retracts the property explicitly (`analytics#setIsAllowed`): unlike an event,
+  which re-checks consent per call, a user property is sticky and gtag/js keeps
+  attaching it to its own automatic events until it is set to null.
 - Local time of day (2026-08-13): GA4's `hour` dimension is in the *property's*
   timezone, which says nothing about when a Europe/Brazil-heavy audience
   actually works. `real_model_open` now carries `local_hour`, the browser's own
-  hour, zero-padded to a string for the same typing reason `open_cid` is
-  prefixed. **Remaining GA4-side config:** an event-scoped dimension from event
-  parameter `local_hour`.
+  hour, prefixed `h.` for the same typing reason `open_cid` is prefixed — and
+  note zero-padding alone does *not* achieve it, since `Number('08')` is 8, so
+  a padded-but-unprefixed hour would still beacon as a number and leave the
+  dimension empty for all 24 values. **Remaining GA4-side config:** an
+  event-scoped dimension from event parameter `local_hour`.
 - Model *name* was considered and deliberately not sent. For remote models the
   name is already derivable from `content_id`; the only case it would add
   information is local uploads, which route by OPFS blob id — so sending it

--- a/design/roadmap.md
+++ b/design/roadmap.md
@@ -745,7 +745,10 @@ which channel *reaches* that audience is the open GTM question owned bizdev-side
   properties. Query it as `customUser:<name>`. Withdrawing analytics consent
   retracts the property explicitly (`analytics#setIsAllowed`): unlike an event,
   which re-checks consent per call, a user property is sticky and gtag/js keeps
-  attaching it to its own automatic events until it is set to null.
+  attaching it to its own automatic events until it is set to null. **Before
+  restoring PrivacyControl to the UI** (commented out of `AboutDialog` today),
+  confirm in GA4 DebugView that null actually clears the property rather than
+  storing null as a value — the retraction path rests on that.
 - Local time of day (2026-08-13): GA4's `hour` dimension is in the *property's*
   timezone, which says nothing about when a Europe/Brazil-heavy audience
   actually works. `real_model_open` now carries `local_hour`, the browser's own

--- a/public/index.html
+++ b/public/index.html
@@ -54,6 +54,23 @@
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
+      // MUST precede config. gtag/js drains this queue in order, and a user
+      // property only attaches to events sent after it is set — config is what
+      // triggers page_view / session_start / first_visit, which are exactly the
+      // events that make landing page and new-vs-returning queryable per user.
+      // The bundle cannot do this: it loads long after config is queued.
+      //
+      // Deliberate duplication of privacy/analytics.js — the `cid.` prefix must
+      // stay in step with analytics#OPEN_CID_PREFIX (a bare id is
+      // numeric-looking, and GA4 won't populate a text dimension from a number),
+      // and the consent check with analytics#isAllowed. Same arrangement the
+      // config ID above already has with ga.js#GA_MEASUREMENT_ID.
+      (function setUserCidBeforeConfig() {
+        if (/(?:^|;\s*)isAnalyticsAllowed=false(?:;|$)/.test(document.cookie)) return;
+        // _ga is `GA<version>.<domain depth>.<id>`, and the id itself has a dot
+        var m = document.cookie.match(/(?:^|;\s*)_ga=GA\d+\.\d+\.([^;]+)/);
+        if (m) gtag('set', 'user_properties', {open_cid: 'cid.' + m[1]});
+      })();
       gtag('config', 'G-GRLNVMZRGW');
     </script>
     <!-- AdSense site verification. Body-after-bundle placement so MSW takes control before the script's network requests fire in dev/test. design/new/ads.md captures why Auto ads stay OFF and which routes may carry ad slots. -->

--- a/public/index.html
+++ b/public/index.html
@@ -54,24 +54,35 @@
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
-      // MUST precede config. gtag/js drains this queue in order, and a user
-      // property only attaches to events sent after it is set — config is what
-      // triggers page_view / session_start / first_visit, which are exactly the
-      // events that make landing page and new-vs-returning queryable per user.
-      // The bundle cannot do this: it loads long after config is queued.
+      // Carried IN the config call rather than a `set` queued before it.
+      // config is what triggers page_view / session_start / first_visit — the
+      // events that make landing page and new-vs-returning queryable per user
+      // — and gtag only guarantees a user property reaches them when it is
+      // passed as config's own `user_properties` field. A preceding `set`
+      // relies on queue-drain ordering that gtag does not document.
       //
-      // Deliberate duplication of privacy/analytics.js — the `cid.` prefix must
-      // stay in step with analytics#OPEN_CID_PREFIX (a bare id is
-      // numeric-looking, and GA4 won't populate a text dimension from a number),
-      // and the consent check with analytics#isAllowed. Same arrangement the
-      // config ID above already has with ga.js#GA_MEASUREMENT_ID.
-      (function setUserCidBeforeConfig() {
-        if (/(?:^|;\s*)isAnalyticsAllowed=false(?:;|$)/.test(document.cookie)) return;
+      // The bundle cannot do this: it loads long after config is queued.
+      // So the `cid.` prefix (analytics#OPEN_CID_PREFIX — a bare id is
+      // numeric-looking, and GA4 won't populate a text dimension from a
+      // number) and the consent rule (analytics#isAllowed) are duplicated
+      // here on purpose, the same arrangement the config ID already has with
+      // ga.js#GA_MEASUREMENT_ID.
+      //
+      // Host and automation are deliberately NOT re-checked. Everything the
+      // stub queues is inert off-prod because ga.js#shouldInitGa never
+      // injects gtag/js there (asserted in ga.test.js), and the E2E suite
+      // reads this buffer on localhost — the same reason isRealModelOpen
+      // documents localhost as a deliberate exception.
+      function userPropsBeforeConfig() {
+        var consent = document.cookie.match(/(?:^|;\s*)isAnalyticsAllowed=([^;]*)/);
+        // absent means allowed (the app's default); anything present but not
+        // exactly 'true' is a denial, matching isAllowed's === 'true' test
+        if (consent && consent[1] !== 'true') return {};
         // _ga is `GA<version>.<domain depth>.<id>`, and the id itself has a dot
         var m = document.cookie.match(/(?:^|;\s*)_ga=GA\d+\.\d+\.([^;]+)/);
-        if (m) gtag('set', 'user_properties', {open_cid: 'cid.' + m[1]});
-      })();
-      gtag('config', 'G-GRLNVMZRGW');
+        return m ? {user_properties: {open_cid: 'cid.' + m[1]}} : {};
+      }
+      gtag('config', 'G-GRLNVMZRGW', userPropsBeforeConfig());
     </script>
     <!-- AdSense site verification. Body-after-bundle placement so MSW takes control before the script's network requests fire in dev/test. design/new/ads.md captures why Auto ads stay OFF and which routes may carry ad slots. -->
     <script async

--- a/src/Containers/CadView.jsx
+++ b/src/Containers/CadView.jsx
@@ -7,7 +7,7 @@ import {captureException} from '@sentry/react'
 import {fileSuffixBoundaryRegex} from '../Filetype'
 import {useAuth0} from '../Auth0/Auth0Proxy'
 import {onHash} from '../Components/Camera/CameraControl'
-import {OPEN_CID_PARAM, getOpenCid, gtagEvent, isRealModelOpen} from '../privacy/analytics'
+import {LOCAL_HOUR_PARAM, OPEN_CID_PARAM, getOpenCid, gtagEvent, isRealModelOpen} from '../privacy/analytics'
 import {getRenderMode} from '../privacy/preferences'
 import {resetState as resetCutPlaneState} from '../Components/CutPlane/CutPlaneMenu'
 import {useIsMobile} from '../Components/Hooks'
@@ -588,6 +588,18 @@ export default function CadView({
       if (openCid) {
         eventParams[OPEN_CID_PARAM] = openCid
       }
+      // GA4's own `hour` dimension is in the *property's* timezone, which
+      // says nothing about when a user in Milan or São Paulo actually
+      // works — and the real-opens audience is Europe + Brazil (bizdev
+      // growth-strategy §2). This is their local hour.
+      //
+      // Zero-padded string, not a number: gtag types each param when it
+      // builds the beacon, and a numeric-looking value goes out in the
+      // number slot, where an event-scoped custom *dimension* won't
+      // populate from it at all. Same trap that made open_cid render as
+      // 1.87152e+09 — see analytics#OPEN_CID_PREFIX. Padding also makes
+      // it sort correctly and match GA4's own `hour` formatting.
+      eventParams[LOCAL_HOUR_PARAM] = String(new Date().getHours()).padStart(2, '0')
       gtagEvent('real_model_open', eventParams)
     }
 

--- a/src/Containers/CadView.jsx
+++ b/src/Containers/CadView.jsx
@@ -7,7 +7,7 @@ import {captureException} from '@sentry/react'
 import {fileSuffixBoundaryRegex} from '../Filetype'
 import {useAuth0} from '../Auth0/Auth0Proxy'
 import {onHash} from '../Components/Camera/CameraControl'
-import {LOCAL_HOUR_PARAM, OPEN_CID_PARAM, getOpenCid, gtagEvent, isRealModelOpen} from '../privacy/analytics'
+import {LOCAL_HOUR_PARAM, OPEN_CID_PARAM, getLocalHour, getOpenCid, gtagEvent, isRealModelOpen} from '../privacy/analytics'
 import {getRenderMode} from '../privacy/preferences'
 import {resetState as resetCutPlaneState} from '../Components/CutPlane/CutPlaneMenu'
 import {useIsMobile} from '../Components/Hooks'
@@ -591,15 +591,9 @@ export default function CadView({
       // GA4's own `hour` dimension is in the *property's* timezone, which
       // says nothing about when a user in Milan or São Paulo actually
       // works — and the real-opens audience is Europe + Brazil (bizdev
-      // growth-strategy §2). This is their local hour.
-      //
-      // Zero-padded string, not a number: gtag types each param when it
-      // builds the beacon, and a numeric-looking value goes out in the
-      // number slot, where an event-scoped custom *dimension* won't
-      // populate from it at all. Same trap that made open_cid render as
-      // 1.87152e+09 — see analytics#OPEN_CID_PREFIX. Padding also makes
-      // it sort correctly and match GA4's own `hour` formatting.
-      eventParams[LOCAL_HOUR_PARAM] = String(new Date().getHours()).padStart(2, '0')
+      // growth-strategy §2). This is their local hour, prefixed so gtag
+      // keeps it in the text slot; see analytics#getLocalHour.
+      eventParams[LOCAL_HOUR_PARAM] = getLocalHour()
       gtagEvent('real_model_open', eventParams)
     }
 

--- a/src/Containers/realModelOpen.spec.ts
+++ b/src/Containers/realModelOpen.spec.ts
@@ -23,11 +23,11 @@ const REAL_MODEL = '/share/v/gh/bldrs-ai/test-models/main/ifc/misc/box.ifc'
  * before they cross the evaluate boundary.
  *
  * @param page Playwright page object
- * @return Array of {name, contentId, hasOpenCid, openCid} per real_model_open event
+ * @return Array of {name, contentId, hasOpenCid, openCid, localHour} per real_model_open event
  */
 async function realModelOpenEvents(
   page: Page,
-): Promise<{name: string, contentId: string, hasOpenCid: boolean, openCid?: unknown}[]> {
+): Promise<{name: string, contentId: string, hasOpenCid: boolean, openCid?: unknown, localHour?: unknown}[]> {
   return await page.evaluate(() => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const dataLayer: any[] = (window as any).dataLayer || []
@@ -38,6 +38,7 @@ async function realModelOpenEvents(
         contentId: String(entry[2]?.content_id ?? ''),
         hasOpenCid: entry[2]?.open_cid !== undefined,
         openCid: entry[2]?.open_cid,
+        localHour: entry[2]?.local_hour,
       }))
   })
 }
@@ -108,5 +109,26 @@ describeMobileAndDesktop('real_model_open GA event', () => {
     // it in the text slot with all its digits intact.
     expect(Number(events[0].openCid)).toBeNaN()
     expect(String(events[0].openCid)).toContain(FAKE_CLIENT_ID)
+  })
+
+  /*
+   * local_hour exists because GA4's own `hour` dimension is in the
+   * property's timezone, which says nothing about when a user in Milan
+   * or São Paulo works. Same typing trap as open_cid: sent as a
+   * zero-padded string so gtag keeps it in the text slot, where an
+   * event-scoped custom dimension can populate from it. An unpadded
+   * hour would beacon as a number and silently fail to populate.
+   */
+  test('sends local_hour as a zero-padded string in the browser timezone', async ({page}) => {
+    await setupVirtualPathIntercept(page, REAL_MODEL, 'box.ifc')
+    await page.goto(REAL_MODEL, {waitUntil: 'domcontentloaded'})
+    await waitForModelReady(page)
+    const events = await realModelOpenEvents(page)
+    expect(events).toHaveLength(1)
+    expect(typeof events[0].localHour).toBe('string')
+    expect(events[0].localHour).toMatch(/^[0-2][0-9]$/)
+    // matches what the browser itself reports, not the server's clock
+    const browserHour = await page.evaluate(() => String(new Date().getHours()).padStart(2, '0'))
+    expect(events[0].localHour).toBe(browserHour)
   })
 })

--- a/src/Containers/realModelOpen.spec.ts
+++ b/src/Containers/realModelOpen.spec.ts
@@ -143,33 +143,50 @@ describeMobileAndDesktop('real_model_open GA event', () => {
   })
 
   /*
-   * The ordering the user property depends on. gtag/js drains dataLayer in
-   * order and a user property only attaches to events sent after it is set,
-   * so the stub must publish it before `config` — config is what triggers
-   * page_view/session_start/first_visit, the events that make landing page
-   * and new-vs-returning queryable per user. Asserting on queue order is the
-   * only way to see this with the loader blocked.
+   * The user property has to reach config's own events — page_view,
+   * session_start, first_visit — since those are what make landing page and
+   * new-vs-returning queryable per user. Carrying it IN the config call is
+   * what guarantees that; a `set` queued beforehand would depend on
+   * queue-drain ordering gtag does not document. With the loader blocked,
+   * inspecting the queued config call is the only way to see it.
    */
-  test('publishes open_cid as a user property before gtag config', async ({page}) => {
+  test('carries open_cid as a user property on the gtag config call', async ({page}) => {
     await page.context().addCookies([
       {name: '_ga', value: `GA1.1.${FAKE_CLIENT_ID}`, domain: 'localhost', path: '/'},
     ])
     await setupVirtualPathIntercept(page, REAL_MODEL, 'box.ifc')
     await page.goto(REAL_MODEL, {waitUntil: 'domcontentloaded'})
     await waitForModelReady(page)
-    const queue = await page.evaluate(() => {
+    const config = await page.evaluate(() => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const dataLayer: any[] = (window as any).dataLayer || []
-      return {
-        setIndex: dataLayer.findIndex((e) => e?.[0] === 'set' && e?.[1] === 'user_properties'),
-        configIndex: dataLayer.findIndex((e) => e?.[0] === 'config'),
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        value: dataLayer.find((e: any) => e?.[0] === 'set' && e?.[1] === 'user_properties')?.[2],
-      }
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const entry = dataLayer.find((e: any) => e?.[0] === 'config')
+      return entry ? {params: entry[2]} : null
     })
-    expect(queue.setIndex).toBeGreaterThanOrEqual(0)
-    expect(queue.configIndex).toBeGreaterThanOrEqual(0)
-    expect(queue.setIndex).toBeLessThan(queue.configIndex)
-    expect(queue.value).toEqual({open_cid: `cid.${FAKE_CLIENT_ID}`})
+    expect(config).not.toBeNull()
+    expect(config?.params?.user_properties).toEqual({open_cid: `cid.${FAKE_CLIENT_ID}`})
+    // the same typing rule the event param follows
+    expect(Number(config?.params?.user_properties?.open_cid)).toBeNaN()
+  })
+
+  // The stub duplicates analytics#isAllowed rather than importing it, so the
+  // duplicate needs its own coverage — a consent gate that fails open is
+  // worse than one that never existed.
+  test('omits the user property when analytics consent is withheld', async ({page}) => {
+    await page.context().addCookies([
+      {name: '_ga', value: `GA1.1.${FAKE_CLIENT_ID}`, domain: 'localhost', path: '/'},
+      {name: 'isAnalyticsAllowed', value: 'false', domain: 'localhost', path: '/'},
+    ])
+    await setupVirtualPathIntercept(page, REAL_MODEL, 'box.ifc')
+    await page.goto(REAL_MODEL, {waitUntil: 'domcontentloaded'})
+    const config = await page.evaluate(() => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const dataLayer: any[] = (window as any).dataLayer || []
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const entry = dataLayer.find((e: any) => e?.[0] === 'config')
+      return entry ? {params: entry[2]} : null
+    })
+    expect(config?.params?.user_properties).toBeUndefined()
   })
 })

--- a/src/Containers/realModelOpen.spec.ts
+++ b/src/Containers/realModelOpen.spec.ts
@@ -114,12 +114,15 @@ describeMobileAndDesktop('real_model_open GA event', () => {
   /*
    * local_hour exists because GA4's own `hour` dimension is in the
    * property's timezone, which says nothing about when a user in Milan
-   * or São Paulo works. Same typing trap as open_cid: sent as a
-   * zero-padded string so gtag keeps it in the text slot, where an
-   * event-scoped custom dimension can populate from it. An unpadded
-   * hour would beacon as a number and silently fail to populate.
+   * or São Paulo works.
+   *
+   * Same typing trap as open_cid, and the reason for the `h.` prefix:
+   * gtag beacons anything numeric-looking as `epn.`, which a text
+   * custom dimension will not populate from. Zero-padding alone does
+   * not help — Number('08') is 8 — so the NaN assertion below is the
+   * one that actually pins this.
    */
-  test('sends local_hour as a zero-padded string in the browser timezone', async ({page}) => {
+  test('sends local_hour as a non-numeric string in the browser timezone', async ({page}) => {
     await setupVirtualPathIntercept(page, REAL_MODEL, 'box.ifc')
     await page.goto(REAL_MODEL, {waitUntil: 'domcontentloaded'})
     // Read before the model loads, and accept the next hour too: a run that
@@ -131,10 +134,11 @@ describeMobileAndDesktop('real_model_open GA event', () => {
     const events = await realModelOpenEvents(page)
     expect(events).toHaveLength(1)
     expect(typeof events[0].localHour).toBe('string')
-    expect(events[0].localHour).toMatch(/^[0-2][0-9]$/)
+    expect(Number(events[0].localHour)).toBeNaN()
     const HOURS_PER_DAY = 24
+    const HOUR_DIGITS = 2
     const accepted = [hourAtStart, (hourAtStart + 1) % HOURS_PER_DAY]
-      .map((h) => String(h).padStart(2, '0'))
+      .map((h) => `h.${String(h).padStart(HOUR_DIGITS, '0')}`)
     expect(accepted).toContain(events[0].localHour)
   })
 

--- a/src/Containers/realModelOpen.spec.ts
+++ b/src/Containers/realModelOpen.spec.ts
@@ -122,13 +122,50 @@ describeMobileAndDesktop('real_model_open GA event', () => {
   test('sends local_hour as a zero-padded string in the browser timezone', async ({page}) => {
     await setupVirtualPathIntercept(page, REAL_MODEL, 'box.ifc')
     await page.goto(REAL_MODEL, {waitUntil: 'domcontentloaded'})
+    // Read before the model loads, and accept the next hour too: a run that
+    // straddles a clock boundary would otherwise fail looking like a product
+    // bug. Comparing against the browser's clock at all is the point — it is
+    // what distinguishes this from GA4's property-timezone `hour`.
+    const hourAtStart = await page.evaluate(() => new Date().getHours())
     await waitForModelReady(page)
     const events = await realModelOpenEvents(page)
     expect(events).toHaveLength(1)
     expect(typeof events[0].localHour).toBe('string')
     expect(events[0].localHour).toMatch(/^[0-2][0-9]$/)
-    // matches what the browser itself reports, not the server's clock
-    const browserHour = await page.evaluate(() => String(new Date().getHours()).padStart(2, '0'))
-    expect(events[0].localHour).toBe(browserHour)
+    const HOURS_PER_DAY = 24
+    const accepted = [hourAtStart, (hourAtStart + 1) % HOURS_PER_DAY]
+      .map((h) => String(h).padStart(2, '0'))
+    expect(accepted).toContain(events[0].localHour)
+  })
+
+  /*
+   * The ordering the user property depends on. gtag/js drains dataLayer in
+   * order and a user property only attaches to events sent after it is set,
+   * so the stub must publish it before `config` — config is what triggers
+   * page_view/session_start/first_visit, the events that make landing page
+   * and new-vs-returning queryable per user. Asserting on queue order is the
+   * only way to see this with the loader blocked.
+   */
+  test('publishes open_cid as a user property before gtag config', async ({page}) => {
+    await page.context().addCookies([
+      {name: '_ga', value: `GA1.1.${FAKE_CLIENT_ID}`, domain: 'localhost', path: '/'},
+    ])
+    await setupVirtualPathIntercept(page, REAL_MODEL, 'box.ifc')
+    await page.goto(REAL_MODEL, {waitUntil: 'domcontentloaded'})
+    await waitForModelReady(page)
+    const queue = await page.evaluate(() => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const dataLayer: any[] = (window as any).dataLayer || []
+      return {
+        setIndex: dataLayer.findIndex((e) => e?.[0] === 'set' && e?.[1] === 'user_properties'),
+        configIndex: dataLayer.findIndex((e) => e?.[0] === 'config'),
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        value: dataLayer.find((e: any) => e?.[0] === 'set' && e?.[1] === 'user_properties')?.[2],
+      }
+    })
+    expect(queue.setIndex).toBeGreaterThanOrEqual(0)
+    expect(queue.configIndex).toBeGreaterThanOrEqual(0)
+    expect(queue.setIndex).toBeLessThan(queue.configIndex)
+    expect(queue.value).toEqual({open_cid: `cid.${FAKE_CLIENT_ID}`})
   })
 })

--- a/src/index/ga.js
+++ b/src/index/ga.js
@@ -1,5 +1,5 @@
 import {captureException} from '@sentry/react'
-import {setGaClientId} from '../privacy/analytics'
+import {setGaClientId, setUserCidProperty} from '../privacy/analytics'
 
 
 // Must match the ID in public/index.html's inline gtag('config') stub —
@@ -68,13 +68,25 @@ export default function setupGa(env = undefined) {
       )
     }
     document.head.appendChild(script)
+    // A returning visitor already has the id in the `_ga` cookie, so
+    // publish the user property now: user properties only attach to
+    // events sent *after* they are set, and the `get` callback below
+    // does not land until gtag/js has loaded. Without this, every
+    // event in that window — which includes each visitor's first
+    // model open — would carry the event param but not the property.
+    setUserCidProperty()
     // Ask GA for this browser's client id so model-open events can
     // carry it as open_cid (see privacy/analytics#setGaClientId for
     // why). The call buffers in dataLayer like any other gtag call and
     // the callback fires once gtag/js has loaded and resolved the id —
     // so it never fires on a blocked client. Events fired before it
     // lands fall back to the _ga cookie in analytics#getGaClientId.
-    window.gtag('get', GA_MEASUREMENT_ID, 'client_id', setGaClientId)
+    window.gtag('get', GA_MEASUREMENT_ID, 'client_id', (cid) => {
+      setGaClientId(cid)
+      // The only path that works for a first-ever visitor, who had no
+      // cookie for the call above to read.
+      setUserCidProperty()
+    })
   } catch (err) {
     captureException(err, {tags: {subsystem: 'ga_init'}})
   }

--- a/src/index/ga.js
+++ b/src/index/ga.js
@@ -68,7 +68,7 @@ export default function setupGa(env = undefined) {
       )
     }
     document.head.appendChild(script)
-    // Third and last place the user property is published, each for a
+    // Second of three places the user property is published, each for a
     // distinct reason. index.html's inline stub sets it before `config`
     // — the only point early enough to reach page_view/session_start.
     // This call re-sets it from the bundle's own cookie parser, which

--- a/src/index/ga.js
+++ b/src/index/ga.js
@@ -68,12 +68,13 @@ export default function setupGa(env = undefined) {
       )
     }
     document.head.appendChild(script)
-    // A returning visitor already has the id in the `_ga` cookie, so
-    // publish the user property now: user properties only attach to
-    // events sent *after* they are set, and the `get` callback below
-    // does not land until gtag/js has loaded. Without this, every
-    // event in that window — which includes each visitor's first
-    // model open — would carry the event param but not the property.
+    // Third and last place the user property is published, each for a
+    // distinct reason. index.html's inline stub sets it before `config`
+    // — the only point early enough to reach page_view/session_start.
+    // This call re-sets it from the bundle's own cookie parser, which
+    // covers a stub-regex miss and costs nothing when it agrees. The
+    // callback below is the only path that works for a first-ever
+    // visitor, who has no cookie for either parser to read.
     setUserCidProperty()
     // Ask GA for this browser's client id so model-open events can
     // carry it as open_cid (see privacy/analytics#setGaClientId for

--- a/src/index/ga.test.js
+++ b/src/index/ga.test.js
@@ -111,7 +111,10 @@ describe('setupGa', () => {
     expect(setCalls[0][2]).toEqual({open_cid: 'cid.1234567890.0987654321'})
   })
 
-  test('does not publish the user property off-prod', () => {
+  // Scoped to setupGa: index.html's inline stub publishes it on every host,
+  // which is harmless off-prod because ga.js never loads gtag/js there, so
+  // the queued entry has nowhere to go.
+  test('setupGa does not publish the user property off-prod', () => {
     Cookies.set('_ga', 'GA1.1.1234567890.0987654321')
     setupGa({hostname: 'localhost', isWebdriver: false})
     expect(window.dataLayer.filter((entry) => entry?.[0] === 'set')).toHaveLength(0)

--- a/src/index/ga.test.js
+++ b/src/index/ga.test.js
@@ -82,6 +82,42 @@ describe('setupGa', () => {
     expect(getGaClientId()).toBe('1234567890.0987654321')
   })
 
+  // Set at BOTH points on purpose: user properties only attach to events
+  // sent after they are set, so a returning visitor's early events —
+  // including their first model open — would otherwise miss it.
+  test('publishes the client id as a user property before and after the callback', () => {
+    Cookies.set('_ga', 'GA1.1.1234567890.0987654321')
+    setupGa({hostname: 'bldrs.ai', isWebdriver: false})
+    const setCalls = window.dataLayer.filter((entry) => entry?.[0] === 'set')
+    expect(setCalls).toHaveLength(1)
+    expect(setCalls[0][1]).toBe('user_properties')
+    expect(setCalls[0][2]).toEqual({open_cid: 'cid.1234567890.0987654321'})
+
+    const getCall = window.dataLayer.find((entry) => entry?.[0] === 'get')
+    getCall[3]('1234567890.0987654321')
+    expect(window.dataLayer.filter((entry) => entry?.[0] === 'set')).toHaveLength(2)
+  })
+
+  // A first-ever visitor has no cookie, so the setup-time call finds
+  // nothing; the callback is the only path that publishes for them.
+  test('publishes the user property for a first visit, once the callback lands', () => {
+    setupGa({hostname: 'bldrs.ai', isWebdriver: false})
+    expect(window.dataLayer.filter((entry) => entry?.[0] === 'set')).toHaveLength(0)
+
+    const getCall = window.dataLayer.find((entry) => entry?.[0] === 'get')
+    getCall[3]('1234567890.0987654321')
+    const setCalls = window.dataLayer.filter((entry) => entry?.[0] === 'set')
+    expect(setCalls).toHaveLength(1)
+    expect(setCalls[0][2]).toEqual({open_cid: 'cid.1234567890.0987654321'})
+  })
+
+  test('does not publish the user property off-prod', () => {
+    Cookies.set('_ga', 'GA1.1.1234567890.0987654321')
+    setupGa({hostname: 'localhost', isWebdriver: false})
+    expect(window.dataLayer.filter((entry) => entry?.[0] === 'set')).toHaveLength(0)
+  })
+
+
   test('does not request a client id off-prod', () => {
     setupGa({hostname: 'localhost', isWebdriver: false})
     expect(window.dataLayer.find((entry) => entry?.[0] === 'get')).toBeUndefined()

--- a/src/privacy/analytics.js
+++ b/src/privacy/analytics.js
@@ -67,6 +67,18 @@ let gaClientId = null
 export const OPEN_CID_PARAM = 'open_cid'
 
 
+/*
+ * Hour of day in the *user's* timezone, on model-open events.
+ *
+ * GA4 already has an `hour` dimension, but it is in the property's
+ * timezone, which says nothing about when someone in Milan or São Paulo
+ * actually works — and real authored opens are a Europe + Brazil story
+ * (bizdev growth-strategy §2). Sent as a zero-padded string; see the
+ * emission site in CadView for why the type matters.
+ */
+export const LOCAL_HOUR_PARAM = 'local_hour'
+
+
 // Cookie GA writes the client id into, as `GA<version>.<domain depth>.<id>`
 // where the id itself contains a dot (GA1.1.1234567890.0987654321).
 const GA_COOKIE_NAME = '_ga'
@@ -143,6 +155,47 @@ const OPEN_CID_PREFIX = 'cid.'
 export function getOpenCid() {
   const cid = getGaClientId()
   return cid === null ? null : `${OPEN_CID_PREFIX}${cid}`
+}
+
+
+/*
+ * Name of the GA4 *user property* carrying the same value as
+ * OPEN_CID_PARAM. Same string on purpose — it is the same identifier,
+ * and GA4 keeps event parameters and user properties in separate
+ * namespaces, so an event-scoped and a user-scoped custom dimension can
+ * both be registered from `open_cid` without colliding.
+ */
+export const OPEN_CID_USER_PROPERTY = OPEN_CID_PARAM
+
+
+/**
+ * Publish the client id as a user property as well as an event param.
+ *
+ * The event param answers "how many models did this person open",
+ * because it rides on real_model_open. It cannot answer anything else:
+ * an event-scoped dimension exists only on the events that carry it, so
+ * session count, engagement duration, landing page and
+ * new-vs-returning are unreachable per user no matter how the GA4 Data
+ * API query is written — filtering to real_model_open yields no
+ * engagement, and not filtering yields "(not set)" for every other
+ * event. A user property attaches to *every* subsequent event and
+ * session from this browser, which is what makes those queryable.
+ *
+ * Requires a matching User-scoped custom dimension GA4-side; without
+ * one the property is collected but not reportable. No backfill, as
+ * ever.
+ *
+ * Called twice by index/ga.js by design — once at setup, so events
+ * fired before gtag/js resolves the id still carry it via the `_ga`
+ * cookie fallback, and again from the `get` callback, which is the
+ * only path that works for a first-ever visitor who has no cookie yet.
+ * Setting it twice with the same value is a no-op GA4-side.
+ */
+export function setUserCidProperty() {
+  const cid = getOpenCid()
+  if (cid && window.gtag && isAllowed()) {
+    window.gtag('set', 'user_properties', {[OPEN_CID_USER_PROPERTY]: cid})
+  }
 }
 
 

--- a/src/privacy/analytics.js
+++ b/src/privacy/analytics.js
@@ -27,7 +27,7 @@ export function setIsAllowed(allowed) {
   // rest of the page's life — including after an opt-out, since
   // index/ga.js has no way to unload the tag it already injected.
   // Withdrawal therefore has to clear it explicitly.
-  syncUserCidProperty(allowed)
+  syncUserCidProperty()
 }
 
 
@@ -225,21 +225,30 @@ export const OPEN_CID_USER_PROPERTY = OPEN_CID_PARAM
  * Setting it twice with the same value is a no-op GA4-side.
  */
 export function setUserCidProperty() {
-  syncUserCidProperty(isAllowed())
+  syncUserCidProperty()
 }
 
 
 /**
- * Publish or retract the user property to match a consent decision.
- * Null is how gtag unsets a user property; there is no delete.
+ * Publish or retract the user property to match current consent.
  *
- * @param {boolean} allowed current analytics consent
+ * Reads isAllowed() rather than taking the decision as an argument, so
+ * a caller passing something merely truthy — setIsAllowed('false')
+ * writes a cookie that isAllowed() then reads as a denial — cannot
+ * publish an identifier the cookie says is not allowed. Consent gates
+ * should fail closed.
+ *
+ * Retraction sets the property to null. Verify in GA4 DebugView that
+ * this actually clears it, rather than storing null as a value, before
+ * PrivacyControl is restored to the UI (AboutDialog has it commented
+ * out today, so nothing in the app can currently withdraw consent). If
+ * null does not clear, this is the one place to change.
  */
-function syncUserCidProperty(allowed) {
+function syncUserCidProperty() {
   if (!window.gtag) {
     return
   }
-  if (!allowed) {
+  if (!isAllowed()) {
     window.gtag('set', 'user_properties', {[OPEN_CID_USER_PROPERTY]: null})
     return
   }

--- a/src/privacy/analytics.js
+++ b/src/privacy/analytics.js
@@ -20,6 +20,14 @@ export function isAllowed() {
 export function setIsAllowed(allowed) {
   assertDefined(allowed)
   Cookies.set(COOKIE_NAME, allowed, {expires: Expires.DAYS})
+  // gtagEvent re-reads consent on every call, so withholding it is
+  // enough to stop our own events. A user property is different: it is
+  // sticky once set, and gtag/js keeps attaching it to the automatic
+  // events it sends on its own (page_view, user_engagement) for the
+  // rest of the page's life — including after an opt-out, since
+  // index/ga.js has no way to unload the tag it already injected.
+  // Withdrawal therefore has to clear it explicitly.
+  syncUserCidProperty(allowed)
 }
 
 
@@ -73,10 +81,35 @@ export const OPEN_CID_PARAM = 'open_cid'
  * GA4 already has an `hour` dimension, but it is in the property's
  * timezone, which says nothing about when someone in Milan or São Paulo
  * actually works — and real authored opens are a Europe + Brazil story
- * (bizdev growth-strategy §2). Sent as a zero-padded string; see the
- * emission site in CadView for why the type matters.
+ * (bizdev growth-strategy §2).
  */
 export const LOCAL_HOUR_PARAM = 'local_hour'
+
+
+/*
+ * Prefix on the LOCAL_HOUR_PARAM value, for the same reason
+ * OPEN_CID_PREFIX exists: gtag types each param when it builds the
+ * beacon, and anything that parses as a number goes out as `epn.`,
+ * which an event-scoped custom *dimension* will not populate from.
+ *
+ * Zero-padding alone does NOT achieve this — `Number('08')` is 8, so
+ * every one of the 24 values would still be numeric and the dimension
+ * would stay empty. The padding is kept only so values sort correctly
+ * and read like GA4's own `hour`.
+ */
+const LOCAL_HOUR_PREFIX = 'h.'
+
+
+/**
+ * The LOCAL_HOUR_PARAM value for right now: the browser's hour, padded
+ * and prefixed so GA4 stores it as text.
+ *
+ * @return {string} e.g. 'h.09'
+ */
+export function getLocalHour() {
+  const HOUR_DIGITS = 2
+  return `${LOCAL_HOUR_PREFIX}${String(new Date().getHours()).padStart(HOUR_DIGITS, '0')}`
+}
 
 
 // Cookie GA writes the client id into, as `GA<version>.<domain depth>.<id>`
@@ -192,8 +225,26 @@ export const OPEN_CID_USER_PROPERTY = OPEN_CID_PARAM
  * Setting it twice with the same value is a no-op GA4-side.
  */
 export function setUserCidProperty() {
+  syncUserCidProperty(isAllowed())
+}
+
+
+/**
+ * Publish or retract the user property to match a consent decision.
+ * Null is how gtag unsets a user property; there is no delete.
+ *
+ * @param {boolean} allowed current analytics consent
+ */
+function syncUserCidProperty(allowed) {
+  if (!window.gtag) {
+    return
+  }
+  if (!allowed) {
+    window.gtag('set', 'user_properties', {[OPEN_CID_USER_PROPERTY]: null})
+    return
+  }
   const cid = getOpenCid()
-  if (cid && window.gtag && isAllowed()) {
+  if (cid) {
     window.gtag('set', 'user_properties', {[OPEN_CID_USER_PROPERTY]: cid})
   }
 }

--- a/src/privacy/analytics.test.js
+++ b/src/privacy/analytics.test.js
@@ -112,6 +112,67 @@ describe('Analytics', () => {
   // Route-result shapes mirror routes.ts#handleRoute output. The one
   // excluded shape is the homepage's bundled demo — everything else is
   // a real open.
+  // The event param answers open depth; the user property is what makes
+  // session- and engagement-scoped questions answerable per user at all.
+  describe('setUserCidProperty', () => {
+    beforeEach(() => {
+      Analytics._resetGaClientIdForTests()
+      Cookies.remove('_ga')
+      Analytics.setIsAllowed(true)
+      window.gtag = jest.fn()
+    })
+
+    afterEach(() => {
+      delete window.gtag
+      Analytics.setIsAllowed(true)
+    })
+
+    test('sets the client id as a user property', () => {
+      Analytics.setGaClientId('1234567890.0987654321')
+      Analytics.setUserCidProperty()
+      expect(window.gtag).toHaveBeenCalledWith(
+        'set', 'user_properties', {open_cid: 'cid.1234567890.0987654321'})
+    })
+
+    // Same prefix trap as the event param: a bare id is numeric-looking,
+    // and a user-scoped custom dimension won't populate from a number.
+    test('sends the prefixed value, never a bare numeric id', () => {
+      Analytics.setGaClientId('1871520000.1754700000')
+      Analytics.setUserCidProperty()
+      const [, , props] = window.gtag.mock.calls[0]
+      expect(props[Analytics.OPEN_CID_USER_PROPERTY]).toMatch(/^cid\./)
+      expect(Number.isNaN(Number(props[Analytics.OPEN_CID_USER_PROPERTY]))).toBe(true)
+    })
+
+    test('falls back to the _ga cookie before the gtag callback lands', () => {
+      Cookies.set('_ga', 'GA1.1.1234567890.0987654321')
+      Analytics.setUserCidProperty()
+      expect(window.gtag).toHaveBeenCalledWith(
+        'set', 'user_properties', {open_cid: 'cid.1234567890.0987654321'})
+    })
+
+    test('no-op when no client id is available', () => {
+      Analytics.setUserCidProperty()
+      expect(window.gtag).not.toHaveBeenCalled()
+    })
+
+    // The property is as much a user identifier as the event param, so
+    // it honours the same consent gate gtagEvent does.
+    test('no-op when analytics consent is withheld', () => {
+      Analytics.setGaClientId('1234567890.0987654321')
+      Analytics.setIsAllowed(false)
+      Analytics.setUserCidProperty()
+      expect(window.gtag).not.toHaveBeenCalled()
+    })
+
+    test('no-op when gtag never loaded', () => {
+      Analytics.setGaClientId('1234567890.0987654321')
+      delete window.gtag
+      expect(() => Analytics.setUserCidProperty()).not.toThrow()
+    })
+  })
+
+
   describe('isRealModelOpen', () => {
     test('false for the bundled homepage demo (/share/v/p/index.ifc)', () => {
       expect(Analytics.isRealModelOpen({

--- a/src/privacy/analytics.test.js
+++ b/src/privacy/analytics.test.js
@@ -112,67 +112,6 @@ describe('Analytics', () => {
   // Route-result shapes mirror routes.ts#handleRoute output. The one
   // excluded shape is the homepage's bundled demo — everything else is
   // a real open.
-  // The event param answers open depth; the user property is what makes
-  // session- and engagement-scoped questions answerable per user at all.
-  describe('setUserCidProperty', () => {
-    beforeEach(() => {
-      Analytics._resetGaClientIdForTests()
-      Cookies.remove('_ga')
-      Analytics.setIsAllowed(true)
-      window.gtag = jest.fn()
-    })
-
-    afterEach(() => {
-      delete window.gtag
-      Analytics.setIsAllowed(true)
-    })
-
-    test('sets the client id as a user property', () => {
-      Analytics.setGaClientId('1234567890.0987654321')
-      Analytics.setUserCidProperty()
-      expect(window.gtag).toHaveBeenCalledWith(
-        'set', 'user_properties', {open_cid: 'cid.1234567890.0987654321'})
-    })
-
-    // Same prefix trap as the event param: a bare id is numeric-looking,
-    // and a user-scoped custom dimension won't populate from a number.
-    test('sends the prefixed value, never a bare numeric id', () => {
-      Analytics.setGaClientId('1871520000.1754700000')
-      Analytics.setUserCidProperty()
-      const [, , props] = window.gtag.mock.calls[0]
-      expect(props[Analytics.OPEN_CID_USER_PROPERTY]).toMatch(/^cid\./)
-      expect(Number.isNaN(Number(props[Analytics.OPEN_CID_USER_PROPERTY]))).toBe(true)
-    })
-
-    test('falls back to the _ga cookie before the gtag callback lands', () => {
-      Cookies.set('_ga', 'GA1.1.1234567890.0987654321')
-      Analytics.setUserCidProperty()
-      expect(window.gtag).toHaveBeenCalledWith(
-        'set', 'user_properties', {open_cid: 'cid.1234567890.0987654321'})
-    })
-
-    test('no-op when no client id is available', () => {
-      Analytics.setUserCidProperty()
-      expect(window.gtag).not.toHaveBeenCalled()
-    })
-
-    // The property is as much a user identifier as the event param, so
-    // it honours the same consent gate gtagEvent does.
-    test('no-op when analytics consent is withheld', () => {
-      Analytics.setGaClientId('1234567890.0987654321')
-      Analytics.setIsAllowed(false)
-      Analytics.setUserCidProperty()
-      expect(window.gtag).not.toHaveBeenCalled()
-    })
-
-    test('no-op when gtag never loaded', () => {
-      Analytics.setGaClientId('1234567890.0987654321')
-      delete window.gtag
-      expect(() => Analytics.setUserCidProperty()).not.toThrow()
-    })
-  })
-
-
   describe('isRealModelOpen', () => {
     test('false for the bundled homepage demo (/share/v/p/index.ifc)', () => {
       expect(Analytics.isRealModelOpen({
@@ -247,6 +186,67 @@ describe('Analytics', () => {
       // localhost must stay true: realModelOpen.spec.ts asserts the
       // event fires in the E2E harness, which serves on localhost.
       expect(Analytics.isRealModelOpen(githubOpen, 'localhost')).toBe(true)
+    })
+  })
+
+
+  // The event param answers open depth; the user property is what makes
+  // session- and engagement-scoped questions answerable per user at all.
+  describe('setUserCidProperty', () => {
+    beforeEach(() => {
+      Analytics._resetGaClientIdForTests()
+      Cookies.remove('_ga')
+      Analytics.setIsAllowed(true)
+      window.gtag = jest.fn()
+    })
+
+    afterEach(() => {
+      delete window.gtag
+      Analytics.setIsAllowed(true)
+    })
+
+    test('sets the client id as a user property', () => {
+      Analytics.setGaClientId('1234567890.0987654321')
+      Analytics.setUserCidProperty()
+      expect(window.gtag).toHaveBeenCalledWith(
+        'set', 'user_properties', {open_cid: 'cid.1234567890.0987654321'})
+    })
+
+    // Same prefix trap as the event param: a bare id is numeric-looking,
+    // and a user-scoped custom dimension won't populate from a number.
+    test('sends the prefixed value, never a bare numeric id', () => {
+      Analytics.setGaClientId('1871520000.1754700000')
+      Analytics.setUserCidProperty()
+      const [, , props] = window.gtag.mock.calls[0]
+      expect(props[Analytics.OPEN_CID_USER_PROPERTY]).toMatch(/^cid\./)
+      expect(Number.isNaN(Number(props[Analytics.OPEN_CID_USER_PROPERTY]))).toBe(true)
+    })
+
+    test('falls back to the _ga cookie before the gtag callback lands', () => {
+      Cookies.set('_ga', 'GA1.1.1234567890.0987654321')
+      Analytics.setUserCidProperty()
+      expect(window.gtag).toHaveBeenCalledWith(
+        'set', 'user_properties', {open_cid: 'cid.1234567890.0987654321'})
+    })
+
+    test('no-op when no client id is available', () => {
+      Analytics.setUserCidProperty()
+      expect(window.gtag).not.toHaveBeenCalled()
+    })
+
+    // The property is as much a user identifier as the event param, so
+    // it honours the same consent gate gtagEvent does.
+    test('no-op when analytics consent is withheld', () => {
+      Analytics.setGaClientId('1234567890.0987654321')
+      Analytics.setIsAllowed(false)
+      Analytics.setUserCidProperty()
+      expect(window.gtag).not.toHaveBeenCalled()
+    })
+
+    test('no-op when gtag never loaded', () => {
+      Analytics.setGaClientId('1234567890.0987654321')
+      delete window.gtag
+      expect(() => Analytics.setUserCidProperty()).not.toThrow()
     })
   })
 })

--- a/src/privacy/analytics.test.js
+++ b/src/privacy/analytics.test.js
@@ -213,7 +213,7 @@ describe('Analytics', () => {
     })
 
     // Same prefix trap as the event param: a bare id is numeric-looking,
-    // and a user-scoped custom dimension won't populate from a number.
+    // and a user-scoped custom dimension won\'t populate from a number.
     test('sends the prefixed value, never a bare numeric id', () => {
       Analytics.setGaClientId('1871520000.1754700000')
       Analytics.setUserCidProperty()
@@ -236,17 +236,83 @@ describe('Analytics', () => {
 
     // The property is as much a user identifier as the event param, so
     // it honours the same consent gate gtagEvent does.
-    test('no-op when analytics consent is withheld', () => {
+    test('publishes no identifier when analytics consent is withheld', () => {
       Analytics.setGaClientId('1234567890.0987654321')
       Analytics.setIsAllowed(false)
+      // setIsAllowed itself retracts the property — that is the
+      // withdrawal suite's subject. Only what follows is under test.
+      window.gtag.mockClear()
       Analytics.setUserCidProperty()
-      expect(window.gtag).not.toHaveBeenCalled()
+      expect(window.gtag).not.toHaveBeenCalledWith(
+        'set', 'user_properties', expect.objectContaining({open_cid: expect.any(String)}))
     })
 
     test('no-op when gtag never loaded', () => {
       Analytics.setGaClientId('1234567890.0987654321')
       delete window.gtag
       expect(() => Analytics.setUserCidProperty()).not.toThrow()
+    })
+  })
+
+
+  // The typing trap that zero-padding alone does NOT solve: Number('08')
+  // is 8, so a padded-but-unprefixed hour still beacons as a number and
+  // the event-scoped dimension stays empty for all 24 values.
+  describe('getLocalHour', () => {
+    test('is not parseable as a number', () => {
+      expect(Number(Analytics.getLocalHour())).toBeNaN()
+    })
+
+    test('carries the browser hour, zero-padded', () => {
+      const HOUR_DIGITS = 2
+      const expected = String(new Date().getHours()).padStart(HOUR_DIGITS, '0')
+      expect(Analytics.getLocalHour()).toBe(`h.${expected}`)
+    })
+
+    test('every hour of the day stays non-numeric', () => {
+      const HOURS_PER_DAY = 24
+      const spy = jest.spyOn(Date.prototype, 'getHours')
+      try {
+        for (let h = 0; h < HOURS_PER_DAY; h++) {
+          spy.mockReturnValue(h)
+          expect(Number(Analytics.getLocalHour())).toBeNaN()
+        }
+      } finally {
+        spy.mockRestore()
+      }
+    })
+  })
+
+
+  // gtagEvent re-reads consent per call, but a user property is sticky —
+  // gtag/js keeps attaching it to its own automatic events after an
+  // opt-out unless it is explicitly cleared.
+  describe('consent withdrawal clears the user property', () => {
+    beforeEach(() => {
+      Analytics._resetGaClientIdForTests()
+      Cookies.remove('_ga')
+      Analytics.setIsAllowed(true)
+      window.gtag = jest.fn()
+    })
+
+    afterEach(() => {
+      delete window.gtag
+      Analytics.setIsAllowed(true)
+    })
+
+    test('opting out retracts it with null', () => {
+      Analytics.setGaClientId('1234567890.0987654321')
+      Analytics.setIsAllowed(false)
+      expect(window.gtag).toHaveBeenLastCalledWith(
+        'set', 'user_properties', {open_cid: null})
+    })
+
+    test('opting back in republishes it', () => {
+      Analytics.setGaClientId('1234567890.0987654321')
+      Analytics.setIsAllowed(false)
+      Analytics.setIsAllowed(true)
+      expect(window.gtag).toHaveBeenLastCalledWith(
+        'set', 'user_properties', {open_cid: 'cid.1234567890.0987654321'})
     })
   })
 })


### PR DESCRIPTION
Two additions to the model-open instrumentation, both answering questions the bizdev dashboard's new per-user card cannot answer today (bldrs-ai/bizdev#268).

## `open_cid` as a user property

The event param rides on `real_model_open`, so an event-scoped dimension built from it can only ever describe model-open events. **Session count, engagement duration, landing page and new-vs-returning are unreachable per user however the query is written** — filter to `real_model_open` and there is no engagement to report; don't filter and every other event answers `(not set)`. A user property attaches to every subsequent event and session from the browser, which is what makes those queryable.

Published at three points, each for a distinct reason:

| where | covers |
|---|---|
| `public/index.html`, carried **in** the `config` call | the events `config` itself triggers — `page_view`, `session_start`, `first_visit`, which are exactly what makes landing page and new-vs-returning per-user meaningful |
| `index/ga.js` at setup | a stub-regex miss; re-sets from the bundle's own cookie parser |
| `index/ga.js` `client_id` callback | a first-ever visitor, who has no `_ga` cookie for either parser to read |

It rides in `config`'s own `user_properties` field rather than a `set` queued beforehand: that's the documented guarantee it reaches config's events, where ordering-before-`config` would depend on queue-drain behaviour gtag doesn't document.

Consent is honoured in both directions — withdrawing retracts the property, since unlike an event (which re-checks per call) a user property is sticky and gtag/js keeps attaching it to its own automatic events.

## `local_hour`

GA4's own `hour` dimension is in the **property's** timezone, which says nothing about when a user in Milan or São Paulo works — and real authored opens are a Europe + Brazil story (bizdev growth-strategy §2).

Prefixed `h.` so gtag keeps it in the text slot. **Zero-padding alone does not achieve this** — `Number('08')` is 8 — so a padded-but-unprefixed hour would beacon as a number and leave the dimension empty for all 24 values. That was a real bug in the first draft of this PR, caught in review; the tests now assert `Number(value)` is `NaN` across all 24 hours rather than asserting the padding.

## Model name — deliberately not sent

This was on the list and I dropped it, because it's a privacy trade rather than a free win.

For remote models the name is already derivable from `content_id`, so a `model_name` param adds nothing. The **only** case it adds information is local uploads, which route by OPFS blob id (`/v/new/<uuid>.ifc`) — so sending it would newly disclose **user-chosen filenames** to Google, for exactly the files that never leave the browser today. A model called `AcmeCorp-Confidential-Tower.ifc` isn't something to start beaconing as a side effect of a dashboard cleanup.

Cost: the dashboard's "most opened" column shows a UUID for uploads. Happy to add it if you want that trade — it's a few lines — but it should be your call.

## Still needs doing in the GA4 console

Neither is reportable until it has a custom definition, and neither backfills:

- **User**-scoped dimension from user property `open_cid` (event- and user-scoped dimensions coexist fine — GA4 namespaces event parameters separately from user properties)
- **Event**-scoped dimension from event parameter `local_hour`

## One thing to verify before restoring PrivacyControl

Consent withdrawal retracts the property by setting it to `null`. I could not verify from here whether gtag treats that as a delete or stores `null` as a value. The path is unreachable today (`PrivacyControl` is commented out of `AboutDialog`), and the roadmap now makes a GA4 DebugView check a prerequisite of restoring that toggle.

## Testing

Three `/review` rounds; every finding fixed or answered in the commit messages. Beyond the pre-commit gate, and because a draft gets no CI:

- `yarn build-prod` ✅
- `yarn test-ci` ✅ (coverage thresholds enforced, 2347 tests)
- `yarn test-flows realModelOpen` ✅ 12 passed, desktop and mobile

New coverage: the user property's value and its consent behaviour in both directions; `getLocalHour` non-numeric across all 24 hours; E2E for the `config`-carried property, for the withheld-consent case (the stub duplicates `isAllowed`, so the duplicate needs its own test), and for `local_hour`'s wire format against the browser's own clock with hour-boundary tolerance.

`package.json`'s version stamp reverted per #1747.