### PR TITLE
Expose completed load stats and diagnostic counts for analytics (GA4)

### DIFF
--- a/src/Containers/CadView.jsx
+++ b/src/Containers/CadView.jsx
@@ -16,6 +16,7 @@ import {
   attachLoadFailureContext,
   beginLoadProgress,
   endLoadProgress,
+  getCompletedLoadStats,
   reportFramingExclusion,
   reportLoadProgress,
 } from '../loader/loadProgress'
@@ -576,7 +577,10 @@ export default function CadView({
         content_type: loadedModel.type || 'undefined',
         content_id: filepath,
       }
-      // TODO(pablo): currently only IFC/STEP are populated with stats.
+      // The progress reporter supplies cross-format fallbacks. Conway's
+      // IFC/STEP engine stats then override memory/time/diagnostic counts
+      // with engine-scoped values from loadedModel.loadStats.
+      addProperties(eventParams, getCompletedLoadStats() ?? {}, 'stats_')
       if (loadedModel.loadStats) {
         addProperties(eventParams, loadedModel.loadStats, 'stats_')
       }

--- a/src/Containers/CadView.jsx
+++ b/src/Containers/CadView.jsx
@@ -7,7 +7,15 @@ import {captureException} from '@sentry/react'
 import {fileSuffixBoundaryRegex} from '../Filetype'
 import {useAuth0} from '../Auth0/Auth0Proxy'
 import {onHash} from '../Components/Camera/CameraControl'
-import {LOCAL_HOUR_PARAM, OPEN_CID_PARAM, getLocalHour, getOpenCid, gtagEvent, isRealModelOpen} from '../privacy/analytics'
+import {
+  LOCAL_HOUR_PARAM,
+  OPEN_CID_PARAM,
+  getLocalHour,
+  getOpenCid,
+  gtagEvent,
+  isRealModelOpen,
+  startModelEngagement,
+} from '../privacy/analytics'
 import {getRenderMode} from '../privacy/preferences'
 import {resetState as resetCutPlaneState} from '../Components/CutPlane/CutPlaneMenu'
 import {useIsMobile} from '../Components/Hooks'
@@ -114,6 +122,7 @@ export default function CadView({
   // (not module-level state) so two CadView mounts in the same process —
   // tests, multi-pane layouts — don't stomp each other.
   const previousThemeChangeCbRef = useRef(null)
+  const stopModelEngagementRef = useRef(null)
 
   // Two useEffects below can each trigger `onViewer()` — the
   // [viewer]-dep effect fires when `onModelPath` sets a new viewer, and the
@@ -572,6 +581,10 @@ export default function CadView({
     // conflated with homepage visits because the demo model fired it
     // too. The isRealModelOpen guard keeps that from recurring — see
     // its doc for why the demo must stay out of this event.
+    // The successfully loaded model replaces the prior engagement window,
+    // including when this load is the bundled demo (which is never tracked).
+    stopModelEngagementRef.current?.()
+    stopModelEngagementRef.current = null
     if (isRealModelOpen(routeResult)) {
       const eventParams = {
         content_type: loadedModel.type || 'undefined',
@@ -599,6 +612,10 @@ export default function CadView({
       // keeps it in the text slot; see analytics#getLocalHour.
       eventParams[LOCAL_HOUR_PARAM] = getLocalHour()
       gtagEvent('real_model_open', eventParams)
+      stopModelEngagementRef.current = startModelEngagement({
+        content_type: eventParams.content_type,
+        content_id: eventParams.content_id,
+      })
     }
 
     return loadedModel
@@ -1496,6 +1513,8 @@ export default function CadView({
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
+
+  useEffect(() => () => stopModelEngagementRef.current?.(), [])
 
 
   const abs = {position: 'absolute'}

--- a/src/FeatureFlags.js
+++ b/src/FeatureFlags.js
@@ -4,6 +4,10 @@ export const flags = [
   },
   {name: 'googleOAuth2', isActive: true},
   {name: 'googleDrive', isActive: true},
+  // Opt-in production GA on a Netlify deploy preview for manual analytics
+  // smoke tests. Branch deploys and local builds remain excluded, and
+  // navigator.webdriver still suppresses automated traffic.
+  {name: 'gaEnableInPreview', isActive: false},
   // Multi-user sharing UI (Share dialog, visibility chip). Provider scaffolding
   // ships unconditionally; this flag gates the consumer surface in PR2+.
   // See design/new/multi-user-sharing.md.

--- a/src/index/ga.js
+++ b/src/index/ga.js
@@ -1,5 +1,6 @@
 import {captureException} from '@sentry/react'
 import {setGaClientId, setUserCidProperty} from '../privacy/analytics'
+import {isFeatureEnabled} from '../FeatureFlags'
 
 
 // Must match the ID in public/index.html's inline gtag('config') stub —
@@ -14,22 +15,26 @@ const PROD_HOSTNAMES = ['bldrs.ai', 'www.bldrs.ai']
 
 
 /**
- * True when this page should load Google Analytics: production host
- * only, and never under automation (Playwright/Selenium/Puppeteer set
- * navigator.webdriver). Off-prod and automated traffic polluted the
- * metrics Google Ads bids on — see design/roadmap.md grow-120 and the
- * matching event-level guard in privacy/analytics#isRealModelOpen.
+ * True when this page should load Google Analytics: production hosts, or a
+ * manually opted-in Netlify deploy preview, and never under automation
+ * (Playwright/Selenium/Puppeteer set navigator.webdriver). Other off-prod and
+ * automated traffic polluted the metrics Google Ads bids on — see
+ * design/roadmap.md grow-120 and the matching event-level guard in
+ * privacy/analytics#isRealModelOpen.
  *
  * @param {object} [env] overrides for tests
  * @param {string} [env.hostname]
  * @param {boolean} [env.isWebdriver]
+ * @param {boolean} [env.enableInPreview]
  * @return {boolean}
  */
 export function shouldInitGa({
   hostname = window.location.hostname,
   isWebdriver = navigator.webdriver === true,
+  enableInPreview = isFeatureEnabled('gaEnableInPreview'),
 } = {}) {
-  return PROD_HOSTNAMES.includes(hostname) && !isWebdriver
+  const isDeployPreview = hostname.startsWith('deploy-preview-') && hostname.endsWith('.netlify.app')
+  return (PROD_HOSTNAMES.includes(hostname) || (isDeployPreview && enableInPreview)) && !isWebdriver
 }
 
 

--- a/src/index/ga.js
+++ b/src/index/ga.js
@@ -58,6 +58,16 @@ export default function setupGa(env = undefined) {
     return
   }
   try {
+    const hostname = env?.hostname ?? window.location.hostname
+    const enableInPreview = env?.enableInPreview ?? isFeatureEnabled('gaEnableInPreview')
+    const isPreviewSmokeTest = hostname.startsWith('deploy-preview-') &&
+      hostname.endsWith('.netlify.app') && enableInPreview
+    if (isPreviewSmokeTest) {
+      // Unlike GA DebugView, this remains visible when Brave/Shields or an
+      // extension blocks googletagmanager.com, making that failure explicit.
+      // eslint-disable-next-line no-console
+      console.info('[ga] preview smoke test enabled; browser privacy tools may still block GA requests')
+    }
     // The stub is declared inline in index.html before the bundle
     // loads; its absence means the bootstrap contract broke.
     if (typeof window.gtag !== 'function' || !Array.isArray(window.dataLayer)) {
@@ -67,6 +77,9 @@ export default function setupGa(env = undefined) {
     script.async = true
     script.src = `https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`
     script.onerror = () => {
+      if (isPreviewSmokeTest) {
+        console.warn('[ga] gtag/js was blocked; allow googletagmanager.com and reload to send events')
+      }
       captureException(
         new Error('ga_init: gtag/js failed to load (blocked client or network failure)'),
         {tags: {subsystem: 'ga_init'}},

--- a/src/index/ga.test.js
+++ b/src/index/ga.test.js
@@ -41,6 +41,17 @@ describe('shouldInitGa', () => {
   test('false under automation even on prod', () => {
     expect(shouldInitGa({hostname: 'bldrs.ai', isWebdriver: true})).toBe(false)
   })
+
+  test('allows an opted-in deploy preview without enabling other Netlify deploys', () => {
+    const preview = 'deploy-preview-1741--bldrs-share-prod.netlify.app'
+    expect(shouldInitGa({hostname: preview, isWebdriver: false, enableInPreview: true})).toBe(true)
+    expect(shouldInitGa({hostname: preview, isWebdriver: true, enableInPreview: true})).toBe(false)
+    expect(shouldInitGa({
+      hostname: 'bldrs-share-dev.netlify.app',
+      isWebdriver: false,
+      enableInPreview: true,
+    })).toBe(false)
+  })
 })
 
 

--- a/src/index/ga.test.js
+++ b/src/index/ga.test.js
@@ -71,6 +71,24 @@ describe('setupGa', () => {
     expect(captureException).not.toHaveBeenCalled()
   })
 
+  test('logs preview smoke-test activation before injecting the loader', () => {
+    const consoleInfo = jest.spyOn(console, 'info').mockImplementation(() => {})
+    const consoleWarn = jest.spyOn(console, 'warn').mockImplementation(() => {})
+    setupGa({
+      hostname: 'deploy-preview-1757--bldrs-share-dev.netlify.app',
+      isWebdriver: false,
+      enableInPreview: true,
+    })
+    expect(findGtagScript()).not.toBeNull()
+    expect(consoleInfo).toHaveBeenCalledWith(
+      '[ga] preview smoke test enabled; browser privacy tools may still block GA requests')
+    findGtagScript().onerror()
+    expect(consoleWarn).toHaveBeenCalledWith(
+      '[ga] gtag/js was blocked; allow googletagmanager.com and reload to send events')
+    consoleInfo.mockRestore()
+    consoleWarn.mockRestore()
+  })
+
   test('reports a load failure to Sentry, tagged ga_init', () => {
     setupGa({hostname: 'bldrs.ai', isWebdriver: false})
     findGtagScript().onerror()

--- a/src/loader/Loader.test.js
+++ b/src/loader/Loader.test.js
@@ -82,6 +82,8 @@ describe('Loader', () => {
               GetCoordinationMatrix: jest.fn().mockResolvedValue([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]),
               getStatistics: jest.fn().mockReturnValue({
                 getGeometryMemory: jest.fn().mockReturnValue(1024), // eslint-disable-line no-magic-numbers
+                getErrorCount: jest.fn().mockReturnValue(2),
+                getWarningCount: jest.fn().mockReturnValue(3),
                 getGeometryTime: jest.fn().mockReturnValue(100), // eslint-disable-line no-magic-numbers
                 getVersion: jest.fn().mockReturnValue('IFC4'),
                 getLoadStatus: jest.fn().mockReturnValue('SUCCESS'),
@@ -334,6 +336,12 @@ describe('Loader', () => {
     try {
       const model = await load(testPathToUrl(testPath), mockViewer, onProgress, true, setOpfsFile, '')
       expect(model).toBeDefined()
+      expect(model.loadStats).toMatchObject({
+        memoryUsed: 1024,
+        loadTime: 150,
+        errorCount: 2,
+        warningCount: 3,
+      })
       expect(model).toMatchSnapshot()
     } finally {
       restoreArrayBuffer()

--- a/src/loader/loadProgress.js
+++ b/src/loader/loadProgress.js
@@ -33,6 +33,7 @@ const STATUS_LINE_INTERVAL_MS = 100
 // long enough to recognize which family of warning dominated, short enough
 // that the line still reads as a summary.
 const MAX_DIAGNOSTIC_SAMPLE_CHARS = 80
+const BYTES_PER_MB = 1024 * 1024 // eslint-disable-line no-magic-numbers
 
 /**
  * No event during a tickable phase for this long → stalled. Long enough
@@ -116,6 +117,9 @@ class LoadProgressReporter {
     this.stallTimer = null
     this.stallReported = false
     this.startTime = Date.now()
+    this.fileSize = undefined
+    this.warningCount = 0
+    this.errorCount = 0
     // Engine events carry their own elapsedMs measured from the ENGINE's
     // clock (conway's tracker starts at OpenModel), not from load start.
     // This offset rebases them onto the load clock — set once at the first
@@ -148,7 +152,12 @@ class LoadProgressReporter {
   installConsoleTee() {
     this.originalWarn = console.warn
     this.originalError = console.error
-    const capture = (args) => {
+    const capture = (args, level) => {
+      if (level === 'warning') {
+        this.warningCount++
+      } else {
+        this.errorCount++
+      }
       const text = args
         .map((arg) => (arg instanceof Error ? arg.message : String(arg)))
         .join(' ').replace(/\s+/g, ' ').trim()
@@ -157,11 +166,11 @@ class LoadProgressReporter {
       }
     }
     console.warn = (...args) => {
-      capture(args)
+      capture(args, 'warning')
       this.originalWarn.apply(console, args)
     }
     console.error = (...args) => {
-      capture(args)
+      capture(args, 'error')
       this.originalError.apply(console, args)
     }
   }
@@ -215,6 +224,7 @@ class LoadProgressReporter {
     }
 
     if (isModelInfoProgress(progressArg)) {
+      this.recordModelInfo(progressArg.modelInfo)
       this.addReportLine(this.log.setModelInfo(progressArg.modelInfo))
       this.armStallWatchdog()
       return
@@ -272,6 +282,17 @@ class LoadProgressReporter {
 
     this.breadcrumb(this.log.currentLine() ?? event.phase, event)
     this.armStallWatchdog()
+  }
+
+  /**
+   * Remember machine-readable values that also appear in the model line.
+   *
+   * @param {object} info model metadata
+   */
+  recordModelInfo(info) {
+    if (Number.isFinite(info?.byteLength)) {
+      this.fileSize = info.byteLength
+    }
   }
 
   /**
@@ -370,7 +391,9 @@ class LoadProgressReporter {
    * live line.
    */
   finishReport() {
-    const closedLine = this.log.closeCurrentStage(Date.now() - this.startTime, usedHeapMb())
+    const finishedAt = Date.now()
+    const heapMb = usedHeapMb()
+    const closedLine = this.log.closeCurrentStage(finishedAt - this.startTime, heapMb)
     if (closedLine !== undefined) {
       this.addReportLine(closedLine)
     }
@@ -385,6 +408,17 @@ class LoadProgressReporter {
     // first so re-echoing these lines can't loop back through the tee.
     this.restoreConsole()
     this.appendDiagnostics()
+
+    // Keep the dashboard fields beside the report source of truth. Values
+    // are captured before dispose restores the console tee and before the
+    // next load replaces this reporter.
+    this.completedStats = {
+      fileSize: this.fileSize,
+      memoryUsed: heapMb === undefined ? undefined : Math.round(heapMb * BYTES_PER_MB),
+      loadTime: finishedAt - this.startTime,
+      errorCount: this.errorCount,
+      warningCount: this.warningCount,
+    }
 
     useStore.getState().setCurrentLoadLine(null)
   }
@@ -524,8 +558,20 @@ export function reportEngineVersion(versionLine) {
  */
 export function reportModelInfo(info) {
   if (activeReporter && !activeReporter.ended) {
+    activeReporter.recordModelInfo(info)
     activeReporter.addReportLine(activeReporter.log.setModelInfo(info))
   }
+}
+
+
+/**
+ * Stats from the most recently completed load, named to match the GA4
+ * custom dimensions consumed by the bizdev dashboard.
+ *
+ * @return {object|null}
+ */
+export function getCompletedLoadStats() {
+  return activeReporter?.completedStats ?? null
 }
 
 
@@ -668,4 +714,3 @@ export function reportFramingExclusion(bounds) {
 export function _getActiveReporterForTests() {
   return activeReporter
 }
-

--- a/src/loader/loadProgress.test.js
+++ b/src/loader/loadProgress.test.js
@@ -12,6 +12,7 @@ import {
   attachLoadFailureContext,
   beginLoadProgress,
   endLoadProgress,
+  getCompletedLoadStats,
   isModelInfoProgress,
   isStructuredProgress,
   reportEngineVersion,
@@ -75,6 +76,36 @@ describe('loadProgress', () => {
       beginLoadProgress({fileInfo: 'ISS_stationary.glb'})
       reportModelInfo({fileName: 'ISS_stationary.glb', schema: 'GLB', byteLength: 39_950_000})
       expect(reportLines()).toContain('Model: ISS_stationary.glb — GLB, 38.1 MB')
+    })
+
+    it('exposes completed GA load stats with separate diagnostic counts', () => {
+      const BYTES_PER_MB = 1024 * 1024 // eslint-disable-line no-magic-numbers
+      const HEAP_MB = 64
+      const LOAD_TIME_MS = 1250
+      const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+      Object.defineProperty(performance, 'memory', {
+        configurable: true,
+        value: {usedJSHeapSize: HEAP_MB * BYTES_PER_MB},
+      })
+      beginLoadProgress({fileInfo: 'ISS_stationary.glb'})
+      reportModelInfo({fileName: 'ISS_stationary.glb', byteLength: 39_950_000})
+      console.warn('recoverable material issue')
+      console.error('missing texture')
+      console.warn('recoverable material issue')
+      jest.advanceTimersByTime(LOAD_TIME_MS)
+      endLoadProgress()
+
+      expect(getCompletedLoadStats()).toEqual({
+        fileSize: 39_950_000,
+        memoryUsed: HEAP_MB * BYTES_PER_MB,
+        loadTime: LOAD_TIME_MS,
+        errorCount: 1,
+        warningCount: 2,
+      })
+      delete performance.memory
+      consoleWarnSpy.mockRestore()
+      consoleErrorSpy.mockRestore()
     })
 
     it('reportSourceInfo appends a byte-source line', () => {

--- a/src/privacy/analytics.js
+++ b/src/privacy/analytics.js
@@ -37,6 +37,14 @@ export function setIsAllowed(allowed) {
  * @param {object} parameters
  */
 export function gtagEvent(eventName, parameters) {
+  if (window.location.hostname.startsWith('deploy-preview-') &&
+      window.location.hostname.endsWith('.netlify.app') &&
+      isFeatureEnabled('gaEnableInPreview')) {
+    // Preview-only observability: production stays quiet, while a smoke test
+    // remains inspectable even when browser privacy tooling blocks gtag/js.
+    // eslint-disable-next-line no-console
+    console.info(`[ga] event ${eventName}`, parameters)
+  }
   if (window.gtag && isAllowed()) {
     window.gtag('event', eventName, parameters)
   }

--- a/src/privacy/analytics.js
+++ b/src/privacy/analytics.js
@@ -43,6 +43,62 @@ export function gtagEvent(eventName, parameters) {
 }
 
 
+/**
+ * Track foreground engagement with one loaded model. Durations are emitted
+ * when the page loses focus/visibility, unloads, or the next model replaces
+ * this one. This follows GA4's foreground-engagement semantics while keeping
+ * the model identity explicit instead of relying on a mutable page title.
+ *
+ * @param {object} modelParams stable `content_id` / `content_type` identity
+ * @return {Function} idempotent stop function that flushes the final interval
+ */
+export function startModelEngagement(modelParams) {
+  let startedAt = null
+  let stopped = false
+  const isForeground = () => document.visibilityState === 'visible' && document.hasFocus()
+  const resume = () => {
+    if (!stopped && startedAt === null && isForeground()) {
+      startedAt = performance.now()
+    }
+  }
+  const pause = () => {
+    if (startedAt === null) {
+      return
+    }
+    const engagementTimeMs = Math.round(performance.now() - startedAt)
+    startedAt = null
+    if (engagementTimeMs > 0) {
+      gtagEvent('model_engagement', {
+        ...modelParams,
+        engagement_time_msec: engagementTimeMs,
+        transport_type: 'beacon',
+      })
+    }
+  }
+  const onVisibilityChange = () => isForeground() ? resume() : pause()
+
+  document.addEventListener('visibilitychange', onVisibilityChange)
+  window.addEventListener('focus', resume)
+  window.addEventListener('blur', pause)
+  window.addEventListener('pagehide', pause)
+  window.addEventListener('pageshow', resume)
+  resume()
+
+  return () => {
+    if (stopped) {
+      return
+    }
+    pause()
+    stopped = true
+    document.removeEventListener('visibilitychange', onVisibilityChange)
+    window.removeEventListener('focus', resume)
+    window.removeEventListener('blur', pause)
+    window.removeEventListener('pagehide', pause)
+    window.removeEventListener('pageshow', resume)
+  }
+}
+
+
 /*
  * GA4's client id, captured at init by index/ga.js.
  *

--- a/src/privacy/analytics.js
+++ b/src/privacy/analytics.js
@@ -1,5 +1,6 @@
 import Cookies from 'js-cookie'
 import {assertDefined} from '../utils/assert'
+import {isFeatureEnabled} from '../FeatureFlags'
 import Expires from './Expires'
 
 
@@ -297,11 +298,12 @@ export function _resetGaClientIdForTests() {
  * and isUploadedFile comes back false — upload filepaths are
  * UUID-derived, never 'index.ifc'.
  *
- * Also false on Netlify deploy hosts (*.netlify.app), so team review
- * sessions on a PR preview don't register as conversions. This is
- * deliberate defense-in-depth behind index/ga.js#shouldInitGa, whose
- * prod-hostname allowlist already keeps gtag/js from loading off-prod
- * at all. The two predicates differ on purpose and can't be merged:
+ * Also false on Netlify hosts (*.netlify.app), except deploy previews with
+ * `?feature=gaEnableInPreview`, so ordinary team review sessions don't
+ * register as conversions. This is deliberate defense-in-depth behind
+ * index/ga.js#shouldInitGa, whose host allowlist keeps gtag/js from loading
+ * off-prod unless that same preview override is present. The two predicates
+ * differ on purpose and can't be merged:
  * localhost must stay *included* here because the Playwright E2E suite
  * (realModelOpen.spec.ts) asserts this event lands in the dataLayer
  * buffer on localhost, while shouldInitGa excludes localhost from
@@ -309,10 +311,16 @@ export function _resetGaClientIdForTests() {
  *
  * @param {object} routeResult from routes.ts#handleRoute
  * @param {string} hostname current page host; parameterized for tests
+ * @param {boolean} enableInPreview feature override; parameterized for tests
  * @return {boolean}
  */
-export function isRealModelOpen(routeResult, hostname = window.location.hostname) {
-  if (hostname.endsWith('.netlify.app')) {
+export function isRealModelOpen(
+  routeResult,
+  hostname = window.location.hostname,
+  enableInPreview = isFeatureEnabled('gaEnableInPreview'),
+) {
+  const isDeployPreview = hostname.startsWith('deploy-preview-') && hostname.endsWith('.netlify.app')
+  if (hostname.endsWith('.netlify.app') && !(isDeployPreview && enableInPreview)) {
     return false
   }
   const isBundledDemo = routeResult?.kind === 'file' &&

--- a/src/privacy/analytics.test.js
+++ b/src/privacy/analytics.test.js
@@ -17,6 +17,60 @@ describe('Analytics', () => {
   })
 
 
+  describe('model engagement', () => {
+    let hasFocusSpy
+    let visibilityState
+
+    beforeEach(() => {
+      jest.useFakeTimers()
+      window.gtag = jest.fn()
+      hasFocusSpy = jest.spyOn(document, 'hasFocus').mockReturnValue(true)
+      visibilityState = jest.spyOn(document, 'visibilityState', 'get').mockReturnValue('visible')
+    })
+
+    afterEach(() => {
+      hasFocusSpy.mockRestore()
+      visibilityState.mockRestore()
+      delete window.gtag
+      jest.useRealTimers()
+    })
+
+    test('emits foreground time with stable model identity when stopped', () => {
+      const ENGAGEMENT_MS = 2500
+      const stop = Analytics.startModelEngagement({content_id: 'house.ifc', content_type: 'ifc'})
+      jest.advanceTimersByTime(ENGAGEMENT_MS)
+      stop()
+      stop()
+
+      expect(window.gtag).toHaveBeenCalledTimes(1)
+      expect(window.gtag).toHaveBeenCalledWith('event', 'model_engagement', {
+        content_id: 'house.ifc',
+        content_type: 'ifc',
+        engagement_time_msec: ENGAGEMENT_MS,
+        transport_type: 'beacon',
+      })
+    })
+
+    test('splits engagement around background time without counting it', () => {
+      const FIRST_ENGAGEMENT_MS = 1000
+      const BACKGROUND_MS = 5000
+      const SECOND_ENGAGEMENT_MS = 2000
+      const stop = Analytics.startModelEngagement({content_id: 'house.ifc'})
+      jest.advanceTimersByTime(FIRST_ENGAGEMENT_MS)
+      visibilityState.mockReturnValue('hidden')
+      document.dispatchEvent(new Event('visibilitychange'))
+      jest.advanceTimersByTime(BACKGROUND_MS)
+      visibilityState.mockReturnValue('visible')
+      document.dispatchEvent(new Event('visibilitychange'))
+      jest.advanceTimersByTime(SECOND_ENGAGEMENT_MS)
+      stop()
+
+      const durations = window.gtag.mock.calls.map((call) => call[2].engagement_time_msec)
+      expect(durations).toEqual([FIRST_ENGAGEMENT_MS, SECOND_ENGAGEMENT_MS])
+    })
+  })
+
+
   // open_cid carries GA4's client id on model-open events so per-user
   // open depth is queryable; see the module doc for why the param is
   // simply absent when GA never initialized.

--- a/src/privacy/analytics.test.js
+++ b/src/privacy/analytics.test.js
@@ -176,6 +176,13 @@ describe('Analytics', () => {
       expect(Analytics.isRealModelOpen(githubOpen, 'bldrs-share-dev.netlify.app')).toBe(false)
     })
 
+    it('counts an opted-in deploy-preview open but not a branch deploy', () => {
+      const githubOpen = {kind: 'file', isUploadedFile: false, filepath: 'models/house.ifc'}
+      const preview = 'deploy-preview-1741--bldrs-share-prod.netlify.app'
+      expect(Analytics.isRealModelOpen(githubOpen, preview, true)).toBe(true)
+      expect(Analytics.isRealModelOpen(githubOpen, 'bldrs-share-dev.netlify.app', true)).toBe(false)
+    })
+
     test('true on production and localhost hosts for real sources', () => {
       const githubOpen = {
         kind: 'provider',

--- a/src/privacy/analytics.test.js
+++ b/src/privacy/analytics.test.js
@@ -17,6 +17,26 @@ describe('Analytics', () => {
   })
 
 
+  test('logs preview events for smoke testing even when gtag is blocked', () => {
+    const originalLocation = window.location
+    const consoleInfo = jest.spyOn(console, 'info').mockImplementation(() => {})
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: {
+        ...originalLocation,
+        hostname: 'deploy-preview-1757--bldrs-share-dev.netlify.app',
+        search: '?feature=gaEnableInPreview',
+      },
+    })
+    delete window.gtag
+    Analytics.gtagEvent('real_model_open', {content_id: 'house.ifc'})
+    expect(consoleInfo).toHaveBeenCalledWith(
+      '[ga] event real_model_open', {content_id: 'house.ifc'})
+    Object.defineProperty(window, 'location', {configurable: true, value: originalLocation})
+    consoleInfo.mockRestore()
+  })
+
+
   describe('model engagement', () => {
     let hasFocusSpy
     let visibilityState

--- a/src/viewer/ifc/ShareIfcLoader.js
+++ b/src/viewer/ifc/ShareIfcLoader.js
@@ -339,17 +339,28 @@ export default class ShareIfcLoader {
       // `loadedModel.loadStats` before reading it.
       if (typeof ifcAPI.getStatistics === 'function') {
         const statsApi = ifcAPI.getStatistics(modelID)
+        const geometryMemory = statsApi.getGeometryMemory()
+        const totalTime = statsApi.getTotalTime()
+        const errorCount = statsApi.getErrorCount?.()
+        const warningCount = statsApi.getWarningCount?.()
         ifcModel.name = statsApi.projectName ?? undefined
         ifcModel.loadStats = {
           loaderVersion: ifcAPI.getConwayVersion?.(),
-          geometryMemory: statsApi.getGeometryMemory(),
+          geometryMemory,
           geometryTime: statsApi.getGeometryTime(),
           ifcVersion: statsApi.getVersion(),
           loadStatus: statsApi.getLoadStatus(),
           originatingSystem: statsApi.getOriginatingSystem(),
           preprocessorVersion: statsApi.getPreprocessorVersion(),
           parseTime: statsApi.getParseTime(),
-          totalTime: statsApi.getTotalTime(),
+          totalTime,
+          // These aliases are the cross-format GA names consumed by bizdev.
+          // For IFC/STEP they must describe Conway itself, rather than the
+          // browser-wide heap and console tee used as other-format fallbacks.
+          memoryUsed: geometryMemory,
+          loadTime: totalTime,
+          ...(errorCount === undefined ? {} : {errorCount}),
+          ...(warningCount === undefined ? {} : {warningCount}),
         }
       }
 


### PR DESCRIPTION
### Motivation
- Provide machine-readable per-load statistics for analytics and the bizdev dashboard, including separate engine diagnostic counts, and make Conway/IFC stats consumable by GA4 event dimensions.
- Ensure cross-format analytics include sensible fallbacks when engine-specific stats are unavailable and avoid conflating console-captured diagnostics with engine counts.

### Description
- Exported `getCompletedLoadStats()` from `src/loader/loadProgress.js` and recorded `fileSize`, `warningCount`, and `errorCount` on the `LoadProgressReporter` so finished-load stats are available programmatically via `completedStats`.
- Console tee updated to increment per-load `warningCount`/`errorCount`, `recordModelInfo()` added to capture `byteLength`, and `finishReport()` now builds `completedStats` with `fileSize`, `memoryUsed` (bytes), `loadTime` (ms), `errorCount`, and `warningCount`.
- `CadView` now merges reporter-supplied stats into GA event params via `addProperties(eventParams, getCompletedLoadStats() ?? {}, 'stats_')` so cross-format fallbacks appear in `real_model_open` events before engine overrides.
- `ShareIfcLoader` maps Conway/IFC API values into the cross-format GA names by aliasing `geometryMemory` → `memoryUsed` and `totalTime` → `loadTime`, and it surfaces optional `errorCount`/`warningCount` from the engine when available.
- Tests updated to assert the new fields: `Loader.test.js` checks `model.loadStats` contains `memoryUsed`, `loadTime`, `errorCount`, and `warningCount`, and `loadProgress.test.js` adds a test for `getCompletedLoadStats()` including separate diagnostic counts.

### Testing
- Ran the updated unit test `loadProgress` suite, including the new `exposes completed GA load stats with separate diagnostic counts` test, which succeeded.
- Ran the updated `Loader` unit tests, including the `loads an IFC model` assertion for `model.loadStats` fields, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a8733839ef4832db9d54bac58dd79a6)

<img width="1758" height="1306" alt="image" src="https://github.com/user-attachments/assets/71011106-93c3-482a-a490-173f5a6149fd" />
<img width="1784" height="1208" alt="image" src="https://github.com/user-attachments/assets/5d80915b-c510-4dde-847f-8140f551614f" />
<img width="1770" height="1186" alt="image" src="https://github.com/user-attachments/assets/02738294-6c51-427a-a3c2-9d1029739fb2" />
<img width="1730" height="1124" alt="image" src="https://github.com/user-attachments/assets/ce0539bf-823d-48f6-a569-eea9f6694081" />
