### PR TITLE
Add the agent-workflow doc: issue-queue burndowns with sub-agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,6 +109,7 @@ This file is the router for AI assistants working in this repo. Keep it small. T
 | Epic/Story/Track catalogue, milestone tier rubric (§2.1), MVP bar + phase plan (§6, ex-"Pro-MVP"), growth-funnel Phase G, AI-workspace pivot (§7), post-MVP loveables | [design/roadmap.md](design/roadmap.md) |
 | Conversational-CAD epic plan (workspace shell / ProjectsDrawer + TopBar, fluid Nav+search, convo panel, multi-user channels), wireframe→issue mapping, epic/sub-issue process | [design/new/conversational-cad.md](design/new/conversational-cad.md) |
 | Persistence direction: OPFS as a git-versioned workspace (repo-as-workspace, LFS-pointer blobs, record-vs-stream convo split, wasm-git vs isomorphic-git investigation, exit plan) | [design/new/workspace-store.md](design/new/workspace-store.md) |
+| Working an issue queue with AI agents — coordinator + per-issue sub-agents, model tiers (Fable coordinates, Opus executes), the dispatch-brief requirements and the 10-point rubric | [design/new/agent-workflow.md](design/new/agent-workflow.md) |
 
 Anything not in this table is invisible to the router. When you create a doc that future assistants should consult, add a row above with a one-line "when to read" hint. Don't rely on filesystem discovery.
 

--- a/design/new/agent-workflow.md
+++ b/design/new/agent-workflow.md
@@ -1,0 +1,78 @@
+# Agent workflow: issue-queue burndowns with sub-agents
+
+How we run sizeable issue queues (triage passes, bug burndowns) with
+AI agents, and the rubric every agent is held to. Established during
+the Aug 2026 conway severe-bug burndown (conway#485/#504/#505/#503,
+and the review of conway#508 that motivated the rubric); this is the
+org direction for both repos, not a conway-only experiment. conway
+carries the same guidance inline in its
+[AGENTS.md](https://github.com/bldrs-ai/conway/blob/main/AGENTS.md)
+§"Issue-queue burndowns".
+
+## Roles and models
+
+A **coordinator** session plans, defines issues and manages the
+queue; it dispatches one **sub-agent per issue** for the hands-on
+work — issue handling, PR authoring, review and release lifecycle.
+Use a Fable-class model for the coordinator and Opus-class for the
+sub-agents.
+
+Sequence agents that share a branch or files; parallelize only
+across disjoint trees. A burndown branch accumulating several
+fixes should land as a single PR when the commits are orthogonal —
+one CI pass instead of five.
+
+## The dispatch brief
+
+Every brief must carry:
+
+- the branch and its current state (head SHA, commits already on it),
+- the verification bar **as numbers** — the suite/test/lint counts
+  the tree meets today, so "green" is checkable, not vibes,
+- the issue's full context, **and** an instruction to read the live
+  issue thread before coding, with explicit license to stop and
+  report if the thread has retracted the premise.
+
+Premises rot. Never assert an issue's triage state in a brief without
+having read its comments — the burndown lost one dispatch exactly
+this way, and the agent that refused to ship against the dead premise
+was right to refuse.
+
+## The rubric
+
+1. **Read the thread first.** If comments retract the premise, stop
+   and report rather than ship.
+2. **Path evidence before claim.** A fix for a specific failure must
+   show the failing path reaches the changed code — call chain,
+   stack, or captured diagnostic. "Consistent with" is not "caused
+   by".
+3. **Claim discipline.** State what the change establishes vs. what
+   it hopes. No closing keywords, and no `(#N)` in a title, for
+   unproven fixes of flaky or statistical bugs — auto-close has
+   burned conway#485 twice.
+4. **Description ≡ diff.** PR and commit text describe the code as
+   it is, not an earlier draft's intent.
+5. **No speculative defenses.** Every guard corresponds to a state
+   something can actually produce; cite what can throw.
+6. **Tests pin the change, not the language.** Prove it: run the new
+   tests against a stash/revert of the source change and show them
+   fail.
+7. **Verify environment assumptions empirically.** Toolchain flags,
+   generated-glue behaviour, schema revisions — read the built
+   artifact or the pinned source, never memory of a different
+   configuration.
+8. **Diagnosis before defense** on silent-corruption and flaky bugs.
+   A change that makes a symptom vanish without establishing
+   mechanism closes an issue while keeping the bug.
+9. **Blast-radius discipline.** Outputs the change shouldn't touch
+   stay byte-identical (conway: regression digests; Share: existing
+   E2E and unit expectations), and the outputs it legitimately
+   changes are enumerated precisely — those baselines need
+   re-blessing, and the reviewer needs the list.
+10. **Report honestly.** Exact counts, verified vs. unverified,
+    confounders named.
+
+Reviewers hold the same bar, in this order: verify claims against
+the diff (not the description), against repo history, then against
+the actual failure path — and grade findings by evidence, not
+plausibility.

--- a/design/new/agent-workflow.md
+++ b/design/new/agent-workflow.md
@@ -7,7 +7,8 @@ and the review of conway#508 that motivated the rubric); this is the
 org direction for both repos, not a conway-only experiment. conway
 carries the same guidance inline in its
 [AGENTS.md](https://github.com/bldrs-ai/conway/blob/main/AGENTS.md)
-§"Issue-queue burndowns".
+§"Issue-queue burndowns: sub-agents and the rubric" (landing via
+conway#520 — merge that before this doc, or the reference dangles).
 
 ## Roles and models
 


### PR DESCRIPTION
Docs-only. Adds `design/new/agent-workflow.md` — the coordinator + per-issue sub-agent model for working sizeable issue queues, the model-tier guidance (Fable-class coordinates; Opus-class handles issues, PR authoring, review and release lifecycle), the dispatch-brief requirements, and the 10-point rubric — plus its router row in `AGENTS.md`.

Written out of the Aug 2026 conway severe-bug burndown (conway#485/#504/#505/#503, and the conway#508 review that motivated the rubric). conway carries the same guidance inline in its `AGENTS.md` (conway PR #520); this is the Share half, since the practice is org direction rather than a one-repo experiment.

**Merge order:** land conway#520 first — this doc cross-links conway `main`'s AGENTS.md §"Issue-queue burndowns: sub-agents and the rubric", which #520 introduces (per the `/review` finding on this PR, fixed in `6558744` by citing the exact heading and recording this constraint).

Per this repo's own docs rules: content lives in the topic doc, the router gains one row, nothing else moves. Being `.md` + `design/`-only, `tools/netlify/ignore-build.sh` skips the deploy preview for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013y57koArrUCwNYRYhn9483