### PR TITLE
Doc the review lifecycle in agent-workflow.md: codex first, sub-agent on timeout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,14 +63,14 @@ This file is the router for AI assistants working in this repo. Keep it small. T
   **Consequence to be aware of:** because every job is gated here, a
   draft gets no CI signal at all, and the husky pre-commit hook covers
   only part of the gap. Three things it does not run, each of which will
-  otherwise first fail at step 3 — after `/review` has signed off, which
+  otherwise first fail at step 3 — after codex has signed off, which
   is exactly the step-4 re-review this lifecycle is trying to avoid:
   (a) `yarn build-prod`, so an esbuild-only breakage (missing asset
   loader, plugin misconfig) survives every draft commit; (b) coverage —
   the hook's `yarn test` runs `test-src`, while CI runs `test-ci` →
   `test-coverage` with thresholds enforced (`tools/jest/jest.config.js`);
   (c) **Playwright**, the big one — E2E specs never execute before step
-  3, so `/review` is reading specs that have never run, against this
+  3, so the reviewer is reading specs that have never run, against this
   file's own mandatory desktop+mobile E2E rule. Before flipping to ready,
   run `yarn build-prod`, `yarn test-ci`, and
   `yarn test-flows-build-and-serve` + `yarn test-flows [spec]` — then undo

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,13 +28,12 @@ This file is the router for AI assistants working in this repo. Keep it small. T
   runs the full suite on every rework push starves the PRs that are
   ready. (1) Open it with `draft: true` — not opened-then-marked.
   (2) Keep it in draft until review has run and every finding is
-  fixed or answered in the thread. **codex is the reviewer** — usually
-  automatic, otherwise `@codex review` on the PR; if it hasn't answered
-  ~10 min after the request, dispatch a sub-agent review and treat that
-  as the round. Docs-only PRs skip review by default, except when the
-  doc *is* the policy (how we review, dispatch or release). Full rules:
-  [design/new/agent-workflow.md](design/new/agent-workflow.md)
-  §"Review". (3) Flip to ready
+  fixed or answered in the thread — who reviews, the timeout fallback,
+  the round cap, and which PRs skip review entirely are all specified
+  in [design/new/agent-workflow.md](design/new/agent-workflow.md)
+  §"Review", which is the single source for review policy. Read it
+  before requesting or skipping a round; don't restate its rules here.
+  (3) Flip to ready
   (`update_pull_request`, `draft: false`); that fires
   `ready_for_review`, which is what starts the gated jobs. (4) Drive CI
   green, and re-request review if the fixes changed the diff beyond a
@@ -63,7 +62,7 @@ This file is the router for AI assistants working in this repo. Keep it small. T
   **Consequence to be aware of:** because every job is gated here, a
   draft gets no CI signal at all, and the husky pre-commit hook covers
   only part of the gap. Three things it does not run, each of which will
-  otherwise first fail at step 3 — after codex has signed off, which
+  otherwise first fail at step 3 — after review has signed off, which
   is exactly the step-4 re-review this lifecycle is trying to avoid:
   (a) `yarn build-prod`, so an esbuild-only breakage (missing asset
   loader, plugin misconfig) survives every draft commit; (b) coverage —
@@ -117,7 +116,7 @@ This file is the router for AI assistants working in this repo. Keep it small. T
 | Epic/Story/Track catalogue, milestone tier rubric (§2.1), MVP bar + phase plan (§6, ex-"Pro-MVP"), growth-funnel Phase G, AI-workspace pivot (§7), post-MVP loveables | [design/roadmap.md](design/roadmap.md) |
 | Conversational-CAD epic plan (workspace shell / ProjectsDrawer + TopBar, fluid Nav+search, convo panel, multi-user channels), wireframe→issue mapping, epic/sub-issue process | [design/new/conversational-cad.md](design/new/conversational-cad.md) |
 | Persistence direction: OPFS as a git-versioned workspace (repo-as-workspace, LFS-pointer blobs, record-vs-stream convo split, wasm-git vs isomorphic-git investigation, exit plan) | [design/new/workspace-store.md](design/new/workspace-store.md) |
-| Working an issue queue with AI agents — coordinator + per-issue sub-agents, model tiers (Fable coordinates, Opus executes), the dispatch-brief requirements, the 10-point rubric, and the review lifecycle (codex first, sub-agent on ~10min timeout, docs-only skips review) | [design/new/agent-workflow.md](design/new/agent-workflow.md) |
+| Working an issue queue with AI agents — coordinator + per-issue sub-agents, model tiers (Fable coordinates, Opus executes), the dispatch-brief requirements, the 10-point rubric, and the review lifecycle — the single source for who reviews a PR, when review is skipped, and how rounds are capped | [design/new/agent-workflow.md](design/new/agent-workflow.md) |
 
 Anything not in this table is invisible to the router. When you create a doc that future assistants should consult, add a row above with a one-line "when to read" hint. Don't rely on filesystem discovery.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,10 +39,12 @@ This file is the router for AI assistants working in this repo. Keep it small. T
   **What the gate covers:** `build` (main.yml) and both `test-flows`
   jobs are skipped on drafts. **Netlify deploy previews still run** —
   they come from Netlify's GitHub integration, not Actions — so a draft
-  normally has a preview URL to click through. (Not for a docs-only PR:
-  `tools/netlify/ignore-build.sh` skips the deploy when every changed
-  file matches `.md` / `design/` / `notes/`. Marketing posts are `.mdx`,
-  so they still build.) Before editing those
+  normally has a preview URL to click through. (`tools/netlify/ignore-build.sh`
+  skips the deploy when every changed file matches `.md` / `design/` /
+  `notes/` — but only from a branch's *second* push onward, since it
+  bails to build when `CACHED_COMMIT_REF` is unset and a new branch has
+  no prior deploy, so the push that opens a docs-only PR still builds
+  (#1766). Marketing posts are `.mdx`, so they always build.) Before editing those
   workflows: the gate is a job-level `if:` (a skipped-by-if job
   satisfies a required check; a workflow that never triggers leaves the
   PR waiting forever); `ready_for_review` and `converted_to_draft` must
@@ -109,7 +111,7 @@ This file is the router for AI assistants working in this repo. Keep it small. T
 | Epic/Story/Track catalogue, milestone tier rubric (§2.1), MVP bar + phase plan (§6, ex-"Pro-MVP"), growth-funnel Phase G, AI-workspace pivot (§7), post-MVP loveables | [design/roadmap.md](design/roadmap.md) |
 | Conversational-CAD epic plan (workspace shell / ProjectsDrawer + TopBar, fluid Nav+search, convo panel, multi-user channels), wireframe→issue mapping, epic/sub-issue process | [design/new/conversational-cad.md](design/new/conversational-cad.md) |
 | Persistence direction: OPFS as a git-versioned workspace (repo-as-workspace, LFS-pointer blobs, record-vs-stream convo split, wasm-git vs isomorphic-git investigation, exit plan) | [design/new/workspace-store.md](design/new/workspace-store.md) |
-| Working an issue queue with AI agents — coordinator + per-issue sub-agents, model tiers (Fable coordinates, Opus executes), the dispatch-brief requirements and the 10-point rubric | [design/new/agent-workflow.md](design/new/agent-workflow.md) |
+| Working an issue queue with AI agents — coordinator + per-issue sub-agents, model tiers (Fable coordinates, Opus executes), the dispatch-brief requirements, the 10-point rubric, and the review lifecycle (codex first, sub-agent on ~10min timeout, docs-only skips review) | [design/new/agent-workflow.md](design/new/agent-workflow.md) |
 
 Anything not in this table is invisible to the router. When you create a doc that future assistants should consult, add a row above with a one-line "when to read" hint. Don't rely on filesystem discovery.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,11 +27,17 @@ This file is the router for AI assistants working in this repo. Keep it small. T
   in flight and CI runners are capped at 4 concurrent jobs, so a PR that
   runs the full suite on every rework push starves the PRs that are
   ready. (1) Open it with `draft: true` — not opened-then-marked.
-  (2) Keep it in draft until `/review` has run and every finding is
-  fixed or answered in the thread. (3) Flip to ready
+  (2) Keep it in draft until review has run and every finding is
+  fixed or answered in the thread. **codex is the reviewer** — usually
+  automatic, otherwise `@codex review` on the PR; if it hasn't answered
+  ~10 min after the request, dispatch a sub-agent review and treat that
+  as the round. Docs-only PRs skip review by default, except when the
+  doc *is* the policy (how we review, dispatch or release). Full rules:
+  [design/new/agent-workflow.md](design/new/agent-workflow.md)
+  §"Review". (3) Flip to ready
   (`update_pull_request`, `draft: false`); that fires
   `ready_for_review`, which is what starts the gated jobs. (4) Drive CI
-  green, and `/review` again if the fixes changed the diff beyond a
+  green, and re-request review if the fixes changed the diff beyond a
   trivial revert — otherwise the reviewed diff isn't the merged diff.
   (5) Update the PR description to match what the change became, merge,
   then close or narrow its issues (partly-addressed → a comment saying

--- a/design/new/agent-workflow.md
+++ b/design/new/agent-workflow.md
@@ -84,7 +84,14 @@ Sub-agents do not review their own code, and the coordinator does not
 review theirs. Review comes from **codex** — usually automatic;
 otherwise request it with an `@codex review` comment on the PR.
 
-Two rules keep that from becoming a bottleneck or a rubber stamp.
+**Docs-only changes skip review by default.** There is no code to
+attack, and a review round on a paragraph costs more than it finds.
+Make an exception where the doc *is* the policy — a change to how we
+review, dispatch or release is worth having codex read, precisely
+because it is the thing codex will be held to.
+
+Three rules keep review from becoming either a bottleneck or a
+rubber stamp.
 
 **Timeout.** If codex has not responded ~10 minutes after the
 request, dispatch a **sub-agent review** and treat that as the round

--- a/design/new/agent-workflow.md
+++ b/design/new/agent-workflow.md
@@ -77,3 +77,37 @@ Reviewers hold the same bar, in this order: verify claims against
 the diff (not the description), against repo history, then against
 the actual failure path — and grade findings by evidence, not
 plausibility.
+
+## Review: codex first, sub-agent on timeout
+
+Sub-agents do not review their own code, and the coordinator does not
+review theirs. Review comes from **codex** — usually automatic;
+otherwise request it with an `@codex review` comment on the PR.
+
+Two rules keep that from becoming a bottleneck or a rubber stamp.
+
+**Timeout.** If codex has not responded ~10 minutes after the
+request, dispatch a **sub-agent review** and treat that as the round
+rather than waiting. A late codex finding still counts — fold it in
+when it arrives, even if a sub-agent round has already run.
+
+**A substituting reviewer needs to be pointed at the hazards.** A
+generic "review this diff" comes back clean on exactly the changes
+that most need scrutiny, because the risky part of a good fix is
+usually an invariant the diff does not mention. Hand the reviewer the
+issue as well as the diff, and name the specific claims to attack —
+the order-preservation argument behind a zero-digest-churn claim, the
+state that has to stay stable across a demand pump, whatever the
+change is actually betting on. A clean review that never engaged with
+the load-bearing claim has not reviewed it.
+
+**Cap the rounds.** A few rounds, not an open-ended dialogue. If
+findings are still arriving after ~3, or the review turns into a long
+back-and-forth, pause it and escalate to the coordinator — that
+pattern usually means the change needs a design decision, not more
+review turns.
+
+One caution from experience: codex has reversed itself on an
+identical commit more than once, clean on one pass and not on the
+next. A single clean pass is not by itself a merge signal. Read what
+it said.


### PR DESCRIPTION
Docs-only. Adds a **Review** section to [`design/new/agent-workflow.md`](design/new/agent-workflow.md) and makes it the single source for review policy, plus one `AGENTS.md` correction this PR happened to disprove.

## Why

The doc already covered roles and models, the dispatch brief, and the 10-point rubric — but said nothing about how review actually gets requested, or what to do when it stalls. Each burndown re-decided it from scratch, usually mid-flight while a sub-agent sat idle waiting on a review that wasn't coming.

## What the Review section records

- **codex is the reviewer.** Sub-agents don't review their own work, and the coordinator doesn't review theirs. Usually automatic; otherwise `@codex review`.
- **Docs-only changes skip review by default** — no code to attack, and a round on a paragraph costs more than it finds. The exception is a doc that *is* the policy, which is why this PR has a review on it.
- **~10 minutes of silence → dispatch a sub-agent review** and treat it as the round. A late codex finding still folds in.
- **A substituting reviewer has to be pointed at the hazards** — hand it the issue, not just the diff, and name the claim to attack. A generic "review this diff" comes back clean on exactly the changes that most need scrutiny, because the risky part of a good fix is usually an invariant the diff never mentions.
- **Rounds cap at ~3**, then escalate.

Plus the caution that codex has reversed itself on an identical commit more than once, so one clean pass isn't a merge signal (conway#566 and conway#569 both cost time that way).

## The `AGENTS.md` changes

Two things, both driven by review:

**Review policy lives in one place.** The router's five-step lifecycle used to require `/review` unconditionally, which would have made the new section dead text — the router wins by default. Fixing that by copying the rules into the router traded a visible contradiction for an invisible one, so step (2) now carries only the lifecycle constraint and a pointer, with an explicit "don't restate its rules here". `grep -c codex AGENTS.md` is 0.

**The Netlify docs-skip claim was wrong.** `AGENTS.md` stated flatly that docs-only PRs get no deploy preview. `tools/netlify/ignore-build.sh:14-16` exits 1 (build) when `CACHED_COMMIT_REF` is unset, and a new branch has no prior successful deploy — so the skip can't fire on the push that opens a PR, only from the second onward. This PR demonstrated it by building a full preview off a one-file `design/` change. Reworded; filed as #1766 for the actual decision.

Note for readers: `CLAUDE.md` is a symlink to `AGENTS.md` — one file, two names.

## Testing

No code changed. The husky pre-commit gate (eslint + typecheck + jest) passed on every commit.

## Review state

Three codex rounds, five findings, all fixed and answered in-thread:

| round | commit | finding |
|---|---|---|
| 1 | `6a03070a` | none |
| 2 | `c7fc6c40` | review trigger vs. root lifecycle; docs-only skip vs. mandatory review; Netlify correction not yet in `AGENTS.md` |
| 3 | `032fd0d4` | two stale `/review` references; review policy duplicated across two documents |

Round 3's second finding is the one worth reading — I'd asked codex to attack whether the two copies could drift, and it found that they could. Flipping to ready at the round cap rather than opening a fourth.
