### PR TITLE
Document engagement_time_msec as GA4-reserved; engagement queries userEngagementDuration

### DIFF
--- a/design/roadmap.md
+++ b/design/roadmap.md
@@ -761,6 +761,21 @@ which channel *reaches* that audience is the open GTM question owned bizdev-side
   a padded-but-unprefixed hour would still beacon as a number and leave the
   dimension empty for all 24 values. **Remaining GA4-side config:** an
   event-scoped dimension from event parameter `local_hour`.
+- Time spent per model (2026-08-20): `analytics#startModelEngagement` emits a
+  `model_engagement` event for each foreground, focused interval a model is
+  open for, carrying the same `content_id`/`content_type` identity as the open
+  and the interval's duration in GA4's reserved `engagement_time_msec`.
+  **Remaining GA4-side config: none** — and deliberately so. Registering
+  `engagement_time_msec` as a custom metric was tried (2026-08-21) and is
+  impossible: Admin rejects the name inline with "Parameter name is not allowed
+  for this scope", so `customEvent:engagement_time_msec` can never resolve and
+  a report naming it 400s. The name is reserved because GA4 consumes it to
+  compute the standard `userEngagementDuration` metric, which is therefore
+  where these durations already are: query `userEngagementDuration` ×
+  `customEvent:content_id`, filtered to eventName `model_engagement`, for total
+  time per model across all users (in *seconds* — GA4 sums our milliseconds).
+  Unlike `open_cid`, this event carries no client id, so engagement is not
+  per-user; the bizdev card labels it "all users" for that reason.
 - Model *name* was considered and deliberately not sent. For remote models the
   name is already derivable from `content_id`; the only case it would add
   information is local uploads, which route by OPFS blob id — so sending it

--- a/design/roadmap.md
+++ b/design/roadmap.md
@@ -774,9 +774,11 @@ which channel *reaches* that audience is the open GTM question owned bizdev-side
   where these durations already are: query `userEngagementDuration` ×
   `customEvent:content_id`, filtered to eventName `model_engagement`, for total
   time per model across all users (the metric is in *seconds*, against the
-  milliseconds we send). Unlike `open_cid`, this event carries no client id, so
-  engagement is not per-user; the bizdev card labels it "all users" for that
-  reason. One caveat to settle in DebugView before anyone treats the number as
+  milliseconds we send). This event carries no `open_cid` *param*, so that query
+  is all-users and the bizdev card labels it so. Per-user engagement is not
+  blocked on adding the param here: the user property above rides on every
+  event including this one, so it comes from registering the **User**-scoped
+  `open_cid` dimension — the config that bullet already lists as outstanding. One caveat to settle in DebugView before anyone treats the number as
   exact: gtag accrues foreground time itself, and whether it replaces that with
   the value we pass or adds to it decides whether the metric is our intervals
   or runs high.

--- a/design/roadmap.md
+++ b/design/roadmap.md
@@ -773,9 +773,13 @@ which channel *reaches* that audience is the open GTM question owned bizdev-side
   compute the standard `userEngagementDuration` metric, which is therefore
   where these durations already are: query `userEngagementDuration` ×
   `customEvent:content_id`, filtered to eventName `model_engagement`, for total
-  time per model across all users (in *seconds* — GA4 sums our milliseconds).
-  Unlike `open_cid`, this event carries no client id, so engagement is not
-  per-user; the bizdev card labels it "all users" for that reason.
+  time per model across all users (the metric is in *seconds*, against the
+  milliseconds we send). Unlike `open_cid`, this event carries no client id, so
+  engagement is not per-user; the bizdev card labels it "all users" for that
+  reason. One caveat to settle in DebugView before anyone treats the number as
+  exact: gtag accrues foreground time itself, and whether it replaces that with
+  the value we pass or adds to it decides whether the metric is our intervals
+  or runs high.
 - Model *name* was considered and deliberately not sent. For remote models the
   name is already derivable from `content_id`; the only case it would add
   information is local uploads, which route by OPFS blob id — so sending it

--- a/design/roadmap.md
+++ b/design/roadmap.md
@@ -778,10 +778,11 @@ which channel *reaches* that audience is the open GTM question owned bizdev-side
   is all-users and the bizdev card labels it so. Per-user engagement is not
   blocked on adding the param here: the user property above rides on every
   event including this one, so it comes from registering the **User**-scoped
-  `open_cid` dimension — the config that bullet already lists as outstanding. One caveat to settle in DebugView before anyone treats the number as
-  exact: gtag accrues foreground time itself, and whether it replaces that with
-  the value we pass or adds to it decides whether the metric is our intervals
-  or runs high.
+  `open_cid` dimension — the config that bullet already lists as outstanding.
+  One caveat to settle in DebugView before anyone treats the number as exact:
+  gtag accrues foreground time itself, and whether it replaces that with the
+  value we pass or adds to it decides whether the metric is our intervals or
+  runs high.
 - Model *name* was considered and deliberately not sent. For remote models the
   name is already derivable from `content_id`; the only case it would add
   information is local uploads, which route by OPFS blob id — so sending it

--- a/src/privacy/analytics.js
+++ b/src/privacy/analytics.js
@@ -83,10 +83,12 @@ export function gtagEvent(eventName, parameters) {
  *      — the metric reports seconds, against the milliseconds sent from
  *      here.
  *
- * So the name is fixed, not incidental. Renaming it to something
- * registerable would take these durations straight back out of
- * `userEngagementDuration` — where every consumer now reads them — in
- * exchange for a custom metric that has to be created GA4-side first.
+ * So the name is load-bearing while the query above is what reads these
+ * durations. Renaming it to something registerable is not impossible, but
+ * it is a migration rather than an edit: the durations leave
+ * `userEngagementDuration` the moment the name changes, and only come back
+ * as a custom metric once one is registered GA4-side and the dashboard is
+ * repointed at it. Don't rename one end alone.
  *
  * Sending it explicitly is also what ties the interval to *this* model:
  * gtag accrues foreground time on its own and attaches it to whatever event

--- a/src/privacy/analytics.js
+++ b/src/privacy/analytics.js
@@ -70,9 +70,12 @@ export function gtagEvent(eventName, parameters) {
  *      so these intervals are already queryable with no GA4-side
  *      registration at all: metric `userEngagementDuration`, dimension
  *      `customEvent:content_id`, filtered to eventName `model_engagement`
- *      — which is what the bizdev dashboard's per-user card asks for
- *      (bizdev `ga/README.md` §"Model engagement"). Note the unit: that
- *      metric reports seconds, GA4 having summed the milliseconds sent here.
+ *      — which is what the bizdev dashboard reads (bizdev `ga/README.md`
+ *      §"Model engagement"). That total is across *all* users and cannot
+ *      be anything else: unlike `real_model_open` this event carries no
+ *      `open_cid`, so there is nothing to key a person to. Mind the unit
+ *      too — the metric reports seconds, against the milliseconds sent
+ *      from here.
  *
  * So the name is fixed, not incidental. Renaming it to something
  * registerable would take these durations straight back out of
@@ -83,6 +86,14 @@ export function gtagEvent(eventName, parameters) {
  * gtag accrues foreground time on its own and attaches it to whatever event
  * it sends next, which is neither model-scoped nor aligned with the
  * visibility windows tracked here.
+ *
+ * How gtag reconciles the two is unverified, and the answer decides how
+ * exact the reported total is: if it replaces its accrued value with the
+ * one sent here, the metric is these intervals; if it adds the two, the
+ * metric runs high. So treat per-model engagement as close rather than
+ * exact until a DebugView pass (or a look at `_et` on the collect beacon)
+ * settles it — and don't write "GA4 summed exactly what we sent" anywhere
+ * downstream before then.
  *
  * @param {object} modelParams stable `content_id` / `content_type` identity
  * @return {Function} idempotent stop function that flushes the final interval

--- a/src/privacy/analytics.js
+++ b/src/privacy/analytics.js
@@ -57,6 +57,33 @@ export function gtagEvent(eventName, parameters) {
  * this one. This follows GA4's foreground-engagement semantics while keeping
  * the model identity explicit instead of relying on a mutable page title.
  *
+ * The duration rides in `engagement_time_msec`, which is GA4's own reserved
+ * parameter rather than a name of our choosing. Two consequences, both
+ * load-bearing:
+ *
+ *   1. It can never be a custom metric. Admin → Custom definitions rejects
+ *      the name inline with "Parameter name is not allowed for this scope"
+ *      (tried 2026-08-21), so `customEvent:engagement_time_msec` never
+ *      resolves and a Data API report naming it 400s forever.
+ *   2. It doesn't need to be. GA4 reserves the name precisely because it
+ *      consumes it to compute the standard `userEngagementDuration` metric,
+ *      so these intervals are already queryable with no GA4-side
+ *      registration at all: metric `userEngagementDuration`, dimension
+ *      `customEvent:content_id`, filtered to eventName `model_engagement`
+ *      — which is what the bizdev dashboard's per-user card asks for
+ *      (bizdev `ga/README.md` §"Model engagement"). Note the unit: that
+ *      metric reports seconds, GA4 having summed the milliseconds sent here.
+ *
+ * So the name is fixed, not incidental. Renaming it to something
+ * registerable would take these durations straight back out of
+ * `userEngagementDuration` — where every consumer now reads them — in
+ * exchange for a custom metric that has to be created GA4-side first.
+ *
+ * Sending it explicitly is also what ties the interval to *this* model:
+ * gtag accrues foreground time on its own and attaches it to whatever event
+ * it sends next, which is neither model-scoped nor aligned with the
+ * visibility windows tracked here.
+ *
  * @param {object} modelParams stable `content_id` / `content_type` identity
  * @return {Function} idempotent stop function that flushes the final interval
  */

--- a/src/privacy/analytics.js
+++ b/src/privacy/analytics.js
@@ -71,11 +71,17 @@ export function gtagEvent(eventName, parameters) {
  *      registration at all: metric `userEngagementDuration`, dimension
  *      `customEvent:content_id`, filtered to eventName `model_engagement`
  *      — which is what the bizdev dashboard reads (bizdev `ga/README.md`
- *      §"Model engagement"). That total is across *all* users and cannot
- *      be anything else: unlike `real_model_open` this event carries no
- *      `open_cid`, so there is nothing to key a person to. Mind the unit
- *      too — the metric reports seconds, against the milliseconds sent
- *      from here.
+ *      §"Model engagement"). As queried today that total is across *all*
+ *      users: unlike `real_model_open` this event carries no `open_cid`
+ *      event param, so that query has nothing to group people by. But
+ *      per-user is reachable, and not by adding that param here — the
+ *      same id also rides as the sticky user property below
+ *      (`setUserCidProperty`), which attaches to this event like any
+ *      other, so a User-scoped dimension would key engagement by person.
+ *      That definition is still unregistered GA4-side, so until it
+ *      exists the number must be labelled all users. Mind the unit too
+ *      — the metric reports seconds, against the milliseconds sent from
+ *      here.
  *
  * So the name is fixed, not incidental. Renaming it to something
  * registerable would take these durations straight back out of

--- a/src/privacy/analytics.test.js
+++ b/src/privacy/analytics.test.js
@@ -55,6 +55,11 @@ describe('Analytics', () => {
       jest.useRealTimers()
     })
 
+    // The param name is pinned, not incidental: GA4 reserves
+    // engagement_time_msec and folds it into the standard
+    // userEngagementDuration metric, which is the only way the durations are
+    // reportable at all (a custom metric on that name cannot be registered).
+    // Renaming it here would empty the bizdev dashboard's engagement column.
     test('emits foreground time with stable model identity when stopped', () => {
       const ENGAGEMENT_MS = 2500
       const stop = Analytics.startModelEngagement({content_id: 'house.ifc', content_type: 'ifc'})

--- a/src/privacy/analytics.test.js
+++ b/src/privacy/analytics.test.js
@@ -55,11 +55,12 @@ describe('Analytics', () => {
       jest.useRealTimers()
     })
 
-    // The param name is pinned, not incidental: GA4 reserves
+    // The param name is load-bearing as things are configured: GA4 reserves
     // engagement_time_msec and folds it into the standard
-    // userEngagementDuration metric, which is the only way the durations are
-    // reportable at all (a custom metric on that name cannot be registered).
-    // Renaming it here would empty the bizdev dashboard's engagement column.
+    // userEngagementDuration metric, which is what the bizdev dashboard
+    // queries. So a rename here is a migration, not an edit — it empties that
+    // column until the new name is registered as a custom metric GA4-side and
+    // the query is repointed at it. See startModelEngagement's doc.
     test('emits foreground time with stable model identity when stopped', () => {
       const ENGAGEMENT_MS = 2500
       const stop = Analytics.startModelEngagement({content_id: 'house.ifc', content_type: 'ifc'})


### PR DESCRIPTION
## What

Documentation only — **no behavior change**. `model_engagement` keeps sending exactly what it sent before.

A live-dashboard session tried to register `engagement_time_msec` as a GA4 event-scoped custom metric so the bizdev dashboard could sum it per model. GA4 Admin rejected it inline with **"Parameter name is not allowed for this scope"**. It is a reserved parameter, so `customEvent:engagement_time_msec` can never resolve and any Data API report naming it 400s — permanently, not pending config.

The name is reserved *because* GA4 consumes it to compute the standard **`userEngagementDuration`** metric. So the durations `startModelEngagement` already emits are reportable with no GA4-side registration at all:

```
metric     userEngagementDuration        (seconds, against the milliseconds we send)
dimension  customEvent:content_id
filter     eventName = model_engagement
```

Nothing in the code said any of this, and this file's whole idiom is recording the GA4-side config each param needs — `open_cid` and `local_hour` both carry theirs.

## Changes

- **`src/privacy/analytics.js`** — `startModelEngagement`'s doc states the constraint, the replacement query, why the param is sent explicitly (gtag's own accrual attaches to whatever event goes next, which is neither model-scoped nor aligned with these visibility windows), and what a rename would actually cost.
- **`src/privacy/analytics.test.js`** — the existing assertion on the param name is annotated as load-bearing.
- **`design/roadmap.md`** — a bullet in the GA4 series recording **Remaining GA4-side config: none**, next to the `open_cid` / `local_hour` entries that do need registration.

## Three things codex corrected, all worth keeping

Each was the same failure mode — an absolute claim where the truth was "as currently configured":

1. **The total is not known to be exact.** gtag accrues foreground time itself; whether it replaces that accrual with our explicit value or adds the two is unverified, and decides whether the metric is our intervals or runs high. The doc now says close-not-exact and names the DebugView / `_et` check that would settle it — instead of asserting GA4 summed what we sent.
2. **Engagement is not permanently un-keyable per user.** Share publishes the same client id as a sticky user property, which rides on `model_engagement` too, so per-user comes from registering the User-scoped dimension — not from adding a param to this event. The earlier wording would have sent someone down exactly that wrong path.
3. **A rename is a migration, not an impossibility.** A *different* name can be registered as a custom metric. What is true is narrower: the current query reads `userEngagementDuration`, which only the reserved name feeds, so a rename empties that column until a custom metric exists and the dashboard is repointed.

## Cross-repo

The query fix is bldrs-ai/bizdev#271 — the per-user card and both copies of the `query_ga` tool prompt, off the dead custom metric and onto `userEngagementDuration`. Landed alongside this.

## Verification

- CI green on the merged commit: `build`, `playwright-run`, `playwright-webifc-run`, Netlify dev + prod.
- Locally before flipping to ready: `yarn test-ci` (239 suites / 2354 tests, coverage thresholds met) and `yarn build-prod`, with the `package.json` version stamp reverted (#1747). Husky gate passed on all four commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CShg8Uig4aHZKjHuwjtGm4