### PR TITLE
Link noisy model loads to dashboard chips via Sentry diagnostics

### DIFF
--- a/src/Containers/CadView.jsx
+++ b/src/Containers/CadView.jsx
@@ -23,6 +23,7 @@ import {load} from '../loader/Loader'
 import {
   attachLoadFailureContext,
   beginLoadProgress,
+  captureLoadDiagnostics,
   endLoadProgress,
   getCompletedLoadStats,
   reportFramingExclusion,
@@ -459,14 +460,6 @@ export default function CadView({
     // so the snackbar keeps only the base "Loading <file>" message.
     beginLoadProgress({
       fileInfo: isGoogleResult ? `gdrive:${routeResult.fileId}` : filepath,
-      // The `content_id` the real_model_open event below will carry, so the
-      // end-of-load Sentry diagnostics event names the same model as the
-      // dashboard chip it's meant to be searched from. Not fileInfo, which
-      // prefers the short `gdrive:<id>` label over Drive's download URL.
-      contentId: filepath,
-      // Keeps that Sentry event on the same population as the GA event —
-      // see loadProgress#captureDiagnostics for why the demo must stay out.
-      isRealOpen: isRealModelOpen(routeResult),
       onStall: (lastEvent) => {
         const where = lastEvent?.phase ? ` on ${lastEvent.phase}` : ''
         setSnackMessage(`${loadingMessageBase}: still working${where}…`)
@@ -620,6 +613,19 @@ export default function CadView({
       // keeps it in the text slot; see analytics#getLocalHour.
       eventParams[LOCAL_HOUR_PARAM] = getLocalHour()
       gtagEvent('real_model_open', eventParams)
+      // Give a chip with non-zero errors/warnings a Sentry event to link
+      // to (issue #1767). Gated on the very counts just assembled above,
+      // because those are what colour the chip — for IFC/STEP they are
+      // Conway's, applied over the reporter's console-tee fallbacks a few
+      // lines up, so gating on the tee would let the event and the chip
+      // disagree. Siting the call here is also what keeps it to real,
+      // successful opens. See loadProgress#captureLoadDiagnostics.
+      captureLoadDiagnostics({
+        errorCount: eventParams.stats_errorCount,
+        warningCount: eventParams.stats_warningCount,
+        contentId: eventParams.content_id,
+        contentType: eventParams.content_type,
+      })
       stopModelEngagementRef.current = startModelEngagement({
         content_type: eventParams.content_type,
         content_id: eventParams.content_id,

--- a/src/Containers/CadView.jsx
+++ b/src/Containers/CadView.jsx
@@ -459,6 +459,14 @@ export default function CadView({
     // so the snackbar keeps only the base "Loading <file>" message.
     beginLoadProgress({
       fileInfo: isGoogleResult ? `gdrive:${routeResult.fileId}` : filepath,
+      // The `content_id` the real_model_open event below will carry, so the
+      // end-of-load Sentry diagnostics event names the same model as the
+      // dashboard chip it's meant to be searched from. Not fileInfo, which
+      // prefers the short `gdrive:<id>` label over Drive's download URL.
+      contentId: filepath,
+      // Keeps that Sentry event on the same population as the GA event —
+      // see loadProgress#captureDiagnostics for why the demo must stay out.
+      isRealOpen: isRealModelOpen(routeResult),
       onStall: (lastEvent) => {
         const where = lastEvent?.phase ? ` on ${lastEvent.phase}` : ''
         setSnackMessage(`${loadingMessageBase}: still working${where}…`)

--- a/src/index/ga.js
+++ b/src/index/ga.js
@@ -1,5 +1,5 @@
-import {captureException, setTag} from '@sentry/react'
-import {SENTRY_CID_TAG, getOpenCidForSentry, setGaClientId, setUserCidProperty} from '../privacy/analytics'
+import {captureException} from '@sentry/react'
+import {setGaClientId, setUserCidProperty, syncSentryCidTag} from '../privacy/analytics'
 import {isFeatureEnabled} from '../FeatureFlags'
 
 
@@ -35,26 +35,6 @@ export function shouldInitGa({
 } = {}) {
   const isDeployPreview = hostname.startsWith('deploy-preview-') && hostname.endsWith('.netlify.app')
   return (PROD_HOSTNAMES.includes(hostname) || (isDeployPreview && enableInPreview)) && !isWebdriver
-}
-
-
-/**
- * Stamp the GA client id onto every subsequent Sentry event as the
- * `open_cid` tag (issue #1767). That tag is the only join between the
- * bizdev dashboard's model-open chips and Sentry: a chip with non-zero
- * errors/warnings links to `open_cid:<id>` on the Sentry issue search,
- * which matched nothing before this existed.
- *
- * Global scope on purpose — set once, carried by everything captured
- * afterwards, load-failure exceptions included. No-op when no id has
- * resolved or consent is withheld; see analytics#getOpenCidForSentry
- * for both, and for why the value is the bare id.
- */
-function applySentryCidTag() {
-  const cid = getOpenCidForSentry()
-  if (cid) {
-    setTag(SENTRY_CID_TAG, cid)
-  }
 }
 
 
@@ -114,11 +94,13 @@ export default function setupGa(env = undefined) {
     // callback below is the only path that works for a first-ever
     // visitor, who has no cookie for either parser to read.
     setUserCidProperty()
-    // Same two-call shape, same reason: this one reads the `_ga` cookie,
-    // so a *returning* visitor's tag is in place from first paint and an
-    // exception thrown before gtag/js resolves still carries it. The
-    // callback below covers the first-ever visitor, who has no cookie.
-    applySentryCidTag()
+    // The Sentry half of the same id, on the same two-call shape and for
+    // the same reason: this one reads the `_ga` cookie, so a *returning*
+    // visitor's tag is in place from first paint and a load-failure
+    // exception thrown before gtag/js resolves still carries it. It is
+    // the only join between Sentry and the bizdev dashboard's model-open
+    // chips (issue #1767); see analytics#syncSentryCidTag.
+    syncSentryCidTag()
     // Ask GA for this browser's client id so model-open events can
     // carry it as open_cid (see privacy/analytics#setGaClientId for
     // why). The call buffers in dataLayer like any other gtag call and
@@ -130,7 +112,7 @@ export default function setupGa(env = undefined) {
       // The only path that works for a first-ever visitor, who had no
       // cookie for the call above to read.
       setUserCidProperty()
-      applySentryCidTag()
+      syncSentryCidTag()
     })
   } catch (err) {
     captureException(err, {tags: {subsystem: 'ga_init'}})

--- a/src/index/ga.js
+++ b/src/index/ga.js
@@ -1,5 +1,5 @@
-import {captureException} from '@sentry/react'
-import {setGaClientId, setUserCidProperty} from '../privacy/analytics'
+import {captureException, setTag} from '@sentry/react'
+import {SENTRY_CID_TAG, getOpenCidForSentry, setGaClientId, setUserCidProperty} from '../privacy/analytics'
 import {isFeatureEnabled} from '../FeatureFlags'
 
 
@@ -35,6 +35,26 @@ export function shouldInitGa({
 } = {}) {
   const isDeployPreview = hostname.startsWith('deploy-preview-') && hostname.endsWith('.netlify.app')
   return (PROD_HOSTNAMES.includes(hostname) || (isDeployPreview && enableInPreview)) && !isWebdriver
+}
+
+
+/**
+ * Stamp the GA client id onto every subsequent Sentry event as the
+ * `open_cid` tag (issue #1767). That tag is the only join between the
+ * bizdev dashboard's model-open chips and Sentry: a chip with non-zero
+ * errors/warnings links to `open_cid:<id>` on the Sentry issue search,
+ * which matched nothing before this existed.
+ *
+ * Global scope on purpose — set once, carried by everything captured
+ * afterwards, load-failure exceptions included. No-op when no id has
+ * resolved or consent is withheld; see analytics#getOpenCidForSentry
+ * for both, and for why the value is the bare id.
+ */
+function applySentryCidTag() {
+  const cid = getOpenCidForSentry()
+  if (cid) {
+    setTag(SENTRY_CID_TAG, cid)
+  }
 }
 
 
@@ -94,6 +114,11 @@ export default function setupGa(env = undefined) {
     // callback below is the only path that works for a first-ever
     // visitor, who has no cookie for either parser to read.
     setUserCidProperty()
+    // Same two-call shape, same reason: this one reads the `_ga` cookie,
+    // so a *returning* visitor's tag is in place from first paint and an
+    // exception thrown before gtag/js resolves still carries it. The
+    // callback below covers the first-ever visitor, who has no cookie.
+    applySentryCidTag()
     // Ask GA for this browser's client id so model-open events can
     // carry it as open_cid (see privacy/analytics#setGaClientId for
     // why). The call buffers in dataLayer like any other gtag call and
@@ -105,6 +130,7 @@ export default function setupGa(env = undefined) {
       // The only path that works for a first-ever visitor, who had no
       // cookie for the call above to read.
       setUserCidProperty()
+      applySentryCidTag()
     })
   } catch (err) {
     captureException(err, {tags: {subsystem: 'ga_init'}})

--- a/src/index/ga.test.js
+++ b/src/index/ga.test.js
@@ -1,10 +1,10 @@
 import Cookies from 'js-cookie'
-import {captureException} from '@sentry/react'
-import {_resetGaClientIdForTests, getGaClientId} from '../privacy/analytics'
+import {captureException, setTag} from '@sentry/react'
+import {_resetGaClientIdForTests, getGaClientId, setIsAllowed} from '../privacy/analytics'
 import setupGa, {GA_MEASUREMENT_ID, shouldInitGa} from './ga'
 
 
-jest.mock('@sentry/react', () => ({captureException: jest.fn()}))
+jest.mock('@sentry/react', () => ({captureException: jest.fn(), setTag: jest.fn()}))
 
 
 /** @return {HTMLScriptElement|null} the injected gtag/js tag, if any */
@@ -19,6 +19,7 @@ beforeEach(() => {
   // getGaClientId falls back to this cookie; clear it so the assertions
   // below see only what setupGa's callback provides.
   Cookies.remove('_ga')
+  Cookies.remove('isAnalyticsAllowed')
   document.head.querySelectorAll('script').forEach((s) => s.remove())
   // Mirror the inline bootstrap index.html declares before the bundle.
   window.dataLayer = []
@@ -153,6 +154,54 @@ describe('setupGa', () => {
   test('does not request a client id off-prod', () => {
     setupGa({hostname: 'localhost', isWebdriver: false})
     expect(window.dataLayer.find((entry) => entry?.[0] === 'get')).toBeUndefined()
+  })
+
+  // The bizdev dashboard links each noisy model-open chip to a Sentry
+  // search on this tag, so nothing matched before it was sent (#1767).
+  describe('open_cid Sentry tag', () => {
+    afterEach(() => {
+      Cookies.remove('isAnalyticsAllowed')
+    })
+
+    // Set from the cookie at setup so a load-failure exception thrown
+    // before gtag/js resolves still carries the tag.
+    test('tags from the _ga cookie at setup, for a returning visitor', () => {
+      Cookies.set('_ga', 'GA1.1.1234567890.0987654321')
+      setupGa({hostname: 'bldrs.ai', isWebdriver: false})
+      expect(setTag).toHaveBeenCalledWith('open_cid', '1234567890.0987654321')
+    })
+
+    // Bare: the cid. prefix exists only to stop GA4 typing the id as a
+    // float, and the dashboard strips it before building the query.
+    test('sends the bare id, without the GA cid. prefix', () => {
+      Cookies.set('_ga', 'GA1.1.1234567890.0987654321')
+      setupGa({hostname: 'bldrs.ai', isWebdriver: false})
+      const values = setTag.mock.calls.map(([, value]) => value)
+      expect(values).not.toContain('cid.1234567890.0987654321')
+    })
+
+    // A first-ever visitor has no cookie; the callback is their only path.
+    test('tags from the gtag callback for a first visit', () => {
+      setupGa({hostname: 'bldrs.ai', isWebdriver: false})
+      expect(setTag).not.toHaveBeenCalled()
+
+      window.dataLayer.find((entry) => entry?.[0] === 'get')[3]('1234567890.0987654321')
+      expect(setTag).toHaveBeenCalledWith('open_cid', '1234567890.0987654321')
+    })
+
+    test('does not tag off-prod, where GA never initializes', () => {
+      Cookies.set('_ga', 'GA1.1.1234567890.0987654321')
+      setupGa({hostname: 'localhost', isWebdriver: false})
+      expect(setTag).not.toHaveBeenCalled()
+    })
+
+    test('does not tag when analytics consent is withheld', () => {
+      Cookies.set('_ga', 'GA1.1.1234567890.0987654321')
+      setIsAllowed(false)
+      setupGa({hostname: 'bldrs.ai', isWebdriver: false})
+      window.dataLayer.find((entry) => entry?.[0] === 'get')[3]('1234567890.0987654321')
+      expect(setTag).not.toHaveBeenCalled()
+    })
   })
 
   test('reports a missing inline bootstrap to Sentry without throwing', () => {

--- a/src/index/ga.test.js
+++ b/src/index/ga.test.js
@@ -180,13 +180,15 @@ describe('setupGa', () => {
       expect(values).not.toContain('cid.1234567890.0987654321')
     })
 
-    // A first-ever visitor has no cookie; the callback is their only path.
+    // A first-ever visitor has no cookie; the callback is their only
+    // path. The setup-time sync still runs — it just has no id to
+    // publish, which is the same undefined a retraction writes.
     test('tags from the gtag callback for a first visit', () => {
       setupGa({hostname: 'bldrs.ai', isWebdriver: false})
-      expect(setTag).not.toHaveBeenCalled()
+      expect(setTag).toHaveBeenLastCalledWith('open_cid', undefined)
 
       window.dataLayer.find((entry) => entry?.[0] === 'get')[3]('1234567890.0987654321')
-      expect(setTag).toHaveBeenCalledWith('open_cid', '1234567890.0987654321')
+      expect(setTag).toHaveBeenLastCalledWith('open_cid', '1234567890.0987654321')
     })
 
     test('does not tag off-prod, where GA never initializes', () => {
@@ -195,12 +197,38 @@ describe('setupGa', () => {
       expect(setTag).not.toHaveBeenCalled()
     })
 
-    test('does not tag when analytics consent is withheld', () => {
+    // undefined is what removes a tag — Sentry drops undefined keys when
+    // it merges scope tags onto an event.
+    test('sends no id when analytics consent is withheld', () => {
       Cookies.set('_ga', 'GA1.1.1234567890.0987654321')
       setIsAllowed(false)
       setupGa({hostname: 'bldrs.ai', isWebdriver: false})
       window.dataLayer.find((entry) => entry?.[0] === 'get')[3]('1234567890.0987654321')
-      expect(setTag).not.toHaveBeenCalled()
+      const values = setTag.mock.calls.filter(([key]) => key === 'open_cid').map(([, value]) => value)
+      expect(values.every((value) => value === undefined)).toBe(true)
+    })
+
+    // Codex review on #1770: gating only the *set* left a previously
+    // published id on Sentry's global scope for the rest of the page's
+    // life, so withdrawal has to clear it — and an event's own tags
+    // merge over the global scope, so even a deliberately cid-less
+    // diagnostics event would have inherited the stale one.
+    test('retracts an already-published tag when consent is withdrawn', () => {
+      Cookies.set('_ga', 'GA1.1.1234567890.0987654321')
+      setupGa({hostname: 'bldrs.ai', isWebdriver: false})
+      expect(setTag).toHaveBeenCalledWith('open_cid', '1234567890.0987654321')
+
+      setIsAllowed(false)
+      expect(setTag).toHaveBeenLastCalledWith('open_cid', undefined)
+    })
+
+    test('republishes the tag when consent is granted again', () => {
+      Cookies.set('_ga', 'GA1.1.1234567890.0987654321')
+      setIsAllowed(false)
+      setupGa({hostname: 'bldrs.ai', isWebdriver: false})
+
+      setIsAllowed(true)
+      expect(setTag).toHaveBeenLastCalledWith('open_cid', '1234567890.0987654321')
     })
   })
 

--- a/src/loader/loadProgress.js
+++ b/src/loader/loadProgress.js
@@ -1,4 +1,5 @@
 import {addBreadcrumb, captureMessage, setContext, setTag} from '@sentry/react'
+import {SENTRY_CID_TAG, getOpenCidForSentry} from '../privacy/analytics'
 import useStore from '../store/useStore'
 import debug from '../utils/debug'
 // Named import so esbuild can prune the rest of the JSON (same trick as
@@ -33,6 +34,16 @@ const STATUS_LINE_INTERVAL_MS = 100
 // long enough to recognize which family of warning dominated, short enough
 // that the line still reads as a summary.
 const MAX_DIAGNOSTIC_SAMPLE_CHARS = 80
+// Sentry truncates tag values past 200 characters, so do it here rather
+// than shipping a value that silently differs from what's searchable. A
+// Drive download URL — the content_id of a Google Drive open — is the
+// realistic case.
+const MAX_TAG_CHARS = 200
+// Distinct diagnostic texts carried on the Sentry event. Same shape
+// problem appendDiagnostics documents: engines emit per-entity messages
+// dedup can't collapse, so one STEP load can produce hundreds. The
+// frequent ones are the triageable ones; the rest stay in the console.
+const MAX_SENTRY_DIAGNOSTICS = 25
 const BYTES_PER_MB = 1024 * 1024 // eslint-disable-line no-magic-numbers
 
 /**
@@ -95,11 +106,20 @@ class LoadProgressReporter {
    * @param {object} opts
    * @param {string} opts.fileInfo short model identity (path/type/size) for
    *   Sentry context and the fallback model line
+   * @param {string} [opts.contentId] the GA `content_id` this load reports
+   *   if it succeeds, so the Sentry diagnostics event and the dashboard's
+   *   model-open chip name the same model. Falls back to fileInfo, which
+   *   differs for Drive opens (`gdrive:<id>` vs the download URL).
+   * @param {boolean} [opts.isRealOpen] analytics#isRealModelOpen's verdict
+   *   for this load; gates the end-of-load Sentry diagnostics event —
+   *   see captureDiagnostics
    * @param {Function} [opts.onStall] called once per silent period with the
    *   last event when the watchdog fires
    */
-  constructor({fileInfo, onStall}) {
+  constructor({fileInfo, contentId = undefined, isRealOpen = false, onStall}) {
     this.fileInfo = fileInfo
+    this.contentId = contentId
+    this.isRealOpen = isRealOpen
     this.onStall = onStall
     // Filename for the "Loaded <name>" grace line when the snackbar has no
     // better name. The STEP header's fileName is unreliable (often a comment),
@@ -389,8 +409,12 @@ class LoadProgressReporter {
    * point so its duration is real), add the separate before/after Total
    * line, then append the captured console warnings/errors, and clear the
    * live line.
+   *
+   * @param {Error} [error] the loader error when the load failed; omitted /
+   *   null on success. Only decides whether this load also reports its
+   *   console diagnostics to Sentry — see captureDiagnostics.
    */
-  finishReport() {
+  finishReport(error = null) {
     const finishedAt = Date.now()
     const heapMb = usedHeapMb()
     const closedLine = this.log.closeCurrentStage(finishedAt - this.startTime, heapMb)
@@ -420,7 +444,114 @@ class LoadProgressReporter {
       warningCount: this.warningCount,
     }
 
+    if (!error) {
+      this.captureDiagnostics()
+    }
+
     useStore.getState().setCurrentLoadLine(null)
+  }
+
+  /**
+   * Fold the deduped diagnostics map into the numbers its two consumers
+   * share: the one-line report summary below Total, and the Sentry event.
+   *
+   * @return {{total: number, distinct: number, topText: string, topCount: number}}
+   */
+  diagnosticsSummary() {
+    let total = 0
+    let topText = ''
+    let topCount = 0
+    for (const [text, count] of this.diagnostics) {
+      total += count
+      if (count > topCount) {
+        topCount = count
+        topText = text
+      }
+    }
+    return {total, distinct: this.diagnostics.size, topText, topCount}
+  }
+
+  /**
+   * Send one Sentry event for a load that finished but logged console
+   * warnings or errors (issue #1767).
+   *
+   * The two populations the bizdev dashboard tries to join were close to
+   * disjoint before this. The errorCount/warningCount behind each
+   * model-open chip come from installConsoleTee above, which only
+   * counts and transcribes — a load that logs five warnings and then
+   * goes on to *succeed* produced no Sentry event at all, and that is
+   * the typical chip. The loads that did reach Sentry hard-failed, so
+   * they never fired `real_model_open` and never became a chip. This is
+   * the missing overlap: one event per noisy load, carrying the same
+   * client id the chip does, so the chip's `open_cid:<id>` link resolves
+   * to something.
+   *
+   * One event per load, not one per console line. Sentry's
+   * captureConsoleIntegration would do the latter and wasm loaders are
+   * chatty enough that it would flood the project.
+   *
+   * Two gates, both about not becoming that flood ourselves:
+   *
+   *   - Real opens only. CadView passes analytics#isRealModelOpen's
+   *     verdict, the same predicate that decides whether this load is a
+   *     chip. The bundled demo loads on every homepage visit, so
+   *     counting it here would turn ordinary traffic into a firehose
+   *     against a load that can never be a chip anyway.
+   *   - Successes only. finishReport skips this on failure, where
+   *     CadView's handler already captures the exception with this same
+   *     report attached by attachLoadFailureContext — a second event
+   *     would just double-report it.
+   */
+  captureDiagnostics() {
+    if (!this.isRealOpen || this.errorCount + this.warningCount === 0) {
+      return
+    }
+    const summary = this.diagnosticsSummary()
+    const tags = {}
+    // Also set on the global scope at init by index/ga.js. Re-set here
+    // because this reads later: a first-ever visitor's id only resolves
+    // once gtag/js loads, which can land after bootstrap but before this
+    // load finishes.
+    const cid = getOpenCidForSentry()
+    if (cid) {
+      tags[SENTRY_CID_TAG] = cid
+    }
+    const contentId = this.contentId ?? this.fileInfo
+    if (contentId) {
+      tags.content_id = String(contentId).slice(0, MAX_TAG_CHARS)
+    }
+    try {
+      captureMessage(diagnosticsTitle(summary.topText), {
+        level: this.errorCount > 0 ? 'error' : 'warning',
+        tags,
+        contexts: {
+          loadDiagnostics: {
+            errorCount: this.errorCount,
+            warningCount: this.warningCount,
+            distinct: summary.distinct,
+            total: summary.total,
+            messages: this.topDiagnostics(MAX_SENTRY_DIAGNOSTICS),
+            report: this.lines.join('\n'),
+          },
+        },
+      })
+    } catch (e) {
+      debug().log('loadProgress#captureDiagnostics: ', e)
+    }
+  }
+
+  /**
+   * The most frequent diagnostics, each prefixed with its occurrence
+   * count, most frequent first.
+   *
+   * @param {number} limit how many distinct messages to keep
+   * @return {string[]} e.g. ['12× Error processing representation #4', …]
+   */
+  topDiagnostics(limit) {
+    return [...this.diagnostics.entries()]
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, limit)
+      .map(([text, count]) => `${count}× ${text}`)
   }
 
   /**
@@ -439,20 +570,9 @@ class LoadProgressReporter {
     if (this.diagnostics.size === 0) {
       return
     }
-    let total = 0
-    let topText = ''
-    let topCount = 0
-    for (const [text, count] of this.diagnostics) {
-      total += count
-      if (count > topCount) {
-        topCount = count
-        topText = text
-      }
-    }
-    const distinctNote = this.diagnostics.size > 1 ? `, ${this.diagnostics.size} distinct` : ''
-    const sample = topText.length > MAX_DIAGNOSTIC_SAMPLE_CHARS ?
-      `${topText.slice(0, MAX_DIAGNOSTIC_SAMPLE_CHARS - 1)}…` :
-      topText
+    const {total, distinct, topText, topCount} = this.diagnosticsSummary()
+    const distinctNote = distinct > 1 ? `, ${distinct} distinct` : ''
+    const sample = ellipsize(topText)
     const sampleNote = topCount > 1 ? `${sample} (×${topCount})` : sample
     this.addReportLine(`Warnings & errors (${total}${distinctNote}): ${sampleNote}`, false)
   }
@@ -521,6 +641,45 @@ function basenameOf(fileInfo) {
   const lastSegment = noQuery.split('/').pop() ?? ''
   // Drop a leading `provider:` tag (gdrive:, opfs:, …) if that's all we have.
   return lastSegment.includes(':') ? lastSegment.split(':').pop() ?? '' : lastSegment
+}
+
+
+/**
+ * Trim a diagnostic to the sample length the report and the Sentry
+ * title share, with an ellipsis when something was dropped.
+ *
+ * @param {string} text
+ * @return {string}
+ */
+function ellipsize(text) {
+  return text.length > MAX_DIAGNOSTIC_SAMPLE_CHARS ?
+    `${text.slice(0, MAX_DIAGNOSTIC_SAMPLE_CHARS - 1)}…` :
+    text
+}
+
+
+/**
+ * The Sentry message for a noisy load, which is also how Sentry groups
+ * and titles the event — it has no exception to fingerprint, so the
+ * message text *is* the grouping key.
+ *
+ * Numbers collapse to `#` because engine diagnostics are per-entity
+ * ("Error processing representation #1234"): the raw text would open a
+ * fresh Sentry issue for every entity of every model, which is the
+ * per-line flood captureDiagnostics exists to avoid. Normalized, each
+ * family of warning gets one issue. An entity marker the message
+ * already spelled `#` is swallowed by the same pass rather than
+ * doubling up into `##`.
+ *
+ * @param {string} topText most frequent diagnostic, '' when every
+ *   captured message was blank
+ * @return {string}
+ */
+function diagnosticsTitle(topText) {
+  const normalized = ellipsize(topText.replace(/#?\d+/g, '#')).trim()
+  return normalized === '' ?
+    'Load completed with console diagnostics' :
+    `Load diagnostics: ${normalized}`
 }
 
 
@@ -637,7 +796,7 @@ export function setLoadSummary(text) {
  */
 export function endLoadProgress(error = null) {
   if (activeReporter && !activeReporter.ended) {
-    activeReporter.finishReport()
+    activeReporter.finishReport(error)
     // The collapsed grace line stays deliberately terse — just the outcome
     // and a name; the timing/heap Total and diagnostics live one expand (or
     // the "i" report) away. The snackbar prefers the store's model.name (the

--- a/src/loader/loadProgress.js
+++ b/src/loader/loadProgress.js
@@ -106,20 +106,11 @@ class LoadProgressReporter {
    * @param {object} opts
    * @param {string} opts.fileInfo short model identity (path/type/size) for
    *   Sentry context and the fallback model line
-   * @param {string} [opts.contentId] the GA `content_id` this load reports
-   *   if it succeeds, so the Sentry diagnostics event and the dashboard's
-   *   model-open chip name the same model. Falls back to fileInfo, which
-   *   differs for Drive opens (`gdrive:<id>` vs the download URL).
-   * @param {boolean} [opts.isRealOpen] analytics#isRealModelOpen's verdict
-   *   for this load; gates the end-of-load Sentry diagnostics event —
-   *   see captureDiagnostics
    * @param {Function} [opts.onStall] called once per silent period with the
    *   last event when the watchdog fires
    */
-  constructor({fileInfo, contentId = undefined, isRealOpen = false, onStall}) {
+  constructor({fileInfo, onStall}) {
     this.fileInfo = fileInfo
-    this.contentId = contentId
-    this.isRealOpen = isRealOpen
     this.onStall = onStall
     // Filename for the "Loaded <name>" grace line when the snackbar has no
     // better name. The STEP header's fileName is unreliable (often a comment),
@@ -409,12 +400,8 @@ class LoadProgressReporter {
    * point so its duration is real), add the separate before/after Total
    * line, then append the captured console warnings/errors, and clear the
    * live line.
-   *
-   * @param {Error} [error] the loader error when the load failed; omitted /
-   *   null on success. Only decides whether this load also reports its
-   *   console diagnostics to Sentry — see captureDiagnostics.
    */
-  finishReport(error = null) {
+  finishReport() {
     const finishedAt = Date.now()
     const heapMb = usedHeapMb()
     const closedLine = this.log.closeCurrentStage(finishedAt - this.startTime, heapMb)
@@ -444,10 +431,6 @@ class LoadProgressReporter {
       warningCount: this.warningCount,
     }
 
-    if (!error) {
-      this.captureDiagnostics()
-    }
-
     useStore.getState().setCurrentLoadLine(null)
   }
 
@@ -472,43 +455,20 @@ class LoadProgressReporter {
   }
 
   /**
-   * Send one Sentry event for a load that finished but logged console
-   * warnings or errors (issue #1767).
+   * Build and send this load's Sentry diagnostics event (issue #1767).
+   * Called only via captureLoadDiagnostics — see there for why the
+   * counts are the caller's rather than this reporter's.
    *
-   * The two populations the bizdev dashboard tries to join were close to
-   * disjoint before this. The errorCount/warningCount behind each
-   * model-open chip come from installConsoleTee above, which only
-   * counts and transcribes — a load that logs five warnings and then
-   * goes on to *succeed* produced no Sentry event at all, and that is
-   * the typical chip. The loads that did reach Sentry hard-failed, so
-   * they never fired `real_model_open` and never became a chip. This is
-   * the missing overlap: one event per noisy load, carrying the same
-   * client id the chip does, so the chip's `open_cid:<id>` link resolves
-   * to something.
-   *
-   * One event per load, not one per console line. Sentry's
-   * captureConsoleIntegration would do the latter and wasm loaders are
-   * chatty enough that it would flood the project.
-   *
-   * Two gates, both about not becoming that flood ourselves:
-   *
-   *   - Real opens only. CadView passes analytics#isRealModelOpen's
-   *     verdict, the same predicate that decides whether this load is a
-   *     chip. The bundled demo loads on every homepage visit, so
-   *     counting it here would turn ordinary traffic into a firehose
-   *     against a load that can never be a chip anyway.
-   *   - Successes only. finishReport skips this on failure, where
-   *     CadView's handler already captures the exception with this same
-   *     report attached by attachLoadFailureContext — a second event
-   *     would just double-report it.
+   * @param {object} opts
+   * @param {number} opts.errorCount the GA `stats_errorCount` for this load
+   * @param {number} opts.warningCount the GA `stats_warningCount`
+   * @param {string} [opts.contentId] the GA `content_id`
+   * @param {string} [opts.contentType] the GA `content_type`
    */
-  captureDiagnostics() {
-    if (!this.isRealOpen || this.errorCount + this.warningCount === 0) {
-      return
-    }
+  captureDiagnostics({errorCount, warningCount, contentId, contentType}) {
     const summary = this.diagnosticsSummary()
     const tags = {}
-    // Also set on the global scope at init by index/ga.js. Re-set here
+    // Also set on the global scope at init by index/ga.js. Re-read here
     // because this reads later: a first-ever visitor's id only resolves
     // once gtag/js loads, which can land after bootstrap but before this
     // load finishes.
@@ -516,33 +476,39 @@ class LoadProgressReporter {
     if (cid) {
       tags[SENTRY_CID_TAG] = cid
     }
-    const contentId = this.contentId ?? this.fileInfo
     if (contentId) {
       tags.content_id = String(contentId).slice(0, MAX_TAG_CHARS)
     }
-    try {
-      captureMessage(diagnosticsTitle(summary.topText), {
-        level: this.errorCount > 0 ? 'error' : 'warning',
-        tags,
-        contexts: {
-          loadDiagnostics: {
-            errorCount: this.errorCount,
-            warningCount: this.warningCount,
-            distinct: summary.distinct,
-            total: summary.total,
-            messages: this.topDiagnostics(MAX_SENTRY_DIAGNOSTICS),
-            report: this.lines.join('\n'),
-          },
-        },
-      })
-    } catch (e) {
-      debug().log('loadProgress#captureDiagnostics: ', e)
+    if (contentType) {
+      tags.content_type = String(contentType).slice(0, MAX_TAG_CHARS)
     }
+    captureMessage(diagnosticsTitle(summary.topText), {
+      level: errorCount > 0 ? 'error' : 'warning',
+      tags,
+      contexts: {
+        loadDiagnostics: {
+          // The counts the dashboard chip is coloured by: Conway's own
+          // for IFC/STEP, this reporter's console tee as the
+          // cross-format fallback (ShareIfcLoader#loadStats).
+          errorCount,
+          warningCount,
+          // The console tee's own view, which on IFC/STEP can disagree
+          // with the counts above — these two describe the messages
+          // carried below, not the chip.
+          consoleTotal: summary.total,
+          consoleDistinct: summary.distinct,
+          messages: this.topDiagnostics(MAX_SENTRY_DIAGNOSTICS),
+          report: this.lines.join('\n'),
+        },
+      },
+    })
   }
 
   /**
    * The most frequent diagnostics, each prefixed with its occurrence
-   * count, most frequent first.
+   * count, most frequent first. Trimmed per entry as well as capped in
+   * number: installConsoleTee collapses multi-line wasm stack traces
+   * onto one line, so an untrimmed entry can be very long.
    *
    * @param {number} limit how many distinct messages to keep
    * @return {string[]} e.g. ['12× Error processing representation #4', …]
@@ -551,7 +517,7 @@ class LoadProgressReporter {
     return [...this.diagnostics.entries()]
       .sort(([, a], [, b]) => b - a)
       .slice(0, limit)
-      .map(([text, count]) => `${count}× ${text}`)
+      .map(([text, count]) => `${count}× ${ellipsize(text)}`)
   }
 
   /**
@@ -666,19 +632,25 @@ function ellipsize(text) {
  * Numbers collapse to `#` because engine diagnostics are per-entity
  * ("Error processing representation #1234"): the raw text would open a
  * fresh Sentry issue for every entity of every model, which is the
- * per-line flood captureDiagnostics exists to avoid. Normalized, each
- * family of warning gets one issue. An entity marker the message
+ * per-line flood captureLoadDiagnostics exists to avoid. Normalized,
+ * each family of warning gets one issue. An entity marker the message
  * already spelled `#` is swallowed by the same pass rather than
  * doubling up into `##`.
  *
- * @param {string} topText most frequent diagnostic, '' when every
- *   captured message was blank
+ * The pass is deliberately indiscriminate: it also collapses digits
+ * inside identifiers, so "IFC4" titles as "IFC#" and "Revit 2024" as
+ * "Revit #". That costs nothing for grouping — the schema and authoring
+ * tool are already on the event's `load` context and the report — and
+ * keeping them would reopen the per-value split this exists to close.
+ *
+ * @param {string} topText most frequent diagnostic, '' when the console
+ *   tee captured nothing (the counts can come from the engine instead)
  * @return {string}
  */
 function diagnosticsTitle(topText) {
   const normalized = ellipsize(topText.replace(/#?\d+/g, '#')).trim()
   return normalized === '' ?
-    'Load completed with console diagnostics' :
+    'Load completed with diagnostics' :
     `Load diagnostics: ${normalized}`
 }
 
@@ -766,6 +738,72 @@ export function attachLoadFailureContext() {
 
 
 /**
+ * Send one Sentry event for a completed load that reported console or
+ * engine diagnostics (issue #1767), so a dashboard model-open chip with
+ * non-zero errors/warnings has a searchable counterpart to link to.
+ *
+ * The two populations the bizdev dashboard tries to join were close to
+ * disjoint before this. The counts behind each chip come from a load
+ * that *succeeded*, and a successful load produced no Sentry event at
+ * all; the loads that did reach Sentry hard-failed, so they never fired
+ * `real_model_open` and never became a chip. This is the missing
+ * overlap: one event per noisy load, carrying the same client id the
+ * chip does, so the chip's `open_cid:<id>` link resolves to something.
+ *
+ * One event per load, not one per console line. Sentry's
+ * captureConsoleIntegration would do the latter and wasm loaders are
+ * chatty enough that it would flood the project.
+ *
+ * **The counts must be the caller's, not this reporter's.** The obvious
+ * gate — the console tee's own errorCount/warningCount — is the wrong
+ * number on exactly the formats this join is about. What colours a chip
+ * is GA's `stats_errorCount` / `stats_warningCount`, and for IFC/STEP
+ * those are Conway's, not the tee's: ShareIfcLoader publishes them on
+ * `loadStats`, which CadView applies *after* getCompletedLoadStats() so
+ * the engine's numbers win. Gating on the tee would let the two
+ * disagree, and each direction of disagreement is worse than the gap
+ * this closes — a red chip whose Sentry link resolves to nothing, or a
+ * green chip with an issue behind it. Both look like the join working.
+ *
+ * So CadView calls this with the very numbers it is about to send to
+ * GA, from inside the `isRealModelOpen` success branch. That siting is
+ * what makes the other two gates structural rather than flags: only
+ * real opens reach it (never the bundled demo, which loads on every
+ * homepage visit and can never be a chip), and only successes do (a
+ * failure is already reported by that path's captureException, with
+ * this same report attached by attachLoadFailureContext).
+ *
+ * Safe no-op when the load reported nothing, or when no reporter ran.
+ * Reads the reporter *after* endLoadProgress disposed it, which is
+ * deliberate and matches getCompletedLoadStats: dispose stops the
+ * watchdog and restores the console but leaves the report readable.
+ *
+ * @param {object} opts
+ * @param {number} [opts.errorCount] GA `stats_errorCount` for this load
+ * @param {number} [opts.warningCount] GA `stats_warningCount`
+ * @param {string} [opts.contentId] GA `content_id`, tagged so the event
+ *   names the same model as the chip
+ * @param {string} [opts.contentType] GA `content_type`, tagged because
+ *   it is the first filter worth having when triaging these
+ */
+export function captureLoadDiagnostics({
+  errorCount = 0,
+  warningCount = 0,
+  contentId = undefined,
+  contentType = undefined,
+} = {}) {
+  if (errorCount + warningCount === 0 || activeReporter === null) {
+    return
+  }
+  try {
+    activeReporter.captureDiagnostics({errorCount, warningCount, contentId, contentType})
+  } catch (e) {
+    debug().log('loadProgress#captureLoadDiagnostics: ', e)
+  }
+}
+
+
+/**
  * Attach a one-line model summary (products, triangles, units, ...) to the
  * in-flight load report — appended to the Total line at finish. No-op when
  * no load is being reported.
@@ -796,7 +834,7 @@ export function setLoadSummary(text) {
  */
 export function endLoadProgress(error = null) {
   if (activeReporter && !activeReporter.ended) {
-    activeReporter.finishReport(error)
+    activeReporter.finishReport()
     // The collapsed grace line stays deliberately terse — just the outcome
     // and a name; the timing/heap Total and diagnostics live one expand (or
     // the "i" report) away. The snackbar prefers the store's model.name (the

--- a/src/loader/loadProgress.test.js
+++ b/src/loader/loadProgress.test.js
@@ -5,7 +5,9 @@ jest.mock('@sentry/react', () => ({
   setTag: jest.fn(),
 }))
 
+import Cookies from 'js-cookie'
 import {captureMessage, setContext, setTag} from '@sentry/react'
+import {_resetGaClientIdForTests} from '../privacy/analytics'
 import useStore from '../store/useStore'
 import {
   STALL_TIMEOUT_MS,
@@ -385,6 +387,146 @@ describe('loadProgress', () => {
         fileInfo: 'index.ifc',
         report: expect.stringContaining('Share v'),
       }))
+    })
+
+    /*
+     * The end-of-load diagnostics event (issue #1767). Its whole
+     * purpose is to give a model-open chip with non-zero
+     * errors/warnings something to link to: before it, a load that
+     * warned and then succeeded produced no Sentry event at all, while
+     * the loads that did reach Sentry had hard-failed and so never
+     * became a chip.
+     */
+    describe('load diagnostics event', () => {
+      /** @return {Array} the [message, context] of the diagnostics capture */
+      function diagnosticsCall() {
+        return captureMessage.mock.calls.find(([, arg]) => typeof arg === 'object' && arg !== null)
+      }
+
+      beforeEach(() => {
+        _resetGaClientIdForTests()
+        // The tag value comes from the real analytics module, whose
+        // cookie fallback is what a returning visitor has.
+        Cookies.set('_ga', 'GA1.1.1234567890.0987654321')
+      })
+
+      afterEach(() => {
+        Cookies.remove('_ga')
+        Cookies.remove('isAnalyticsAllowed')
+      })
+
+      it('sends one event per noisy load, tagged with the bare cid and content_id', () => {
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+        beginLoadProgress({fileInfo: 'gdrive:abc123', contentId: 'https://drive/abc123', isRealOpen: true})
+        console.warn('No basis found for brep!')
+        console.warn('No basis found for brep!')
+        endLoadProgress()
+
+        const [message, context] = diagnosticsCall()
+        expect(message).toBe('Load diagnostics: No basis found for brep!')
+        // Warnings only — nothing here failed.
+        expect(context.level).toBe('warning')
+        // Bare id: the GA param's `cid.` prefix would not match the
+        // dashboard's Sentry query.
+        expect(context.tags.open_cid).toBe('1234567890.0987654321')
+        // The GA content_id, not the shorter `gdrive:` report label, so
+        // the event names the same model as the chip.
+        expect(context.tags.content_id).toBe('https://drive/abc123')
+        expect(context.contexts.loadDiagnostics).toEqual(expect.objectContaining({
+          warningCount: 2,
+          errorCount: 0,
+          distinct: 1,
+          total: 2,
+          messages: ['2× No basis found for brep!'],
+          report: expect.stringContaining('Share v'),
+        }))
+        warnSpy.mockRestore()
+      })
+
+      it('raises the level to error when the load logged errors', () => {
+        const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+        beginLoadProgress({fileInfo: 'index.stp', isRealOpen: true})
+        console.error('CDT Exception (hemisphere: 0)')
+        endLoadProgress()
+
+        expect(diagnosticsCall()[1].level).toBe('error')
+        // No contentId given, so the report's own file identity stands in.
+        expect(diagnosticsCall()[1].tags.content_id).toBe('index.stp')
+        errorSpy.mockRestore()
+      })
+
+      it('stays silent for a clean load', () => {
+        beginLoadProgress({fileInfo: 'index.ifc', isRealOpen: true})
+        reportLoadProgress({phase: 'geometry', completed: 1, total: 1, elapsedMs: 5})
+        endLoadProgress()
+        expect(captureMessage).not.toHaveBeenCalled()
+      })
+
+      // The bundled demo loads on every homepage visit and can never be
+      // a chip, so counting it would make this a firehose.
+      it('stays silent for the bundled demo', () => {
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+        beginLoadProgress({fileInfo: 'index.ifc', isRealOpen: false})
+        console.warn('No basis found for brep!')
+        endLoadProgress()
+        expect(captureMessage).not.toHaveBeenCalled()
+        warnSpy.mockRestore()
+      })
+
+      // The failure path already reaches Sentry via CadView's
+      // captureException, with this same report attached.
+      it('stays silent for a failed load', () => {
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+        beginLoadProgress({fileInfo: 'index.ifc', isRealOpen: true})
+        console.warn('No basis found for brep!')
+        endLoadProgress(new Error('bad header'))
+        expect(captureMessage).not.toHaveBeenCalled()
+        warnSpy.mockRestore()
+      })
+
+      // Sentry groups a message event by its text, and engine
+      // diagnostics are per-entity, so the digits have to go or every
+      // entity of every model opens its own issue.
+      it('groups by message family, collapsing per-entity numbers', () => {
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+        beginLoadProgress({fileInfo: 'Arty_Z7_PCB.stp', isRealOpen: true})
+        console.warn('Error processing representation #1204')
+        endLoadProgress()
+        expect(diagnosticsCall()[0]).toBe('Load diagnostics: Error processing representation #')
+        warnSpy.mockRestore()
+      })
+
+      it('caps the distinct messages it carries but still reports the true totals', () => {
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+        const distinctCount = 200
+        beginLoadProgress({fileInfo: 'Arty_Z7_PCB.stp', isRealOpen: true})
+        for (let i = 0; i < distinctCount; i++) {
+          console.warn(`Error processing representation #${i}`)
+        }
+        console.warn('No basis found for brep!')
+        console.warn('No basis found for brep!')
+        endLoadProgress()
+
+        const {loadDiagnostics} = diagnosticsCall()[1].contexts
+        const maxCarried = 25
+        expect(loadDiagnostics.messages).toHaveLength(maxCarried)
+        // Most frequent first, so the sample that won the report line
+        // leads here too.
+        expect(loadDiagnostics.messages[0]).toBe('2× No basis found for brep!')
+        expect(loadDiagnostics.distinct).toBe(distinctCount + 1)
+        expect(loadDiagnostics.total).toBe(distinctCount + 2)
+        warnSpy.mockRestore()
+      })
+
+      it('omits the cid tag when analytics consent is withheld', () => {
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+        Cookies.set('isAnalyticsAllowed', 'false')
+        beginLoadProgress({fileInfo: 'index.ifc', isRealOpen: true})
+        console.warn('No basis found for brep!')
+        endLoadProgress()
+        expect(diagnosticsCall()[1].tags).not.toHaveProperty('open_cid')
+        warnSpy.mockRestore()
+      })
     })
 
     it('ignores straggler progress after endLoadProgress', () => {

--- a/src/loader/loadProgress.test.js
+++ b/src/loader/loadProgress.test.js
@@ -13,6 +13,7 @@ import {
   STALL_TIMEOUT_MS,
   attachLoadFailureContext,
   beginLoadProgress,
+  captureLoadDiagnostics,
   endLoadProgress,
   getCompletedLoadStats,
   isModelInfoProgress,
@@ -390,14 +391,13 @@ describe('loadProgress', () => {
     })
 
     /*
-     * The end-of-load diagnostics event (issue #1767). Its whole
-     * purpose is to give a model-open chip with non-zero
-     * errors/warnings something to link to: before it, a load that
-     * warned and then succeeded produced no Sentry event at all, while
-     * the loads that did reach Sentry had hard-failed and so never
-     * became a chip.
+     * The end-of-load diagnostics event (issue #1767): the counterpart
+     * a dashboard model-open chip with non-zero errors/warnings links
+     * to. CadView drives it from inside the real_model_open branch, so
+     * the counts here are the GA stats_* ones that colour the chip —
+     * NOT the console tee's, which disagree with them on IFC/STEP.
      */
-    describe('load diagnostics event', () => {
+    describe('captureLoadDiagnostics', () => {
       /** @return {Array} the [message, context] of the diagnostics capture */
       function diagnosticsCall() {
         return captureMessage.mock.calls.find(([, arg]) => typeof arg === 'object' && arg !== null)
@@ -415,12 +415,17 @@ describe('loadProgress', () => {
         Cookies.remove('isAnalyticsAllowed')
       })
 
-      it('sends one event per noisy load, tagged with the bare cid and content_id', () => {
+      it('sends one event per noisy load, tagged with the bare cid, content_id and type', () => {
         const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
-        beginLoadProgress({fileInfo: 'gdrive:abc123', contentId: 'https://drive/abc123', isRealOpen: true})
+        beginLoadProgress({fileInfo: 'gdrive:abc123'})
         console.warn('No basis found for brep!')
         console.warn('No basis found for brep!')
         endLoadProgress()
+        captureLoadDiagnostics({
+          warningCount: 2,
+          contentId: 'https://drive/abc123',
+          contentType: 'ifc',
+        })
 
         const [message, context] = diagnosticsCall()
         expect(message).toBe('Load diagnostics: No basis found for brep!')
@@ -429,57 +434,67 @@ describe('loadProgress', () => {
         // Bare id: the GA param's `cid.` prefix would not match the
         // dashboard's Sentry query.
         expect(context.tags.open_cid).toBe('1234567890.0987654321')
-        // The GA content_id, not the shorter `gdrive:` report label, so
-        // the event names the same model as the chip.
         expect(context.tags.content_id).toBe('https://drive/abc123')
+        expect(context.tags.content_type).toBe('ifc')
         expect(context.contexts.loadDiagnostics).toEqual(expect.objectContaining({
           warningCount: 2,
           errorCount: 0,
-          distinct: 1,
-          total: 2,
+          consoleDistinct: 1,
+          consoleTotal: 2,
           messages: ['2× No basis found for brep!'],
           report: expect.stringContaining('Share v'),
         }))
         warnSpy.mockRestore()
       })
 
-      it('raises the level to error when the load logged errors', () => {
+      it('raises the level to error when the load reported errors', () => {
         const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
-        beginLoadProgress({fileInfo: 'index.stp', isRealOpen: true})
+        beginLoadProgress({fileInfo: 'index.stp'})
         console.error('CDT Exception (hemisphere: 0)')
         endLoadProgress()
+        captureLoadDiagnostics({errorCount: 1})
 
         expect(diagnosticsCall()[1].level).toBe('error')
-        // No contentId given, so the report's own file identity stands in.
-        expect(diagnosticsCall()[1].tags.content_id).toBe('index.stp')
         errorSpy.mockRestore()
       })
 
-      it('stays silent for a clean load', () => {
-        beginLoadProgress({fileInfo: 'index.ifc', isRealOpen: true})
+      it('stays silent when the load reported no errors or warnings', () => {
+        beginLoadProgress({fileInfo: 'index.ifc'})
         reportLoadProgress({phase: 'geometry', completed: 1, total: 1, elapsedMs: 5})
         endLoadProgress()
+        captureLoadDiagnostics({errorCount: 0, warningCount: 0})
         expect(captureMessage).not.toHaveBeenCalled()
       })
 
-      // The bundled demo loads on every homepage visit and can never be
-      // a chip, so counting it would make this a firehose.
-      it('stays silent for the bundled demo', () => {
+      /*
+       * The bug this gating shape exists to prevent (PR #1770 review).
+       * On IFC/STEP the chip is coloured by Conway's counts, which
+       * ShareIfcLoader publishes on loadStats and CadView applies over
+       * the reporter's console-tee fallbacks. A tee-gated capture would
+       * disagree with the chip in both directions.
+       */
+      it('fires on engine counts even when the console tee caught nothing', () => {
+        beginLoadProgress({fileInfo: 'index.ifc'})
+        endLoadProgress()
+        captureLoadDiagnostics({errorCount: 4, contentType: 'ifc'})
+
+        const [message, context] = diagnosticsCall()
+        // No console text to name a family by, so the title stays generic.
+        expect(message).toBe('Load completed with diagnostics')
+        expect(context.contexts.loadDiagnostics).toEqual(expect.objectContaining({
+          errorCount: 4,
+          consoleTotal: 0,
+          messages: [],
+        }))
+      })
+
+      it('stays silent when the engine reports clean but the console was chatty', () => {
         const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
-        beginLoadProgress({fileInfo: 'index.ifc', isRealOpen: false})
+        beginLoadProgress({fileInfo: 'index.ifc'})
         console.warn('No basis found for brep!')
         endLoadProgress()
-        expect(captureMessage).not.toHaveBeenCalled()
-        warnSpy.mockRestore()
-      })
-
-      // The failure path already reaches Sentry via CadView's
-      // captureException, with this same report attached.
-      it('stays silent for a failed load', () => {
-        const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
-        beginLoadProgress({fileInfo: 'index.ifc', isRealOpen: true})
-        console.warn('No basis found for brep!')
-        endLoadProgress(new Error('bad header'))
+        // Conway said zero, so the chip is green — no event behind it.
+        captureLoadDiagnostics({errorCount: 0, warningCount: 0, contentType: 'ifc'})
         expect(captureMessage).not.toHaveBeenCalled()
         warnSpy.mockRestore()
       })
@@ -489,41 +504,49 @@ describe('loadProgress', () => {
       // entity of every model opens its own issue.
       it('groups by message family, collapsing per-entity numbers', () => {
         const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
-        beginLoadProgress({fileInfo: 'Arty_Z7_PCB.stp', isRealOpen: true})
+        beginLoadProgress({fileInfo: 'Arty_Z7_PCB.stp'})
         console.warn('Error processing representation #1204')
         endLoadProgress()
+        captureLoadDiagnostics({warningCount: 1})
         expect(diagnosticsCall()[0]).toBe('Load diagnostics: Error processing representation #')
         warnSpy.mockRestore()
       })
 
-      it('caps the distinct messages it carries but still reports the true totals', () => {
+      it('caps both the number of messages and the length of each', () => {
         const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
         const distinctCount = 200
-        beginLoadProgress({fileInfo: 'Arty_Z7_PCB.stp', isRealOpen: true})
+        const overlongChars = 300
+        beginLoadProgress({fileInfo: 'Arty_Z7_PCB.stp'})
         for (let i = 0; i < distinctCount; i++) {
           console.warn(`Error processing representation #${i}`)
         }
-        console.warn('No basis found for brep!')
-        console.warn('No basis found for brep!')
+        // A collapsed wasm stack trace: one very long line.
+        console.warn(`stack ${'x'.repeat(overlongChars)}`)
+        console.warn(`stack ${'x'.repeat(overlongChars)}`)
         endLoadProgress()
+        captureLoadDiagnostics({warningCount: distinctCount + 2})
 
         const {loadDiagnostics} = diagnosticsCall()[1].contexts
         const maxCarried = 25
+        const maxEntryChars = 90
         expect(loadDiagnostics.messages).toHaveLength(maxCarried)
-        // Most frequent first, so the sample that won the report line
-        // leads here too.
-        expect(loadDiagnostics.messages[0]).toBe('2× No basis found for brep!')
-        expect(loadDiagnostics.distinct).toBe(distinctCount + 1)
-        expect(loadDiagnostics.total).toBe(distinctCount + 2)
+        // Most frequent first, and trimmed.
+        expect(loadDiagnostics.messages[0]).toMatch(/^2× stack x+…$/)
+        expect(Math.max(...loadDiagnostics.messages.map((m) => m.length)))
+          .toBeLessThan(maxEntryChars)
+        // The true totals still ride along.
+        expect(loadDiagnostics.consoleDistinct).toBe(distinctCount + 1)
+        expect(loadDiagnostics.consoleTotal).toBe(distinctCount + 2)
         warnSpy.mockRestore()
       })
 
       it('omits the cid tag when analytics consent is withheld', () => {
         const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
         Cookies.set('isAnalyticsAllowed', 'false')
-        beginLoadProgress({fileInfo: 'index.ifc', isRealOpen: true})
+        beginLoadProgress({fileInfo: 'index.ifc'})
         console.warn('No basis found for brep!')
         endLoadProgress()
+        captureLoadDiagnostics({warningCount: 1})
         expect(diagnosticsCall()[1].tags).not.toHaveProperty('open_cid')
         warnSpy.mockRestore()
       })

--- a/src/privacy/analytics.js
+++ b/src/privacy/analytics.js
@@ -303,6 +303,50 @@ export function getOpenCid() {
 
 
 /*
+ * Name of the *Sentry tag* carrying the same client id. Identical to
+ * OPEN_CID_PARAM on purpose: it is the same identifier, the bizdev
+ * dashboard builds its Sentry search URL straight from the GA param
+ * name, and the two live in separate namespaces so there is no
+ * collision to avoid (issue #1767).
+ *
+ * It has to be a tag and not a context field. Sentry indexes tags for
+ * issue search; context values are display-only, so a cid folded into
+ * the `load` context that loadProgress#applySentryLoadState already
+ * sets would be invisible to `open_cid:<id>` queries.
+ */
+export const SENTRY_CID_TAG = OPEN_CID_PARAM
+
+
+/**
+ * The SENTRY_CID_TAG value for this client: the *bare* client id, not
+ * the `cid.`-prefixed getOpenCid form. That prefix exists purely to stop
+ * GA4 typing a numeric-looking id as a float (see OPEN_CID_PREFIX);
+ * Sentry stores tag values as strings and has no such problem, and the
+ * dashboard strips the prefix before building the search URL — so bare
+ * is what makes the two ids compare equal.
+ *
+ * Null when no id has resolved, and null when analytics consent is
+ * withheld: a cid is an analytics identifier, so a visitor who declined
+ * must not have one stapled to their error reports either. Same reason
+ * syncUserCidProperty retracts the GA user property, and read from
+ * isAllowed() here for the same fail-closed reason. Callers must omit
+ * the tag rather than send a blank.
+ *
+ * Coverage is structurally partial and will stay that way: a client
+ * that blocks GA never resolves a cid, and per the triage notes in
+ * index/sentry.js that ad-blocked emerging-markets mobile cohort is
+ * this project's single largest source of Sentry events. An empty
+ * search result therefore cannot distinguish "this user hit no errors"
+ * from "this user had no cid".
+ *
+ * @return {string|null}
+ */
+export function getOpenCidForSentry() {
+  return isAllowed() ? getGaClientId() : null
+}
+
+
+/*
  * Name of the GA4 *user property* carrying the same value as
  * OPEN_CID_PARAM. Same string on purpose — it is the same identifier,
  * and GA4 keeps event parameters and user properties in separate

--- a/src/privacy/analytics.js
+++ b/src/privacy/analytics.js
@@ -1,4 +1,5 @@
 import Cookies from 'js-cookie'
+import {setTag} from '@sentry/react'
 import {assertDefined} from '../utils/assert'
 import {isFeatureEnabled} from '../FeatureFlags'
 import Expires from './Expires'
@@ -29,6 +30,12 @@ export function setIsAllowed(allowed) {
   // index/ga.js has no way to unload the tag it already injected.
   // Withdrawal therefore has to clear it explicitly.
   syncUserCidProperty()
+  // Sentry's global-scope tag is sticky in exactly the same way, and for
+  // a sharper reason: it outlives withdrawal on *every* later event, and
+  // an event's own tags merge OVER the global scope, so even a
+  // deliberately cid-less event (loadProgress#captureDiagnostics) would
+  // still inherit the stale one.
+  syncSentryCidTag()
 }
 
 
@@ -343,6 +350,29 @@ export const SENTRY_CID_TAG = OPEN_CID_PARAM
  */
 export function getOpenCidForSentry() {
   return isAllowed() ? getGaClientId() : null
+}
+
+
+/**
+ * Publish or retract the Sentry `open_cid` tag to match current consent,
+ * the exact counterpart of syncUserCidProperty for the GA user property.
+ *
+ * Both halves matter. The tag lives on Sentry's *global* scope so that
+ * everything captured afterwards carries it — load-failure exceptions
+ * included, which is the point — but that same stickiness means merely
+ * declining to set a new value leaves a previously published id
+ * attached to every later event. Withdrawal has to clear it.
+ *
+ * Retraction sets the tag to `undefined` rather than null, which is what
+ * actually removes it: applyScopeDataToEvent runs the scope's tags
+ * through dropUndefinedKeys before merging, so an undefined value is
+ * omitted from the payload, while null would transmit as a literal.
+ *
+ * Called at init from index/ga.js (twice, tracking the cookie fallback
+ * and the gtag callback) and from setIsAllowed on any consent change.
+ */
+export function syncSentryCidTag() {
+  setTag(SENTRY_CID_TAG, getOpenCidForSentry() ?? undefined)
 }
 
 

--- a/src/privacy/analytics.test.js
+++ b/src/privacy/analytics.test.js
@@ -189,6 +189,55 @@ describe('Analytics', () => {
   })
 
 
+  /*
+   * Sentry's half of the same id (issue #1767). Bare, because the
+   * `cid.` prefix only exists to stop GA4 typing the value as a float,
+   * and the dashboard strips it before searching Sentry.
+   */
+  describe('getOpenCidForSentry', () => {
+    beforeEach(() => {
+      Analytics._resetGaClientIdForTests()
+      Cookies.remove('_ga')
+      Cookies.remove('isAnalyticsAllowed')
+    })
+
+    afterEach(() => {
+      Cookies.remove('isAnalyticsAllowed')
+    })
+
+    test('null when no client id is available, so the tag is omitted', () => {
+      expect(Analytics.getOpenCidForSentry()).toBeNull()
+    })
+
+    test('is the bare id, not the cid.-prefixed GA param value', () => {
+      Analytics.setGaClientId('1871520000.1754700000')
+      expect(Analytics.getOpenCidForSentry()).toBe('1871520000.1754700000')
+      expect(Analytics.getOpenCidForSentry()).not.toBe(Analytics.getOpenCid())
+    })
+
+    test('reads the cookie fallback, so a returning visitor is tagged at first paint', () => {
+      Cookies.set('_ga', 'GA1.1.1871520000.1754700000')
+      expect(Analytics.getOpenCidForSentry()).toBe('1871520000.1754700000')
+    })
+
+    // Fails closed for the same reason syncUserCidProperty does: a
+    // declined visitor must not have an analytics id on their error
+    // reports either.
+    test('null when analytics consent is withheld', () => {
+      Analytics.setGaClientId('1871520000.1754700000')
+      Analytics.setIsAllowed(false)
+      expect(Analytics.getOpenCidForSentry()).toBeNull()
+    })
+
+    // Same identifier, and the dashboard builds the Sentry query from
+    // the GA param name.
+    test('the Sentry tag name matches the GA param name', () => {
+      expect(Analytics.SENTRY_CID_TAG).toBe(Analytics.OPEN_CID_PARAM)
+      expect(Analytics.SENTRY_CID_TAG).toBe('open_cid')
+    })
+  })
+
+
   // Route-result shapes mirror routes.ts#handleRoute output. The one
   // excluded shape is the homepage's bundled demo — everything else is
   // a real open.

--- a/src/privacy/analytics.test.js
+++ b/src/privacy/analytics.test.js
@@ -1,4 +1,7 @@
+jest.mock('@sentry/react', () => ({setTag: jest.fn()}))
+
 import Cookies from 'js-cookie'
+import {setTag} from '@sentry/react'
 import * as Analytics from './analytics'
 
 
@@ -234,6 +237,51 @@ describe('Analytics', () => {
     test('the Sentry tag name matches the GA param name', () => {
       expect(Analytics.SENTRY_CID_TAG).toBe(Analytics.OPEN_CID_PARAM)
       expect(Analytics.SENTRY_CID_TAG).toBe('open_cid')
+    })
+  })
+
+
+  /*
+   * The tag lives on Sentry's global scope, so it outlives a consent
+   * withdrawal unless something clears it — and an event's own tags
+   * merge over the global scope, so a deliberately cid-less event would
+   * inherit a stale one (Codex review on #1770).
+   */
+  describe('syncSentryCidTag', () => {
+    beforeEach(() => {
+      setTag.mockClear()
+      Analytics._resetGaClientIdForTests()
+      Cookies.remove('_ga')
+      Cookies.remove('isAnalyticsAllowed')
+    })
+
+    afterEach(() => {
+      Cookies.remove('isAnalyticsAllowed')
+    })
+
+    test('publishes the bare id when consent allows', () => {
+      Analytics.setGaClientId('1871520000.1754700000')
+      Analytics.syncSentryCidTag()
+      expect(setTag).toHaveBeenCalledWith('open_cid', '1871520000.1754700000')
+    })
+
+    // undefined, not null: Sentry's applyScopeDataToEvent runs scope
+    // tags through dropUndefinedKeys, so undefined is what removes the
+    // tag while null would transmit as a literal value.
+    test('retracts with undefined when consent is withheld', () => {
+      Analytics.setGaClientId('1871520000.1754700000')
+      Cookies.set('isAnalyticsAllowed', 'false')
+      Analytics.syncSentryCidTag()
+      expect(setTag).toHaveBeenCalledWith('open_cid', undefined)
+    })
+
+    test('setIsAllowed(false) retracts a tag already published', () => {
+      Analytics.setGaClientId('1871520000.1754700000')
+      Analytics.syncSentryCidTag()
+      setTag.mockClear()
+
+      Analytics.setIsAllowed(false)
+      expect(setTag).toHaveBeenCalledWith('open_cid', undefined)
     })
   })
 


### PR DESCRIPTION
## Summary

Closes #1767. The bizdev dashboard links each model-open chip with non-zero errors/warnings to a Sentry search on the GA client id, and Share supplied neither half of that join. This adds both.

Before this, a load that warned and then *succeeded* produced no Sentry event at all — and that is the typical chip. The loads that did reach Sentry hard-failed, so they never fired `real_model_open` and never became a chip. The two populations were close to disjoint; this is the missing overlap.

## Key Changes

**The `open_cid` tag.** `analytics#getOpenCidForSentry()` returns the *bare* client id — the `cid.` prefix exists only to stop GA4 coercing a numeric-looking id to a float, and the dashboard strips it before building the query, so bare is what makes the two ids compare equal. `index/ga.js` publishes it as a Sentry **tag**, not a context field: only tags are indexed for issue search. Set at both points the GA user property is — the `_ga` cookie fallback at setup, so a returning visitor's load-failure exceptions carry it from first paint, and the gtag callback, the only path for a first-ever visitor.

**The diagnostics event.** `loadProgress#captureLoadDiagnostics()` sends one `captureMessage` per completed load that reported diagnostics, carrying the deduped messages and the load report, tagged with `open_cid`, `content_id` and `content_type`. One event per load rather than per console line — `captureConsoleIntegration` would do the latter, and wasm loaders are chatty enough to flood the project.

**Consent tracking.** `analytics#syncSentryCidTag()` owns publish *and* retract, mirroring `syncUserCidProperty`, with `setIsAllowed` calling it on any consent change. Retraction writes `undefined` rather than `null`, which is what actually removes a tag: `applyScopeDataToEvent` runs scope tags through `dropUndefinedKeys` before merging.

**Grouping.** A message event has no exception to fingerprint, so Sentry groups it by its text. The title collapses digit runs, giving one issue per warning *family* instead of one per entity — without it, `Error processing representation #1234` would open a fresh issue for every entity of every model.

## Where the gate lives, and why

`captureLoadDiagnostics` is called from `CadView`, immediately after `eventParams` is assembled and inside the same `isRealModelOpen` guard, gating on `stats_errorCount + stats_warningCount`.

That siting is load-bearing rather than incidental. The obvious gate — the console tee's own counters in `LoadProgressReporter` — is the wrong number on exactly the formats this join is about: `ShareIfcLoader` publishes Conway's counts on `loadStats`, and `CadView` applies those *after* `getCompletedLoadStats()`, so for IFC/STEP the engine's numbers are what colour the chip. Gating on the tee would let the event and the chip disagree, and each direction of disagreement is worse than the gap being closed — a red chip whose `open_cid:` link resolves to nothing, or a green chip with an issue behind it. Both look like the join working.

Calling from that branch also makes the other two gates structural instead of flags: only real opens reach it (never the bundled demo, which loads on every homepage visit and can never be a chip), and only successful ones (a failure is already reported by that path's `captureException`, with the same report attached by `attachLoadFailureContext`).

## Known coverage limit

A GA-blocked client never resolves a cid, so its events carry no tag. Per the triage notes in `index/sentry.js` that ad-blocked mobile cohort is this project's largest single source of Sentry events, so cid coverage will be structurally partial: an empty search result cannot distinguish "this user hit no errors" from "this user had no cid".

## Testing

Unit tests across `analytics.test.js`, `ga.test.js` and `loadProgress.test.js` cover the bare-id contract, both consent directions including retraction of an already-published tag, tag presence and absence, message-family grouping, the count and per-message length caps, and both directions of the engine-vs-console-tee split (engine reports errors with a silent tee → fires; engine clean with a chatty console → silent).

No E2E: every acceptance criterion is Sentry-side, Sentry has no DSN off-prod, and `shouldInitGa` refuses to initialize GA under `navigator.webdriver`, so there is nothing a Playwright spec could observe.

https://claude.ai/code/session_016bDXSZHWKbsxFGn4oBVf5F