### PR TITLE
Stop the file-browser tests paying for a viewer they never look at

### DIFF
--- a/src/Components/Open/Github.spec.ts
+++ b/src/Components/Open/Github.spec.ts
@@ -97,6 +97,21 @@ describe('Open 100: GitHub Integration', () => {
    * (orgs, repos, branches, contents) is served by the MSW handlers.
    */
   describe('File browser Selector UI', () => {
+    // These three tests are the suite's most interaction-heavy, and on a
+    // GPU-less runner every interaction is expensive. Measured on a 4-core
+    // headless box (#1759): a marketing page with no viewer round-trips
+    // page.evaluate in ~9ms and hits rAF every ~16ms, but once the viewer's
+    // always-on render loop is driving an EffectComposer through
+    // SwiftShader those become ~90ms and ~85ms — the main thread is pinned
+    // at ~12fps. Playwright's actionability checks poll on rAF, so a plain
+    // click on the settled viewer page costs ~1.3s. At ~12 interactions
+    // plus a model load these tests run ~16s alone and ~40s when several
+    // land on the same runner at once, which is how they blew the 30s
+    // default. The budget below is sized off that worst case with headroom;
+    // it is a budget fix, not a cause fix — the render loop is the cause
+    // and it is untouched here.
+    describe.configure({timeout: 90_000})
+
     /**
      * Log in and reveal the GitHub file browser inside the Open dialog.
      *
@@ -105,8 +120,12 @@ describe('Open 100: GitHub Integration', () => {
     async function openGithubBrowser(page: Page) {
       await homepageSetup(page)
       await setupAuthenticationIntercepts(page)
+      // No second goto to /share/v/p/index.ifc here: the helper above
+      // already lands on exactly that URL with the model ready and MSW's
+      // service worker controlling the page. Re-navigating starts a second
+      // IFC+wasm load that nothing awaits, so it burns the main thread
+      // underneath every click that follows — worth ~5s per test (#1759).
       await returningUserVisitsHomepageWaitForModel(page)
-      await page.goto('/share/v/p/index.ifc', {waitUntil: 'domcontentloaded'})
       await auth0Login(page)
       await page.getByTestId('control-button-open').click()
       await page.getByRole('tab', {name: 'GitHub'}).click()

--- a/src/Components/Open/Github.spec.ts
+++ b/src/Components/Open/Github.spec.ts
@@ -2,6 +2,7 @@ import {Page, expect, test} from '@playwright/test'
 import {
   auth0Login,
   homepageSetup,
+  pauseViewerRendering,
   returningUserVisitsHomepageWaitForModel,
   setIsReturningUser,
   setupAuthenticationIntercepts,
@@ -97,35 +98,31 @@ describe('Open 100: GitHub Integration', () => {
    * (orgs, repos, branches, contents) is served by the MSW handlers.
    */
   describe('File browser Selector UI', () => {
-    // These three tests are the suite's most interaction-heavy, and on a
-    // GPU-less runner every interaction is expensive. Measured on a 4-core
-    // headless box (#1759): a marketing page with no viewer round-trips
-    // page.evaluate in ~9ms and hits rAF every ~16ms, but once the viewer's
-    // always-on render loop is driving an EffectComposer through
-    // SwiftShader those become ~90ms and ~85ms — the main thread is pinned
-    // at ~12fps. Playwright's actionability checks poll on rAF, so a plain
-    // click on the settled viewer page costs ~1.3s. At ~12 interactions
-    // plus a model load these tests run ~16s alone and ~40s when several
-    // land on the same runner at once, which is how they blew the 30s
-    // default. The budget below is sized off that worst case with headroom;
-    // it is a budget fix, not a cause fix — the render loop is the cause
-    // and it is untouched here.
-    describe.configure({timeout: 90_000})
-
     /**
      * Log in and reveal the GitHub file browser inside the Open dialog.
+     *
+     * These are the most interaction-heavy tests in the suite, and they
+     * used to overrun the 30s budget whenever more than one landed on a
+     * runner at once (#1759). Two things in this setup were paying for a
+     * 3D viewer these tests never look at; both are removed below, which
+     * is what keeps them inside the default timeout.
      *
      * @param page - Playwright page object
      */
     async function openGithubBrowser(page: Page) {
       await homepageSetup(page)
       await setupAuthenticationIntercepts(page)
-      // No second goto to /share/v/p/index.ifc here: the helper above
+      // No second goto to /share/v/p/index.ifc here: the helper below
       // already lands on exactly that URL with the model ready and MSW's
-      // service worker controlling the page. Re-navigating starts a second
-      // IFC+wasm load that nothing awaits, so it burns the main thread
-      // underneath every click that follows — worth ~5s per test (#1759).
+      // service worker controlling the page. Re-navigating started a
+      // second IFC+wasm load that nothing awaited, so it burned the main
+      // thread underneath every click that followed.
       await returningUserVisitsHomepageWaitForModel(page)
+      // Freeze the scene before touching any UI. Everything below is
+      // dialog interaction — no screenshots, no camera, no highlighting —
+      // so the frames the viewer would keep painting buy nothing and cost
+      // ~7x on every click. See pauseViewerRendering for the measurements.
+      await pauseViewerRendering(page)
       await auth0Login(page)
       await page.getByTestId('control-button-open').click()
       await page.getByRole('tab', {name: 'GitHub'}).click()
@@ -141,12 +138,18 @@ describe('Open 100: GitHub Integration', () => {
      * @param optionName - the option's accessible name
      */
     async function pickOption(page: Page, testId: string, optionName: string) {
-      // force: MUI's Select renders a zero-opacity native <input> over the
-      // combobox, so a normal click fails the actionability hit-test. MUI opens
-      // the menu on mousedown regardless, so a forced click is both safe and
-      // sufficient here (same reason for the other combobox opens below).
+      // Deliberately NOT force-clicked. Closing a MUI menu runs a ~400ms Grow
+      // transition, and its full-screen backdrop stays mounted for the whole
+      // exit — so right after picking an option, the next field is still
+      // covered. A forced click punches straight through that backdrop: the
+      // backdrop swallows it as a click-away, the menu never opens, and the
+      // test hangs later on a locator that looks unrelated. An ordinary click
+      // hit-tests instead, so Playwright simply waits for the backdrop to
+      // unmount. That also keeps the test honest — a dropdown that genuinely
+      // will not open now fails here rather than being clicked through
+      // (#1759).
       const combobox = page.getByTestId(testId).getByRole('combobox')
-      await combobox.click({force: true})
+      await combobox.click()
       const option = page.getByRole('option', {name: optionName, exact: true})
       await option.waitFor({state: 'visible'})
       await option.click()
@@ -184,7 +187,7 @@ describe('Open 100: GitHub Integration', () => {
       await selectOrgSettled(page)
 
       // Switch the Repository field into "Enter name..." text mode and type.
-      await page.getByTestId('openRepository').getByRole('combobox').click({force: true})
+      await page.getByTestId('openRepository').getByRole('combobox').click()
       const enterName = page.getByRole('option', {name: 'Enter name...', exact: true})
       await enterName.waitFor({state: 'visible'})
       await enterName.click()
@@ -200,7 +203,7 @@ describe('Open 100: GitHub Integration', () => {
       await expect(page.getByTestId('openRepository').getByRole('combobox')).toContainText('test-repo')
 
       // Selecting the filtered match drives the downstream file listing.
-      await page.getByTestId('openFile').getByRole('combobox').click({force: true})
+      await page.getByTestId('openFile').getByRole('combobox').click()
       await expect(page.getByRole('option', {name: 'window.ifc', exact: true})).toBeVisible()
     })
 

--- a/src/tests/e2e/utils.ts
+++ b/src/tests/e2e/utils.ts
@@ -319,6 +319,52 @@ export async function dismissLoadGrace(page: Page) {
 
 
 /**
+ * Stop the viewer painting frames, for tests that drive UI over a loaded
+ * model but never assert on the canvas.
+ *
+ * The render loop is always-on: the fork's rAF loop calls the closure
+ * installed via `ThreeContext.setRenderUpdate`, which drives an
+ * `EffectComposer` (DESIGN.md §"Render loop & perf monitor"). Headless CI
+ * has no GPU, so that composer runs through SwiftShader and pins the page's
+ * main thread even when nothing on screen is moving. Playwright polls
+ * actionability on rAF, so the whole harness inherits the frame time.
+ * Measured on a 4-core headless runner: rAF every ~74ms and a single click
+ * ~978ms while painting, versus ~16ms and ~139ms once paused (#1759).
+ *
+ * Replacing the update closure leaves the rAF loop itself running, so the
+ * page keeps ticking normally — it just stops rendering, and the canvas
+ * holds its last painted frame. That makes this safe for dialog/panel flows
+ * and WRONG for anything that screenshots the scene, moves the camera, or
+ * asserts on highlighting. There is no resume: call it after the model is
+ * ready and treat the scene as frozen for the rest of the test.
+ *
+ * Throws rather than degrading if the seam moves. A silent no-op here would
+ * quietly restore the slow path and show up much later as unexplained
+ * timeouts, which is exactly the failure #1759 spent two runs diagnosing.
+ *
+ * @param page - Playwright page object
+ */
+export async function pauseViewerRendering(page: Page) {
+  const paused = await page.evaluate(() => {
+    // `window.useStore` is exposed by BaseRoutes under the test client id
+    // (see the OAUTH_2_CLIENT_ID guard there); `viewer` is set by CadView
+    // once the viewer is initialized.
+    const withStore = window as unknown as {
+      useStore?: {getState: () => {viewer?: {context?: {setRenderUpdate?: (fn: () => void) => void}}}}
+    }
+    const context = withStore.useStore?.getState().viewer?.context
+    if (typeof context?.setRenderUpdate !== 'function') {
+      return false
+    }
+    // Paused deliberately; see this helper's docstring.
+    context.setRenderUpdate(() => undefined)
+    return true
+  })
+  expect(paused, 'pauseViewerRendering: no render seam at window.useStore.getState().viewer.context').toBe(true)
+}
+
+
+/**
  * Helper to register an intercept and navigate to a route
  *
  * @param page - Playwright page object


### PR DESCRIPTION
Closes #1759

## What was actually wrong

Two independent causes, neither of them the dropdown. **No timeout override anywhere** — everything below runs on the 30s default, per STYLE.md §Misc.

### 1. The viewer's render loop makes every Playwright interaction ~7x more expensive

The rAF loop drives an `EffectComposer` (DESIGN.md §"Render loop & perf monitor"). A GPU-less runner puts that through SwiftShader, which pins the page's main thread **forever** — not just during load. Playwright polls actionability on rAF, so the harness inherits the frame time.

| page state | `page.evaluate(() => 1)` | rAF interval | one `control-button-open` click |
|---|---|---|---|
| marketing page, no viewer | 8.8 ms | 15.8 ms | — |
| viewer, model loaded, settled 3s | 91.5 ms | 85.3 ms | **978 ms** |
| same page, render loop paused | 3.4 ms | 16.3 ms | **139 ms** |

These tests never look at the canvas, so the new `pauseViewerRendering` helper swaps the per-frame closure for a no-op through the documented `ThreeContext.setRenderUpdate` seam, reached via the `window.useStore` handle the test build already exposes. **No product code changes.** The rAF loop itself keeps running — the page ticks normally, it just stops painting.

### 2. `force: true` was punching through a modal backdrop

Closing a MUI menu runs a ~400ms Grow transition, and its full-screen backdrop stays mounted for the whole exit. Right after picking an option, the next field is still covered. Caught directly — `document.elementFromPoint` at the repo combobox's centre, immediately before the click that hung:

```
elementAtCenter=DIV.MuiBackdrop-root   listboxes=1     <- org menu still closing
```

A forced click ignores that. The backdrop ate it as a click-away, the menu never opened, and the test hung later on a locator that looked unrelated. Dropping `force` restores the hit-test, so Playwright waits the backdrop out: the unforced click then opens the menu in **83 ms**.

The comment justifying `force` claimed a zero-opacity native input covers the combobox and defeats the hit-test. That is not what happens on MUI 5.16.8 — unforced clicks work. Worth being blunt: `force` made the test do something a real user cannot do, and that is exactly what hid this for as long as it did.

### 3. A redundant navigation (kept from the first round)

`openGithubBrowser` re-navigated to `/share/v/p/index.ifc` right after `returningUserVisitsHomepageWaitForModel`, which already lands on that exact URL with the model ready and MSW's service worker controlling the page. The re-navigation started a second IFC+wasm load that nothing awaited. Measured A/B at 4 workers, twice each: 41–48s → 37–42s per test.

## Is the product broken?

**No.** The dropdowns open on an ordinary click, and all three flows now drive them through real Chromium with real, un-forced clicks — every org → repo → file pick lands. A modal backdrop absorbing a click aimed at what is underneath it is what a backdrop is *for*; a real user cannot click through it and would not want to. The bug was the test claiming a capability users don't have.

## Verification

| | result |
|---|---|
| The three tests, 4 workers, default timeout | 8.9s / 9.2s / 9.5s — three consecutive runs, all green |
| Mutation: restore `force: true` | **3 failed** |
| Mutation: drop `pauseViewerRendering` | **3 failed** |
| Mutation: revert the whole change (first round) | **3 failed**, twice, all at 30.1–30.4s |
| Full suite, `--workers=2` (matches `test-flows.yml`) | **153 passed / 0 failed / 44 skipped / 0 flaky**, 11.6 min |
| `yarn test-ci` | 239 suites, 2354 passed / 5 skipped; coverage thresholds held |
| `yarn build-prod` | exit 0 |

Both fixes are independently load-bearing. Suite wall time drops 14.4 → 11.6 min.

A note on worker count: #1759's numbers came from 4 workers, which over-subscribes a 4-vCPU box against this repo's own measured guidance (`test-flows.yml`: "3 workers => 4 failed / 134 passed, 2 workers => green"). My first full run at 4 workers invented failures in `GoogleDriveConnect.spec.ts` and `NavTree/Synchronization` that are not real. The 2-worker numbers above are the trustworthy ones.

`tools/updateVersion.mjs` stamped `package.json` on each build; reverted every time, and the commits carry no version change (#1747).

## The 44 skipped tests

They are **not** the form-factor split, which #1759 suspected. The six specs using `describeMobileAndDesktop` contain zero skip sites, and the helper only sets a viewport — it never skips. All 44 are static `test.skip` / `describe.skip` / `test.fixme` across 19 spec files, every one a deliberate disable:

| count | source |
|---|---|
| 12 | `IframeIntegration.spec.ts` (whole suite) |
| 6 | `Samples.spec.ts` (two suites) |
| 4 | `Imagine.spec.ts` (#1077 / #1269) |
| 3 | `test.fixme` GLB cache-hit — Properties, NavTree, sceneHighlightPermalink |
| 2 each | routes, OpenModelDialog, Github, Filetypes, Screenshot, MarkerSelection |
| 1 each | Alert, ShowVersion, SaveModel, EditModel, ManageProfile, Note, BotChat |

The largest theme is `TODO(#1269)` model-load flake. Nothing is skipped accidentally and nothing in that set is hiding a regression behind an unexplained mechanism.

## Two things found, not fixed here

- **`dismissLoadGrace` has been a silent no-op.** It reads `window.store`; the app exposes `window.useStore` (`BaseRoutes.jsx`). Its own docstring says it no-ops on non-test builds, so the guard has been swallowing the mismatch. Fixing it would start dismissing a snackbar that screenshot baselines currently include, so it wants its own PR.
- **`GoogleDriveConnect.spec.ts` has the identical redundant `page.goto`**, so it pays the same doubled model load. Not failing, so out of scope — but it is the next-cheapest suite-time saving, and `pauseViewerRendering` would apply there too.