### PR TITLE
M3: fixed-memory streaming load with parse-time preview geometry (conway 1.501 → 1.588.1550)

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@babel/plugin-syntax-import-assertions": "7.18.6",
     "@babel/preset-env": "7.18.10",
     "@babel/preset-react": "7.18.6",
-    "@bldrs-ai/conway": "1.534.1505",
+    "@bldrs-ai/conway": "1.535.1506",
     "@bldrs-ai/ifclib": "5.3.3",
     "@emotion/react": "11.10.0",
     "@emotion/styled": "11.10.0",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@babel/plugin-syntax-import-assertions": "7.18.6",
     "@babel/preset-env": "7.18.10",
     "@babel/preset-react": "7.18.6",
-    "@bldrs-ai/conway": "1.560.1539",
+    "@bldrs-ai/conway": "1.578.1546",
     "@bldrs-ai/ifclib": "5.3.3",
     "@emotion/react": "11.10.0",
     "@emotion/styled": "11.10.0",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@babel/plugin-syntax-import-assertions": "7.18.6",
     "@babel/preset-env": "7.18.10",
     "@babel/preset-react": "7.18.6",
-    "@bldrs-ai/conway": "1.519.1471",
+    "@bldrs-ai/conway": "1.529.1492",
     "@bldrs-ai/ifclib": "5.3.3",
     "@emotion/react": "11.10.0",
     "@emotion/styled": "11.10.0",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@babel/plugin-syntax-import-assertions": "7.18.6",
     "@babel/preset-env": "7.18.10",
     "@babel/preset-react": "7.18.6",
-    "@bldrs-ai/conway": "1.530.1503",
+    "@bldrs-ai/conway": "1.394.1504",
     "@bldrs-ai/ifclib": "5.3.3",
     "@emotion/react": "11.10.0",
     "@emotion/styled": "11.10.0",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@babel/plugin-syntax-import-assertions": "7.18.6",
     "@babel/preset-env": "7.18.10",
     "@babel/preset-react": "7.18.6",
-    "@bldrs-ai/conway": "1.510.1439",
+    "@bldrs-ai/conway": "1.511.1441",
     "@bldrs-ai/ifclib": "5.3.3",
     "@emotion/react": "11.10.0",
     "@emotion/styled": "11.10.0",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@babel/plugin-syntax-import-assertions": "7.18.6",
     "@babel/preset-env": "7.18.10",
     "@babel/preset-react": "7.18.6",
-    "@bldrs-ai/conway": "1.578.1546",
+    "@bldrs-ai/conway": "1.564.1548",
     "@bldrs-ai/ifclib": "5.3.3",
     "@emotion/react": "11.10.0",
     "@emotion/styled": "11.10.0",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@babel/plugin-syntax-import-assertions": "7.18.6",
     "@babel/preset-env": "7.18.10",
     "@babel/preset-react": "7.18.6",
-    "@bldrs-ai/conway": "1.394.1504",
+    "@bldrs-ai/conway": "1.534.1505",
     "@bldrs-ai/ifclib": "5.3.3",
     "@emotion/react": "11.10.0",
     "@emotion/styled": "11.10.0",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@babel/plugin-syntax-import-assertions": "7.18.6",
     "@babel/preset-env": "7.18.10",
     "@babel/preset-react": "7.18.6",
-    "@bldrs-ai/conway": "1.501.1426",
+    "@bldrs-ai/conway": "1.509.1435",
     "@bldrs-ai/ifclib": "5.3.3",
     "@emotion/react": "11.10.0",
     "@emotion/styled": "11.10.0",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@babel/plugin-syntax-import-assertions": "7.18.6",
     "@babel/preset-env": "7.18.10",
     "@babel/preset-react": "7.18.6",
-    "@bldrs-ai/conway": "1.529.1492",
+    "@bldrs-ai/conway": "1.530.1503",
     "@bldrs-ai/ifclib": "5.3.3",
     "@emotion/react": "11.10.0",
     "@emotion/styled": "11.10.0",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@babel/plugin-syntax-import-assertions": "7.18.6",
     "@babel/preset-env": "7.18.10",
     "@babel/preset-react": "7.18.6",
-    "@bldrs-ai/conway": "1.509.1435",
+    "@bldrs-ai/conway": "1.510.1439",
     "@bldrs-ai/ifclib": "5.3.3",
     "@emotion/react": "11.10.0",
     "@emotion/styled": "11.10.0",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@babel/plugin-syntax-import-assertions": "7.18.6",
     "@babel/preset-env": "7.18.10",
     "@babel/preset-react": "7.18.6",
-    "@bldrs-ai/conway": "1.514.1452",
+    "@bldrs-ai/conway": "1.516.1463",
     "@bldrs-ai/ifclib": "5.3.3",
     "@emotion/react": "11.10.0",
     "@emotion/styled": "11.10.0",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@babel/plugin-syntax-import-assertions": "7.18.6",
     "@babel/preset-env": "7.18.10",
     "@babel/preset-react": "7.18.6",
-    "@bldrs-ai/conway": "1.564.1548",
+    "@bldrs-ai/conway": "1.588.1550",
     "@bldrs-ai/ifclib": "5.3.3",
     "@emotion/react": "11.10.0",
     "@emotion/styled": "11.10.0",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@babel/plugin-syntax-import-assertions": "7.18.6",
     "@babel/preset-env": "7.18.10",
     "@babel/preset-react": "7.18.6",
-    "@bldrs-ai/conway": "1.543.1513",
+    "@bldrs-ai/conway": "1.549.1515",
     "@bldrs-ai/ifclib": "5.3.3",
     "@emotion/react": "11.10.0",
     "@emotion/styled": "11.10.0",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@babel/plugin-syntax-import-assertions": "7.18.6",
     "@babel/preset-env": "7.18.10",
     "@babel/preset-react": "7.18.6",
-    "@bldrs-ai/conway": "1.512.1444",
+    "@bldrs-ai/conway": "1.513.1447",
     "@bldrs-ai/ifclib": "5.3.3",
     "@emotion/react": "11.10.0",
     "@emotion/styled": "11.10.0",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@babel/plugin-syntax-import-assertions": "7.18.6",
     "@babel/preset-env": "7.18.10",
     "@babel/preset-react": "7.18.6",
-    "@bldrs-ai/conway": "1.513.1447",
+    "@bldrs-ai/conway": "1.514.1452",
     "@bldrs-ai/ifclib": "5.3.3",
     "@emotion/react": "11.10.0",
     "@emotion/styled": "11.10.0",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@babel/plugin-syntax-import-assertions": "7.18.6",
     "@babel/preset-env": "7.18.10",
     "@babel/preset-react": "7.18.6",
-    "@bldrs-ai/conway": "1.549.1515",
+    "@bldrs-ai/conway": "1.560.1539",
     "@bldrs-ai/ifclib": "5.3.3",
     "@emotion/react": "11.10.0",
     "@emotion/styled": "11.10.0",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@babel/plugin-syntax-import-assertions": "7.18.6",
     "@babel/preset-env": "7.18.10",
     "@babel/preset-react": "7.18.6",
-    "@bldrs-ai/conway": "1.536.1507",
+    "@bldrs-ai/conway": "1.543.1513",
     "@bldrs-ai/ifclib": "5.3.3",
     "@emotion/react": "11.10.0",
     "@emotion/styled": "11.10.0",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@babel/plugin-syntax-import-assertions": "7.18.6",
     "@babel/preset-env": "7.18.10",
     "@babel/preset-react": "7.18.6",
-    "@bldrs-ai/conway": "1.516.1463",
+    "@bldrs-ai/conway": "1.519.1471",
     "@bldrs-ai/ifclib": "5.3.3",
     "@emotion/react": "11.10.0",
     "@emotion/styled": "11.10.0",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@babel/plugin-syntax-import-assertions": "7.18.6",
     "@babel/preset-env": "7.18.10",
     "@babel/preset-react": "7.18.6",
-    "@bldrs-ai/conway": "1.535.1506",
+    "@bldrs-ai/conway": "1.536.1507",
     "@bldrs-ai/ifclib": "5.3.3",
     "@emotion/react": "11.10.0",
     "@emotion/styled": "11.10.0",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@babel/plugin-syntax-import-assertions": "7.18.6",
     "@babel/preset-env": "7.18.10",
     "@babel/preset-react": "7.18.6",
-    "@bldrs-ai/conway": "1.511.1441",
+    "@bldrs-ai/conway": "1.512.1444",
     "@bldrs-ai/ifclib": "5.3.3",
     "@emotion/react": "11.10.0",
     "@emotion/styled": "11.10.0",

--- a/src/loader/Loader.cover.test.js
+++ b/src/loader/Loader.cover.test.js
@@ -54,6 +54,65 @@ function makeViewerStub() {
 }
 
 
+/**
+ * Viewer whose Conway API can optionally parse an OPFS File via
+ * OpenModelStream. Parse rejects after Loader has hashed so the
+ * hash/buffering spies stay observable.
+ *
+ * @param {object} [opts]
+ * @param {boolean} [opts.streamOpen]
+ * @return {object}
+ */
+function makeIfcViewer({streamOpen = false} = {}) {
+  const ifcAPI = {
+    OpenModel: jest.fn(() => {
+      throw new Error('open failed')
+    }),
+    StreamAllMeshes: jest.fn(),
+    GetCoordinationMatrix: jest.fn().mockResolvedValue(new Array(16).fill(0)),
+    getStatistics: jest.fn().mockReturnValue({
+      getGeometryMemory: () => 0,
+      getGeometryTime: () => 0,
+      getVersion: () => 'IFC4',
+      getLoadStatus: () => 'SUCCESS',
+      getOriginatingSystem: () => 'test',
+      getPreprocessorVersion: () => '1.0',
+      getParseTime: () => 0,
+      getTotalTime: () => 0,
+    }),
+    getConwayVersion: () => '1.0.0',
+  }
+  if (streamOpen) {
+    ifcAPI.OpenModelStream = jest.fn(() => {
+      throw new Error('stream open failed')
+    })
+    ifcAPI.ExtractGeometryBatchAsync = jest.fn()
+  }
+  const ifc = {
+    type: null,
+    ifcLastError: null,
+    addIfcModel: jest.fn(),
+    loader: {
+      parse: jest.fn(),
+      ifcManager: {
+        state: {models: []},
+        applyWebIfcConfig: jest.fn().mockResolvedValue(),
+        setupCoordinationMatrix: jest.fn(),
+        ifcAPI,
+      },
+    },
+    context: {
+      items: {ifcModels: []},
+      fitToFrame: jest.fn(),
+    },
+  }
+  return {
+    IFC: ifc,
+    ifcLoader: new ShareIfcLoader({ifcAPI, ifc}),
+  }
+}
+
+
 /** MockBlob with an arrayBuffer() that yields the given bytes. */
 class MockFile {
   /** @param {ArrayBuffer|Uint8Array|string} content */
@@ -61,18 +120,35 @@ class MockFile {
     this.content = content
   }
 
-  /** @return {Promise<ArrayBuffer>} */
-  async arrayBuffer() {
+  /** @return {Uint8Array} */
+  bytes_() {
     if (typeof this.content === 'string') {
-      return new TextEncoder().encode(this.content).buffer
+      return new TextEncoder().encode(this.content)
     }
     if (this.content instanceof Uint8Array) {
-      return this.content.buffer.slice(
-        this.content.byteOffset,
-        this.content.byteOffset + this.content.byteLength,
-      )
+      return this.content
     }
-    return this.content
+    return new Uint8Array(this.content)
+  }
+
+  /** @return {number} */
+  get size() {
+    return this.bytes_().byteLength
+  }
+
+  /**
+   * @param {number} start
+   * @param {number} [end]
+   * @return {MockFile}
+   */
+  slice(start, end = this.size) {
+    return new MockFile(this.bytes_().subarray(start, end))
+  }
+
+  /** @return {Promise<ArrayBuffer>} */
+  async arrayBuffer() {
+    const bytes = this.bytes_()
+    return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength)
   }
 }
 
@@ -435,6 +511,56 @@ describe('load() error/edge paths with OPFS enabled', () => {
     ).rejects.toThrow()
 
     expect(spy).toHaveBeenCalledTimes(1)
+  })
+
+
+  it('does not arrayBuffer an uploaded IFC when OpenModelStream can take the File', async () => {
+    const file = new MockFile(new Uint8Array(512).fill(0x20))
+    const arrayBufferSpy = jest.spyOn(file, 'arrayBuffer')
+    const sliceSpy = jest.spyOn(file, 'slice')
+    getModelFromOPFS.mockReset()
+    getModelFromOPFS.mockResolvedValue(file)
+    dereferenceAndProxyDownloadContents.mockResolvedValue([
+      'blob:http://localhost/uuid.ifc',
+      '',
+      false,
+      false,
+    ])
+
+    await expect(
+      load(
+        '12345678-1234-4abc-9def-123456789abc.ifc',
+        makeIfcViewer({streamOpen: true}),
+        onProgress, true, setOpfsFile, ''),
+    ).rejects.toThrow()
+
+    expect(arrayBufferSpy).not.toHaveBeenCalled()
+    expect(sliceSpy).toHaveBeenCalled()
+    expect(onProgress).toHaveBeenCalledWith('Hashing model...')
+  })
+
+
+  it('hashes the single parse buffer when store-open is unavailable', async () => {
+    const file = new MockFile(new Uint8Array(512).fill(0x20))
+    const arrayBufferSpy = jest.spyOn(file, 'arrayBuffer')
+    getModelFromOPFS.mockReset()
+    getModelFromOPFS.mockResolvedValue(file)
+    dereferenceAndProxyDownloadContents.mockResolvedValue([
+      'blob:http://localhost/uuid.ifc',
+      '',
+      false,
+      false,
+    ])
+
+    await expect(
+      load(
+        '12345678-1234-4abc-9def-123456789abc.ifc',
+        makeIfcViewer({streamOpen: false}),
+        onProgress, true, setOpfsFile, ''),
+    ).rejects.toThrow()
+
+    expect(arrayBufferSpy).toHaveBeenCalledTimes(1)
+    expect(onProgress).toHaveBeenCalledWith('Buffering model bytes...')
   })
 
 

--- a/src/loader/Loader.cover.test.js
+++ b/src/loader/Loader.cover.test.js
@@ -413,6 +413,31 @@ describe('load() error/edge paths with OPFS enabled', () => {
   })
 
 
+  it('reads an uploaded OPFS file only once so SHA-1 shares the parse buffer', async () => {
+    // wantGlb is default-on. Non-GitHub sources hash the bytes for the
+    // GLB cache key; that used to be a second arrayBuffer() of the same
+    // File (~860 MB on PSB). The parse buffer is the hash input.
+    const file = new MockFile(new Uint8Array(4))
+    const spy = jest.spyOn(file, 'arrayBuffer')
+    getModelFromOPFS.mockReset()
+    getModelFromOPFS.mockResolvedValue(file)
+    dereferenceAndProxyDownloadContents.mockResolvedValue([
+      'blob:http://localhost/uuid.stl',
+      '',
+      false,
+      false,
+    ])
+
+    const uuidPath = '12345678-1234-4abc-9def-123456789abc.stl'
+
+    await expect(
+      load(uuidPath, viewer, onProgress, true, setOpfsFile, ''),
+    ).rejects.toThrow()
+
+    expect(spy).toHaveBeenCalledTimes(1)
+  })
+
+
   // TODO: Loader.js tags errors with `isOutOfMemory` by calling
   // `isOutOfMemoryError(err)` from src/utils/oom.js, which is message-
   // sniffing based. The refactor should confirm the OOM shapes it looks

--- a/src/loader/Loader.js
+++ b/src/loader/Loader.js
@@ -362,8 +362,9 @@ export async function load(
       // Non-GitHub sources have no upstream sha. Hash the parse buffer
       // itself so we do not materialise the file twice (once for SHA-1,
       // once for Conway) — ~860 MB on PSB. sha1Hex only reads; it does
-      // not copy. A GLB cache hit still replaces modelData with the
-      // artifact (different bytes).
+      // not copy. Store-backed opens fingerprint the File in native
+      // per-slice SHA-1s (not a JS SHA-1 of the whole object). A GLB
+      // cache hit still replaces modelData with the artifact.
       //
       // Self-contained try/catch: if the hash or cache lookup fails (e.g.
       // `window.crypto.subtle` absent in some jsdom test envs, OPFS sync-

--- a/src/loader/Loader.js
+++ b/src/loader/Loader.js
@@ -62,7 +62,7 @@ import stlToThree from './stl'
 import xyzToThree from './xyz'
 import {isFeatureEnabled} from '../FeatureFlags'
 import useStore from '../store/useStore'
-import {sha1Hex} from '../utils/contentHash'
+import {sha1Hex, sha1HexFromBlob} from '../utils/contentHash'
 import {markIfOutOfMemory} from '../utils/oom'
 
 
@@ -80,6 +80,7 @@ import {markIfOutOfMemory} from '../utils/oom'
 // the camera nonstop). 5s is past the point where a returning visitor
 // would notice "cache hasn't warmed yet."
 const SCHEDULE_IDLE_TIMEOUT_MS = 5_000
+const LFS_POINTER_PROBE_BYTES = 256
 
 
 /**
@@ -91,6 +92,42 @@ function scheduleIdleWork(fn) {
     return
   }
   setTimeout(fn, 0)
+}
+
+
+/**
+ * True when Conway can parse an OPFS File through `OpenModelStream`
+ * (M1b) so we never allocate a full-source ArrayBuffer.
+ *
+ * @param {object} viewer
+ * @param {boolean} isIfc
+ * @return {boolean}
+ */
+function canOpenFromStore(viewer, isIfc) {
+  if (!isIfc || isFeatureEnabled('disableStreamOpen')) {
+    return false
+  }
+  const ifcAPI = viewer?.IFC?.loader?.ifcManager?.ifcAPI
+  return typeof ifcAPI?.OpenModelStream === 'function'
+}
+
+
+/**
+ * Bytes for the Git LFS pointer sniff. A live File/Blob was already
+ * probed via its first 256 bytes before being passed through as
+ * `modelData`; don't treat the handle itself as a pointer.
+ *
+ * @param {ArrayBuffer|Uint8Array|Blob|string|null|undefined} data
+ * @return {ArrayBuffer|Uint8Array|string|null|undefined}
+ */
+function probeLfsBytes(data) {
+  if (data !== null && data !== undefined &&
+      typeof data.size === 'number' && typeof data.slice === 'function' &&
+      !(data instanceof ArrayBuffer) && !ArrayBuffer.isView(data) &&
+      typeof data !== 'string') {
+    return null
+  }
+  return data
 }
 
 
@@ -338,9 +375,18 @@ export async function load(
       // do anyway if the lookup returned null.
       if (wantGlb && !cacheKeyArgs && file) {
         try {
-          onProgress('Buffering model bytes...')
-          modelData = await file.arrayBuffer()
-          const contentSha = await sha1Hex(modelData)
+          // M1b: when Conway can parse from the OPFS File store, hash
+          // the File in slices and skip the full-source ArrayBuffer —
+          // ~860 MB on PSB. Older engines fall through to buffering.
+          if (canOpenFromStore(viewer, isIfc)) {
+            onProgress('Hashing model...')
+          } else {
+            onProgress('Buffering model bytes...')
+            modelData = await file.arrayBuffer()
+          }
+          const contentSha = modelData !== undefined ?
+            await sha1Hex(modelData) :
+            await sha1HexFromBlob(file)
           cacheKeyArgs = buildNonGitHubCacheArgs(kindLabel, path, contentSha)
           if (cacheKeyArgs) {
             glbVerbose(
@@ -374,11 +420,23 @@ export async function load(
         glbExportContext = {kindLabel, cacheKeyArgs, sourceFile: opfsSourceFile}
       }
 
+      if (modelData === undefined &&
+          canOpenFromStore(viewer, isIfc) &&
+          !cameFromGlbCache) {
+        const head = await file.slice(0, LFS_POINTER_PROBE_BYTES).arrayBuffer()
+        if (opfsEntryKey !== null && looksLikeLfsPointer(head)) {
+          // Fall through to the existing LFS-evict path below with a
+          // tiny probe so we don't have to buffer the whole file.
+          modelData = head
+        } else {
+          modelData = file
+        }
+      }
       if (modelData === undefined) {
         onProgress('Buffering model bytes...')
         modelData = await file.arrayBuffer()
       }
-      if (opfsEntryKey !== null && looksLikeLfsPointer(modelData)) {
+      if (opfsEntryKey !== null && looksLikeLfsPointer(probeLfsBytes(modelData))) {
         // A cache entry written before the Git LFS redirect landed
         // holds the ~130-byte pointer instead of the model, and its key
         // (pointer-blob sha + owner/repo/branch/path) is exactly the
@@ -480,7 +538,7 @@ export async function load(
   // us ~130 bytes of text naming the object instead of the model, and
   // the format loader then fails somewhere deep in its parser with an
   // error that never mentions LFS. Say what actually went wrong.
-  if (looksLikeLfsPointer(modelData)) {
+  if (looksLikeLfsPointer(probeLfsBytes(modelData))) {
     throw new Error(
       'This file is stored with Git LFS, so the URL returned a pointer file instead of the model. ' +
       'Open it via its github.com/<org>/<repo>/blob/<ref>/<path> URL, which resolves LFS content.')
@@ -505,7 +563,7 @@ export async function load(
   reportModelInfo({
     fileName: path.substring(path.lastIndexOf('/') + 1) || path,
     schema: formatTag,
-    byteLength: modelData?.byteLength ?? modelData?.length,
+    byteLength: modelData?.byteLength ?? modelData?.length ?? modelData?.size,
   })
 
   // readModel throws on any falsy model (surfacing viewer.IFC.ifcLastError

--- a/src/loader/Loader.js
+++ b/src/loader/Loader.js
@@ -317,9 +317,16 @@ export async function load(
           'Source: network download (GitHub), cached to OPFS')
       }
 
-      // For non-GitHub sources we don't have an upstream sha, so we hash the
-      // bytes ourselves to build the cache key. This is the same File we'd
-      // read for parse below; reading it twice is cheap (OPFS).
+      // Disk handle of the *source* (IFC/STEP), captured before any GLB
+      // swap. Spill pages this File; the hash/parse ArrayBuffer is a
+      // separate JS copy. An OPFS File pins nothing.
+      const opfsSourceFile = file
+
+      // Non-GitHub sources have no upstream sha. Hash the parse buffer
+      // itself so we do not materialise the file twice (once for SHA-1,
+      // once for Conway) — ~860 MB on PSB. sha1Hex only reads; it does
+      // not copy. A GLB cache hit still replaces modelData with the
+      // artifact (different bytes).
       //
       // Self-contained try/catch: if the hash or cache lookup fails (e.g.
       // `window.crypto.subtle` absent in some jsdom test envs, OPFS sync-
@@ -331,8 +338,9 @@ export async function load(
       // do anyway if the lookup returned null.
       if (wantGlb && !cacheKeyArgs && file) {
         try {
-          const sourceBytes = await file.arrayBuffer()
-          const contentSha = await sha1Hex(sourceBytes)
+          onProgress('Buffering model bytes...')
+          modelData = await file.arrayBuffer()
+          const contentSha = await sha1Hex(modelData)
           cacheKeyArgs = buildNonGitHubCacheArgs(kindLabel, path, contentSha)
           if (cacheKeyArgs) {
             glbVerbose(
@@ -346,6 +354,7 @@ export async function load(
               ;[loader, isLoaderAsync, isFormatText, isIfc, fixupCb] = swapToGlbLoader(viewer)
               file = glbFile
               cameFromGlbCache = true
+              modelData = await glbFile.arrayBuffer()
             } else {
               glbInfo(`reader: ${kindLabel} cache MISS, will export after parse`)
             }
@@ -359,17 +368,16 @@ export async function load(
       }
 
       if (wantGlb && isIfc && cacheKeyArgs) {
-        // `sourceFile` is the OPFS-backed File whose exact bytes are
-        // parsed below (`modelData = await file.arrayBuffer()`; IFC/STEP
-        // load with isFormatText=false, so no decode in between). The
-        // post-writer source spill backs Conway's window reads with it —
-        // identity by construction, and a disk-backed handle, so
-        // capturing it here pins nothing.
-        glbExportContext = {kindLabel, cacheKeyArgs, sourceFile: file}
+        // Spill backs Conway's window reads with this OPFS File — the
+        // source, never a swapped-in GLB. Identity by construction
+        // (same handle we arrayBuffer'd for parse on a miss).
+        glbExportContext = {kindLabel, cacheKeyArgs, sourceFile: opfsSourceFile}
       }
 
-      onProgress('Buffering model bytes...')
-      modelData = await file.arrayBuffer()
+      if (modelData === undefined) {
+        onProgress('Buffering model bytes...')
+        modelData = await file.arrayBuffer()
+      }
       if (opfsEntryKey !== null && looksLikeLfsPointer(modelData)) {
         // A cache entry written before the Git LFS redirect landed
         // holds the ~130-byte pointer instead of the model, and its key

--- a/src/loader/Loader.js
+++ b/src/loader/Loader.js
@@ -414,9 +414,8 @@ export async function load(
       }
 
       if (wantGlb && isIfc && cacheKeyArgs) {
-        // Spill backs Conway's window reads with this OPFS File — the
-        // source, never a swapped-in GLB. Identity by construction
-        // (same handle we arrayBuffer'd for parse on a miss).
+        // Spill pages from the OPFS source handle captured before any
+        // GLB swap — never a cache-hit artifact.
         glbExportContext = {kindLabel, cacheKeyArgs, sourceFile: opfsSourceFile}
       }
 
@@ -424,9 +423,7 @@ export async function load(
           canOpenFromStore(viewer, isIfc) &&
           !cameFromGlbCache) {
         const head = await file.slice(0, LFS_POINTER_PROBE_BYTES).arrayBuffer()
-        if (opfsEntryKey !== null && looksLikeLfsPointer(head)) {
-          // Fall through to the existing LFS-evict path below with a
-          // tiny probe so we don't have to buffer the whole file.
+        if (looksLikeLfsPointer(head)) {
           modelData = head
         } else {
           modelData = file

--- a/src/utils/contentHash.js
+++ b/src/utils/contentHash.js
@@ -56,21 +56,55 @@ export async function sha1HexFromBlob(blob, chunkBytes = HASH_CHUNK_BYTES) {
   if (size === 0) {
     return sha1Hex(new Uint8Array(0))
   }
+  return hexFromBytes_(await digestBlobSliced_(blob, chunkBytes))
+}
+
+
+/**
+ * Fold `sliceDigest` into the running 20-byte hash.
+ *
+ * @param {Uint8Array|undefined} running
+ * @param {Uint8Array} sliceDigest
+ * @return {Promise<Uint8Array>}
+ */
+async function foldDigest_(running, sliceDigest) {
+  if (running === undefined) {
+    return sliceDigest
+  }
+  const folded = new Uint8Array(running.length + sliceDigest.length)
+  folded.set(running)
+  folded.set(sliceDigest, running.length)
+  return new Uint8Array(await window.crypto.subtle.digest('SHA-1', folded))
+}
+
+
+/**
+ * One scratch buffer: copy each slice into it and drop the slice.
+ * Yields every few chunks so a tight await loop cannot pin
+ * unreclaimed ArrayBuffers the way the 1.510 smoke did (+410 MB).
+ *
+ * @param {Blob} blob
+ * @param {number} chunkBytes
+ * @return {Promise<Uint8Array>}
+ */
+async function digestBlobSliced_(blob, chunkBytes) {
+  const scratch = new Uint8Array(chunkBytes)
+  const size = blob.size
   let running
+  let slices = 0
   for (let at = 0; at < size; at += chunkBytes) {
     const end = Math.min(at + chunkBytes, size)
+    const incoming = new Uint8Array(await blob.slice(at, end).arrayBuffer())
+    scratch.set(incoming)
     const sliceDigest = new Uint8Array(
-      await window.crypto.subtle.digest('SHA-1', await blob.slice(at, end).arrayBuffer()))
-    if (running === undefined) {
-      running = sliceDigest
-    } else {
-      const folded = new Uint8Array(running.length + sliceDigest.length)
-      folded.set(running)
-      folded.set(sliceDigest, running.length)
-      running = new Uint8Array(await window.crypto.subtle.digest('SHA-1', folded))
+      await window.crypto.subtle.digest('SHA-1', scratch.subarray(0, incoming.length)))
+    running = await foldDigest_(running, sliceDigest)
+    slices++
+    if (slices % 8 === 0) {
+      await new Promise((resolve) => setTimeout(resolve, 0))
     }
   }
-  return hexFromBytes_(running)
+  return running
 }
 
 

--- a/src/utils/contentHash.js
+++ b/src/utils/contentHash.js
@@ -1,4 +1,4 @@
-/* eslint-disable no-magic-numbers -- SHA-1 constants and bit widths */
+/* eslint-disable no-magic-numbers -- SHA-1 digest length and hex width */
 // Content-hash helpers for the GLB cache.
 //
 // For non-GitHub source kinds (local, upload, external URL, Google Drive
@@ -24,175 +24,64 @@ export async function sha1Hex(buffer) {
   }
   const view = ArrayBuffer.isView(buffer) ? buffer : new Uint8Array(buffer)
   const digest = await window.crypto.subtle.digest('SHA-1', view)
-  const bytes = new Uint8Array(digest)
+  return hexFromBytes_(new Uint8Array(digest))
+}
+
+
+// Cache fingerprint only — not a standard SHA-1 of the file.
+// Native SHA-1 per slice (the same SubtleCrypto path as sha1Hex), then
+// fold each digest into the running hash. A JS incremental SHA-1 of
+// an 860 MB OPFS File was ~23s; this stays I/O + native digest.
+//
+// Single-slice inputs (the common test / small-file case) are exactly
+// sha1Hex of the bytes. Multi-slice is sha1(prevDigest || sliceDigest)
+// and is not interchangeable with a whole-file SHA-1.
+const HASH_CHUNK_BYTES = 8 * 1024 * 1024
+
+
+/**
+ * Cache fingerprint of a Blob/File. Slices so the whole object is never
+ * resident. Same digest as {@link sha1Hex} when the blob fits in one
+ * slice; otherwise a chained fold of per-slice SHA-1s.
+ *
+ * @param {Blob} blob a Blob or File (OPFS handle)
+ * @param {number} [chunkBytes] slice size; tests pass a small value
+ * @return {Promise<string>} 40-char lowercase hex string
+ */
+export async function sha1HexFromBlob(blob, chunkBytes = HASH_CHUNK_BYTES) {
+  if (blob === null || blob === undefined || typeof blob.slice !== 'function') {
+    throw new Error('sha1HexFromBlob: blob is required')
+  }
+  const size = blob.size
+  if (size === 0) {
+    return sha1Hex(new Uint8Array(0))
+  }
+  let running
+  for (let at = 0; at < size; at += chunkBytes) {
+    const end = Math.min(at + chunkBytes, size)
+    const sliceDigest = new Uint8Array(
+      await window.crypto.subtle.digest('SHA-1', await blob.slice(at, end).arrayBuffer()))
+    if (running === undefined) {
+      running = sliceDigest
+    } else {
+      const folded = new Uint8Array(running.length + sliceDigest.length)
+      folded.set(running)
+      folded.set(sliceDigest, running.length)
+      running = new Uint8Array(await window.crypto.subtle.digest('SHA-1', folded))
+    }
+  }
+  return hexFromBytes_(running)
+}
+
+
+/**
+ * @param {Uint8Array} bytes
+ * @return {string} lowercase hex
+ */
+function hexFromBytes_(bytes) {
   let out = ''
   for (let i = 0; i < bytes.length; i++) {
     out += bytes[i].toString(HEX_BASE).padStart(2, '0')
   }
   return out
-}
-
-
-// 1 MiB slices — small enough that hashing an OPFS File never allocates
-// the whole model, large enough that SubtleCrypto-equivalent throughput
-// stays I/O bound.
-const HASH_CHUNK_BYTES = 1024 * 1024
-const SHA1_BLOCK = 64
-const SHA1_WORD_COUNT = 80
-const BITS_PER_BYTE = 8
-const SHA1_LEN_BYTES = 8
-
-
-/**
- * Compute the hex-encoded SHA-1 of a Blob/File by hashing 1 MiB slices
- * so the whole object is never resident. Same digest as {@link sha1Hex}
- * on the concatenated bytes.
- *
- * @param {Blob} blob a Blob or File (OPFS handle)
- * @return {Promise<string>} 40-char lowercase hex string
- */
-export async function sha1HexFromBlob(blob) {
-  if (blob === null || blob === undefined || typeof blob.slice !== 'function') {
-    throw new Error('sha1HexFromBlob: blob is required')
-  }
-  const hasher = new Sha1()
-  const size = blob.size
-  for (let at = 0; at < size; at += HASH_CHUNK_BYTES) {
-    const end = Math.min(at + HASH_CHUNK_BYTES, size)
-    const buf = await blob.slice(at, end).arrayBuffer()
-    hasher.update(new Uint8Array(buf))
-  }
-  return hasher.hex()
-}
-
-
-/**
- * Incremental SHA-1. Used only for Blob hashing — `sha1Hex` stays on
- * `crypto.subtle` so a one-buffer digest doesn't fork implementations.
- */
-class Sha1 {
-  /** Construct a fresh hasher. */
-  constructor() {
-    this.h0 = 0x67452301
-    this.h1 = 0xEFCDAB89
-    this.h2 = 0x98BADCFE
-    this.h3 = 0x10325476
-    this.h4 = 0xC3D2E1F0
-    this.block = new Uint8Array(SHA1_BLOCK)
-    this.blockUsed = 0
-    this.bytesHashed = 0
-  }
-
-  /**
-   * Absorb `bytes`.
-   *
-   * @param {Uint8Array} bytes
-   */
-  update(bytes) {
-    this.bytesHashed += bytes.length
-    let offset = 0
-    while (offset < bytes.length) {
-      const take = Math.min(SHA1_BLOCK - this.blockUsed, bytes.length - offset)
-      this.block.set(bytes.subarray(offset, offset + take), this.blockUsed)
-      this.blockUsed += take
-      offset += take
-      if (this.blockUsed === SHA1_BLOCK) {
-        this.compress_(this.block)
-        this.blockUsed = 0
-      }
-    }
-  }
-
-  /**
-   * @return {string} 40-char lowercase hex digest
-   */
-  hex() {
-    const bitLenHi = Math.floor(this.bytesHashed / 0x20000000)
-    const bitLenLo = (this.bytesHashed * BITS_PER_BYTE) >>> 0
-    this.update(new Uint8Array([0x80]))
-    if (this.blockUsed > SHA1_BLOCK - SHA1_LEN_BYTES) {
-      this.block.fill(0, this.blockUsed)
-      this.compress_(this.block)
-      this.blockUsed = 0
-    }
-    this.block.fill(0, this.blockUsed, SHA1_BLOCK - SHA1_LEN_BYTES)
-    const view = new DataView(this.block.buffer)
-    view.setUint32(SHA1_BLOCK - SHA1_LEN_BYTES, bitLenHi)
-    view.setUint32(SHA1_BLOCK - 4, bitLenLo)
-    this.compress_(this.block)
-
-    const out = new Uint8Array(20)
-    const result = new DataView(out.buffer)
-    result.setUint32(0, this.h0)
-    result.setUint32(4, this.h1)
-    result.setUint32(8, this.h2)
-    result.setUint32(12, this.h3)
-    result.setUint32(16, this.h4)
-    let hex = ''
-    for (let i = 0; i < out.length; i++) {
-      hex += out[i].toString(HEX_BASE).padStart(2, '0')
-    }
-    return hex
-  }
-
-  /**
-   * Process one 64-byte block.
-   *
-   * @param {Uint8Array} block
-   */
-  compress_(block) {
-    const w = new Uint32Array(SHA1_WORD_COUNT)
-    const view = new DataView(block.buffer, block.byteOffset, SHA1_BLOCK)
-    for (let i = 0; i < 16; i++) {
-      w[i] = view.getUint32(i * 4)
-    }
-    for (let i = 16; i < SHA1_WORD_COUNT; i++) {
-      w[i] = rotl_(w[i - 3] ^ w[i - 8] ^ w[i - 14] ^ w[i - 16], 1)
-    }
-    let a = this.h0
-    let b = this.h1
-    let c = this.h2
-    let d = this.h3
-    let e = this.h4
-    for (let i = 0; i < SHA1_WORD_COUNT; i++) {
-      let f
-      let k
-      if (i < 20) {
-        f = (b & c) | ((~b) & d)
-        k = 0x5A827999
-      } else if (i < 40) {
-        f = b ^ c ^ d
-        k = 0x6ED9EBA1
-      } else if (i < 60) {
-        f = (b & c) | (b & d) | (c & d)
-        k = 0x8F1BBCDC
-      } else {
-        f = b ^ c ^ d
-        k = 0xCA62C1D6
-      }
-      const temp = (rotl_(a, 5) + f + e + k + w[i]) >>> 0
-      e = d
-      d = c
-      c = rotl_(b, 30)
-      b = a
-      a = temp
-    }
-    this.h0 = (this.h0 + a) >>> 0
-    this.h1 = (this.h1 + b) >>> 0
-    this.h2 = (this.h2 + c) >>> 0
-    this.h3 = (this.h3 + d) >>> 0
-    this.h4 = (this.h4 + e) >>> 0
-  }
-}
-
-
-/**
- * 32-bit left rotate.
- *
- * @param {number} value
- * @param {number} bits
- * @return {number}
- */
-function rotl_(value, bits) {
-  return ((value << bits) | (value >>> (32 - bits))) >>> 0
 }

--- a/src/utils/contentHash.js
+++ b/src/utils/contentHash.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-magic-numbers -- SHA-1 constants and bit widths */
 // Content-hash helpers for the GLB cache.
 //
 // For non-GitHub source kinds (local, upload, external URL, Google Drive
@@ -29,4 +30,169 @@ export async function sha1Hex(buffer) {
     out += bytes[i].toString(HEX_BASE).padStart(2, '0')
   }
   return out
+}
+
+
+// 1 MiB slices — small enough that hashing an OPFS File never allocates
+// the whole model, large enough that SubtleCrypto-equivalent throughput
+// stays I/O bound.
+const HASH_CHUNK_BYTES = 1024 * 1024
+const SHA1_BLOCK = 64
+const SHA1_WORD_COUNT = 80
+const BITS_PER_BYTE = 8
+const SHA1_LEN_BYTES = 8
+
+
+/**
+ * Compute the hex-encoded SHA-1 of a Blob/File by hashing 1 MiB slices
+ * so the whole object is never resident. Same digest as {@link sha1Hex}
+ * on the concatenated bytes.
+ *
+ * @param {Blob} blob a Blob or File (OPFS handle)
+ * @return {Promise<string>} 40-char lowercase hex string
+ */
+export async function sha1HexFromBlob(blob) {
+  if (blob === null || blob === undefined || typeof blob.slice !== 'function') {
+    throw new Error('sha1HexFromBlob: blob is required')
+  }
+  const hasher = new Sha1()
+  const size = blob.size
+  for (let at = 0; at < size; at += HASH_CHUNK_BYTES) {
+    const end = Math.min(at + HASH_CHUNK_BYTES, size)
+    const buf = await blob.slice(at, end).arrayBuffer()
+    hasher.update(new Uint8Array(buf))
+  }
+  return hasher.hex()
+}
+
+
+/**
+ * Incremental SHA-1. Used only for Blob hashing — `sha1Hex` stays on
+ * `crypto.subtle` so a one-buffer digest doesn't fork implementations.
+ */
+class Sha1 {
+  /** Construct a fresh hasher. */
+  constructor() {
+    this.h0 = 0x67452301
+    this.h1 = 0xEFCDAB89
+    this.h2 = 0x98BADCFE
+    this.h3 = 0x10325476
+    this.h4 = 0xC3D2E1F0
+    this.block = new Uint8Array(SHA1_BLOCK)
+    this.blockUsed = 0
+    this.bytesHashed = 0
+  }
+
+  /**
+   * Absorb `bytes`.
+   *
+   * @param {Uint8Array} bytes
+   */
+  update(bytes) {
+    this.bytesHashed += bytes.length
+    let offset = 0
+    while (offset < bytes.length) {
+      const take = Math.min(SHA1_BLOCK - this.blockUsed, bytes.length - offset)
+      this.block.set(bytes.subarray(offset, offset + take), this.blockUsed)
+      this.blockUsed += take
+      offset += take
+      if (this.blockUsed === SHA1_BLOCK) {
+        this.compress_(this.block)
+        this.blockUsed = 0
+      }
+    }
+  }
+
+  /**
+   * @return {string} 40-char lowercase hex digest
+   */
+  hex() {
+    const bitLenHi = Math.floor(this.bytesHashed / 0x20000000)
+    const bitLenLo = (this.bytesHashed * BITS_PER_BYTE) >>> 0
+    this.update(new Uint8Array([0x80]))
+    if (this.blockUsed > SHA1_BLOCK - SHA1_LEN_BYTES) {
+      this.block.fill(0, this.blockUsed)
+      this.compress_(this.block)
+      this.blockUsed = 0
+    }
+    this.block.fill(0, this.blockUsed, SHA1_BLOCK - SHA1_LEN_BYTES)
+    const view = new DataView(this.block.buffer)
+    view.setUint32(SHA1_BLOCK - SHA1_LEN_BYTES, bitLenHi)
+    view.setUint32(SHA1_BLOCK - 4, bitLenLo)
+    this.compress_(this.block)
+
+    const out = new Uint8Array(20)
+    const result = new DataView(out.buffer)
+    result.setUint32(0, this.h0)
+    result.setUint32(4, this.h1)
+    result.setUint32(8, this.h2)
+    result.setUint32(12, this.h3)
+    result.setUint32(16, this.h4)
+    let hex = ''
+    for (let i = 0; i < out.length; i++) {
+      hex += out[i].toString(HEX_BASE).padStart(2, '0')
+    }
+    return hex
+  }
+
+  /**
+   * Process one 64-byte block.
+   *
+   * @param {Uint8Array} block
+   */
+  compress_(block) {
+    const w = new Uint32Array(SHA1_WORD_COUNT)
+    const view = new DataView(block.buffer, block.byteOffset, SHA1_BLOCK)
+    for (let i = 0; i < 16; i++) {
+      w[i] = view.getUint32(i * 4)
+    }
+    for (let i = 16; i < SHA1_WORD_COUNT; i++) {
+      w[i] = rotl_(w[i - 3] ^ w[i - 8] ^ w[i - 14] ^ w[i - 16], 1)
+    }
+    let a = this.h0
+    let b = this.h1
+    let c = this.h2
+    let d = this.h3
+    let e = this.h4
+    for (let i = 0; i < SHA1_WORD_COUNT; i++) {
+      let f
+      let k
+      if (i < 20) {
+        f = (b & c) | ((~b) & d)
+        k = 0x5A827999
+      } else if (i < 40) {
+        f = b ^ c ^ d
+        k = 0x6ED9EBA1
+      } else if (i < 60) {
+        f = (b & c) | (b & d) | (c & d)
+        k = 0x8F1BBCDC
+      } else {
+        f = b ^ c ^ d
+        k = 0xCA62C1D6
+      }
+      const temp = (rotl_(a, 5) + f + e + k + w[i]) >>> 0
+      e = d
+      d = c
+      c = rotl_(b, 30)
+      b = a
+      a = temp
+    }
+    this.h0 = (this.h0 + a) >>> 0
+    this.h1 = (this.h1 + b) >>> 0
+    this.h2 = (this.h2 + c) >>> 0
+    this.h3 = (this.h3 + d) >>> 0
+    this.h4 = (this.h4 + e) >>> 0
+  }
+}
+
+
+/**
+ * 32-bit left rotate.
+ *
+ * @param {number} value
+ * @param {number} bits
+ * @return {number}
+ */
+function rotl_(value, bits) {
+  return ((value << bits) | (value >>> (32 - bits))) >>> 0
 }

--- a/src/utils/contentHash.test.js
+++ b/src/utils/contentHash.test.js
@@ -65,7 +65,7 @@ describe('utils/contentHash sha1HexFromBlob', () => {
       .toBe('da39a3ee5e6b4b0d3255bfef95601890afd80709')
   })
 
-  it('hashes a multi-chunk blob identically to sha1Hex', async () => {
+  it('hashes a multi-chunk blob identically to sha1Hex when it fits one slice', async () => {
     const bytes = new Uint8Array(MIB + OVERSIZE_TAIL)
     for (let i = 0; i < bytes.length; i++) {
       bytes[i] = i & BYTE_MASK
@@ -73,7 +73,41 @@ describe('utils/contentHash sha1HexFromBlob', () => {
     expect(await sha1HexFromBlob(new Blob([bytes]))).toBe(await sha1Hex(bytes))
   })
 
+  it('folds per-slice SHA-1s when the blob spans several slices', async () => {
+    const bytes = new Uint8Array(MIB + OVERSIZE_TAIL)
+    for (let i = 0; i < bytes.length; i++) {
+      bytes[i] = i & BYTE_MASK
+    }
+    const blob = new Blob([bytes])
+    const chunk = MIB
+    const first = await sha1Hex(bytes.subarray(0, chunk))
+    const second = await sha1Hex(bytes.subarray(chunk))
+    const firstBytes = hexToBytes_(first)
+    const secondBytes = hexToBytes_(second)
+    const folded = new Uint8Array(firstBytes.length + secondBytes.length)
+    folded.set(firstBytes)
+    folded.set(secondBytes, firstBytes.length)
+    expect(await sha1HexFromBlob(blob, chunk)).toBe(await sha1Hex(folded))
+    expect(await sha1HexFromBlob(blob, chunk)).not.toBe(await sha1Hex(bytes))
+    expect(await sha1HexFromBlob(blob, chunk)).toBe(await sha1HexFromBlob(blob, chunk))
+  })
+
   it('throws on null input', async () => {
     await expect(sha1HexFromBlob(null)).rejects.toThrow(/blob/)
   })
 })
+
+
+/**
+ * @param {string} hex
+ * @return {Uint8Array}
+ */
+function hexToBytes_(hex) {
+  const out = new Uint8Array(hex.length / 2)
+  for (let i = 0; i < out.length; i++) {
+    out[i] = parseInt(hex.slice(i * 2, (i * 2) + 2), HEX_PARSE)
+  }
+  return out
+}
+
+const HEX_PARSE = 16

--- a/src/utils/contentHash.test.js
+++ b/src/utils/contentHash.test.js
@@ -1,4 +1,11 @@
-import {sha1Hex} from './contentHash'
+import {sha1Hex, sha1HexFromBlob} from './contentHash'
+
+
+/* eslint-disable no-magic-numbers -- chunk-boundary fixture sizes */
+const MIB = 1024 * 1024
+const OVERSIZE_TAIL = 17
+const BYTE_MASK = 0xff
+/* eslint-enable no-magic-numbers */
 
 
 // jest-fixed-jsdom ships crypto.subtle, but be defensive in case the
@@ -42,5 +49,31 @@ describe('utils/contentHash sha1Hex', () => {
 
   it('throws on null input', async () => {
     await expect(sha1Hex(null)).rejects.toThrow(/buffer/)
+  })
+})
+
+
+describe('utils/contentHash sha1HexFromBlob', () => {
+  it('matches sha1Hex on the same bytes', async () => {
+    const bytes = new TextEncoder().encode('abc')
+    const blob = new Blob([bytes])
+    expect(await sha1HexFromBlob(blob)).toBe(await sha1Hex(bytes))
+  })
+
+  it('hashes an empty blob', async () => {
+    expect(await sha1HexFromBlob(new Blob([])))
+      .toBe('da39a3ee5e6b4b0d3255bfef95601890afd80709')
+  })
+
+  it('hashes a multi-chunk blob identically to sha1Hex', async () => {
+    const bytes = new Uint8Array(MIB + OVERSIZE_TAIL)
+    for (let i = 0; i < bytes.length; i++) {
+      bytes[i] = i & BYTE_MASK
+    }
+    expect(await sha1HexFromBlob(new Blob([bytes]))).toBe(await sha1Hex(bytes))
+  })
+
+  it('throws on null input', async () => {
+    await expect(sha1HexFromBlob(null)).rejects.toThrow(/blob/)
   })
 })

--- a/src/viewer/ProgressiveLoadSession.js
+++ b/src/viewer/ProgressiveLoadSession.js
@@ -650,18 +650,29 @@ export default class ProgressiveLoadSession {
 
   /** Remove the preview group and dispose its meshes' GPU resources. */
   teardownPreview_() {
+    // Imposters must not survive the durable model. Pull any aabb
+    // wire cubes off the scene first — they can leave the preview
+    // group (outlier eviction) and would otherwise stay after finish.
+    if (this.scene !== null && typeof this.scene.traverse === 'function') {
+      const strays = []
+      this.scene.traverse((obj) => {
+        if (obj.userData && obj.userData.aabbImposter) {
+          strays.push(obj)
+        }
+      })
+      for (const obj of strays) {
+        obj.removeFromParent?.()
+      }
+    }
     if (this.previewGroup === null || !this.previewInstalled) {
       return
     }
     try {
-      this.scene.remove(this.previewGroup)
-      for (const child of this.previewGroup.children) {
-        child.geometry?.dispose?.()
-        const materials = Array.isArray(child.material) ? child.material : [child.material]
-        for (const material of materials) {
-          material?.dispose?.()
-        }
+      const group = this.previewGroup
+      while (group.children.length > 0) {
+        group.remove(group.children[0])
       }
+      this.scene.remove(group)
     } catch (e) {
       debug(WARN).warn('demand preview teardown failed:', e)
     }

--- a/src/viewer/ProgressiveLoadSession.js
+++ b/src/viewer/ProgressiveLoadSession.js
@@ -650,6 +650,30 @@ export default class ProgressiveLoadSession {
 
   /** Remove the preview group and dispose its meshes' GPU resources. */
   teardownPreview_() {
+    // Preview geometry and materials are SHARED across meshes by design:
+    // parsePreviewMesh pools materials by rgba, keys payload geometry by
+    // geometryExpressID for mapped reuse, and every aabb imposter
+    // instances one unit cube. So disposal collects UNIQUE resources
+    // from every preview object and frees each once — the pre-imposter
+    // per-child dispose would hit shared ones repeatedly, and dropping
+    // disposal outright (this PR's interim state) retained up to the
+    // preview byte cap of uploaded WebGL buffers per load until page
+    // refresh (Codex review on #1753). The caches themselves are
+    // per-load Maps in ShareIfcLoader.parse, so nothing re-uses these
+    // instances after finish/abort.
+    const geometries = new Set()
+    const materials = new Set()
+    const retire = (obj) => {
+      if (obj.geometry !== undefined && obj.geometry !== null) {
+        geometries.add(obj.geometry)
+      }
+      const mats = Array.isArray(obj.material) ? obj.material : [obj.material]
+      for (const material of mats) {
+        if (material !== undefined && material !== null) {
+          materials.add(material)
+        }
+      }
+    }
     // Imposters must not survive the durable model. Pull any aabb
     // wire cubes off the scene first — they can leave the preview
     // group (outlier eviction) and would otherwise stay after finish.
@@ -661,21 +685,29 @@ export default class ProgressiveLoadSession {
         }
       })
       for (const obj of strays) {
+        retire(obj)
         obj.removeFromParent?.()
       }
     }
-    if (this.previewGroup === null || !this.previewInstalled) {
-      return
-    }
-    try {
-      const group = this.previewGroup
-      while (group.children.length > 0) {
-        group.remove(group.children[0])
+    if (this.previewGroup !== null && this.previewInstalled) {
+      try {
+        const group = this.previewGroup
+        while (group.children.length > 0) {
+          const child = group.children[0]
+          retire(child)
+          group.remove(child)
+        }
+        this.scene.remove(group)
+      } catch (e) {
+        debug(WARN).warn('demand preview teardown failed:', e)
       }
-      this.scene.remove(group)
-    } catch (e) {
-      debug(WARN).warn('demand preview teardown failed:', e)
+      this.previewInstalled = false
     }
-    this.previewInstalled = false
+    for (const geometry of geometries) {
+      geometry.dispose?.()
+    }
+    for (const material of materials) {
+      material.dispose?.()
+    }
   }
 }

--- a/src/viewer/ProgressiveLoadSession.test.js
+++ b/src/viewer/ProgressiveLoadSession.test.js
@@ -168,6 +168,32 @@ describe('ProgressiveLoadSession', () => {
     expect(stray.parent).toBeNull()
   })
 
+  // Codex review on #1753: teardown had lost its dispose pass when the
+  // shared aabb cube arrived, retaining every load's uploaded preview
+  // buffers until page refresh. Resources are pooled across meshes
+  // (parsePreviewMesh caches; the imposter unit cube), so each unique
+  // one must be disposed exactly once — not per mesh, not zero times.
+  it('finish disposes shared preview resources exactly once', () => {
+    const geometry = new BoxGeometry(1, 1, 1)
+    const material = new MeshBasicMaterial()
+    const geometryDispose = jest.spyOn(geometry, 'dispose')
+    const materialDispose = jest.spyOn(material, 'dispose')
+    const shared = (x) => {
+      const mesh = new Mesh(geometry, material)
+      mesh.matrixAutoUpdate = false
+      mesh.matrix = new Matrix4().makeTranslation(x, 0, 0)
+      return mesh
+    }
+    session.addPreviewMesh(shared(0))
+    session.addPreviewMesh(shared(1))
+    const stray = shared(2)
+    stray.userData.aabbImposter = true
+    scene.add(stray)
+    session.finish()
+    expect(geometryDispose).toHaveBeenCalledTimes(1)
+    expect(materialDispose).toHaveBeenCalledTimes(1)
+  })
+
 
   it('abort tears the preview down and lands in aborted', () => {
     session.addPreviewMesh(cubeAt(0))

--- a/src/viewer/ProgressiveLoadSession.test.js
+++ b/src/viewer/ProgressiveLoadSession.test.js
@@ -157,6 +157,18 @@ describe('ProgressiveLoadSession', () => {
     expect(controls.fits).toHaveLength(1)
   })
 
+  it('finish removes aabb imposters even if they left the preview group', () => {
+    session.addPreviewMesh(cubeAt(0))
+    const stray = cubeAt(5)
+    stray.userData.aabbImposter = true
+    scene.add(stray)
+    expect(scene.children).toContain(stray)
+    session.finish()
+    expect(scene.children).not.toContain(stray)
+    expect(stray.parent).toBeNull()
+  })
+
+
   it('abort tears the preview down and lands in aborted', () => {
     session.addPreviewMesh(cubeAt(0))
     session.abort()

--- a/src/viewer/ifc/ShareIfcLoader.aabb.test.js
+++ b/src/viewer/ifc/ShareIfcLoader.aabb.test.js
@@ -52,25 +52,28 @@ function makeSession(accept = true) {
  * @return {object}
  */
 function makeRing() {
-  return {meshes: [], origin: {xyz: null}, cap: AABB_IMPOSTER_CAP}
+  return {meshes: [], cap: AABB_IMPOSTER_CAP}
 }
 
 
 describe('viewer/ifc/ShareIfcLoader applyAabbImposter', () => {
-  it('places the first box at the origin and later boxes relative to it', () => {
+  // Conway emits imposters in the durable coordination frame, so the
+  // matrix that arrives is already where the box belongs. The old
+  // re-anchor onto the first accepted box shifted every plate off the
+  // durable geometry (conway#515 review findings).
+  it('leaves the stamped matrix alone', () => {
     const session = makeSession()
     const ring = makeRing()
     const first = makeMesh(100, 200, 300)
     const second = makeMesh(110, 200, 300)
     applyAabbImposter(first, session, ring)
     applyAabbImposter(second, session, ring)
-    expect(first.matrix.elements[12]).toBe(0)
-    expect(first.matrix.elements[13]).toBe(0)
-    expect(first.matrix.elements[14]).toBe(0)
-    expect(second.matrix.elements[12]).toBe(10)
-    expect(second.matrix.elements[13]).toBe(0)
-    expect(second.matrix.elements[14]).toBe(0)
-    expect(ring.origin.xyz).toEqual([100, 200, 300])
+    expect(first.matrix.elements[12]).toBe(100)
+    expect(first.matrix.elements[13]).toBe(200)
+    expect(first.matrix.elements[14]).toBe(300)
+    expect(second.matrix.elements[12]).toBe(110)
+    expect(second.matrix.elements[13]).toBe(200)
+    expect(second.matrix.elements[14]).toBe(300)
   })
 
 
@@ -78,9 +81,12 @@ describe('viewer/ifc/ShareIfcLoader applyAabbImposter', () => {
     const session = makeSession()
     const ring = makeRing()
     const coordination = {offset: undefined}
-    applyAabbImposter(makeMesh(8, 16, 24), session, ring)
+    const mesh = makeMesh(8, 16, 24)
+    applyAabbImposter(mesh, session, ring)
     expect(coordination.offset).toBeUndefined()
-    expect(ring.origin.xyz).toEqual([8, 16, 24])
+    expect(mesh.matrix.elements[12]).toBe(8)
+    expect(mesh.matrix.elements[13]).toBe(16)
+    expect(mesh.matrix.elements[14]).toBe(24)
   })
 
 

--- a/src/viewer/ifc/ShareIfcLoader.aabb.test.js
+++ b/src/viewer/ifc/ShareIfcLoader.aabb.test.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-magic-numbers */
-import {AABB_IMPOSTER_CAP, applyAabbImposter} from './ShareIfcLoader'
+import {AABB_IMPOSTER_CAP, applyAabbImposter, clearAabbImposters} from './ShareIfcLoader'
 
 
 /**
@@ -124,5 +124,21 @@ describe('viewer/ifc/ShareIfcLoader applyAabbImposter', () => {
     expect(ring.meshes.includes(rejected)).toBe(false)
     expect(accepting.previewGroup.children).toHaveLength(3)
     expect(rejected.parent).toBeNull()
+  })
+
+
+  it('detaches every accepted box at the end of the load', () => {
+    const session = makeSession()
+    const ring = makeRing()
+    const first = makeMesh(0, 0, 0)
+    const second = makeMesh(4, 0, 0)
+    applyAabbImposter(first, session, ring)
+    applyAabbImposter(second, session, ring)
+    expect(session.previewGroup.children).toHaveLength(2)
+    clearAabbImposters(ring, session)
+    expect(ring.meshes).toHaveLength(0)
+    expect(session.previewGroup.children).toHaveLength(0)
+    expect(first.parent).toBeNull()
+    expect(second.parent).toBeNull()
   })
 })

--- a/src/viewer/ifc/ShareIfcLoader.aabb.test.js
+++ b/src/viewer/ifc/ShareIfcLoader.aabb.test.js
@@ -52,7 +52,7 @@ function makeSession(accept = true) {
  * @return {object}
  */
 function makeRing() {
-  return {meshes: [], cap: AABB_IMPOSTER_CAP}
+  return {meshes: [], byExpressID: new Map(), cap: AABB_IMPOSTER_CAP}
 }
 
 
@@ -94,21 +94,88 @@ describe('viewer/ifc/ShareIfcLoader applyAabbImposter', () => {
     const session = makeSession()
     const ring = makeRing()
     const first = makeMesh(0, 0, 0)
-    applyAabbImposter(first, session, ring)
+    applyAabbImposter(first, session, ring, 0)
     for (let i = 1; i < AABB_IMPOSTER_CAP; i++) {
-      applyAabbImposter(makeMesh(i, 0, 0), session, ring)
+      applyAabbImposter(makeMesh(i, 0, 0), session, ring, i)
     }
     expect(ring.meshes).toHaveLength(AABB_IMPOSTER_CAP)
     expect(session.previewGroup.children).toHaveLength(AABB_IMPOSTER_CAP)
     expect(session.previewGroup.children[0]).toBe(first)
 
     const extra = makeMesh(AABB_IMPOSTER_CAP, 0, 0)
-    applyAabbImposter(extra, session, ring)
+    applyAabbImposter(extra, session, ring, AABB_IMPOSTER_CAP)
     expect(ring.meshes).toHaveLength(AABB_IMPOSTER_CAP)
     expect(session.previewGroup.children).toHaveLength(AABB_IMPOSTER_CAP)
     expect(session.previewGroup.children.includes(first)).toBe(false)
     expect(session.previewGroup.children.includes(extra)).toBe(true)
     expect(first.parent).toBeNull()
+    // The evicted plate's key goes with it — otherwise a later
+    // re-emission of expressID 0 would try to replace a detached mesh.
+    expect(ring.byExpressID.size).toBe(AABB_IMPOSTER_CAP)
+    expect(ring.byExpressID.has(0)).toBe(false)
+    expect(ring.byExpressID.get(AABB_IMPOSTER_CAP)).toBe(extra)
+  })
+
+
+  // conway#519: the store path emits each spatial node twice by design —
+  // an early coarse plate from a prefix generation, then a refined one
+  // after the parse. The second emission refines the first in place.
+  it('replaces the plate already drawn for the same expressID', () => {
+    const session = makeSession()
+    const ring = makeRing()
+    const coarse = makeMesh(1, 2, 3)
+    const refined = makeMesh(10, 20, 30)
+    applyAabbImposter(coarse, session, ring, 42)
+    applyAabbImposter(refined, session, ring, 42)
+    expect(ring.meshes).toEqual([refined])
+    expect(session.previewGroup.children).toEqual([refined])
+    expect(coarse.parent).toBeNull()
+    expect(session.previewGroup.children[0].matrix.elements[12]).toBe(10)
+    expect(ring.byExpressID.size).toBe(1)
+    expect(ring.byExpressID.get(42)).toBe(refined)
+  })
+
+
+  it('does not spend a cap slot on a replacement', () => {
+    const session = makeSession()
+    const ring = makeRing()
+    for (let i = 0; i < AABB_IMPOSTER_CAP; i++) {
+      applyAabbImposter(makeMesh(i, 0, 0), session, ring, i)
+    }
+    const oldest = ring.meshes[0]
+    const refined = makeMesh(0, 0, 7)
+    applyAabbImposter(refined, session, ring, AABB_IMPOSTER_CAP - 1)
+    // A full ring plus a replacement is still a full ring, and the
+    // replacement must not have evicted the oldest plate to make room.
+    expect(ring.meshes).toHaveLength(AABB_IMPOSTER_CAP)
+    expect(session.previewGroup.children).toHaveLength(AABB_IMPOSTER_CAP)
+    expect(ring.meshes[0]).toBe(oldest)
+    expect(oldest.parent).toBe(session.previewGroup)
+    expect(ring.meshes[AABB_IMPOSTER_CAP - 1]).toBe(refined)
+    expect(ring.byExpressID.size).toBe(AABB_IMPOSTER_CAP)
+  })
+
+
+  // A refused update must not delete standing scenery: the outlier guard
+  // rejecting the NEW plate leaves the old one on screen and tracked.
+  it('keeps the standing plate when its replacement is rejected', () => {
+    const accepting = makeSession(true)
+    const ring = makeRing()
+    const standing = makeMesh(1, 1, 1)
+    applyAabbImposter(standing, accepting, ring, 7)
+    const rejecting = {
+      previewGroup: accepting.previewGroup,
+      addPreviewMesh() {
+        // Outlier: do not parent.
+      },
+    }
+    const rejected = makeMesh(10000, 0, 0)
+    applyAabbImposter(rejected, rejecting, ring, 7)
+    expect(ring.meshes).toEqual([standing])
+    expect(accepting.previewGroup.children).toEqual([standing])
+    expect(standing.parent).toBe(accepting.previewGroup)
+    expect(rejected.parent).toBeNull()
+    expect(ring.byExpressID.get(7)).toBe(standing)
   })
 
 
@@ -138,11 +205,12 @@ describe('viewer/ifc/ShareIfcLoader applyAabbImposter', () => {
     const ring = makeRing()
     const first = makeMesh(0, 0, 0)
     const second = makeMesh(4, 0, 0)
-    applyAabbImposter(first, session, ring)
-    applyAabbImposter(second, session, ring)
+    applyAabbImposter(first, session, ring, 1)
+    applyAabbImposter(second, session, ring, 2)
     expect(session.previewGroup.children).toHaveLength(2)
     clearAabbImposters(ring, session)
     expect(ring.meshes).toHaveLength(0)
+    expect(ring.byExpressID.size).toBe(0)
     expect(session.previewGroup.children).toHaveLength(0)
     expect(first.parent).toBeNull()
     expect(second.parent).toBeNull()

--- a/src/viewer/ifc/ShareIfcLoader.aabb.test.js
+++ b/src/viewer/ifc/ShareIfcLoader.aabb.test.js
@@ -1,0 +1,128 @@
+/* eslint-disable no-magic-numbers */
+import {AABB_IMPOSTER_CAP, applyAabbImposter} from './ShareIfcLoader'
+
+
+/**
+ * @param {number} tx
+ * @param {number} ty
+ * @param {number} tz
+ * @return {object}
+ */
+function makeMesh(tx, ty, tz) {
+  const elements = [
+    1, 0, 0, 0,
+    0, 1, 0, 0,
+    0, 0, 1, 0,
+    tx, ty, tz, 1,
+  ]
+  return {matrix: {elements}, parent: null}
+}
+
+
+/**
+ * @param {boolean} accept
+ * @return {object}
+ */
+function makeSession(accept = true) {
+  const previewGroup = {
+    children: [],
+    add(mesh) {
+      mesh.parent = this
+      this.children.push(mesh)
+    },
+    remove(mesh) {
+      this.children = this.children.filter((child) => child !== mesh)
+      if (mesh.parent === this) {
+        mesh.parent = null
+      }
+    },
+  }
+  return {
+    previewGroup,
+    addPreviewMesh(mesh) {
+      if (accept) {
+        previewGroup.add(mesh)
+      }
+    },
+  }
+}
+
+
+/**
+ * @return {object}
+ */
+function makeRing() {
+  return {meshes: [], origin: {xyz: null}, cap: AABB_IMPOSTER_CAP}
+}
+
+
+describe('viewer/ifc/ShareIfcLoader applyAabbImposter', () => {
+  it('places the first box at the origin and later boxes relative to it', () => {
+    const session = makeSession()
+    const ring = makeRing()
+    const first = makeMesh(100, 200, 300)
+    const second = makeMesh(110, 200, 300)
+    applyAabbImposter(first, session, ring)
+    applyAabbImposter(second, session, ring)
+    expect(first.matrix.elements[12]).toBe(0)
+    expect(first.matrix.elements[13]).toBe(0)
+    expect(first.matrix.elements[14]).toBe(0)
+    expect(second.matrix.elements[12]).toBe(10)
+    expect(second.matrix.elements[13]).toBe(0)
+    expect(second.matrix.elements[14]).toBe(0)
+    expect(ring.origin.xyz).toEqual([100, 200, 300])
+  })
+
+
+  it('does not write a durable coordination offset', () => {
+    const session = makeSession()
+    const ring = makeRing()
+    const coordination = {offset: undefined}
+    applyAabbImposter(makeMesh(8, 16, 24), session, ring)
+    expect(coordination.offset).toBeUndefined()
+    expect(ring.origin.xyz).toEqual([8, 16, 24])
+  })
+
+
+  it('drops the first accepted box when the 101st lands', () => {
+    const session = makeSession()
+    const ring = makeRing()
+    const first = makeMesh(0, 0, 0)
+    applyAabbImposter(first, session, ring)
+    for (let i = 1; i < AABB_IMPOSTER_CAP; i++) {
+      applyAabbImposter(makeMesh(i, 0, 0), session, ring)
+    }
+    expect(ring.meshes).toHaveLength(AABB_IMPOSTER_CAP)
+    expect(session.previewGroup.children).toHaveLength(AABB_IMPOSTER_CAP)
+    expect(session.previewGroup.children[0]).toBe(first)
+
+    const extra = makeMesh(AABB_IMPOSTER_CAP, 0, 0)
+    applyAabbImposter(extra, session, ring)
+    expect(ring.meshes).toHaveLength(AABB_IMPOSTER_CAP)
+    expect(session.previewGroup.children).toHaveLength(AABB_IMPOSTER_CAP)
+    expect(session.previewGroup.children.includes(first)).toBe(false)
+    expect(session.previewGroup.children.includes(extra)).toBe(true)
+    expect(first.parent).toBeNull()
+  })
+
+
+  it('does not keep a mesh that addPreviewMesh rejected', () => {
+    const accepting = makeSession(true)
+    const ring = makeRing()
+    for (let i = 0; i < 3; i++) {
+      applyAabbImposter(makeMesh(i, 0, 0), accepting, ring)
+    }
+    const rejecting = {
+      previewGroup: accepting.previewGroup,
+      addPreviewMesh() {
+        // Outlier: do not parent.
+      },
+    }
+    const rejected = makeMesh(10000, 0, 0)
+    applyAabbImposter(rejected, rejecting, ring)
+    expect(ring.meshes).toHaveLength(3)
+    expect(ring.meshes.includes(rejected)).toBe(false)
+    expect(accepting.previewGroup.children).toHaveLength(3)
+    expect(rejected.parent).toBeNull()
+  })
+})

--- a/src/viewer/ifc/ShareIfcLoader.js
+++ b/src/viewer/ifc/ShareIfcLoader.js
@@ -147,6 +147,25 @@ export function applyAabbImposter(mesh, session, ring) {
 
 
 /**
+ * Detach every accepted AABB wire cube. Called at the end of the load
+ * so none remain once the durable mesh is on screen.
+ *
+ * @param {object} ring `{meshes, origin, cap}`
+ * @param {object} session ProgressiveLoadSession
+ */
+export function clearAabbImposters(ring, session) {
+  const group = session.previewGroup
+  for (const mesh of ring.meshes) {
+    if (group !== null && group !== undefined) {
+      group.remove(mesh)
+    }
+    mesh.removeFromParent?.()
+  }
+  ring.meshes.length = 0
+}
+
+
+/**
  * IFC loader for ShareViewer. Single entry point: `parse(buffer)`.
  *
  * Holds a `ShareIfcManager` (`this.ifcManager`) — consumer code
@@ -354,8 +373,9 @@ export default class ShareIfcLoader {
         decorateConwayDirectIfcModel(ifcModel, ifcAPI, modelID, {scene})
       }
 
-      // Swap the preview out before the real model installs — the
-      // session stops the camera follow and disposes preview meshes.
+      // Drop parse-time imposters before the durable model installs.
+      // finish() also scene-walks leftover aabb wire cubes.
+      clearAabbImposters(aabbRing, session)
       session.finish()
 
       ifc.addIfcModel(ifcModel)

--- a/src/viewer/ifc/ShareIfcLoader.js
+++ b/src/viewer/ifc/ShareIfcLoader.js
@@ -104,7 +104,8 @@ export const AABB_IMPOSTER_CAP = 100
 
 
 /**
- * Add an AABB wire cube to the preview, ring-tracked for eviction.
+ * Add an AABB wire cube to the preview, keyed by expressID and
+ * ring-tracked for eviction.
  *
  * Placement is NOT this function's business: conway emits imposter
  * `flatTransformation` in the same durable coordination frame as regular
@@ -117,25 +118,90 @@ export const AABB_IMPOSTER_CAP = 100
  * recentres nothing) invented an offset that had not existed. See
  * conway#515's review-findings comment for the frame contract.
  *
+ * REPLACE-BY-EXPRESSID (conway#519): the store preview channel emits each
+ * spatial node TWICE by design — once early, from a prefix generation
+ * seconds into the parse (possibly a coarse Z band with degenerate XY),
+ * and again after the parse with full samples and the latched coordination
+ * frame. A re-emitted `aabb` payload REPLACES the plate already drawn for
+ * that expressID; it must not add a second one, and the replacement takes
+ * the old plate's slot rather than consuming a fresh one. Vertex-carrying
+ * payloads are unaffected — they are keyed by `geometryExpressID` and
+ * never re-sent.
+ *
+ * The old mesh is only detached, never disposed: the unit-cube geometry
+ * and the wire materials are pooled per load in
+ * `payloadToPreviewMesh`'s caches, so the replacement is very likely
+ * holding the same instances.
+ *
+ * `ProgressiveLoadSession`'s preview bounds union is grow-only, so a
+ * replaced coarse plate's old bounds linger in the camera-fit union until
+ * the next refit. Acceptable for preview scenery: it can only over-frame
+ * for a moment, and the whole imposter set is torn down at load end.
+ *
  * Ring-track only meshes that `addPreviewMesh` actually parented —
- * outlier rejects must not occupy a slot or evict a visible cube.
+ * outlier rejects must not occupy a slot or evict a visible cube. That
+ * also means a REJECTED replacement leaves the standing plate for its
+ * expressID alone: a refused update must never delete visible scenery.
  *
  * @param {object} mesh three.js Mesh, matrix already stamped
  * @param {object} session ProgressiveLoadSession
- * @param {object} ring `{meshes, cap}`
+ * @param {object} ring `{meshes, byExpressID, cap}`
+ * @param {number} [expressID] the payload's expressID — the replace key
  */
-export function applyAabbImposter(mesh, session, ring) {
+export function applyAabbImposter(mesh, session, ring, expressID) {
   session.addPreviewMesh(mesh)
   if (mesh.parent !== session.previewGroup) {
     return
   }
+  const keyed = expressID !== undefined && expressID !== null
+  const prior = keyed ? ring.byExpressID.get(expressID) : undefined
+  if (prior !== undefined) {
+    detachImposter_(prior, session)
+    // Eviction below deletes the map entry with the mesh, so a mapped
+    // mesh is always still in the ring — but take the push fallback
+    // rather than corrupting the ring on an index of -1.
+    const at = ring.meshes.indexOf(prior)
+    if (at === -1) {
+      ring.meshes.push(mesh)
+    } else {
+      ring.meshes[at] = mesh
+    }
+    ring.byExpressID.set(expressID, mesh)
+    return
+  }
   if (ring.meshes.length >= ring.cap) {
     const old = ring.meshes.shift()
-    if (old !== undefined && session.previewGroup !== null) {
-      session.previewGroup.remove(old)
+    if (old !== undefined) {
+      detachImposter_(old, session)
+      // Reverse lookup by scan: the ring is capped at AABB_IMPOSTER_CAP,
+      // so this is a bounded walk on an eviction that only happens once
+      // per accepted plate, and it keeps the ring to one map.
+      for (const [id, tracked] of ring.byExpressID) {
+        if (tracked === old) {
+          ring.byExpressID.delete(id)
+          break
+        }
+      }
     }
   }
   ring.meshes.push(mesh)
+  if (keyed) {
+    ring.byExpressID.set(expressID, mesh)
+  }
+}
+
+
+/**
+ * Detach one imposter from the preview group. Geometry/materials are
+ * pooled per load, so nothing is disposed here.
+ *
+ * @param {object} mesh
+ * @param {object} session ProgressiveLoadSession
+ */
+function detachImposter_(mesh, session) {
+  if (session.previewGroup !== null && session.previewGroup !== undefined) {
+    session.previewGroup.remove(mesh)
+  }
 }
 
 
@@ -143,7 +209,7 @@ export function applyAabbImposter(mesh, session, ring) {
  * Detach every accepted AABB wire cube. Called at the end of the load
  * so none remain once the durable mesh is on screen.
  *
- * @param {object} ring `{meshes, cap}`
+ * @param {object} ring `{meshes, byExpressID, cap}`
  * @param {object} session ProgressiveLoadSession
  */
 export function clearAabbImposters(ring, session) {
@@ -155,6 +221,9 @@ export function clearAabbImposters(ring, session) {
     mesh.removeFromParent?.()
   }
   ring.meshes.length = 0
+  // The replace key map holds a strong ref to every accepted plate —
+  // clearing the list alone would keep the whole ring alive past teardown.
+  ring.byExpressID.clear()
 }
 
 
@@ -273,7 +342,11 @@ export default class ShareIfcLoader {
       // whose placement never resolved), so it must never decide where
       // the durable model renders.
       const coordination = {offset: undefined}
-      const aabbRing = {meshes: [], cap: AABB_IMPOSTER_CAP}
+      // `byExpressID` is the replace key for spatial imposters: conway's
+      // store path emits each spatial node early and again at parse end
+      // (conway#519), and the second emission must refine the first plate
+      // rather than stack a second one on top of it.
+      const aabbRing = {meshes: [], byExpressID: new Map(), cap: AABB_IMPOSTER_CAP}
 
       const onPreviewMesh = !usePreview ? undefined : (payload) => {
         try {
@@ -283,7 +356,7 @@ export default class ShareIfcLoader {
             return
           }
           if (payload.aabb) {
-            applyAabbImposter(mesh, session, aabbRing)
+            applyAabbImposter(mesh, session, aabbRing, payload.expressID)
             return
           }
           session.addPreviewMesh(mesh)

--- a/src/viewer/ifc/ShareIfcLoader.js
+++ b/src/viewer/ifc/ShareIfcLoader.js
@@ -96,11 +96,6 @@ function logInstancedModelStats(ifcAPI, modelID, captured, force = false) {
  */
 
 
-/** Column-major Matrix4 translation slots. */
-const MAT_TX = 12
-const MAT_TY = 13
-const MAT_TZ = 14
-
 /**
  * Last-N wire boxes: enough to read as a growing mass, cheap enough
  * that the preview group stays fixed-mem.
@@ -109,29 +104,27 @@ export const AABB_IMPOSTER_CAP = 100
 
 
 /**
- * Recenter an AABB wire cube onto the first accepted box, then add it.
- * Only ring-track meshes that `addPreviewMesh` actually parented —
- * outlier rejects must not occupy a slot or evict a visible cube.
+ * Add an AABB wire cube to the preview, ring-tracked for eviction.
  *
- * This translation is local to the parse-time preview. It must not
- * write `coordination.offset`; that latch belongs to the durable
- * builder's COORDINATE_TO_ORIGIN frame.
+ * Placement is NOT this function's business: conway emits imposter
+ * `flatTransformation` in the same durable coordination frame as regular
+ * preview meshes (metres, Y-up, COORDINATE_TO_ORIGIN-recentred), and
+ * `payloadToPreviewMesh` has already applied the shared Share-side
+ * `coordination` offset. This used to re-anchor every box by subtracting
+ * the first accepted box's translation — an arbitrary anchor that pushed
+ * the plates off the durable geometry by (first plate centre − durable
+ * anchor), and on near-origin models (where conway's model-zero policy
+ * recentres nothing) invented an offset that had not existed. See
+ * conway#515's review-findings comment for the frame contract.
+ *
+ * Ring-track only meshes that `addPreviewMesh` actually parented —
+ * outlier rejects must not occupy a slot or evict a visible cube.
  *
  * @param {object} mesh three.js Mesh, matrix already stamped
  * @param {object} session ProgressiveLoadSession
- * @param {object} ring `{meshes, origin:{xyz}, cap}`
+ * @param {object} ring `{meshes, cap}`
  */
 export function applyAabbImposter(mesh, session, ring) {
-  if (ring.origin.xyz === null) {
-    ring.origin.xyz = [
-      mesh.matrix.elements[MAT_TX],
-      mesh.matrix.elements[MAT_TY],
-      mesh.matrix.elements[MAT_TZ],
-    ]
-  }
-  mesh.matrix.elements[MAT_TX] -= ring.origin.xyz[0]
-  mesh.matrix.elements[MAT_TY] -= ring.origin.xyz[1]
-  mesh.matrix.elements[MAT_TZ] -= ring.origin.xyz[2]
   session.addPreviewMesh(mesh)
   if (mesh.parent !== session.previewGroup) {
     return
@@ -150,7 +143,7 @@ export function applyAabbImposter(mesh, session, ring) {
  * Detach every accepted AABB wire cube. Called at the end of the load
  * so none remain once the durable mesh is on screen.
  *
- * @param {object} ring `{meshes, origin, cap}`
+ * @param {object} ring `{meshes, cap}`
  * @param {object} session ProgressiveLoadSession
  */
 export function clearAabbImposters(ring, session) {
@@ -280,7 +273,7 @@ export default class ShareIfcLoader {
       // whose placement never resolved), so it must never decide where
       // the durable model renders.
       const coordination = {offset: undefined}
-      const aabbRing = {meshes: [], origin: {xyz: null}, cap: AABB_IMPOSTER_CAP}
+      const aabbRing = {meshes: [], cap: AABB_IMPOSTER_CAP}
 
       const onPreviewMesh = !usePreview ? undefined : (payload) => {
         try {

--- a/src/viewer/ifc/ShareIfcLoader.js
+++ b/src/viewer/ifc/ShareIfcLoader.js
@@ -96,6 +96,56 @@ function logInstancedModelStats(ifcAPI, modelID, captured, force = false) {
  */
 
 
+/** Column-major Matrix4 translation slots. */
+const MAT_TX = 12
+const MAT_TY = 13
+const MAT_TZ = 14
+
+/**
+ * Last-N wire boxes: enough to read as a growing mass, cheap enough
+ * that the preview group stays fixed-mem.
+ */
+export const AABB_IMPOSTER_CAP = 100
+
+
+/**
+ * Recenter an AABB wire cube onto the first accepted box, then add it.
+ * Only ring-track meshes that `addPreviewMesh` actually parented —
+ * outlier rejects must not occupy a slot or evict a visible cube.
+ *
+ * This translation is local to the parse-time preview. It must not
+ * write `coordination.offset`; that latch belongs to the durable
+ * builder's COORDINATE_TO_ORIGIN frame.
+ *
+ * @param {object} mesh three.js Mesh, matrix already stamped
+ * @param {object} session ProgressiveLoadSession
+ * @param {object} ring `{meshes, origin:{xyz}, cap}`
+ */
+export function applyAabbImposter(mesh, session, ring) {
+  if (ring.origin.xyz === null) {
+    ring.origin.xyz = [
+      mesh.matrix.elements[MAT_TX],
+      mesh.matrix.elements[MAT_TY],
+      mesh.matrix.elements[MAT_TZ],
+    ]
+  }
+  mesh.matrix.elements[MAT_TX] -= ring.origin.xyz[0]
+  mesh.matrix.elements[MAT_TY] -= ring.origin.xyz[1]
+  mesh.matrix.elements[MAT_TZ] -= ring.origin.xyz[2]
+  session.addPreviewMesh(mesh)
+  if (mesh.parent !== session.previewGroup) {
+    return
+  }
+  if (ring.meshes.length >= ring.cap) {
+    const old = ring.meshes.shift()
+    if (old !== undefined && session.previewGroup !== null) {
+      session.previewGroup.remove(old)
+    }
+  }
+  ring.meshes.push(mesh)
+}
+
+
 /**
  * IFC loader for ShareViewer. Single entry point: `parse(buffer)`.
  *
@@ -211,14 +261,7 @@ export default class ShareIfcLoader {
       // whose placement never resolved), so it must never decide where
       // the durable model renders.
       const coordination = {offset: undefined}
-      const aabbRing = []
-      // Last-N wire boxes: enough to read as a growing mass, cheap
-      // enough that the preview group stays fixed-mem.
-      const aabbCap = 100
-      const matTx = 12
-      const matTy = 13
-      const matTz = 14
-      const aabbOrigin = {xyz: null}
+      const aabbRing = {meshes: [], origin: {xyz: null}, cap: AABB_IMPOSTER_CAP}
 
       const onPreviewMesh = !usePreview ? undefined : (payload) => {
         try {
@@ -228,23 +271,8 @@ export default class ShareIfcLoader {
             return
           }
           if (payload.aabb) {
-            if (aabbOrigin.xyz === null) {
-              aabbOrigin.xyz = [
-                mesh.matrix.elements[matTx],
-                mesh.matrix.elements[matTy],
-                mesh.matrix.elements[matTz],
-              ]
-            }
-            mesh.matrix.elements[matTx] -= aabbOrigin.xyz[0]
-            mesh.matrix.elements[matTy] -= aabbOrigin.xyz[1]
-            mesh.matrix.elements[matTz] -= aabbOrigin.xyz[2]
-            if (aabbRing.length >= aabbCap) {
-              const old = aabbRing.shift()
-              if (old !== undefined && session.previewGroup !== null) {
-                session.previewGroup.remove(old)
-              }
-            }
-            aabbRing.push(mesh)
+            applyAabbImposter(mesh, session, aabbRing)
+            return
           }
           session.addPreviewMesh(mesh)
         } catch (e) {

--- a/src/viewer/ifc/ShareIfcLoader.js
+++ b/src/viewer/ifc/ShareIfcLoader.js
@@ -211,14 +211,42 @@ export default class ShareIfcLoader {
       // whose placement never resolved), so it must never decide where
       // the durable model renders.
       const coordination = {offset: undefined}
+      const aabbRing = []
+      // Last-N wire boxes: enough to read as a growing mass, cheap
+      // enough that the preview group stays fixed-mem.
+      const aabbCap = 100
+      const matTx = 12
+      const matTy = 13
+      const matTz = 14
+      const aabbOrigin = {xyz: null}
 
       const onPreviewMesh = !usePreview ? undefined : (payload) => {
         try {
           const mesh = payloadToPreviewMesh(
             payload, previewGeometryCache, previewMaterialCache, coordination)
-          if (mesh !== null) {
-            session.addPreviewMesh(mesh)
+          if (mesh === null) {
+            return
           }
+          if (payload.aabb) {
+            if (aabbOrigin.xyz === null) {
+              aabbOrigin.xyz = [
+                mesh.matrix.elements[matTx],
+                mesh.matrix.elements[matTy],
+                mesh.matrix.elements[matTz],
+              ]
+            }
+            mesh.matrix.elements[matTx] -= aabbOrigin.xyz[0]
+            mesh.matrix.elements[matTy] -= aabbOrigin.xyz[1]
+            mesh.matrix.elements[matTz] -= aabbOrigin.xyz[2]
+            if (aabbRing.length >= aabbCap) {
+              const old = aabbRing.shift()
+              if (old !== undefined && session.previewGroup !== null) {
+                session.previewGroup.remove(old)
+              }
+            }
+            aabbRing.push(mesh)
+          }
+          session.addPreviewMesh(mesh)
         } catch (e) {
           debug(WARN).warn('parse preview mesh skipped:', e)
         }

--- a/src/viewer/ifc/ShareIfcLoader.js
+++ b/src/viewer/ifc/ShareIfcLoader.js
@@ -104,6 +104,15 @@ export const AABB_IMPOSTER_CAP = 100
 
 
 /**
+ * Whether parse-time spatial imposters (the storey/space AABB plates) are
+ * rendered. Off: they are cosmetic, and the last unpolished corner of an
+ * otherwise release-ready load path. The real prefix meshes still stream
+ * during parse, so first pixels are unaffected.
+ */
+const SHOW_AABB_IMPOSTERS = false
+
+
+/**
  * Add an AABB wire cube to the preview, keyed by expressID and
  * ring-tracked for eviction.
  *
@@ -356,6 +365,16 @@ export default class ShareIfcLoader {
             return
           }
           if (payload.aabb) {
+            // Spatial imposters are off for this release: the plates are
+            // the least-settled part of the preview channel (rotation,
+            // scale and banding each took a conway round to get right)
+            // and they are cosmetic — the real prefix meshes below give
+            // first pixels on their own. Dropping the payload rather
+            // than asking conway not to emit it keeps the engine
+            // contract unchanged, so flipping this back is one constant.
+            if (!SHOW_AABB_IMPOSTERS) {
+              return
+            }
             applyAabbImposter(mesh, session, aabbRing, payload.expressID)
             return
           }

--- a/src/viewer/ifc/conwayDirectIfcLoader.js
+++ b/src/viewer/ifc/conwayDirectIfcLoader.js
@@ -158,12 +158,39 @@ export async function parseIfcWithConway(
     // onto the screen and one that shows nothing until the end-of-load
     // build, and until now the log said nothing either way — a blank
     // 9-second parse and a healthy streaming parse looked identical.
+    //
+    // Conway's deferred open only emits headerParse/dataParse; the
+    // pump never starts a geometry phase. Report one here so the load
+    // log splits Parsing from Geometry (same labels as a classic
+    // extractIFCGeometryData open). elapsedMs omitted: the reporter
+    // stamps wall-clock so we don't fight Conway's parse-relative clock.
     let pumpedBatches = 0
+    let geometryTotal
+    let geometryDone = 0
+    const reportGeometry = (completed, total) => {
+      if (typeof onProgress !== 'function') {
+        return
+      }
+      onProgress({
+        phase: 'geometry',
+        completed,
+        total,
+        unit: 'products',
+      })
+    }
     for (;;) {
       const batch = []
       // eslint-disable-next-line new-cap
       const {extracted, remaining} = ifcAPI.ExtractGeometryBatch(
         modelID, DEMAND_EXTRACT_BATCH_SIZE, (flatMesh) => batch.push(flatMesh))
+      if (geometryTotal === undefined && (extracted > 0 || remaining > 0)) {
+        geometryTotal = extracted + remaining
+        reportGeometry(0, geometryTotal)
+      }
+      geometryDone += extracted
+      if (geometryTotal !== undefined) {
+        reportGeometry(geometryDone, geometryTotal)
+      }
       if (batch.length > 0) {
         captured.push(...batch)
         pumpedBatches++

--- a/src/viewer/ifc/conwayDirectIfcLoader.js
+++ b/src/viewer/ifc/conwayDirectIfcLoader.js
@@ -207,9 +207,14 @@ export async function parseIfcWithConway(
       let extracted
       let remaining
       if (typeof ifcAPI.ExtractGeometryBatchAsync === 'function') {
+        // Store-backed extract pages each product's #ref closure from
+        // OPFS before extracting it. A 64-product batch serialises
+        // that I/O and holds first pixels until ~halfway through
+        // Geometry; 8 keeps file-order streaming and still amortises
+        // the per-batch scene update.
         // eslint-disable-next-line new-cap
         const pumped = await ifcAPI.ExtractGeometryBatchAsync(
-          modelID, DEMAND_EXTRACT_BATCH_SIZE, (flatMesh) => batch.push(flatMesh))
+          modelID, ASYNC_DEMAND_EXTRACT_BATCH_SIZE, (flatMesh) => batch.push(flatMesh))
         extracted = pumped.extracted
         remaining = pumped.remaining
       } else {
@@ -324,8 +329,11 @@ export async function parseIfcWithConway(
 
 // Products extracted per demand batch: large enough that per-batch
 // capture/render overhead amortizes, small enough that first pixels
-// arrive within a couple of seconds of parse completing.
+// arrive within a couple of seconds of parse completing. The async
+// (store-backed) path is smaller because each product pays OPFS
+// prefetch before extract — see ExtractGeometryBatchAsync above.
 const DEMAND_EXTRACT_BATCH_SIZE = 64
+const ASYNC_DEMAND_EXTRACT_BATCH_SIZE = 8
 
 
 /**

--- a/src/viewer/ifc/conwayDirectIfcLoader.js
+++ b/src/viewer/ifc/conwayDirectIfcLoader.js
@@ -139,7 +139,11 @@ export async function parseIfcWithConway(
       !isFeatureEnabled('disableStreamOpen') &&
       typeof ifcAPI.OpenModelStreamed === 'function' &&
       typeof ifcAPI.ExtractGeometryBatch === 'function') {
-    const deferSettings = {...openSettings, DEFER_GEOMETRY: true}
+    const deferSettings = {
+      ...openSettings,
+      DEFER_GEOMETRY: true,
+      GEOMETRY_BUDGET_MB: GEOMETRY_BUDGET_MB,
+    }
     if (onPreviewMesh) {
       // Slice A2 (parse-time preview channel): conway emits preview
       // payloads between the parse's cooperative yields. Passing the
@@ -254,6 +258,28 @@ export async function parseIfcWithConway(
 // Products extracted per demand batch: large enough that per-batch
 // capture/render overhead amortizes, small enough that first pixels
 // arrive within a couple of seconds of parse completing.
+/**
+ * Cap on the native geometry conway keeps resident, in MB, for the deferred
+ * path only. Least-recently-used assets are evicted at each pump batch.
+ *
+ * Measured engine-side on PSB (860 MB) at our batch size: the wasm high-water
+ * falls from 1284 MB to 298 MB, with the geometry stage slightly faster
+ * (23.6s against 25.7s) and identical delivered meshes. 256 MB was also
+ * measured and buys much less (803 MB), because the live set rarely reaches
+ * the ceiling. The heap runs 3-4x the budget — allocator overhead and
+ * fragmentation — so this targets roughly a 300 MB residency, not 64 MB.
+ *
+ * Safe here for one specific reason: eviction frees an asset from
+ * GetGeometry until something re-extracts it, and this loader copies every
+ * payload at delivery (the bldrs-ai/Share#1640 invariant). A change that
+ * made it hold geometry IDs and fetch them later would break quietly, so
+ * that invariant is now load-bearing rather than merely true.
+ *
+ * Ignored by engines predating conway#535 — unknown settings are dropped —
+ * so this is inert until the conway bump in #1753 lands.
+ */
+const GEOMETRY_BUDGET_MB = 64
+
 const DEMAND_EXTRACT_BATCH_SIZE = 64
 
 

--- a/src/viewer/ifc/conwayDirectIfcLoader.js
+++ b/src/viewer/ifc/conwayDirectIfcLoader.js
@@ -122,7 +122,7 @@ export async function parseIfcWithConway(
       typeof ifcAPI.OpenModelStream === 'function' ?
     makeBlobByteStore(buffer) :
     null
-  const data = store === null ?
+  let data = store === null ?
     (buffer instanceof Uint8Array ? buffer : new Uint8Array(buffer)) :
     null
   let openSettings = settings ?? {COORDINATE_TO_ORIGIN: true, USE_FAST_BOOLS: true}
@@ -158,12 +158,20 @@ export async function parseIfcWithConway(
       deferSettings.ON_PREVIEW_MESH = onPreviewMesh
     }
     let modelID
+    let openData = data
     if (store !== null) {
       // eslint-disable-next-line new-cap
       modelID = await ifcAPI.OpenModelStream(store, deferSettings)
+      if (typeof modelID !== 'number' || modelID < 0) {
+        // IFC-only store path: STEP / failed sniff falls back to a
+        // buffered streamed open (conway#510 contract).
+        openData = await bytesFromSource(buffer)
+        // eslint-disable-next-line new-cap
+        modelID = await ifcAPI.OpenModelStreamed(openData, deferSettings)
+      }
     } else {
       // eslint-disable-next-line new-cap
-      modelID = await ifcAPI.OpenModelStreamed(data, deferSettings)
+      modelID = await ifcAPI.OpenModelStreamed(openData, deferSettings)
     }
     if (typeof modelID !== 'number' || modelID < 0) {
       throw new Error(`parseIfcWithConway: OpenModel returned ${modelID}`)
@@ -287,6 +295,11 @@ export async function parseIfcWithConway(
   if (!isFeatureEnabled('disableStreamOpen') && store !== null) {
     // eslint-disable-next-line new-cap
     modelID = await ifcAPI.OpenModelStream(store, openSettings)
+    if (typeof modelID !== 'number' || modelID < 0) {
+      data = await bytesFromSource(buffer)
+      // eslint-disable-next-line new-cap
+      modelID = await ifcAPI.OpenModelStreamed(data, openSettings)
+    }
   } else if (!isFeatureEnabled('disableStreamOpen') && typeof ifcAPI.OpenModelStreamed === 'function') {
     // eslint-disable-next-line new-cap
     modelID = await ifcAPI.OpenModelStreamed(data, openSettings)
@@ -325,6 +338,26 @@ function isBlobSource(value) {
   return value !== null && value !== undefined &&
     typeof value.size === 'number' && typeof value.slice === 'function' &&
     !(value instanceof ArrayBuffer) && !ArrayBuffer.isView(value)
+}
+
+
+/**
+ * Materialise a parse source as a Uint8Array (store-open fallback).
+ *
+ * @param {ArrayBuffer|Uint8Array|Blob} source
+ * @return {Promise<Uint8Array>}
+ */
+async function bytesFromSource(source) {
+  if (source instanceof Uint8Array) {
+    return source
+  }
+  if (source instanceof ArrayBuffer) {
+    return new Uint8Array(source)
+  }
+  if (typeof source?.arrayBuffer === 'function') {
+    return new Uint8Array(await source.arrayBuffer())
+  }
+  throw new Error('parseIfcWithConway: cannot buffer source for fallback open')
 }
 
 

--- a/src/viewer/ifc/conwayDirectIfcLoader.js
+++ b/src/viewer/ifc/conwayDirectIfcLoader.js
@@ -48,6 +48,7 @@
 
 import {isFeatureEnabled} from '../../FeatureFlags'
 import {reportEngineVersion} from '../../loader/loadProgress'
+import {makeBlobByteStore} from '../../loader/opfsSourceByteStore'
 import debug, {WARN} from '../../utils/debug'
 import {attachInstanceMapSubsets} from '../three/elementSubsets'
 import {instanceMapFromGeometry} from './IfcInstanceMap'
@@ -116,7 +117,14 @@ export async function parseIfcWithConway(
   if (typeof ifcAPI.getConwayVersion === 'function') {
     reportEngineVersion(ifcAPI.getConwayVersion())
   }
-  const data = buffer instanceof Uint8Array ? buffer : new Uint8Array(buffer)
+  const store = isBlobSource(buffer) &&
+      !isFeatureEnabled('disableStreamOpen') &&
+      typeof ifcAPI.OpenModelStream === 'function' ?
+    makeBlobByteStore(buffer) :
+    null
+  const data = store === null ?
+    (buffer instanceof Uint8Array ? buffer : new Uint8Array(buffer)) :
+    null
   let openSettings = settings ?? {COORDINATE_TO_ORIGIN: true, USE_FAST_BOOLS: true}
   if (onProgress) {
     // ON_MODEL_INFO (conway extension) arrives once, right after the header
@@ -137,8 +145,10 @@ export async function parseIfcWithConway(
   // through to the classic selection below.
   if (isFeatureEnabled('demandGeometry') &&
       !isFeatureEnabled('disableStreamOpen') &&
-      typeof ifcAPI.OpenModelStreamed === 'function' &&
-      typeof ifcAPI.ExtractGeometryBatch === 'function') {
+      (typeof ifcAPI.OpenModelStreamed === 'function' ||
+        typeof ifcAPI.OpenModelStream === 'function') &&
+      (typeof ifcAPI.ExtractGeometryBatch === 'function' ||
+        typeof ifcAPI.ExtractGeometryBatchAsync === 'function')) {
     const deferSettings = {...openSettings, DEFER_GEOMETRY: true}
     if (onPreviewMesh) {
       // Slice A2 (parse-time preview channel): conway emits preview
@@ -147,8 +157,14 @@ export async function parseIfcWithConway(
       // settings are ignored), so no feature detection is needed here.
       deferSettings.ON_PREVIEW_MESH = onPreviewMesh
     }
-    // eslint-disable-next-line new-cap
-    const modelID = await ifcAPI.OpenModelStreamed(data, deferSettings)
+    let modelID
+    if (store !== null) {
+      // eslint-disable-next-line new-cap
+      modelID = await ifcAPI.OpenModelStream(store, deferSettings)
+    } else {
+      // eslint-disable-next-line new-cap
+      modelID = await ifcAPI.OpenModelStreamed(data, deferSettings)
+    }
     if (typeof modelID !== 'number' || modelID < 0) {
       throw new Error(`parseIfcWithConway: OpenModel returned ${modelID}`)
     }
@@ -180,9 +196,21 @@ export async function parseIfcWithConway(
     }
     for (;;) {
       const batch = []
-      // eslint-disable-next-line new-cap
-      const {extracted, remaining} = ifcAPI.ExtractGeometryBatch(
-        modelID, DEMAND_EXTRACT_BATCH_SIZE, (flatMesh) => batch.push(flatMesh))
+      let extracted
+      let remaining
+      if (typeof ifcAPI.ExtractGeometryBatchAsync === 'function') {
+        // eslint-disable-next-line new-cap
+        const pumped = await ifcAPI.ExtractGeometryBatchAsync(
+          modelID, DEMAND_EXTRACT_BATCH_SIZE, (flatMesh) => batch.push(flatMesh))
+        extracted = pumped.extracted
+        remaining = pumped.remaining
+      } else {
+        // eslint-disable-next-line new-cap
+        const pumped = ifcAPI.ExtractGeometryBatch(
+          modelID, DEMAND_EXTRACT_BATCH_SIZE, (flatMesh) => batch.push(flatMesh))
+        extracted = pumped.extracted
+        remaining = pumped.remaining
+      }
       if (geometryTotal === undefined && (extracted > 0 || remaining > 0)) {
         geometryTotal = extracted + remaining
         reportGeometry(0, geometryTotal)
@@ -256,7 +284,10 @@ export async function parseIfcWithConway(
   //   3. OpenModel: classic synchronous open (real web-ifc, old pins).
   // All feature-detected, so any engine pin keeps loading.
   let modelID
-  if (!isFeatureEnabled('disableStreamOpen') && typeof ifcAPI.OpenModelStreamed === 'function') {
+  if (!isFeatureEnabled('disableStreamOpen') && store !== null) {
+    // eslint-disable-next-line new-cap
+    modelID = await ifcAPI.OpenModelStream(store, openSettings)
+  } else if (!isFeatureEnabled('disableStreamOpen') && typeof ifcAPI.OpenModelStreamed === 'function') {
     // eslint-disable-next-line new-cap
     modelID = await ifcAPI.OpenModelStreamed(data, openSettings)
   } else if (typeof ifcAPI.OpenModelAsync === 'function') {
@@ -282,6 +313,19 @@ export async function parseIfcWithConway(
 // capture/render overhead amortizes, small enough that first pixels
 // arrive within a couple of seconds of parse completing.
 const DEMAND_EXTRACT_BATCH_SIZE = 64
+
+
+/**
+ * A Blob/File the M1b store-backed open can read via `slice()`.
+ *
+ * @param {unknown} value
+ * @return {boolean}
+ */
+function isBlobSource(value) {
+  return value !== null && value !== undefined &&
+    typeof value.size === 'number' && typeof value.slice === 'function' &&
+    !(value instanceof ArrayBuffer) && !ArrayBuffer.isView(value)
+}
 
 
 /**

--- a/src/viewer/ifc/conwayDirectIfcLoader.test.js
+++ b/src/viewer/ifc/conwayDirectIfcLoader.test.js
@@ -190,6 +190,9 @@ describe('viewer/ifc/conwayDirectIfcLoader', () => {
         // Deferred settings rode the open.
         const [, settings] = ifcAPI.OpenModelStreamed.mock.calls[0]
         expect(settings.DEFER_GEOMETRY).toBe(true)
+        // The residency budget rides on the deferred path only, and is what
+        // keeps the wasm high-water bounded (PSB: 1284 MB -> 298 MB).
+        expect(settings.GEOMETRY_BUDGET_MB).toBe(64)
         // 150 products in batches of 64 → 3 extraction rounds; all
         // meshes accumulate AND stream incrementally.
         expect(result.captured).toHaveLength(150)
@@ -207,6 +210,9 @@ describe('viewer/ifc/conwayDirectIfcLoader', () => {
         expect(result.modelID).toBe(5)
         const [, settings] = ifcAPI.OpenModelStreamed.mock.calls[0]
         expect(settings?.DEFER_GEOMETRY).toBeUndefined()
+        // ...and never on the classic path, which does not pump and would
+        // have geometry evicted from under a consumer reading it later.
+        expect(settings?.GEOMETRY_BUDGET_MB).toBeUndefined()
         expect(ifcAPI.StreamAllMeshes).toHaveBeenCalledTimes(1)
       })
 

--- a/src/viewer/ifc/conwayDirectIfcLoader.test.js
+++ b/src/viewer/ifc/conwayDirectIfcLoader.test.js
@@ -291,6 +291,26 @@ describe('viewer/ifc/conwayDirectIfcLoader', () => {
         const [, settings] = ifcAPI.OpenModelStreamed.mock.calls[0]
         expect(settings.ON_PREVIEW_MESH).toBeUndefined()
       })
+
+      it('opens a File via OpenModelStream and pumps ExtractGeometryBatchAsync', async () => {
+        mockIsFeatureEnabled.mockImplementation((name) => name === 'demandGeometry')
+        const ifcAPI = makeDemandAPI(10)
+        ifcAPI.OpenModelStream = jest.fn(() => Promise.resolve(3))
+        ifcAPI.ExtractGeometryBatchAsync = jest.fn((modelID, batchSize, cb) =>
+          // eslint-disable-next-line new-cap
+          ifcAPI.ExtractGeometryBatch(modelID, batchSize, cb))
+        const file = new Blob([new Uint8Array([1, 2, 3, 4])])
+        const result = await parseIfcWithConway(file, ifcAPI)
+        expect(result.modelID).toBe(3)
+        expect(ifcAPI.OpenModelStream).toHaveBeenCalledTimes(1)
+        const [store, settings] = ifcAPI.OpenModelStream.mock.calls[0]
+        expect(store.byteLength).toBe(4)
+        expect(typeof store.read).toBe('function')
+        expect(settings.DEFER_GEOMETRY).toBe(true)
+        expect(ifcAPI.OpenModelStreamed).not.toHaveBeenCalled()
+        expect(ifcAPI.ExtractGeometryBatchAsync).toHaveBeenCalled()
+        expect(result.captured).toHaveLength(10)
+      })
     })
 
     describe('open-path selection (disableStreamOpen flag)', () => {

--- a/src/viewer/ifc/conwayDirectIfcLoader.test.js
+++ b/src/viewer/ifc/conwayDirectIfcLoader.test.js
@@ -198,6 +198,19 @@ describe('viewer/ifc/conwayDirectIfcLoader', () => {
         expect(ifcAPI.StreamAllMeshes).not.toHaveBeenCalled()
       })
 
+      it('reports a Geometry progress stage across the demand pump', async () => {
+        mockIsFeatureEnabled.mockImplementation((name) => name === 'demandGeometry')
+        const ifcAPI = makeDemandAPI(150)
+        const progress = []
+        await parseIfcWithConway(
+          new ArrayBuffer(4), ifcAPI, undefined, (event) => progress.push(event))
+        const geometry = progress.filter((event) => event.phase === 'geometry')
+        expect(geometry.length).toBeGreaterThan(1)
+        expect(geometry[0]).toMatchObject({completed: 0, total: 150, unit: 'products'})
+        expect(geometry[geometry.length - 1]).toMatchObject({completed: 150, total: 150})
+        expect(geometry.every((event) => event.elapsedMs === undefined)).toBe(true)
+      })
+
       it('falls through to the classic selection when the engine lacks the pump', async () => {
         mockIsFeatureEnabled.mockImplementation((name) => name === 'demandGeometry')
         const ifcAPI = makeDemandAPI(10)

--- a/src/viewer/ifc/conwayDirectIfcLoader.test.js
+++ b/src/viewer/ifc/conwayDirectIfcLoader.test.js
@@ -311,6 +311,20 @@ describe('viewer/ifc/conwayDirectIfcLoader', () => {
         expect(ifcAPI.ExtractGeometryBatchAsync).toHaveBeenCalled()
         expect(result.captured).toHaveLength(10)
       })
+
+      it('falls back to OpenModelStreamed when OpenModelStream returns -1', async () => {
+        mockIsFeatureEnabled.mockImplementation((name) => name === 'demandGeometry')
+        const ifcAPI = makeDemandAPI(10)
+        ifcAPI.OpenModelStream = jest.fn(() => Promise.resolve(-1))
+        const file = new Blob([new Uint8Array([1, 2, 3, 4])])
+        const result = await parseIfcWithConway(file, ifcAPI)
+        expect(result.modelID).toBe(5)
+        expect(ifcAPI.OpenModelStream).toHaveBeenCalledTimes(1)
+        expect(ifcAPI.OpenModelStreamed).toHaveBeenCalledTimes(1)
+        const [data] = ifcAPI.OpenModelStreamed.mock.calls[0]
+        expect(data).toBeInstanceOf(Uint8Array)
+        expect(result.captured).toHaveLength(10)
+      })
     })
 
     describe('open-path selection (disableStreamOpen flag)', () => {

--- a/src/viewer/ifc/conwayDirectIfcLoader.test.js
+++ b/src/viewer/ifc/conwayDirectIfcLoader.test.js
@@ -309,6 +309,7 @@ describe('viewer/ifc/conwayDirectIfcLoader', () => {
         expect(settings.DEFER_GEOMETRY).toBe(true)
         expect(ifcAPI.OpenModelStreamed).not.toHaveBeenCalled()
         expect(ifcAPI.ExtractGeometryBatchAsync).toHaveBeenCalled()
+        expect(ifcAPI.ExtractGeometryBatchAsync.mock.calls[0][1]).toBe(8)
         expect(result.captured).toHaveLength(10)
       })
 

--- a/src/viewer/ifc/parsePreviewMesh.js
+++ b/src/viewer/ifc/parsePreviewMesh.js
@@ -50,7 +50,7 @@ const AABB_GEOMETRY_KEY = -1
  */
 export function payloadToPreviewMesh(payload, geometryCache, materialCache, coordination = null) {
   if (payload.aabb) {
-    return aabbPayloadToMesh_(payload, geometryCache, materialCache)
+    return aabbPayloadToMesh_(payload, geometryCache, materialCache, coordination)
   }
   let geometry = geometryCache.get(payload.geometryExpressID)
   if (geometry === undefined) {
@@ -79,16 +79,30 @@ export function payloadToPreviewMesh(payload, geometryCache, materialCache, coor
   const mesh = new Mesh(geometry, material)
   mesh.matrixAutoUpdate = false
   mesh.matrix.fromArray(payload.flatTransformation)
-  // Read-only: `offset === undefined` means the durable builder has not
-  // decided the frame yet — render unrecentred rather than letting an
-  // untrusted preview payload decide it (see the coordination param doc).
-  if (coordination !== null &&
-      coordination.offset !== undefined && coordination.offset !== null) {
-    mesh.matrix.elements[12] -= coordination.offset[0]
-    mesh.matrix.elements[13] -= coordination.offset[1]
-    mesh.matrix.elements[14] -= coordination.offset[2]
-  }
+  recenterOntoCoordination_(mesh, coordination)
   return mesh
+}
+
+
+/**
+ * Subtract the shared origin-recenter offset from an already-stamped
+ * preview matrix. READ-ONLY on `coordination`: `offset === undefined`
+ * means the durable builder has not decided the frame yet — render
+ * unrecentred rather than letting an untrusted preview payload decide it
+ * (see the `coordination` param doc on `payloadToPreviewMesh`).
+ *
+ * @param {object} mesh Mesh whose `matrix` is already `fromArray`'d
+ * @param {object|null} coordination shared frame, `{offset}`
+ */
+function recenterOntoCoordination_(mesh, coordination) {
+  if (coordination === null ||
+      coordination.offset === undefined || coordination.offset === null) {
+    return
+  }
+  const [ox, oy, oz] = coordination.offset
+  mesh.matrix.elements[12] -= ox
+  mesh.matrix.elements[13] -= oy
+  mesh.matrix.elements[14] -= oz
 }
 
 
@@ -96,12 +110,28 @@ export function payloadToPreviewMesh(payload, geometryCache, materialCache, coor
  * Shared unit cube + per-payload transform. One BufferGeometry for the
  * whole load; Share recycles the last N Mesh wrappers.
  *
+ * Imposters are coordinated exactly like carrier payloads: conway emits
+ * their `flatTransformation` in the same durable frame (metres, Y-up,
+ * recentred by COORDINATE_TO_ORIGIN) as regular preview meshes, so the
+ * only Share-side adjustment is the shared `coordination` offset. It used
+ * to arrive in raw IFC model space, which Share compensated for by
+ * re-anchoring the boxes onto the first one that landed — an arbitrary
+ * anchor that offset the plates from the durable geometry, and invented
+ * an offset on near-origin models where conway recentres nothing. See
+ * conway#515's review-findings comment for the frame contract.
+ * `payload.aabb` itself stays RAW model-space bounds, for reference only:
+ * it is the "is this an imposter?" discriminator here, never a source of
+ * placement. `payload.solid` is still honoured when present, but conway
+ * stopped sending it in the same change — plates fall through to the
+ * wireframe default.
+ *
  * @param {object} payload
  * @param {Map} geometryCache
  * @param {Map} materialCache
+ * @param {object} [coordination] shared origin-recenter frame, `{offset}`
  * @return {object}
  */
-function aabbPayloadToMesh_(payload, geometryCache, materialCache) {
+function aabbPayloadToMesh_(payload, geometryCache, materialCache, coordination = null) {
   let geometry = geometryCache.get(AABB_GEOMETRY_KEY)
   if (geometry === undefined) {
     geometry = new BoxGeometry(1, 1, 1)
@@ -123,6 +153,7 @@ function aabbPayloadToMesh_(payload, geometryCache, materialCache) {
   const mesh = new Mesh(geometry, material)
   mesh.matrixAutoUpdate = false
   mesh.matrix.fromArray(payload.flatTransformation)
+  recenterOntoCoordination_(mesh, coordination)
   mesh.userData.aabbImposter = true
   return mesh
 }

--- a/src/viewer/ifc/parsePreviewMesh.js
+++ b/src/viewer/ifc/parsePreviewMesh.js
@@ -108,11 +108,12 @@ function aabbPayloadToMesh_(payload, geometryCache, materialCache) {
     geometryCache.set(AABB_GEOMETRY_KEY, geometry)
   }
   const {x, y, z, w} = payload.color
-  const materialKey = `aabb:${x},${y},${z},${w}`
+  const filled = payload.solid === true
+  const materialKey = `aabb:${x},${y},${z},${w}:${filled ? 'solid' : 'wire'}`
   let material = materialCache.get(materialKey)
   if (material === undefined) {
     material = makeSurfaceMaterial({color: makeSurfaceColor(x, y, z), side: DoubleSide})
-    material.wireframe = true
+    material.wireframe = !filled
     if (w !== 1) {
       material.transparent = true
       material.opacity = w

--- a/src/viewer/ifc/parsePreviewMesh.js
+++ b/src/viewer/ifc/parsePreviewMesh.js
@@ -1,4 +1,5 @@
 import {
+  BoxGeometry,
   BufferAttribute,
   BufferGeometry,
   DoubleSide,
@@ -7,6 +8,9 @@ import {
   Mesh,
 } from 'three'
 import {makeSurfaceColor, makeSurfaceMaterial} from '../lookMaterial'
+
+
+const AABB_GEOMETRY_KEY = -1
 
 
 /**
@@ -45,6 +49,9 @@ import {makeSurfaceColor, makeSurfaceMaterial} from '../lookMaterial'
  *   references geometry this load has not seen (nothing to render)
  */
 export function payloadToPreviewMesh(payload, geometryCache, materialCache, coordination = null) {
+  if (payload.aabb) {
+    return aabbPayloadToMesh_(payload, geometryCache, materialCache)
+  }
   let geometry = geometryCache.get(payload.geometryExpressID)
   if (geometry === undefined) {
     if (payload.vertexData === undefined || payload.indexData === undefined) {
@@ -81,5 +88,40 @@ export function payloadToPreviewMesh(payload, geometryCache, materialCache, coor
     mesh.matrix.elements[13] -= coordination.offset[1]
     mesh.matrix.elements[14] -= coordination.offset[2]
   }
+  return mesh
+}
+
+
+/**
+ * Shared unit cube + per-payload transform. One BufferGeometry for the
+ * whole load; Share recycles the last N Mesh wrappers.
+ *
+ * @param {object} payload
+ * @param {Map} geometryCache
+ * @param {Map} materialCache
+ * @return {object}
+ */
+function aabbPayloadToMesh_(payload, geometryCache, materialCache) {
+  let geometry = geometryCache.get(AABB_GEOMETRY_KEY)
+  if (geometry === undefined) {
+    geometry = new BoxGeometry(1, 1, 1)
+    geometryCache.set(AABB_GEOMETRY_KEY, geometry)
+  }
+  const {x, y, z, w} = payload.color
+  const materialKey = `aabb:${x},${y},${z},${w}`
+  let material = materialCache.get(materialKey)
+  if (material === undefined) {
+    material = makeSurfaceMaterial({color: makeSurfaceColor(x, y, z), side: DoubleSide})
+    material.wireframe = true
+    if (w !== 1) {
+      material.transparent = true
+      material.opacity = w
+    }
+    materialCache.set(materialKey, material)
+  }
+  const mesh = new Mesh(geometry, material)
+  mesh.matrixAutoUpdate = false
+  mesh.matrix.fromArray(payload.flatTransformation)
+  mesh.userData.aabbImposter = true
   return mesh
 }

--- a/src/viewer/ifc/parsePreviewMesh.test.js
+++ b/src/viewer/ifc/parsePreviewMesh.test.js
@@ -86,6 +86,24 @@ describe('viewer/ifc/parsePreviewMesh', () => {
     expect(geometryCache.size).toBe(1)
   })
 
+
+  it('does not apply the durable coordination offset to aabb imposters', () => {
+    const mesh = payloadToPreviewMesh(
+      makePayload({
+        aabb: {min: [0, 0, 0], max: [1, 1, 1]},
+        vertexData: undefined,
+        indexData: undefined,
+        geometryExpressID: -1,
+      }),
+      new Map(),
+      new Map(),
+      {offset: [100, 200, 300]},
+    )
+    expect(mesh.matrix.elements[12]).toBe(10)
+    expect(mesh.matrix.elements[13]).toBe(20)
+    expect(mesh.matrix.elements[14]).toBe(30)
+  })
+
   it('marks translucent colors transparent', () => {
     const materialCache = new Map()
     const mesh = payloadToPreviewMesh(

--- a/src/viewer/ifc/parsePreviewMesh.test.js
+++ b/src/viewer/ifc/parsePreviewMesh.test.js
@@ -87,6 +87,25 @@ describe('viewer/ifc/parsePreviewMesh', () => {
   })
 
 
+  it('fills spatial-structure imposters when payload.solid is set', () => {
+    const mesh = payloadToPreviewMesh(
+      makePayload({
+        aabb: {min: [0, 0, 0], max: [2, 4, 6]},
+        solid: true,
+        color: {x: 0, y: 0, z: 0, w: 0.3},
+        vertexData: undefined,
+        indexData: undefined,
+        geometryExpressID: -1,
+      }),
+      new Map(),
+      new Map())
+    expect(mesh.material.wireframe).toBe(false)
+    expect(mesh.material.transparent).toBe(true)
+    expect(mesh.material.opacity).toBe(0.3)
+    expect(mesh.userData.aabbImposter).toBe(true)
+  })
+
+
   it('does not apply the durable coordination offset to aabb imposters', () => {
     const mesh = payloadToPreviewMesh(
       makePayload({

--- a/src/viewer/ifc/parsePreviewMesh.test.js
+++ b/src/viewer/ifc/parsePreviewMesh.test.js
@@ -58,6 +58,34 @@ describe('viewer/ifc/parsePreviewMesh', () => {
     expect(mesh).toBeNull()
   })
 
+  it('instances a shared unit cube for aabb imposters', () => {
+    const geometryCache = new Map()
+    const materialCache = new Map()
+    const aabb = {min: [0, 0, 0], max: [2, 4, 6]}
+    const first = payloadToPreviewMesh(
+      makePayload({
+        aabb,
+        vertexData: undefined,
+        indexData: undefined,
+        geometryExpressID: -1,
+      }),
+      geometryCache, materialCache)
+    const second = payloadToPreviewMesh(
+      makePayload({
+        expressID: 99,
+        aabb,
+        vertexData: undefined,
+        indexData: undefined,
+        geometryExpressID: -1,
+      }),
+      geometryCache, materialCache)
+    expect(first).not.toBeNull()
+    expect(first.material.wireframe).toBe(true)
+    expect(first.userData.aabbImposter).toBe(true)
+    expect(second.geometry).toBe(first.geometry)
+    expect(geometryCache.size).toBe(1)
+  })
+
   it('marks translucent colors transparent', () => {
     const materialCache = new Map()
     const mesh = payloadToPreviewMesh(

--- a/src/viewer/ifc/parsePreviewMesh.test.js
+++ b/src/viewer/ifc/parsePreviewMesh.test.js
@@ -106,21 +106,58 @@ describe('viewer/ifc/parsePreviewMesh', () => {
   })
 
 
-  it('does not apply the durable coordination offset to aabb imposters', () => {
+  /**
+   * @param {object} [overrides] payload field overrides
+   * @return {object} an imposter payload (box, no vertex/index data)
+   */
+  function makeAabbPayload(overrides = {}) {
+    return makePayload({
+      aabb: {min: [0, 0, 0], max: [1, 1, 1]},
+      vertexData: undefined,
+      indexData: undefined,
+      geometryExpressID: -1,
+      ...overrides,
+    })
+  }
+
+
+  // Imposters arrive in the same durable frame as carrier payloads
+  // (conway#515 review findings), so they take the same Share-side
+  // recentre — no imposter-specific anchoring anywhere.
+  it('applies the durable coordination offset to aabb imposters', () => {
     const mesh = payloadToPreviewMesh(
-      makePayload({
-        aabb: {min: [0, 0, 0], max: [1, 1, 1]},
-        vertexData: undefined,
-        indexData: undefined,
-        geometryExpressID: -1,
-      }),
-      new Map(),
-      new Map(),
-      {offset: [100, 200, 300]},
-    )
+      makeAabbPayload(), new Map(), new Map(), {offset: [100, 200, 300]})
+    expect(mesh.matrix.elements[12]).toBe(-90)
+    expect(mesh.matrix.elements[13]).toBe(-180)
+    expect(mesh.matrix.elements[14]).toBe(-270)
+  })
+
+
+  it.each([
+    ['undefined', undefined],
+    ['null', null],
+  ])('renders aabb imposters unrecentred while offset is %s', (label, offset) => {
+    const mesh = payloadToPreviewMesh(
+      makeAabbPayload(), new Map(), new Map(), {offset})
     expect(mesh.matrix.elements[12]).toBe(10)
     expect(mesh.matrix.elements[13]).toBe(20)
     expect(mesh.matrix.elements[14]).toBe(30)
+  })
+
+
+  it('never latches the coordination frame from an aabb imposter', () => {
+    const coordination = {offset: undefined}
+    payloadToPreviewMesh(makeAabbPayload(), new Map(), new Map(), coordination)
+    expect(coordination.offset).toBeUndefined()
+  })
+
+
+  it('applies the durable coordination offset to carrier payloads', () => {
+    const mesh = payloadToPreviewMesh(
+      makePayload(), new Map(), new Map(), {offset: [1, 2, 3]})
+    expect(mesh.matrix.elements[12]).toBe(9)
+    expect(mesh.matrix.elements[13]).toBe(18)
+    expect(mesh.matrix.elements[14]).toBe(27)
   })
 
   it('marks translucent colors transparent', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2473,10 +2473,10 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@bldrs-ai/conway@1.549.1515":
-  version "1.549.1515"
-  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.549.1515.tgz#230253f6b55a0b1a79a07b477b7a2507a0c8edac"
-  integrity sha512-rBPoCMDnt2yddZg6TVwctgrkfY5oF98iI9rO4O1Ybyd2NjBiNLX6xDCE8eoZrsWGCEwT5ttv1pqDQDNtvKNk9A==
+"@bldrs-ai/conway@1.560.1539":
+  version "1.560.1539"
+  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.560.1539.tgz#b415a4cf41d180015853ce3365f631c069b4e55e"
+  integrity sha512-3jk+MHhR5m9L4Bkyqdjk91LCnEW0rDecO6/2yMu+sdKr05+cS/H8mtFywSOJOaApZLAnL63/Bet943fpNAPBAQ==
   dependencies:
     gl-matrix "3.4.3"
     seedrandom "3.0.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2473,10 +2473,10 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@bldrs-ai/conway@1.516.1463":
-  version "1.516.1463"
-  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.516.1463.tgz#fea9d32ed899fd844022f195d4dd897b8b0036f8"
-  integrity sha512-SumWfZzuI3WwlqW+ZqR2ggXmHjYmCePu2rrpIbhwlg43viIsS0rYC8jDHLvDOFsvRtgv7YZV4rcmmkJ3vzhaYA==
+"@bldrs-ai/conway@1.519.1471":
+  version "1.519.1471"
+  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.519.1471.tgz#3d18164363a43f04ccb788974fffcce09a0ac2d2"
+  integrity sha512-RZj0ExQnoWhsfWBWvA6KKPg/Qa/vWZH5aVeo2MmD7zxVopk0fBbc3IkwMIjLX3OgcPazDIO6/VEFhIxuCDzj1Q==
   dependencies:
     gl-matrix "3.4.3"
     seedrandom "3.0.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2473,10 +2473,10 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@bldrs-ai/conway@1.535.1506":
-  version "1.535.1506"
-  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.535.1506.tgz#92cb1a3f9b8f023d7fb2cb28ae95c95d514a39ac"
-  integrity sha512-A4DsIWMRNJ2gf6QPzjhQWDtfoXdgmb02xA+HDX6UPCQixJPu7xxTTeo9bK06cDedZFLyYc8msf15yaenITGbgQ==
+"@bldrs-ai/conway@1.536.1507":
+  version "1.536.1507"
+  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.536.1507.tgz#8a7c7113a691beba7fbbc3159141305d23db89f6"
+  integrity sha512-yv7ryhw5N+eGEc4Zfc1QnpF+Jhye7mumqQ6/m0uNtoU5uQ1VhAWy1udNK0RwRFX6SDL1kApbztAGXzDjBtjWqA==
   dependencies:
     gl-matrix "3.4.3"
     seedrandom "3.0.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2473,10 +2473,10 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@bldrs-ai/conway@1.578.1546":
-  version "1.578.1546"
-  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.578.1546.tgz#bed40b30dd2f496cba0280446cf51126b2ae2f75"
-  integrity sha512-X69nWA1VanfrbT7jOrb1eN5G7AWPqI90mhTnG/uEH4RiOw/CHhFASa6AW2rF2FsxRFDQZykfqV119pECI/+H8A==
+"@bldrs-ai/conway@1.564.1548":
+  version "1.564.1548"
+  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.564.1548.tgz#3970f123877757a53d7f2bbbf0b30c799ab5ec4f"
+  integrity sha512-SJlkLgf7byFhQeTxCMPPJden+bUqJOMKRt4ZrXhcrpnCgy7Rjs2N+F47C0irsp3tkwh8JuTf9b3bx4ipxgdqSQ==
   dependencies:
     gl-matrix "3.4.3"
     seedrandom "3.0.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2473,10 +2473,10 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@bldrs-ai/conway@1.543.1513":
-  version "1.543.1513"
-  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.543.1513.tgz#e0ee264159ae8225a86ba15af4e22f072bbbb66e"
-  integrity sha512-1dU1YqD1FOOkpt3jX7lq1KOvCT/scI1drBa7f7gm0McxGpaEgLfSSoBenbYDDcfM5WzCRqkv4kuUznN0kdCQ1w==
+"@bldrs-ai/conway@1.549.1515":
+  version "1.549.1515"
+  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.549.1515.tgz#230253f6b55a0b1a79a07b477b7a2507a0c8edac"
+  integrity sha512-rBPoCMDnt2yddZg6TVwctgrkfY5oF98iI9rO4O1Ybyd2NjBiNLX6xDCE8eoZrsWGCEwT5ttv1pqDQDNtvKNk9A==
   dependencies:
     gl-matrix "3.4.3"
     seedrandom "3.0.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2473,10 +2473,10 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@bldrs-ai/conway@1.509.1435":
-  version "1.509.1435"
-  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.509.1435.tgz#e5fa9e9200476772482b62d58eb1f25fa2ba37eb"
-  integrity sha512-6ZBVGUlUkhZgrOmz4dDcDmbCDWw5VB4pUd18LYFtt9Af9m6w1Pm7v3kr1ZRjP+7YT32nHt1vyBzs4TDHmhB2fQ==
+"@bldrs-ai/conway@1.510.1439":
+  version "1.510.1439"
+  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.510.1439.tgz#b084556826dffa6f64f4c95b9ce4432ee5c226fb"
+  integrity sha512-vfxyRRMfaCZylkVjcC7RCeFIHbCeTQ27ribyaMovMQfO6CRbrCb8FidsFWCHy4vUCnb0qj+D777aesPjJm0M8Q==
   dependencies:
     gl-matrix "3.4.3"
     seedrandom "3.0.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2473,10 +2473,10 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@bldrs-ai/conway@1.564.1548":
-  version "1.564.1548"
-  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.564.1548.tgz#3970f123877757a53d7f2bbbf0b30c799ab5ec4f"
-  integrity sha512-SJlkLgf7byFhQeTxCMPPJden+bUqJOMKRt4ZrXhcrpnCgy7Rjs2N+F47C0irsp3tkwh8JuTf9b3bx4ipxgdqSQ==
+"@bldrs-ai/conway@1.588.1550":
+  version "1.588.1550"
+  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.588.1550.tgz#43011e0287e1570a674449001abb14e415a357ee"
+  integrity sha512-zK8BS8W9YZMRoqkG8fUbUWklhkcnh91qlU4+kA157zi14t0pmybaY9EISmF878b8Rq3P/9EdV+r9R+GbxCgqwg==
   dependencies:
     gl-matrix "3.4.3"
     seedrandom "3.0.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2473,10 +2473,10 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@bldrs-ai/conway@1.512.1444":
-  version "1.512.1444"
-  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.512.1444.tgz#2b218746aff4ae74310fd07308cebfc5167654c9"
-  integrity sha512-r1oGwomJaiJGxQw5pKd/nPwfdablHvnDg1sHQMEX5L8qTvOLvJrWvWZAoF96Hga9364BKjq3IKnhCfaJS42XkQ==
+"@bldrs-ai/conway@1.513.1447":
+  version "1.513.1447"
+  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.513.1447.tgz#5135596cd6b13475532cf30b4bf84ad1479d2136"
+  integrity sha512-Mz5Cldlao8dJR7vZN8/uW+URh6MCL+eShblET7liT1m9cBhohU1bqunVSMUHWUUx7UEDOPw3ypP7Oi2QO2xHVA==
   dependencies:
     gl-matrix "3.4.3"
     seedrandom "3.0.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2473,10 +2473,10 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@bldrs-ai/conway@1.530.1503":
-  version "1.530.1503"
-  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.530.1503.tgz#73cffad5bceaf304d912a1ad6d84f1b27624ef91"
-  integrity sha512-4g5FLy5x8poumYnuJP3ctnM7DNo2HukusS3yNRl6NI4lPBv7dOxwdcq51PouGqf9W7c/x33aRUgZUK4GYDECgg==
+"@bldrs-ai/conway@1.394.1504":
+  version "1.394.1504"
+  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.394.1504.tgz#32eeeee1069af090239e708a064b15ae6f9be23f"
+  integrity sha512-npkpufCwVmNff+UDxgucZG/j2YOEpVg1vmwK4dL5E0M8epzfZjYUjDCw0/LBWJpjkbFRcTO483fHoSWxAMVu8A==
   dependencies:
     gl-matrix "3.4.3"
     seedrandom "3.0.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2473,10 +2473,10 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@bldrs-ai/conway@1.560.1539":
-  version "1.560.1539"
-  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.560.1539.tgz#b415a4cf41d180015853ce3365f631c069b4e55e"
-  integrity sha512-3jk+MHhR5m9L4Bkyqdjk91LCnEW0rDecO6/2yMu+sdKr05+cS/H8mtFywSOJOaApZLAnL63/Bet943fpNAPBAQ==
+"@bldrs-ai/conway@1.578.1546":
+  version "1.578.1546"
+  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.578.1546.tgz#bed40b30dd2f496cba0280446cf51126b2ae2f75"
+  integrity sha512-X69nWA1VanfrbT7jOrb1eN5G7AWPqI90mhTnG/uEH4RiOw/CHhFASa6AW2rF2FsxRFDQZykfqV119pECI/+H8A==
   dependencies:
     gl-matrix "3.4.3"
     seedrandom "3.0.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2473,10 +2473,10 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@bldrs-ai/conway@1.510.1439":
-  version "1.510.1439"
-  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.510.1439.tgz#b084556826dffa6f64f4c95b9ce4432ee5c226fb"
-  integrity sha512-vfxyRRMfaCZylkVjcC7RCeFIHbCeTQ27ribyaMovMQfO6CRbrCb8FidsFWCHy4vUCnb0qj+D777aesPjJm0M8Q==
+"@bldrs-ai/conway@1.511.1441":
+  version "1.511.1441"
+  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.511.1441.tgz#941e097e9efd04b1b6ff6e23563bac5018b679a3"
+  integrity sha512-Qut301rFPEoujvP6aRSXcRI70tLykngw3DMZ0bgciegA7AV8xwXfpCPAyBcg4JP2hE2EipcJ39vuQLFN8+p8gg==
   dependencies:
     gl-matrix "3.4.3"
     seedrandom "3.0.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2473,10 +2473,10 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@bldrs-ai/conway@1.513.1447":
-  version "1.513.1447"
-  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.513.1447.tgz#5135596cd6b13475532cf30b4bf84ad1479d2136"
-  integrity sha512-Mz5Cldlao8dJR7vZN8/uW+URh6MCL+eShblET7liT1m9cBhohU1bqunVSMUHWUUx7UEDOPw3ypP7Oi2QO2xHVA==
+"@bldrs-ai/conway@1.514.1452":
+  version "1.514.1452"
+  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.514.1452.tgz#20c7571b01f0af2dfb8e60f4d417a264514fc08a"
+  integrity sha512-xIkviTpydJSbeT2haJSi1CmBFDUK5JJaUMVzStYCvbrey8l6pugdhIdNcUBLWz3bboYQ33MMWsG/8ZtAtlJo4A==
   dependencies:
     gl-matrix "3.4.3"
     seedrandom "3.0.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2473,10 +2473,10 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@bldrs-ai/conway@1.501.1426":
-  version "1.501.1426"
-  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.501.1426.tgz#de9c393f4711017983ebb11368f642af13de3b6e"
-  integrity sha512-7NeR4s1z33voBJwG1Lpg4jKqyEzdFyuQWdd/G8IuPVDO8cCaglmjihsaS8flJX8ilyZiYH2UljMxfDU/Uuh0Ug==
+"@bldrs-ai/conway@1.509.1435":
+  version "1.509.1435"
+  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.509.1435.tgz#e5fa9e9200476772482b62d58eb1f25fa2ba37eb"
+  integrity sha512-6ZBVGUlUkhZgrOmz4dDcDmbCDWw5VB4pUd18LYFtt9Af9m6w1Pm7v3kr1ZRjP+7YT32nHt1vyBzs4TDHmhB2fQ==
   dependencies:
     gl-matrix "3.4.3"
     seedrandom "3.0.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2473,10 +2473,10 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@bldrs-ai/conway@1.534.1505":
-  version "1.534.1505"
-  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.534.1505.tgz#4ce246a3fa0c4c7833a9a6ad206a966d2d51cc8a"
-  integrity sha512-YoYDZB0MSWwrZTKVCYM6NNa6m7vDjQ3G1Os6pp52cxdXEv8tkeXn4Z7BJ/wmMGmgUTm6LpOA9c63FqZGU59tXQ==
+"@bldrs-ai/conway@1.535.1506":
+  version "1.535.1506"
+  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.535.1506.tgz#92cb1a3f9b8f023d7fb2cb28ae95c95d514a39ac"
+  integrity sha512-A4DsIWMRNJ2gf6QPzjhQWDtfoXdgmb02xA+HDX6UPCQixJPu7xxTTeo9bK06cDedZFLyYc8msf15yaenITGbgQ==
   dependencies:
     gl-matrix "3.4.3"
     seedrandom "3.0.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2473,10 +2473,10 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@bldrs-ai/conway@1.519.1471":
-  version "1.519.1471"
-  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.519.1471.tgz#3d18164363a43f04ccb788974fffcce09a0ac2d2"
-  integrity sha512-RZj0ExQnoWhsfWBWvA6KKPg/Qa/vWZH5aVeo2MmD7zxVopk0fBbc3IkwMIjLX3OgcPazDIO6/VEFhIxuCDzj1Q==
+"@bldrs-ai/conway@1.529.1492":
+  version "1.529.1492"
+  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.529.1492.tgz#508356325600fabd2dda31ad47254196a4a19510"
+  integrity sha512-pQV2uKkJT83z1VvS4wxjXnZ8CvPdOt/KeBxOkpx9FNflYopTv5YSaoGrqiFE1lljP736xI0cYZte0wRVq69h5A==
   dependencies:
     gl-matrix "3.4.3"
     seedrandom "3.0.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2473,10 +2473,10 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@bldrs-ai/conway@1.394.1504":
-  version "1.394.1504"
-  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.394.1504.tgz#32eeeee1069af090239e708a064b15ae6f9be23f"
-  integrity sha512-npkpufCwVmNff+UDxgucZG/j2YOEpVg1vmwK4dL5E0M8epzfZjYUjDCw0/LBWJpjkbFRcTO483fHoSWxAMVu8A==
+"@bldrs-ai/conway@1.534.1505":
+  version "1.534.1505"
+  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.534.1505.tgz#4ce246a3fa0c4c7833a9a6ad206a966d2d51cc8a"
+  integrity sha512-YoYDZB0MSWwrZTKVCYM6NNa6m7vDjQ3G1Os6pp52cxdXEv8tkeXn4Z7BJ/wmMGmgUTm6LpOA9c63FqZGU59tXQ==
   dependencies:
     gl-matrix "3.4.3"
     seedrandom "3.0.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2473,10 +2473,10 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@bldrs-ai/conway@1.514.1452":
-  version "1.514.1452"
-  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.514.1452.tgz#20c7571b01f0af2dfb8e60f4d417a264514fc08a"
-  integrity sha512-xIkviTpydJSbeT2haJSi1CmBFDUK5JJaUMVzStYCvbrey8l6pugdhIdNcUBLWz3bboYQ33MMWsG/8ZtAtlJo4A==
+"@bldrs-ai/conway@1.516.1463":
+  version "1.516.1463"
+  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.516.1463.tgz#fea9d32ed899fd844022f195d4dd897b8b0036f8"
+  integrity sha512-SumWfZzuI3WwlqW+ZqR2ggXmHjYmCePu2rrpIbhwlg43viIsS0rYC8jDHLvDOFsvRtgv7YZV4rcmmkJ3vzhaYA==
   dependencies:
     gl-matrix "3.4.3"
     seedrandom "3.0.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2473,10 +2473,10 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@bldrs-ai/conway@1.511.1441":
-  version "1.511.1441"
-  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.511.1441.tgz#941e097e9efd04b1b6ff6e23563bac5018b679a3"
-  integrity sha512-Qut301rFPEoujvP6aRSXcRI70tLykngw3DMZ0bgciegA7AV8xwXfpCPAyBcg4JP2hE2EipcJ39vuQLFN8+p8gg==
+"@bldrs-ai/conway@1.512.1444":
+  version "1.512.1444"
+  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.512.1444.tgz#2b218746aff4ae74310fd07308cebfc5167654c9"
+  integrity sha512-r1oGwomJaiJGxQw5pKd/nPwfdablHvnDg1sHQMEX5L8qTvOLvJrWvWZAoF96Hga9364BKjq3IKnhCfaJS42XkQ==
   dependencies:
     gl-matrix "3.4.3"
     seedrandom "3.0.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2473,10 +2473,10 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@bldrs-ai/conway@1.529.1492":
-  version "1.529.1492"
-  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.529.1492.tgz#508356325600fabd2dda31ad47254196a4a19510"
-  integrity sha512-pQV2uKkJT83z1VvS4wxjXnZ8CvPdOt/KeBxOkpx9FNflYopTv5YSaoGrqiFE1lljP736xI0cYZte0wRVq69h5A==
+"@bldrs-ai/conway@1.530.1503":
+  version "1.530.1503"
+  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.530.1503.tgz#73cffad5bceaf304d912a1ad6d84f1b27624ef91"
+  integrity sha512-4g5FLy5x8poumYnuJP3ctnM7DNo2HukusS3yNRl6NI4lPBv7dOxwdcq51PouGqf9W7c/x33aRUgZUK4GYDECgg==
   dependencies:
     gl-matrix "3.4.3"
     seedrandom "3.0.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2473,10 +2473,10 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@bldrs-ai/conway@1.536.1507":
-  version "1.536.1507"
-  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.536.1507.tgz#8a7c7113a691beba7fbbc3159141305d23db89f6"
-  integrity sha512-yv7ryhw5N+eGEc4Zfc1QnpF+Jhye7mumqQ6/m0uNtoU5uQ1VhAWy1udNK0RwRFX6SDL1kApbztAGXzDjBtjWqA==
+"@bldrs-ai/conway@1.543.1513":
+  version "1.543.1513"
+  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.543.1513.tgz#e0ee264159ae8225a86ba15af4e22f072bbbb66e"
+  integrity sha512-1dU1YqD1FOOkpt3jX7lq1KOvCT/scI1drBa7f7gm0McxGpaEgLfSSoBenbYDDcfM5WzCRqkv4kuUznN0kdCQ1w==
   dependencies:
     gl-matrix "3.4.3"
     seedrandom "3.0.5"


### PR DESCRIPTION
The Share half of conway's M-milestone loading work: **fast, fixed-memory model loading with streaming preview geometry, for IFC and STEP**. Bumps `@bldrs-ai/conway` **1.501.1426 → 1.588.1550** and carries every Share-side half of the engine contract changes that range introduced.

14 files, all on the conway-direct load path. There is no new feature flag — this rides the existing deferred/store path.

> **Two rows in the ledger below have a minor number that goes backwards. That is correct — do not "fix" them.**
> conway's `auto-publish` derives the minor from the first `#N` in the squash
> title, so #581 (which closes issue #564) published as 1.**564**.1548, and
> #531 published as 1.**394**.1504. The **build number is the monotonic
> part**. Root cause: [conway#533](https://github.com/bldrs-ai/conway/issues/533).
>
> **The current pin is not one of them.** 1.588.1550 is monotonic in both
> parts against 1.580.1549, and `npm dist-tags.latest` resolves to it
> without auto-publish's out-of-order fallback.

---

## What this changes

### Opening a model without copying it

| | before | now |
|---|---|---|
| OPFS cache-hit IFC | full `ArrayBuffer` materialised (848 MB on PSB) | opened from the `File` in place via `OpenModelStream` |
| fingerprint | needed the whole buffer resident | native per-slice SHA-1, one reused scratch buffer |
| LFS probe | only when `opfsEntryKey` was set | always, before any `File` passthrough |

STEP falls back to `OpenModelStreamed`; an engine that refuses store-open (returns `-1`) buffers and retries rather than failing the load. The IFC is no longer `arrayBuffer()`'d twice — the parse buffer is hashed directly.

### Holding memory flat

- **Windowed source.** The demand pump pages the source through a ~64 MB window; the Geometry line reports `window=N MB`.
- **Resident-geometry budget** (`accc55a`). `GEOMETRY_BUDGET_MB = 64` on the deferred path, turning on conway#535's LRU eviction. Engine-measured on PSB at our batch size of 8: **wasm high-water 1284 → 298 MB**, delivered meshes identical, Geometry slightly faster (23.6 s vs 25.7 s). 256 MB was also measured and buys much less (803 MB) — the live set rarely reaches that ceiling.

  Safe for one specific reason worth stating: eviction frees an asset from `GetGeometry` until something re-extracts it, and this loader copies every payload at delivery (the #1640 invariant). That invariant used to be merely true; it is now load-bearing, and the test asserts both halves — the classic path stays unbudgeted, because it does not pump and would have geometry evicted from under a later consumer.
- **Preview teardown disposes pooled resources exactly once** (`c1812b3`, `09b943d`). The dispose pass had been dropped wholesale when the shared imposter cube arrived, rather than made shared-aware. Teardown now walks stray imposters plus the preview group and disposes each unique geometry/material once.
- **The rel-aggregates pass no longer retains the whole model** (conway#550). Reading `relAggregate.RelatedObjects` memoised the materialised entity array onto the relationship, so every related product — and the tessellation subtree each one memoises — stayed reachable for the whole loop, and the per-product B-rep graphs summed instead of overlapping. The pass also had no suspension point, so on a model whose products are *all* aggregate targets the cooperative driver yielded nothing during 100% of the real work. This is what made SKYLARK250 hang the browser at an earlier pin.
- **And the prefetch that fed it no longer pages a whole relationship ahead of the stepper** (conway#563 + conway#566). #550 made the *pass* step per product and left the *prefetch* per relationship, so on SKYLARK250 — where two `IfcRelAggregates` cover all 1,992 products — windowed residency was still defeated for exactly the model it exists for. Together the two take parse→first-mesh from **315,903 ms → 266 ms** and whole-load peak resident source from **381.7 → 61.7 MiB**.
- **AP214 demand-unit slicing** (conway#582). Arty_Z7's worst single main-thread block **17,731 ms → 600 ms**. This fixes the *freeze*, not the *cost* — the work still happens, it is just sliced into units the event loop can interleave with, so the tab stays responsive through it.

### First pixels during the parse

Real placed prefix meshes stream while the file is still parsing, through the same 64 MB window, extraction time-budgeted at ~20 ms/tick (conway#519) so the preview fills in batches rather than one girder at a time.

The engine-side reason this works at all is [conway#542](https://github.com/bldrs-ai/conway/issues/542), whose fix landed in [conway#543](https://github.com/bldrs-ai/conway/pull/543). Its finding reframes what "slow first load" even means: whether a model shows anything during parse is a property of the **writer**, not the authoring tool or the file size.

| writer | forward refs | products deferring | first preview mesh |
|---|---|---|---|
| ODA (PSB, 861 MB) | 0.1% | 0.5% | 269 ms |
| Tekla (D3D, 224 MB) | 0.0% | 0.0% | streams cleanly |
| Archicad/DDS_IFC (DOWA, 398 MB) | 19.8% | **100%** | 8891 ms → **5849 ms** |
| Archicad/DDS_IFC (MB-Khaya, 31 MB) | 74.1% | **100%** | 979 ms → 758 ms |
| ST-DEVELOPER (BLSN, 282 MB STEP) | 25.7% | **100%** | no prefix trick helps |

PSB — the model we have been smoking all along — is the *best* case in the corpus, which is why the blank-screen problem kept not reproducing. Numbers are from conway's Node harness on the dev corpus, not from a browser. conway#543's review found two defects in the script that produced them, both flattering, so treat the exact percentages as approximate pending a re-run; the ordering and the conclusion are unaffected.

**Time-to-first-pixel is measured but not yet visible here.** conway#543 adds a `Preview:` line. Share cannot display it: `applyEngineLogLevel()` mutes conway to `WARNING` by default, `loadProgress.js`'s console tee captures only `warn`/`error`, and `setPreviewStats()` has no caller. Tracked as [conway#544](https://github.com/bldrs-ai/conway/issues/544). So first pixels on this smoke are still judged by eye. Known gap, not an oversight.

### Spatial AABB plates are OFF

`SHOW_AABB_IMPOSTERS = false` (`e9896c4`). The plates cost three conway rounds — scale/solid ([#516](https://github.com/bldrs-ai/conway/pull/516)), rotation ([#517](https://github.com/bldrs-ai/conway/issues/517)), banding and early skeleton ([#518](https://github.com/bldrs-ai/conway/issues/518)) — and they are cosmetic: real prefix meshes carry first pixels. Turned off at the Share end rather than by asking conway to stop emitting, so the engine contract is unchanged and re-enabling is one constant.

The consumer contract stays in place and tested: an `aabb` payload re-emitted with an `expressID` already drawn **replaces** that plate rather than adding a second one — no extra cap slot, cannot evict a visible plate, nothing disposed on replace, and a plate rejected by the outlier guard leaves the standing plate on screen, because a refused update must not delete scenery it failed to refine.

### Observability

Geometry is its own load-log stage during the demand pump, with heap delta and `window=`.

---

## Conway version ledger

Each bump is a contract change with a Share-side half in this PR.

| pin | conway | what it brought here |
|---|---|---|
| 1.510.1439 | #510 | `OpenModelStream` store-backed open |
| 1.513.1447 | #513 | rematerialise extract buffers; parallel `#ref` prefetch |
| 1.514.1452 | #514 | `Faces[]` as one address span; storey plates; store-path prefix extract during parse |
| 1.516.1463 | #516 | imposter coordination-frame fix → Share drops the first-box re-anchor, threads `coordination` through the aabb path |
| 1.519.1471 | #519 | rotation-aware plates (#517); time-budgeted preview + early skeleton (#518) → Share keys plates by `expressID` |
| 1.529.1492 | #529 | concurrent-prefetch residency fix (#526) — the `StepBufferNotResidentError` that aborted a large-model load outright |
| 1.530.1503 | #530 | M2 prefix index: type index from columns; spatial-names skeleton during parse; `LongName` fix |
| 1.394.1504 | #531 | scripts/design only — engine-identical to 1.530.1503; the number moved *backwards* (see the note at the top) |
| 1.534.1505 | #534 | incremental delta capture — no more O(batches × scene) re-walk; PSB Geometry 37.0 → 25.3 s at batch 8 |
| 1.535.1506 | #535 | resident-geometry LRU budget + native-identity refcounting |
| 1.536.1507 | #536 | dispatch-time placement + `SetGeometryShard` — **inert on this PR's path**; gated behind a claimed shard, which Share never claims. Consumed by #1756 instead. |
| 1.543.1513 | #538, #543 | #538: residency-independent dispatch keys + `SetCoordinationFrame`. **#543**: deferred preview products are retried against the longer index instead of abandoned, on **both** the store and resident paths, plus time-to-first-pixel instrumentation. |
| 1.548.1514 | #548 | harness only — RFC 4180 quoting for the benchmark CSVs and a delta emitted when blessing a release. |
| 1.549.1515 | #550 | The rel-aggregates pass stops retaining the model and gains a suspension point. SKYLARK250: peak live JS heap **3784 → 982 MB**, peak RSS **5314 → 3152 MB**, event-loop heartbeat from **1 firing in 104 s (max stall 100,877 ms)** to 597 firings at 11.98/s. Digests byte-identical. |
| 1.560.1539 | #553, #556, #557/#559, #558/#560 | **Measurement and CI only — no engine change reaches Share.** |
| 1.578.1546 | #563, #566, #567, #568, #569, #570, #578 | **Four of seven are runtime for Share.** **#563** fixes the style-seed scan on the windowed path: SKYLARK250 parse→first-mesh **315,903 → 41,658 ms**. **#566** finishes it by paging an aggregate's products per stepper step: **35,758 → 266 ms**, whole-load peak resident source **381.7 → 61.7 MiB**, longest event-loop starvation **34,866 → 45 ms**. **#568 §4** stops a STEP complex instance being extracted by both passes and drawn twice. **#569** counts the Geometry denominator in products rather than relationships. **#567** and **#578** move `conway-geom`. |
| 1.564.1548 | #581, #582 (+ conway-geom#183) | **The STEP/AP214 round.** **#582** slices AP214 demand units: Arty_Z7's worst main-thread block **17,731 → 600 ms**. **#581 + conway-geom#183** scope the deflection floor to the **defining representation**: Arty geometry **33,981 → 20,265 ms**, payload **403.878 → 138.366 MB**, peak wasm heap **707.0 → 357.5 MB**. Composed on one box, Arty geometry **34,169–37,235 → 22,484–24,985 ms**, payload **−66%**, heap **−49%**. |
| **1.588.1550** | #586, #588 | **The current pin — and the first head in this PR's life whose engine has blessed baselines behind it.** Neither changes geometry. **#586** gates the per-item error log on prefixes and stops `DanglingReferenceError` reporting recoverable prefix misses as errors — console noise only. **#588** fixes the **STEP NavTree dying with `Error: Function not implemented.` on any product with no name**: `resolveLabel()` ended on `productDef.name ?? ''`, but `name` is not an attribute of `product_definition` in AP214 — it is DERIVED onto a getter that throws, so the `?? ''` was unreachable and `getSpatialStructure` failed for the whole model. See the smoke item. |

### conway-geom churn — **now blessed**

**This is the part of the bump that can change what a model looks like.** Three rounds moved `conway-geom` during this PR's life, and all three are blessed together by the `rc-1.588.1550` pass:

| round | via | driver | outcome |
|---|---|---|---|
| **R1** | conway#567 | conway-geom#178 — NURBS inverse-solve convergence target made relative | 4 models, 1,179 of 178,273 rows |
| **R2** | conway#578 | conway-geom#180 — stale tessellation candidates + NURBS trim-bounds cap | 4 models, 15 of 179,788 rows |
| **R3** | conway#581 | conway-geom#183 — deflection floor scoped to the defining representation | **blessed** — see below |

**The combined bless is [test-models#58](https://github.com/bldrs-ai/test-models/pull/58)**, from [run 32884504977](https://github.com/bldrs-ai/conway/actions/runs/32884504977) on tag `rc-1.588.1550` @ [`d75c2f03`](https://github.com/bldrs-ai/conway/commit/d75c2f0337f2588df2282ca760dff4bdde5aff14). 33 baselines changed, dominated by `Arty_Z7.csv` at **1171 rows** — which matches conway#581's own prediction of "1,169 of 94,510 rows across 3 models". Everything else moves 1–34 rows. No NEW parse/extract failures, no unexpected zero-geometry models. `benchmarks/conway1.588.1550-ci_test-models/` carries the perf snapshot and its delta against the previous blessed one.

R3 is still the round most likely to be *visible*, because a deflection floor scoped differently changes tessellation density directly, and the payload dropping 66% on Arty is exactly that showing up as bytes. **A digest bless records that the change happened; it does not judge whether it looks right.** That is what the Arty_Z7 "look at it" smoke item is for.

Two things in R2 are improvements you could see rather than just digest movement: `Orbiter_v1.1_Gear_7.5.step` stops trapping (`memory access out of bounds` on two `ADVANCED_FACE`s, gone), and conway#578 adds an extractor fix so an UNSPECIFIED-trimmed `IFCLINE` carrying only parameter values no longer collapses to a single point.

### Why 1.549 → 1.560 needed no re-smoke

**Scoped to that bump only.** Share reaches conway through exactly three import paths — `@bldrs-ai/conway/compiled/src/compat/web-ifc/`, `@bldrs-ai/conway/src/core/progress_log`, and `@bldrs-ai/conway/web-ifc`. **Neither `compat/` nor `core/progress_log` is touched anywhere in 1.549 → 1.560.** Outside the CLI harnesses and tests, five files changed, all either comment-only, Node-only, additive perf columns, or not referenced by Share. And rc-1.560.1539's full-corpus run changed **zero** digest files on **both** corpora against 1.549.1515.

### Why everything after 1.560 *does* need one

**Six PRs across 1.560 → 1.578 → 1.564.1548 change the code Share's store-backed deferred open runs**, and three of them change geometry: #563 and #566 rewrite the windowed prefetch; #568 §4 changes which related objects the aggregates pass defers; #569 changes the numbers on the `geometry` progress events Share renders; #582 changes AP214 unit scheduling; #567, #578 and #581 move `conway-geom` three times.

**And 1.564.1548 → 1.588.1550 adds one more that is runtime for Share:** #588 changes `resolveLabel` in `AP214ProductStructureExtraction`, which is what Share's STEP NavTree reaches through `getSpatialStructure`. It is a pure repair — the old path threw — but it is not inert, so it gets its own smoke item rather than being waved through.

---

## Smoke history

| round | conway | outcome |
|---|---|---|
| 1 | 1.514.1452 | PSB 62.7 s; imposters offset and solid-faced → conway#515 |
| 2 | 1.516.1463 | 61.4 s — frame fix cost nothing; plates still rotated; blank first ~10 s → conway#517 / #518 |
| 3 | 1.519.1471 | PSB clean at 53.4 s, but a **larger model failed outright** with `StepBufferNotResidentError` → conway#526 |
| 4 | 1.394.1504 | PSB 52.1 s — Parse 15.5 s, Geometry 30.1 s, 60.7 → 2299 MB, `window=60.66` |
| 5 | 1.543.1513 | First round where the preview read as intended. **SKYLARK250 hung the browser** → conway#549, fixed by #550. |
| 6 | 1.578.1546 | Not smoked — superseded before a human got to it. |
| 7 | 1.564.1548 | Not smoked — superseded by the rc pin below. |
| **8** | **1.588.1550** | **Smoked and approved.** |

Two runs at 84 s and 127 s early on were machine-load noise: Geometry varied 1.9× between identical runs.

---

## Smoke checklist for this head (`00de01a6`, conway 1.588.1550)

Deploy preview; load PSB from OPFS cache, the large model that died on round 3, **SKYLARK250**, **Arty_Z7**, and **`nist_ctc_04_asme1_rd.stp`**.

- **Arty_Z7 is the headline.** It is the model both #581 and #582 target, and a STEP/AP214 file, so it exercises the *resident* path rather than the windowed one. Three things to judge:
  - **No long freeze.** #582 cuts the worst single main-thread block **17,731 → 600 ms**. A multi-second lockup is a finding.
  - **Geometry roughly a third faster.** Engine-measured **34,169–37,235 → 22,484–24,985 ms** composed. A Geometry time back near 34 s is a regression.
  - **Look at it, not just the clock.** Payload **−66%**, peak wasm heap **−49%**, because the deflection floor is now scoped to the defining representation — a tessellation-density change. The baselines are blessed now, but a bless records *that* geometry moved, not that it looks right. **Anything coarser, faceted, or dropped is exactly what this smoke is for.**
- **`nist_ctc_04_asme1_rd.stp` NavTree** (#588). The tree should read **`NIST PMI CTC 04 ASME1`**, not `Object`, with **no red `Error: Function not implemented.`** in the console. Four of the six affected corpus models get a real name; `nist_stc_09_asme1_ap242-e3` and `nist_ftc_09_asme1_ap242-e1` get `''` because those files carry no name, id or description at all — that is correct, not a miss. Note a reload will look fine either way, because the GLB cache hits and the STEP path never re-runs — **judge it on a cold load.**
- **SKYLARK250 must load without hanging the tab.** Primary pass condition is **UI responsiveness**. conway#566 measured parse→first-mesh at **266 ms** (from 315,903 ms before #563) and longest event-loop starvation at **45 ms** (from 34,866 ms). Those are Node-harness figures, so a browser number in the same *order* is confirmation — **but a stall of even one or two seconds is a 20–40× regression and a finding, not a pass.** Nothing in this pin touches that path, so a *change* here is the finding.
- **The Geometry progress bar should advance in products, not sit at half.** conway#569 fixed a denominator that counted `IfcRelAggregates` records rather than the products under them. **Two caveats before calling a stall a regression:** (1) the **Share half of [conway#565](https://github.com/bldrs-ai/conway/issues/565) is not in this PR** — `conwayDirectIfcLoader.js` still latches `geometryTotal` from the first pump return and accumulates `extracted` itself, competing with conway's own `geometry` events; and (2) `geometryDone` only counts products that actually produced geometry, so on a model with geometry-less products the bar can legitimately stop short of full. A bar that *moves* is the pass condition; a bar frozen at a fixed fraction for the whole stage is the regression.
- **PSB Geometry should hold at round 4's ~⅓ drop** from 30.1 s. Parse and Assemble unchanged. A Geometry *regression* is the finding.
- **Memory should stay visibly lower** than round 4's 2299 MB peak, from the 64 MB budget. The report's heap column is `performance.memory` and excludes `WebAssembly.Memory`, so wasm-side improvements are only partly visible.
- **The round-3 model must complete.** A product that genuinely cannot be paged should degrade to one missing product plus a console log, never an aborted load.
- **Preview meshes appear during Parsing, filling in batches**, not one girder at a time.
- **No cubes or plates at any point** — imposters are off. If one appears, that is a finding.
- **Do not look for a `Preview:` line**; Share cannot show it yet (conway#544).
- Nothing left over after Total; `window=` still ≈64 MB; no extract `TypeError`s.
- Load log will read **`Conway v1.588.1550`**.

---

## Verified before smoking

**Stated precisely, because the two heads were verified to different depths.**

The full local gate — the checks a draft PR never gets, since `build` and both `test-flows` jobs are skipped on drafts — was run at **conway 1.564.1548 on head `0d0ed0f5`**:

| check | result at 1.564.1548 (`0d0ed0f5`) | baseline at 1.578.1546 (`9b1fe767`) |
|---|---|---|
| `yarn build-prod` | **exit 0** | exit 0 |
| `yarn test-ci` | **240 suites / 240, 2382 passed + 5 skipped / 2387, 13 snapshots; coverage gate held** | identical |
| **Playwright E2E** | **153 passed / 0 failed / 44 skipped**, 197 tests, **0 flaky**, **12.7 min** at CI's own 2 workers | 153 / 0 / 44, 197, 0 flaky, 11.8 min |

Zero delta in either direction. The 11.8 → 12.7 min wall clock is machine-load noise: no individual spec changed status.

**At the current head `00de01a6` (conway 1.588.1550), only the husky pre-commit gate has been re-run** — eslint + typecheck + full Jest, green: **240 suites / 240, 2382 passed + 5 skipped, 13 snapshots**. `yarn build-prod`, `yarn test-ci` coverage thresholds and Playwright have **not** been re-run at this pin. The delta over the fully-verified head is two conway PRs, and only one of them (#588) is runtime for Share. Flipping to ready fires the gated CI jobs, which covers it.

Note what the gate does and does not cover. It exercises Share's own code against the new engine; it does **not** load PSB, SKYLARK250, Arty_Z7 or any large model, so **none of the runtime improvements this pin is for are verified by it** — that is what the smoke checklist is for. In particular **the E2E suite cannot see the conway-geom changes at all**, because no fixture in it is NURBS-heavy. The suite guards against the bump *breaking* something; it is not evidence that it *helps*.

The suite was also run at **1.536.1507, 1.543.1513, 1.549.1515 and 1.578.1546** earlier in this PR's life, with the failing-test sets diffed programmatically: no test newly failed at the new pin and none newly passed, so nothing has implicated a conway bump at any point in this arc.

**The two E2E failures this PR previously carried are gone.** `src/Components/Open/Github.spec.ts` `:152` and `:163` were filed as #1759 and fixed on main by #1764, which this branch merged in (`4ac7836`).

Worth recording, because it changes how to read the earlier rounds: **#1759 was never a product bug.** The dropdowns open on an ordinary click. The tests were clicking with `force: true` straight through a MUI backdrop that stays mounted for the ~400 ms Grow exit, so the click was eaten as a click-away; and the always-on render loop makes every Playwright action ~7× more expensive on a GPU-less runner (one click: 978 ms with the viewer live, 139 ms with rendering paused). The fix is test-only.

One caveat on that merge: **#1764's final diff never received an automated review pass.** Codex hit its usage limit. What backs it instead is green CI on every job, a full local suite at 2 workers, and independent mutation checks on both fixes.

---

## Corpus evidence

**rc-1.588.1550** ([run 32884504977](https://github.com/bldrs-ai/conway/actions/runs/32884504977)) — **the pass this PR was waiting on**, and the one that blesses R1, R2 and R3 together:

- Public bless [test-models#58](https://github.com/bldrs-ai/test-models/pull/58): 33 baselines, **`Arty_Z7.csv` 1171 rows** (R3's deflection floor, matching #581's prediction), everything else 1–34 rows.
- **No NEW parse/extract failures.** No unexpected zero-geometry models.
- `benchmarks/conway1.588.1550-ci_test-models/` carries this release's steady per-model timings plus a delta against the previous blessed snapshot — the first rc in this arc to produce one, since the perf snapshot is `rc-*`-tag-gated by design and an earlier `workflow_dispatch` run skipped it silently.

**rc-1.549.1515** ([run 32550854090](https://github.com/bldrs-ai/conway/actions/runs/32550854090)) — private corpus:

- **Zero digest churn.** **Zero `OK → FAIL`.** 97 `OK → OK`, 2 `FAIL → OK`, 8 `N/A → OK`.
- Of the 28 models taking ≥5 s, **26 got faster** — PSB 43.8 → 24.7 s, Autodesk Hospital 30.2 → 19.2 s, DOWA 16.4 → 13.0 s. (That delta spans 1.451 → 1.549, so it credits the whole streaming arc.)

Small models pay a flat ~+85–108 ms in the geometry stage regardless of size — a fixed setup cost, not a scaling regression. Worth a decision at some point; not a blocker here.

**rc-1.560.1539** ([run 32609023219](https://github.com/bldrs-ai/conway/actions/runs/32609023219)) — **both** corpora: zero digest churn on both, `geometryMemoryMbDelta` 0.00 on all 97 public rows. The public corpus became whole again here — two formerly LFS-broken models produce digests for the first time ([test-models#52](https://github.com/bldrs-ai/test-models/issues/52) → [#53](https://github.com/bldrs-ai/test-models/pull/53)).

That run gives SKYLARK250 its numbers from the shipped bench. **These are the pre-#563/#566 figures:**

| | |
|---|---|
| parse / geometry / total | 4,964 / 21,780 / **26,744 ms** |
| `geometryMemoryMb` (payload) | 185.2 |
| `peakWasmHeapMb` | 706.9 |
| `peakRssMb` | **2,618.3** |
| `retainedRssMb` after teardown + settle | 2,263.7 |

The bench opens a **resident, fully-extracted** model where Share runs a **windowed deferred pump**, so it cannot exercise #563 or #566 and has no column approximating time-to-first-mesh — [conway#562](https://github.com/bldrs-ai/conway/issues/562) §2, still open. It does exercise the resident path that #581/#582 change.

The JS heap releases completely; RSS does not. Retained external (572 MB) is close to the wasm heap, which is grow-only and so structurally un-returnable. Corpus-wide the retention ratio climbs with model size (31% → 87%, median 56% over the 29 models above 300 MB), which reads as allocator arenas rather than a SKYLARK-specific leak. Tracked under [conway#554](https://github.com/bldrs-ai/conway/issues/554); does not gate this PR.

Ignore the `perf-three-*` delta comments on conway's rc runs. That is a separate headless-three render benchmark whose baseline is "whatever artifact ran last" and whose engine labels both read `conway1.1.0`. Its 1.558 → 1.560 table shows every one of 47 models 19–32% slower with `Δ geomMem MB` = 0 and RSS flat — a uniform scale factor across a 4000× dynamic range, i.e. a slower runner, not conway.

---

## Open upstream, and relevant to what you will see

- **[conway#565](https://github.com/bldrs-ai/conway/issues/565)** — **open for the Share half.** conway#569 fixed the engine's Geometry denominator; `conwayDirectIfcLoader.js` still derives a second, competing set of `geometry` progress events. Likely fix: delete Share's `reportGeometry` and let conway's pump own the phase. Directly shapes what the progress-bar smoke item can conclude.
- **[conway#574](https://github.com/bldrs-ai/conway/issues/574)** — a related product whose extraction throws is abandoned by the relationship-wide catch while the progress prefix still counted it, so the bar can drop a tail in one step.
- **[conway#546](https://github.com/bldrs-ai/conway/issues/546)** — grid-placed products lose preview retry, a regression from #543's own classification narrowing.
- **[conway#547](https://github.com/bldrs-ai/conway/issues/547)** — retry-first scheduling may starve fresh-product discovery on a large unresolvable backlog. Unverified.
- **[conway#544](https://github.com/bldrs-ai/conway/issues/544)** — the `Preview:` line still is not visible in Share.
- **[conway#533](https://github.com/bldrs-ai/conway/issues/533)** — auto-publish derives the minor from the merge title's first `#N`. Bitten twice in this ledger (1.394.1504, 1.564.1548); the current pin is unaffected.
- **[conway#545](https://github.com/bldrs-ai/conway/issues/545)** — conway's CI clones an `eigen` submodule from gitlab.com on every run and never compiles it. Has failed with both 403 and 502, and once silently blocked a publish.
- **[conway#551](https://github.com/bldrs-ai/conway/issues/551)** — the SKYLARK probe should be committed so its numbers stay falsifiable.

### Landing behind this PR, not in it

The `rc-1.588.1550` engine still carries two known silent-correctness defects in STEP curve handling, both found while investigating [test-models-private#93](https://github.com/bldrs-ai/test-models-private/issues/93) (Orbiter). Neither is in this pin; both are queued for the next rc, and both are listed here so a later finding on a STEP model can be matched against them rather than filed twice:

- **[conway#589](https://github.com/bldrs-ai/conway/issues/589)** (fix in [#593](https://github.com/bldrs-ai/conway/pull/593), green, held) — `readReal` returns `NaN` for any real whose total decimal shift reaches 64, silently, in **both** the STEP and IFC front ends. On Orbiter that is 48,593 NaN vertices across five solids. 6 models move.
- **[conway#599](https://github.com/bldrs-ai/conway/issues/599)** (fix in [conway-geom#185](https://github.com/bldrs-ai/conway-geom/pull/185) + [conway#600](https://github.com/bldrs-ai/conway/pull/600), drafts, held) — a cartesian B-spline trim is searched over raw knot values instead of the normalised parameter, so **86% of the corpus's cartesian-trimmed 3D extractions** search a wrong sub-interval and many collapse to a straight chord where an arc belongs. 51% of Orbiter's trimmed edges and 72% of `Right_Hand.step`'s were chords. 24 models move.

## Not closed by this PR

Share #1602, conway #446 and conway #392 stay open until write-through of a network body lands.

## Related

[#1756](https://github.com/bldrs-ai/Share/pull/1756) (geometry worker pool, `?feature=workers`) is stacked on this branch and consumes the #536/#538 sharding machinery that is inert here.

**Smoked and approved on this head.** Merging main in before submit.