### PR TITLE
Bump GLB schema to 0.16.0 so cached models pick up the new coordination frame

### DIFF
--- a/src/loader/glbCacheKey.js
+++ b/src/loader/glbCacheKey.js
@@ -15,6 +15,25 @@
 /**
  * Current Bldrs GLB artifact schema version. Bumped on any backwards-
  * incompatible change to the BLDRS_* extension contract or cache-key shape.
+ * 0.16.0 — retires artifacts baked in the old coordination frame. conway
+ *         1.501.1426 (bldrs-ai/conway#501, issue conway#87) stopped anchoring
+ *         `COORDINATE_TO_ORIGIN` on whichever element a file happens to
+ *         declare first: a model inside the precision budget now keeps the
+ *         coordinates its file authored. index.ifc moved by (+76, 0,
+ *         +11.4504) — x ∈ [-76, 10] became x ∈ [0, 86] — and every other
+ *         near-origin model moved by its own old recentre.
+ *         Geometry is baked into the GLB in world coordinates and nothing in
+ *         the cache key identifies the engine, so without this bump a user
+ *         holding a pre-1.501 artifact keeps rendering the model at its old
+ *         position while the app's cameras — the homepage default in
+ *         `utils/navigate.js`, and every `#c:` permalink captured after the
+ *         bump — point at the new one. Reported as an offset homepage logo
+ *         that a cache clear fixed, which is exactly the shape of this bug:
+ *         cache-hit users see it, cache-miss users don't, so it survives
+ *         local testing.
+ *         Same failure mode and same remedy as 0.15.0 below; that entry's
+ *         note about pairing an engine bump with a schema bump is the rule
+ *         this follows.
  * 0.15.0 — retires STEP artifacts baked at the wrong world scale. conway
  *         1.460.1363 (bldrs-ai/conway#458, PR conway#460) stopped applying a
  *         STEP file's length-unit factor as its RECIPROCAL, so a millimetre
@@ -137,7 +156,7 @@
  * 0.2.0 — generalised cache key from GitHub-only (owner/repo/branch) to a
  *         per-source-kind 3-level namespace (ns1/ns2/ns3).
  */
-export const BLDRS_GLB_SCHEMA_VERSION = '0.15.0'
+export const BLDRS_GLB_SCHEMA_VERSION = '0.16.0'
 
 
 /**


### PR DESCRIPTION
Follow-up to #1749. Reported from a real homepage load: **the logo rendered offset, and clearing the cache fixed it.**

## Why

#1749 shipped conway `1.501.1426`, which changed where models land — inside the precision budget a model now keeps the coordinates its file authored (conway#501 / conway#87). `index.ifc` moved by `(+76, 0, +11.4504)`, and Share's cameras moved with it, including the homepage default in `utils/navigate.js`.

But **geometry is baked into the cached GLB in world coordinates, and nothing in the cache key identifies the engine.** So anyone holding a pre-`1.501` artifact keeps rendering the model at its old position while the new cameras aim at the new one. The model looks offset and stays that way until the cache is cleared — which is precisely the report.

## The fix

Bump `BLDRS_GLB_SCHEMA_VERSION` to `0.16.0`. The version is part of the artifact filename, so `index.0.15.0.glb` → `index.0.16.0.glb`: every pre-fix artifact reads as a miss and the next load re-bakes it in the new frame.

This is the same failure mode as the `0.15.0` entry directly below it in the version log — an engine change that moves baked world coordinates — and that entry's own note about pairing an engine bump with a schema bump is the rule I should have followed when landing the conway bump in #1749. The new log entry records the mechanism, the measured offset, and why it only shows up for cache-hit users.

## Verification, and its limit

- Full Jest suite green (2347). The schema-version tests read the constant rather than hardcoding it, so they follow the bump.
- Mechanism checked directly: `glbArtifactPath('index.ifc')` returns `index.0.16.0.glb` against `index.0.15.0.glb` for the old version, so the invalidation is real.

**No E2E covers this**, and that's worth flagging rather than hiding: `SHARE_CONFIG=playwright` sets `OPFS_IS_ENABLED=false`, so no spec in the suite exercises a cache hit at all (`Properties.cacheHit.spec.ts` is already `test.fixme` for related reasons). I tried to reproduce the round-trip under Playwright and got two identical passes with no `[glb] cache HIT/MISS` lines, because the cache was never engaged. That gap is why this bug reached a user: it only exists for cache-hit users, and local testing is all cache-miss.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Vh2vC2y6Q5jgzfTzyRvmA

---
_Generated by [Claude Code](https://claude.ai/code/session_015Vh2vC2y6Q5jgzfTzyRvmA)_