### PR TITLE
Add Google Search Console verification meta tag

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -10,6 +10,7 @@
           content="width=device-width, user-scalable=no, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0">
     <link rel="icon" href="/favicon.ico"/>
     <title>bldrs.ai</title>
+    <meta name="google-site-verification" content="soxvqCycG6656Bmiml345OQ0BPfPnfzHBx_CJ3dSEeQ" />
     <!-- Start Single Page Apps for GitHub Pages -->
     <script type="application/javascript">
       // Single Page Apps for GitHub Pages


### PR DESCRIPTION
Adds the Google Search Console site-verification meta tag for the `https://bldrs.ai/` URL-prefix property.

Why a meta tag rather than the Google Analytics verification method: Search Console's GA method requires the gtag snippet to sit literally inside `<head>`. Ours is a static tag but lives in `<body>`, after the module loader, so GSC's check fails with "The Google Analytics tracking code on your site is in the wrong location on the page." The GTM method is also unavailable (no GTM container).

This tag is inert — no script, no request, no runtime effect. Once merged and deployed, ownership can be verified in Search Console, which unblocks search-query reporting and the GA4 ↔ Search Console link.