### PR TITLE
Fix model handle mismatch in GLB cache for STEP files

### DIFF
--- a/src/Components/NavTree/NavTree.cacheHit.spec.ts
+++ b/src/Components/NavTree/NavTree.cacheHit.spec.ts
@@ -140,4 +140,64 @@ describe('View 100: NavTree on cache-hit GLB', () => {
     const MIN_TREE_ITEMS = 5
     expect(itemCount).toBeGreaterThan(MIN_TREE_ITEMS)
   })
+
+  // SKIP REASON: the OPFS/MSW harness gap above, same as its IFC sibling.
+  //
+  // Worth having as its own test rather than a parameterisation of the one
+  // above, because the two formats reach the writer through different Conway
+  // opens and a STEP-only regression is invisible to an IFC fixture. That is
+  // exactly what bldrs-ai/Share#1776 was: Conway's store-backed open reserves
+  // the model handle before it sniffs the format and is IFC-only, so a STEP
+  // file burned handle 0 and parsed as handle 1, the writer's captures went to
+  // a handle Conway had never opened, and the artifact cached with neither
+  // BLDRS_spatial_tree nor BLDRS_element_properties. The IFC path was
+  // untouched throughout. The observable symptom is the assertion below: the
+  // cache-hit tree collapses to the model root repeated a couple of times
+  // (Loader.js's `ifcManager.getSpatialStructure = () => model` fallback,
+  // walking the GLB scene graph) instead of the real assembly hierarchy.
+  test.fixme('cache-hit GLB renders NavTree for a STEP model', async ({page}) => {
+    const TEST_TIMEOUT = 120_000
+    test.setTimeout(TEST_TIMEOUT)
+
+    const glbLogs: string[] = []
+    page.on('console', (msg) => {
+      const text = msg.text()
+      if (text.startsWith('[glb]')) {
+        glbLogs.push(text)
+      }
+    })
+
+    const CACHE_TIMEOUT = 30_000
+    await page.goto('/share/v/p/index.step')
+    await waitForModelReady(page)
+    await page.waitForFunction(
+      ({logs}) => logs.some((l: string) => l.includes('writer: wrote')),
+      {logs: glbLogs},
+      {timeout: CACHE_TIMEOUT},
+    )
+    expect(glbLogs.some((l) => l.includes('cache MISS'))).toBe(true)
+
+    glbLogs.length = 0
+    await page.goto('/share/v/p/index.step')
+    await waitForModelReady(page)
+    await page.waitForFunction(
+      ({logs}) => logs.some((l: string) => l.includes('cache HIT')),
+      {logs: glbLogs},
+      {timeout: CACHE_TIMEOUT},
+    )
+
+    // The tree must come from the cached extension, not the scene-graph
+    // fallback. This log line IS the discriminant — without it the panel
+    // still renders rows, just the wrong ones.
+    await page.waitForFunction(
+      ({logs}) => logs.some((l: string) => l.includes('hydrated NavTree from BLDRS_spatial_tree')),
+      {logs: glbLogs},
+      {timeout: CACHE_TIMEOUT},
+    )
+
+    await page.getByTestId('control-button-navigation').click()
+    const navTreePanel = page.getByTestId('NavTreePanel')
+    await expect(navTreePanel).toBeVisible()
+    await expect(navTreePanel.locator('[role="treeitem"]').first()).toBeVisible()
+  })
 })

--- a/src/Filetype.js
+++ b/src/Filetype.js
@@ -410,12 +410,49 @@ export function classifyStepFamily(header) {
  * @return {string|null} the schema name, e.g. 'IFC4' or 'AUTOMOTIVE_DESIGN'
  */
 export function stepSchemaName(header) {
-  const schemaMatch = maskPart21Comments(header).match(FILE_SCHEMA_VALUE)
-  return schemaMatch === null ? null : schemaMatch[1]
+  const section = part21HeaderSection(maskPart21Comments(header))
+  if (section === null) {
+    return null
+  }
+  // LAST match, not first: conway's parser stores header entities in a Map
+  // keyed by name (`step_parser.js:193`), so a header carrying FILE_SCHEMA
+  // twice overwrites and the last one wins. Reading the first would have us
+  // answer from one entity and conway from the other — and on
+  // `FILE_SCHEMA(('IFC4')); FILE_SCHEMA(('AUTOMOTIVE_DESIGN'));` that is the
+  // dangerous direction: we say IFC, conway says AP214, and a STEP file goes
+  // down the IFC-only store open (bldrs-ai/Share#1776).
+  const matches = [...section.matchAll(FILE_SCHEMA_VALUE)]
+  return matches.length === 0 ? null : matches[matches.length - 1][1]
 }
 
 
-const FILE_SCHEMA_VALUE = /FILE_SCHEMA\s*\(\s*\(\s*'\s*([A-Za-z0-9_]+)/i
+const FILE_SCHEMA_VALUE = /FILE_SCHEMA\s*\(\s*\(\s*'\s*([A-Za-z0-9_]+)/ig
+
+
+/**
+ * The HEADER section of a Part-21 file, or null when there is none in the
+ * window. Pass comment-masked text.
+ *
+ * Bounding matters because the caller sniffs a fixed 64 KiB prefix, which on
+ * any real model runs well into DATA — where a quoted string is free to
+ * contain something that looks like a header entity. conway reads FILE_SCHEMA
+ * from the parsed HEADER section only, so scanning past ENDSEC could have us
+ * answer IFC from a property value while conway answers AP214 from the real
+ * header. Truncating early (an `ENDSEC;` inside a header string literal, say)
+ * costs at worst a missed schema, which reads as "did not say" and buffers.
+ *
+ * @param {string} masked comment-masked Part-21 text
+ * @return {string|null} the header section's text
+ */
+function part21HeaderSection(masked) {
+  const start = masked.search(/\bHEADER\s*;/i)
+  if (start === -1) {
+    return null
+  }
+  const rest = masked.slice(start)
+  const end = rest.search(/\bENDSEC\s*;/i)
+  return end === -1 ? rest : rest.slice(0, end)
+}
 
 
 /**

--- a/src/Filetype.js
+++ b/src/Filetype.js
@@ -410,25 +410,83 @@ export function classifyStepFamily(header) {
  * @return {string|null} the schema name, e.g. 'IFC4' or 'AUTOMOTIVE_DESIGN'
  */
 export function stepSchemaName(header) {
-  const schemaMatch = header.match(FILE_SCHEMA_VALUE)
+  const schemaMatch = maskPart21Comments(header).match(FILE_SCHEMA_VALUE)
   return schemaMatch === null ? null : schemaMatch[1]
 }
 
 
-// ISO-10303-21 permits a `/* ... */` comment anywhere whitespace is allowed,
-// and conway's `StepHeaderParser` consumes one AS whitespace (its
-// `whitespace()` loops on the comment parser), so `ModelFormatDetector` reads
-// `FILE_SCHEMA /* exported by ... */ (('IFC4'))` as IFC. A bare `\s*` here
-// would not, and this function's job is to reach conway's answer from the
-// same bytes: disagreeing costs a large model its windowed parse and the
-// whole-source allocation that avoids (`Loader.js#canOpenFromStore`).
-//
-// Deliberately NOT applied after the opening quote — inside a Part-21 string
-// literal `/*` is ordinary text, not a comment. An unterminated comment
-// matches nothing and yields null, which is the safe direction: buffer.
-const PART21_GAP = String.raw`(?:\s|/\*[\s\S]*?\*/)*`
-const FILE_SCHEMA_VALUE = new RegExp(
-  `FILE_SCHEMA${PART21_GAP}\\(${PART21_GAP}\\(${PART21_GAP}'\\s*([A-Za-z0-9_]+)`, 'i')
+const FILE_SCHEMA_VALUE = /FILE_SCHEMA\s*\(\s*\(\s*'\s*([A-Za-z0-9_]+)/i
+
+
+/**
+ * Blank out ISO-10303-21 `/* ... *``/` comments, leaving string literals
+ * intact, so a text scan sees what conway's parser sees.
+ *
+ * Two failures motivate this, and only masking fixes both. Part-21 permits a
+ * comment anywhere whitespace is allowed and conway's `StepHeaderParser`
+ * consumes one AS whitespace (its `whitespace()` loops on the comment
+ * parser), so:
+ *
+ *   - `FILE_SCHEMA /* note *``/ (('IFC4'))` is IFC to conway. A plain `\s*`
+ *     scan misses it and reports no schema — costing a large IFC its
+ *     windowed parse.
+ *   - `/* FILE_SCHEMA(('IFC4')); *``/ FILE_SCHEMA(('AUTOMOTIVE_DESIGN'));` is
+ *     AP214 to conway. A raw-text scan finds the commented-out entity first
+ *     and reports IFC — the dangerous direction, which sends a STEP file
+ *     down conway's IFC-only store open and burns a model handle
+ *     (bldrs-ai/Share#1776).
+ *
+ * The second is why this masks rather than making the gap pattern
+ * comment-aware: a token can be *inside* a comment, not merely separated by
+ * one, and no amount of tolerance between tokens excludes it.
+ *
+ * String-literal aware, because inside a Part-21 string `/*` is ordinary
+ * text. An apostrophe is escaped by doubling it (`''`), which keeps the
+ * string open. An unterminated comment swallows the rest of the window,
+ * which matches conway's own reading and fails safe: no schema found.
+ *
+ * @param {string} text a Part-21 header window
+ * @return {string} the same text with comment spans replaced by a space
+ */
+function maskPart21Comments(text) {
+  let out = ''
+  let at = 0
+  let inString = false
+  while (at < text.length) {
+    const c = text[at]
+    if (inString) {
+      if (c === `'` && text[at + 1] === `'`) {
+        out += `''`
+        at += 2
+        continue
+      }
+      if (c === `'`) {
+        inString = false
+      }
+      out += c
+      at++
+      continue
+    }
+    if (c === `'`) {
+      inString = true
+      out += c
+      at++
+      continue
+    }
+    if (c === '/' && text[at + 1] === '*') {
+      const end = text.indexOf('*/', at + 2)
+      if (end === -1) {
+        return out
+      }
+      out += ' '
+      at = end + 2
+      continue
+    }
+    out += c
+    at++
+  }
+  return out
+}
 
 
 /**

--- a/src/Filetype.js
+++ b/src/Filetype.js
@@ -383,11 +383,35 @@ export function analyzeHeaderStr(header) {
  * @return {string} 'ifc' or 'step'
  */
 export function classifyStepFamily(header) {
-  const schemaMatch = header.match(/FILE_SCHEMA\s*\(\s*\(\s*'\s*([A-Za-z0-9_]+)/i)
-  if (schemaMatch === null) {
+  const schema = stepSchemaName(header)
+  if (schema === null) {
     return 'ifc'
   }
-  return /^IFC/i.test(schemaMatch[1]) ? 'ifc' : 'step'
+  return /^IFC/i.test(schema) ? 'ifc' : 'step'
+}
+
+
+/**
+ * The FILE_SCHEMA value of an ISO-10303-21 header, or null when the entry
+ * is absent from the sniffed window or carries no parseable name — an
+ * empty `FILE_SCHEMA(( ))` / `FILE_SCHEMA(( '' ))`, which is malformed but
+ * does occur in the wild.
+ *
+ * Split out of {@link classifyStepFamily} so a caller can tell "this file
+ * says STEP" apart from "this file did not say". The classifier folds both
+ * into 'ifc': the right default when the answer only picks a filename, and
+ * the wrong one for a caller whose false-'ifc' costs more than a false
+ * 'step'. `Loader.js#canOpenFromStore` is the second kind — it gates
+ * conway's IFC-only store open, where guessing 'ifc' burns a model handle
+ * and caches a GLB with no NavTree (bldrs-ai/Share#1776) — so it requires a
+ * non-null name here before it trusts the classification.
+ *
+ * @param {string} header
+ * @return {string|null} the schema name, e.g. 'IFC4' or 'AUTOMOTIVE_DESIGN'
+ */
+export function stepSchemaName(header) {
+  const schemaMatch = header.match(/FILE_SCHEMA\s*\(\s*\(\s*'\s*([A-Za-z0-9_]+)/i)
+  return schemaMatch === null ? null : schemaMatch[1]
 }
 
 

--- a/src/Filetype.js
+++ b/src/Filetype.js
@@ -410,9 +410,25 @@ export function classifyStepFamily(header) {
  * @return {string|null} the schema name, e.g. 'IFC4' or 'AUTOMOTIVE_DESIGN'
  */
 export function stepSchemaName(header) {
-  const schemaMatch = header.match(/FILE_SCHEMA\s*\(\s*\(\s*'\s*([A-Za-z0-9_]+)/i)
+  const schemaMatch = header.match(FILE_SCHEMA_VALUE)
   return schemaMatch === null ? null : schemaMatch[1]
 }
+
+
+// ISO-10303-21 permits a `/* ... */` comment anywhere whitespace is allowed,
+// and conway's `StepHeaderParser` consumes one AS whitespace (its
+// `whitespace()` loops on the comment parser), so `ModelFormatDetector` reads
+// `FILE_SCHEMA /* exported by ... */ (('IFC4'))` as IFC. A bare `\s*` here
+// would not, and this function's job is to reach conway's answer from the
+// same bytes: disagreeing costs a large model its windowed parse and the
+// whole-source allocation that avoids (`Loader.js#canOpenFromStore`).
+//
+// Deliberately NOT applied after the opening quote — inside a Part-21 string
+// literal `/*` is ordinary text, not a comment. An unterminated comment
+// matches nothing and yields null, which is the safe direction: buffer.
+const PART21_GAP = String.raw`(?:\s|/\*[\s\S]*?\*/)*`
+const FILE_SCHEMA_VALUE = new RegExp(
+  `FILE_SCHEMA${PART21_GAP}\\(${PART21_GAP}\\(${PART21_GAP}'\\s*([A-Za-z0-9_]+)`, 'i')
 
 
 /**

--- a/src/Filetype.js
+++ b/src/Filetype.js
@@ -426,7 +426,15 @@ export function stepSchemaName(header) {
 }
 
 
-const FILE_SCHEMA_VALUE = /FILE_SCHEMA\s*\(\s*\(\s*'\s*([A-Za-z0-9_]+)/ig
+// `\b` anchors the entity name so the scan cannot start inside a longer
+// identifier. conway parses header records under their exact names and
+// inspects only the `FILE_SCHEMA` key, so `NOT_FILE_SCHEMA(('IFC4'));` is
+// invisible to it — while an unanchored scan reads it as the schema. With
+// last-wins that is the dangerous direction whenever the lookalike follows
+// the real entity: we answer IFC, conway answers AP214. `\b` suffices
+// because `_` is a word character, so there is no boundary inside
+// `NOT_FILE_SCHEMA`.
+const FILE_SCHEMA_VALUE = /\bFILE_SCHEMA\s*\(\s*\(\s*'\s*([A-Za-z0-9_]+)/ig
 
 
 /**

--- a/src/Filetype.test.js
+++ b/src/Filetype.test.js
@@ -429,6 +429,17 @@ describe('Filetype', () => {
       ))).toBe('IFC4')
     })
 
+    it('does not match FILE_SCHEMA inside a longer entity name', () => {
+      // conway parses header records under their exact names and inspects
+      // only the `FILE_SCHEMA` key, so `NOT_FILE_SCHEMA` is invisible to it.
+      // An unanchored scan reads it as the schema — and with last-wins that
+      // is the dangerous direction whenever the lookalike follows the real
+      // entity: we answer IFC where conway answers AP214.
+      const body = `FILE_SCHEMA(('AUTOMOTIVE_DESIGN'));\nNOT_FILE_SCHEMA(('IFC4'));`
+      expect(stepSchemaName(hdr(body))).toBe('AUTOMOTIVE_DESIGN')
+      expect(analyzeHeaderStr(hdr(body))).toBe('step')
+    })
+
     it('separates "did not say" from "said STEP"', () => {
       // The distinction `classifyStepFamily` cannot express, because it
       // folds both into 'ifc'. A caller whose false-'ifc' is expensive —

--- a/src/Filetype.test.js
+++ b/src/Filetype.test.js
@@ -366,26 +366,24 @@ describe('Filetype', () => {
   })
 
   describe('stepSchemaName', () => {
+    // Real input, because the scan is bounded to the HEADER section: a bare
+    // fragment has no section to find and correctly reads as "did not say".
+    const hdr = (body) => `ISO-10303-21;\nHEADER;\n${body}\nENDSEC;\nDATA;\nENDSEC;\n`
+
     it('returns the declared schema for both families', () => {
-      expect(stepSchemaName('FILE_SCHEMA((\'IFC4\'));')).toBe('IFC4')
-      expect(stepSchemaName('FILE_SCHEMA((\'AUTOMOTIVE_DESIGN\'));')).toBe('AUTOMOTIVE_DESIGN')
-      expect(stepSchemaName('FILE_SCHEMA  ( ( \' IFC2X3 \' ) );')).toBe('IFC2X3')
+      expect(stepSchemaName(hdr(`FILE_SCHEMA(('IFC4'));`))).toBe('IFC4')
+      expect(stepSchemaName(hdr(`FILE_SCHEMA(('AUTOMOTIVE_DESIGN'));`))).toBe('AUTOMOTIVE_DESIGN')
+      expect(stepSchemaName(hdr(`FILE_SCHEMA  ( ( ' IFC2X3 ' ) );`))).toBe('IFC2X3')
     })
 
-    it('skips Part-21 comments the way conway\'s header parser does', () => {
+    it(`skips Part-21 comments the way conway's header parser does`, () => {
       // ISO-10303-21 allows a comment anywhere whitespace is allowed, and
       // conway's `StepHeaderParser` consumes one as whitespace — so
       // `ModelFormatDetector` calls these IFC. Reading them as "no schema"
       // would cost a large IFC its windowed parse.
-      expect(stepSchemaName('FILE_SCHEMA /* exported by X */ ((\'IFC4\'));')).toBe('IFC4')
-      expect(stepSchemaName('FILE_SCHEMA((/* why */\'IFC4\'));')).toBe('IFC4')
-      expect(stepSchemaName('FILE_SCHEMA/* a */(/* b */(/* c */\'IFC4\'));')).toBe('IFC4')
-      // An unterminated comment matches nothing — null, i.e. buffer. That is
-      // the safe direction for a header we cannot read.
-      expect(stepSchemaName('FILE_SCHEMA /* unterminated ((\'IFC4\'));')).toBeNull()
-      // `/*` inside the string literal is ordinary text, not a comment, so
-      // the gap rule must not be applied after the opening quote.
-      expect(stepSchemaName('FILE_SCHEMA((\'IFC4\'));/* trailing */')).toBe('IFC4')
+      expect(stepSchemaName(hdr(`FILE_SCHEMA /* exported by X */ (('IFC4'));`))).toBe('IFC4')
+      expect(stepSchemaName(hdr(`FILE_SCHEMA((/* why */'IFC4'));`))).toBe('IFC4')
+      expect(stepSchemaName(hdr(`FILE_SCHEMA/* a */(/* b */(/* c */'IFC4'));`))).toBe('IFC4')
     })
 
     it('ignores a FILE_SCHEMA entity that is itself inside a comment', () => {
@@ -394,23 +392,41 @@ describe('Filetype', () => {
       // tolerance BETWEEN tokens excludes it. conway's parser skips the
       // comment and reads AP214; a raw-text scan would answer IFC, send a
       // STEP file down conway's IFC-only store open, and burn a model handle.
-      const header =
-        '/* FILE_SCHEMA((\'IFC4\')); */\nFILE_SCHEMA((\'AUTOMOTIVE_DESIGN\'));'
-      expect(stepSchemaName(header)).toBe('AUTOMOTIVE_DESIGN')
-      expect(analyzeHeaderStr(`ISO-10303-21;\n${header}`)).toBe('step')
+      const body = `/* FILE_SCHEMA(('IFC4')); */\nFILE_SCHEMA(('AUTOMOTIVE_DESIGN'));`
+      expect(stepSchemaName(hdr(body))).toBe('AUTOMOTIVE_DESIGN')
+      expect(analyzeHeaderStr(hdr(body))).toBe('step')
+    })
+
+    it('takes the LAST FILE_SCHEMA, matching conway\'s last-wins Map', () => {
+      // conway stores header entities in a Map keyed by name
+      // (`step_parser.js:193`), so a duplicated FILE_SCHEMA overwrites.
+      // Reading the first would answer IFC here where conway answers AP214 —
+      // the dangerous direction again.
+      const body = `FILE_SCHEMA(('IFC4'));\nFILE_SCHEMA(('AUTOMOTIVE_DESIGN'));`
+      expect(stepSchemaName(hdr(body))).toBe('AUTOMOTIVE_DESIGN')
+      expect(analyzeHeaderStr(hdr(body))).toBe('step')
+    })
+
+    it('ignores a FILE_SCHEMA lookalike past ENDSEC', () => {
+      // The caller sniffs a fixed 64 KiB prefix, which on any real model runs
+      // well into DATA, where a quoted string may contain anything. conway
+      // reads FILE_SCHEMA from the HEADER section only.
+      const text = `ISO-10303-21;\nHEADER;\nFILE_SCHEMA(('AUTOMOTIVE_DESIGN'));\nENDSEC;\n` +
+        `DATA;\n#1=IFCPROPERTYSINGLEVALUE('FILE_SCHEMA((''IFC4''));');\nENDSEC;\n`
+      expect(stepSchemaName(text)).toBe('AUTOMOTIVE_DESIGN')
     })
 
     it('keeps a comment-like sequence inside a string literal', () => {
       // Inside a Part-21 string `/*` is ordinary text. Masking it would join
       // the surrounding text and could resurrect the bug it exists to fix.
-      expect(stepSchemaName(
-        'FILE_NAME(\'/* not a comment\',\'*/\');\nFILE_SCHEMA((\'AUTOMOTIVE_DESIGN\'));',
-      )).toBe('AUTOMOTIVE_DESIGN')
+      expect(stepSchemaName(hdr(
+        `FILE_NAME('/* not a comment','*/');\nFILE_SCHEMA(('AUTOMOTIVE_DESIGN'));`,
+      ))).toBe('AUTOMOTIVE_DESIGN')
       // A doubled apostrophe escapes one inside the string; the string stays
       // open across it, so the `/*` after it is still literal.
-      expect(stepSchemaName(
-        'FILE_NAME(\'it\'\'s /* fine\');\nFILE_SCHEMA((\'IFC4\'));',
-      )).toBe('IFC4')
+      expect(stepSchemaName(hdr(
+        `FILE_NAME('it''s /* fine');\nFILE_SCHEMA(('IFC4'));`,
+      ))).toBe('IFC4')
     })
 
     it('separates "did not say" from "said STEP"', () => {
@@ -419,11 +435,13 @@ describe('Filetype', () => {
       // `Loader.js#canOpenFromStore` gating conway's IFC-only store open —
       // needs a non-null name before it trusts the classification.
       expect(stepSchemaName('HEADER;\nENDSEC;')).toBeNull()
-      expect(stepSchemaName('FILE_SCHEMA(());')).toBeNull()
-      expect(stepSchemaName('FILE_SCHEMA((\'\'));')).toBeNull()
+      expect(stepSchemaName(hdr(`FILE_SCHEMA(());`))).toBeNull()
+      expect(stepSchemaName(hdr(`FILE_SCHEMA((''));`))).toBeNull()
+      // No HEADER section at all — nothing conway would parse a schema from.
+      expect(stepSchemaName(`FILE_SCHEMA(('IFC4'));`)).toBeNull()
       // Same inputs, classifier still answers 'ifc' — that default is why
       // the guard above exists.
-      expect(analyzeHeaderStr('ISO-10303-21;\nFILE_SCHEMA((\'\'));')).toBe('ifc')
+      expect(analyzeHeaderStr(hdr(`FILE_SCHEMA((''));`))).toBe('ifc')
     })
   })
 })

--- a/src/Filetype.test.js
+++ b/src/Filetype.test.js
@@ -388,6 +388,31 @@ describe('Filetype', () => {
       expect(stepSchemaName('FILE_SCHEMA((\'IFC4\'));/* trailing */')).toBe('IFC4')
     })
 
+    it('ignores a FILE_SCHEMA entity that is itself inside a comment', () => {
+      // The dangerous direction, and the one a comment-tolerant gap pattern
+      // cannot fix: the whole entity sits INSIDE the comment, so no amount of
+      // tolerance BETWEEN tokens excludes it. conway's parser skips the
+      // comment and reads AP214; a raw-text scan would answer IFC, send a
+      // STEP file down conway's IFC-only store open, and burn a model handle.
+      const header =
+        '/* FILE_SCHEMA((\'IFC4\')); */\nFILE_SCHEMA((\'AUTOMOTIVE_DESIGN\'));'
+      expect(stepSchemaName(header)).toBe('AUTOMOTIVE_DESIGN')
+      expect(analyzeHeaderStr(`ISO-10303-21;\n${header}`)).toBe('step')
+    })
+
+    it('keeps a comment-like sequence inside a string literal', () => {
+      // Inside a Part-21 string `/*` is ordinary text. Masking it would join
+      // the surrounding text and could resurrect the bug it exists to fix.
+      expect(stepSchemaName(
+        'FILE_NAME(\'/* not a comment\',\'*/\');\nFILE_SCHEMA((\'AUTOMOTIVE_DESIGN\'));',
+      )).toBe('AUTOMOTIVE_DESIGN')
+      // A doubled apostrophe escapes one inside the string; the string stays
+      // open across it, so the `/*` after it is still literal.
+      expect(stepSchemaName(
+        'FILE_NAME(\'it\'\'s /* fine\');\nFILE_SCHEMA((\'IFC4\'));',
+      )).toBe('IFC4')
+    })
+
     it('separates "did not say" from "said STEP"', () => {
       // The distinction `classifyStepFamily` cannot express, because it
       // folds both into 'ifc'. A caller whose false-'ifc' is expensive —

--- a/src/Filetype.test.js
+++ b/src/Filetype.test.js
@@ -372,6 +372,22 @@ describe('Filetype', () => {
       expect(stepSchemaName('FILE_SCHEMA  ( ( \' IFC2X3 \' ) );')).toBe('IFC2X3')
     })
 
+    it('skips Part-21 comments the way conway\'s header parser does', () => {
+      // ISO-10303-21 allows a comment anywhere whitespace is allowed, and
+      // conway's `StepHeaderParser` consumes one as whitespace — so
+      // `ModelFormatDetector` calls these IFC. Reading them as "no schema"
+      // would cost a large IFC its windowed parse.
+      expect(stepSchemaName('FILE_SCHEMA /* exported by X */ ((\'IFC4\'));')).toBe('IFC4')
+      expect(stepSchemaName('FILE_SCHEMA((/* why */\'IFC4\'));')).toBe('IFC4')
+      expect(stepSchemaName('FILE_SCHEMA/* a */(/* b */(/* c */\'IFC4\'));')).toBe('IFC4')
+      // An unterminated comment matches nothing — null, i.e. buffer. That is
+      // the safe direction for a header we cannot read.
+      expect(stepSchemaName('FILE_SCHEMA /* unterminated ((\'IFC4\'));')).toBeNull()
+      // `/*` inside the string literal is ordinary text, not a comment, so
+      // the gap rule must not be applied after the opening quote.
+      expect(stepSchemaName('FILE_SCHEMA((\'IFC4\'));/* trailing */')).toBe('IFC4')
+    })
+
     it('separates "did not say" from "said STEP"', () => {
       // The distinction `classifyStepFamily` cannot express, because it
       // folds both into 'ifc'. A caller whose false-'ifc' is expensive —

--- a/src/Filetype.test.js
+++ b/src/Filetype.test.js
@@ -8,6 +8,7 @@ import {
   isExtensionSupported,
   pathSuffixSupported,
   splitAroundExtension,
+  stepSchemaName,
   supportedTypes,
 } from './Filetype'
 
@@ -361,6 +362,27 @@ describe('Filetype', () => {
       expect(getValidExtension('model.usda')).toBe('usda')
       expect(getValidExtension('model.usdc')).toBe('usdc')
       expect(getValidExtension('model.USDZ')).toBe('usdz')
+    })
+  })
+
+  describe('stepSchemaName', () => {
+    it('returns the declared schema for both families', () => {
+      expect(stepSchemaName('FILE_SCHEMA((\'IFC4\'));')).toBe('IFC4')
+      expect(stepSchemaName('FILE_SCHEMA((\'AUTOMOTIVE_DESIGN\'));')).toBe('AUTOMOTIVE_DESIGN')
+      expect(stepSchemaName('FILE_SCHEMA  ( ( \' IFC2X3 \' ) );')).toBe('IFC2X3')
+    })
+
+    it('separates "did not say" from "said STEP"', () => {
+      // The distinction `classifyStepFamily` cannot express, because it
+      // folds both into 'ifc'. A caller whose false-'ifc' is expensive —
+      // `Loader.js#canOpenFromStore` gating conway's IFC-only store open —
+      // needs a non-null name before it trusts the classification.
+      expect(stepSchemaName('HEADER;\nENDSEC;')).toBeNull()
+      expect(stepSchemaName('FILE_SCHEMA(());')).toBeNull()
+      expect(stepSchemaName('FILE_SCHEMA((\'\'));')).toBeNull()
+      // Same inputs, classifier still answers 'ifc' — that default is why
+      // the guard above exists.
+      expect(analyzeHeaderStr('ISO-10303-21;\nFILE_SCHEMA((\'\'));')).toBe('ifc')
     })
   })
 })

--- a/src/loader/Loader.cover.test.js
+++ b/src/loader/Loader.cover.test.js
@@ -540,6 +540,38 @@ describe('load() error/edge paths with OPFS enabled', () => {
   })
 
 
+  it('buffers an uploaded STEP file rather than offering it to the store open', async () => {
+    // Conway's store-backed open is IFC-only, and it reserves the model
+    // handle before it sniffs the format — so handing it a STEP file burns
+    // handle 0 on a model that never opens and the buffered retry parses as
+    // handle 1. Every Share call site that passes the scene-level id 0 then
+    // addresses a model Conway does not have, which is how a STEP model's
+    // cached GLB ended up with no NavTree and no Properties (#1776). Nothing
+    // is lost by buffering here: the store path had no STEP implementation.
+    const file = new MockFile(new Uint8Array(512).fill(0x20))
+    const arrayBufferSpy = jest.spyOn(file, 'arrayBuffer')
+    getModelFromOPFS.mockReset()
+    getModelFromOPFS.mockResolvedValue(file)
+    dereferenceAndProxyDownloadContents.mockResolvedValue([
+      'blob:http://localhost/uuid.stp',
+      '',
+      false,
+      false,
+    ])
+
+    await expect(
+      load(
+        '12345678-1234-4abc-9def-123456789abc.stp',
+        makeIfcViewer({streamOpen: true}),
+        onProgress, true, setOpfsFile, ''),
+    ).rejects.toThrow()
+
+    expect(arrayBufferSpy).toHaveBeenCalledTimes(1)
+    expect(onProgress).toHaveBeenCalledWith('Buffering model bytes...')
+    expect(onProgress).not.toHaveBeenCalledWith('Hashing model...')
+  })
+
+
   it('hashes the single parse buffer when store-open is unavailable', async () => {
     const file = new MockFile(new Uint8Array(512).fill(0x20))
     const arrayBufferSpy = jest.spyOn(file, 'arrayBuffer')

--- a/src/loader/Loader.cover.test.js
+++ b/src/loader/Loader.cover.test.js
@@ -113,6 +113,32 @@ function makeIfcViewer({streamOpen = false} = {}) {
 }
 
 
+// Part-21 header fixtures. `canOpenFromStore` decides the store path from
+// FILE_SCHEMA, not from the suffix, so these tests need real headers: a body
+// of filler bytes would sniff as "no schema found" and buffer for a reason
+// the test did not intend to exercise.
+/**
+ * @param {string} schema the FILE_SCHEMA value, e.g. 'IFC4'
+ * @return {string} a minimal ISO-10303-21 header declaring it
+ */
+function part21(schema) {
+  return `ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION((''),'2;1');
+FILE_NAME('t','',(''),(''),'','','');
+FILE_SCHEMA(('${schema}'));
+ENDSEC;
+DATA;
+ENDSEC;
+END-ISO-10303-21;
+`
+}
+
+
+const IFC_SOURCE = part21('IFC4')
+const STEP_SOURCE = part21('AUTOMOTIVE_DESIGN')
+
+
 /** MockBlob with an arrayBuffer() that yields the given bytes. */
 class MockFile {
   /** @param {ArrayBuffer|Uint8Array|string} content */
@@ -515,7 +541,7 @@ describe('load() error/edge paths with OPFS enabled', () => {
 
 
   it('does not arrayBuffer an uploaded IFC when OpenModelStream can take the File', async () => {
-    const file = new MockFile(new Uint8Array(512).fill(0x20))
+    const file = new MockFile(IFC_SOURCE)
     const arrayBufferSpy = jest.spyOn(file, 'arrayBuffer')
     const sliceSpy = jest.spyOn(file, 'slice')
     getModelFromOPFS.mockReset()
@@ -548,7 +574,7 @@ describe('load() error/edge paths with OPFS enabled', () => {
     // addresses a model Conway does not have, which is how a STEP model's
     // cached GLB ended up with no NavTree and no Properties (#1776). Nothing
     // is lost by buffering here: the store path had no STEP implementation.
-    const file = new MockFile(new Uint8Array(512).fill(0x20))
+    const file = new MockFile(STEP_SOURCE)
     const arrayBufferSpy = jest.spyOn(file, 'arrayBuffer')
     getModelFromOPFS.mockReset()
     getModelFromOPFS.mockResolvedValue(file)
@@ -572,8 +598,65 @@ describe('load() error/edge paths with OPFS enabled', () => {
   })
 
 
+  it('keeps the store open for IFC content carrying a STEP suffix', async () => {
+    // The suffix is not the format. `findLoader` takes `loader.type` from the
+    // filename, so a suffix test would deny this file the windowed parse and
+    // buffer its whole source — on a large mislabelled model that is exactly
+    // the hundreds-of-MB allocation M3 removed. FILE_SCHEMA says IFC4, conway's
+    // own sniff will agree, so the store path is both safe and worth taking.
+    const file = new MockFile(IFC_SOURCE)
+    const arrayBufferSpy = jest.spyOn(file, 'arrayBuffer')
+    getModelFromOPFS.mockReset()
+    getModelFromOPFS.mockResolvedValue(file)
+    dereferenceAndProxyDownloadContents.mockResolvedValue([
+      'blob:http://localhost/uuid.step',
+      '',
+      false,
+      false,
+    ])
+
+    await expect(
+      load(
+        '12345678-1234-4abc-9def-123456789abc.step',
+        makeIfcViewer({streamOpen: true}),
+        onProgress, true, setOpfsFile, ''),
+    ).rejects.toThrow()
+
+    expect(arrayBufferSpy).not.toHaveBeenCalled()
+    expect(onProgress).toHaveBeenCalledWith('Hashing model...')
+  })
+
+
+  it('buffers a part-21 file whose FILE_SCHEMA is missing', async () => {
+    // Unknown format buffers rather than gambling: a wrong "yes" burns a model
+    // handle and caches a GLB with no NavTree, a wrong "no" costs one load's
+    // memory win. Every real part-21 file carries FILE_SCHEMA well inside
+    // conway's 64 KiB sniff window, so this is a corrupt-file path.
+    const file = new MockFile('ISO-10303-21;\nHEADER;\nENDSEC;\n')
+    const arrayBufferSpy = jest.spyOn(file, 'arrayBuffer')
+    getModelFromOPFS.mockReset()
+    getModelFromOPFS.mockResolvedValue(file)
+    dereferenceAndProxyDownloadContents.mockResolvedValue([
+      'blob:http://localhost/uuid.ifc',
+      '',
+      false,
+      false,
+    ])
+
+    await expect(
+      load(
+        '12345678-1234-4abc-9def-123456789abc.ifc',
+        makeIfcViewer({streamOpen: true}),
+        onProgress, true, setOpfsFile, ''),
+    ).rejects.toThrow()
+
+    expect(arrayBufferSpy).toHaveBeenCalledTimes(1)
+    expect(onProgress).toHaveBeenCalledWith('Buffering model bytes...')
+  })
+
+
   it('hashes the single parse buffer when store-open is unavailable', async () => {
-    const file = new MockFile(new Uint8Array(512).fill(0x20))
+    const file = new MockFile(IFC_SOURCE)
     const arrayBufferSpy = jest.spyOn(file, 'arrayBuffer')
     getModelFromOPFS.mockReset()
     getModelFromOPFS.mockResolvedValue(file)

--- a/src/loader/Loader.cover.test.js
+++ b/src/loader/Loader.cover.test.js
@@ -627,12 +627,17 @@ describe('load() error/edge paths with OPFS enabled', () => {
   })
 
 
-  it('buffers a part-21 file whose FILE_SCHEMA is missing', async () => {
+  it('buffers a part-21 file that declares no schema name', async () => {
     // Unknown format buffers rather than gambling: a wrong "yes" burns a model
     // handle and caches a GLB with no NavTree, a wrong "no" costs one load's
     // memory win. Every real part-21 file carries FILE_SCHEMA well inside
     // conway's 64 KiB sniff window, so this is a corrupt-file path.
-    const file = new MockFile('ISO-10303-21;\nHEADER;\nENDSEC;\n')
+    //
+    // The entry is PRESENT here but empty — the case a bare "is FILE_SCHEMA in
+    // the header?" guard waves through, since `classifyStepFamily` answers
+    // 'ifc' for anything it cannot parse. The gate requires a parsed schema
+    // name (`Filetype.stepSchemaName`), so this buffers.
+    const file = new MockFile('ISO-10303-21;\nHEADER;\nFILE_SCHEMA((\'\'));\nENDSEC;\n')
     const arrayBufferSpy = jest.spyOn(file, 'arrayBuffer')
     getModelFromOPFS.mockReset()
     getModelFromOPFS.mockResolvedValue(file)

--- a/src/loader/Loader.cover.test.js
+++ b/src/loader/Loader.cover.test.js
@@ -212,7 +212,48 @@ describe('Loader exported helpers', () => {
 })
 
 
+// `ShareIfcLoader#parse` logs the parse failure with `console.error` before
+// rethrowing, so every rejection-based case below emits one by design. A test
+// run should print nothing unexpected (STYLE.md §"Console hygiene"), so divert
+// them into a buffer — and assert on the buffer rather than silently
+// swallowing it, per PLAYBOOK §"Keep the test console clean" move 2. Anything
+// that is NOT one of these induced failures fails the test instead of
+// scrolling past in the noise.
+const EXPECTED_LOADER_ERRORS =
+  /open failed|is not a function|Failed to fetch model data|Unknown filetype|Could not guess filetype/i
+
+
+/**
+ * Divert `console.error` for one test. Returns the buffer plus a restore.
+ *
+ * @return {{lines: string[], restore: Function}}
+ */
+function divertConsoleError() {
+  const original = console.error
+  const lines = []
+  console.error = (...args) => {
+    lines.push(args.map((a) => (a instanceof Error ? `${a.name}: ${a.message}` : String(a))).join(' '))
+  }
+  return {lines, restore: () => {
+    console.error = original
+  }}
+}
+
+
 describe('load() with isOpfsAvailable=false (axios path)', () => {
+  let consoleError
+
+  beforeEach(() => {
+    consoleError = divertConsoleError()
+  })
+
+  afterEach(() => {
+    consoleError.restore()
+    for (const line of consoleError.lines) {
+      expect(line).toMatch(EXPECTED_LOADER_ERRORS)
+    }
+  })
+
   let viewer
   let onProgress
   let setOpfsFile
@@ -365,6 +406,19 @@ describe('load() with isOpfsAvailable=false (axios path)', () => {
 
 
 describe('load() error/edge paths with OPFS enabled', () => {
+  let consoleError
+
+  beforeEach(() => {
+    consoleError = divertConsoleError()
+  })
+
+  afterEach(() => {
+    consoleError.restore()
+    for (const line of consoleError.lines) {
+      expect(line).toMatch(EXPECTED_LOADER_ERRORS)
+    }
+  })
+
   let viewer
   let onProgress
   let setOpfsFile

--- a/src/loader/Loader.js
+++ b/src/loader/Loader.js
@@ -99,12 +99,25 @@ function scheduleIdleWork(fn) {
  * True when Conway can parse an OPFS File through `OpenModelStream`
  * (M1b) so we never allocate a full-source ArrayBuffer.
  *
+ * Gated on the resolved format (`loader.type`, the extension
+ * `findLoader` settled on — sniffed for extension-less uploads), NOT on
+ * `isIfc`: `isIfc` is true for STEP too, but Conway's store-backed open
+ * is IFC-only (`IfcApiModelPassthroughFactory.fromStore` returns
+ * `undefined` for AP214/AP203/AP242), and it reserves the model handle
+ * before it sniffs. Offering it a STEP file therefore burns handle 0
+ * on a model that never opens, and the buffered `OpenModelStreamed`
+ * retry parses as handle 1 — which silently broke every Share call site
+ * that passes the scene-level id 0 (`CadView.jsx` pins
+ * `model.modelID = 0`), the GLB writer's spatial-tree and
+ * element-properties captures among them (#1776). Buffering STEP here
+ * costs nothing: the store path had no STEP implementation to lose.
+ *
  * @param {object} viewer
- * @param {boolean} isIfc
+ * @param {string} loaderType resolved format tag, i.e. `loader.type`
  * @return {boolean}
  */
-function canOpenFromStore(viewer, isIfc) {
-  if (!isIfc || isFeatureEnabled('disableStreamOpen')) {
+function canOpenFromStore(viewer, loaderType) {
+  if (loaderType !== 'ifc' || isFeatureEnabled('disableStreamOpen')) {
     return false
   }
   const ifcAPI = viewer?.IFC?.loader?.ifcManager?.ifcAPI
@@ -379,7 +392,7 @@ export async function load(
           // M1b: when Conway can parse from the OPFS File store, hash
           // the File in slices and skip the full-source ArrayBuffer —
           // ~860 MB on PSB. Older engines fall through to buffering.
-          if (canOpenFromStore(viewer, isIfc)) {
+          if (canOpenFromStore(viewer, loader.type)) {
             onProgress('Hashing model...')
           } else {
             onProgress('Buffering model bytes...')
@@ -421,7 +434,7 @@ export async function load(
       }
 
       if (modelData === undefined &&
-          canOpenFromStore(viewer, isIfc) &&
+          canOpenFromStore(viewer, loader.type) &&
           !cameFromGlbCache) {
         const head = await file.slice(0, LFS_POINTER_PROBE_BYTES).arrayBuffer()
         if (looksLikeLfsPointer(head)) {
@@ -574,6 +587,25 @@ export async function load(
     throw markIfOutOfMemory(e)
   }
 
+  // Conway's handle for THIS parse, latched before the model leaves
+  // `load()`. Two different numbers travel under the name "modelID" and
+  // they are only equal when Conway handed us handle 0:
+  //
+  //   - the scene-level id every ShareViewer/CadView call site passes,
+  //     which `CadView.jsx#loadModel` pins to 0 on the model object
+  //     the moment `load()` resolves (its issue-#91 hack), and
+  //   - Conway's engine handle, which `decorateConwayDirectIfcModel`
+  //     wrote onto the same `model.modelID` property a moment ago.
+  //
+  // The idle GLB writer below runs after that overwrite, so reading
+  // `model.modelID` there yielded the scene id, not the engine handle —
+  // and a capture aimed at a handle Conway never opened comes back
+  // empty, so the artifact cached with no NavTree and no Properties
+  // (#1776). `canOpenFromStore` now keeps the two numbers equal in
+  // practice; latching here keeps the writer correct even when they
+  // diverge again (an IFC whose windowed open throws and falls back).
+  const engineModelID = typeof model.modelID === 'number' ? model.modelID : 0
+
   model.isUploadedFile = isUploadedFile
   // Used for automatic naming, page title and other areas that need a mime type.
   model.mimeType = loader.type
@@ -702,6 +734,7 @@ export async function load(
         kindLabel: glbExportContext.kindLabel,
         cacheKeyArgs: glbExportContext.cacheKeyArgs,
         ifcManager: viewer?.IFC?.loader?.ifcManager ?? null,
+        modelID: engineModelID,
       }).finally(() => {
         useStore.getState().setIsCacheWriteInFlight(false)
         // The writer's property/tree captures were the LAST load-time
@@ -714,7 +747,8 @@ export async function load(
         // model was parsed from. Cache-hit GLB loads never get here
         // (no writer is scheduled) — nothing to spill. Fail-soft: any
         // guard failure keeps the resident buffer (pre-spill behavior).
-        spillModelSource(viewer?.IFC?.loader?.ifcManager?.ifcAPI, 0, glbExportContext.sourceFile)
+        spillModelSource(
+          viewer?.IFC?.loader?.ifcManager?.ifcAPI, engineModelID, glbExportContext.sourceFile)
         // Same safe point, wasm-side twin of the source spill: the
         // scene is built and the GLB written, so nothing reads conway's
         // native geometry again — free it (per-model) so repeated loads
@@ -726,7 +760,7 @@ export async function load(
           if (isFeatureEnabled('demandGeometry') &&
               typeof releaseAPI?.ReleaseModelGeometry === 'function') {
             // eslint-disable-next-line new-cap
-            const released = releaseAPI.ReleaseModelGeometry(0)
+            const released = releaseAPI.ReleaseModelGeometry(engineModelID)
             glbVerbose('writer: native geometry released =', released)
           }
         } catch (e) {

--- a/src/loader/Loader.js
+++ b/src/loader/Loader.js
@@ -94,12 +94,6 @@ const STORE_FORMAT_SNIFF_BYTES = 65_536
 // separates IFC from STEP, so the suffix is not evidence either way.
 const PART21_LOADER_TYPES = new Set(['ifc', 'step', 'stp'])
 
-// Presence check for the classifier's input. `classifyStepFamily` answers
-// 'ifc' when FILE_SCHEMA is absent — the right default for naming an upload,
-// the wrong one here, where a false 'ifc' burns a model handle. Require the
-// entry to actually be in the sniffed window before trusting the verdict.
-const FILE_SCHEMA_PRESENT = /FILE_SCHEMA\s*\(/i
-
 
 /**
  * @param {Function} fn
@@ -160,8 +154,16 @@ async function canOpenFromStore(viewer, loaderType, file) {
   }
   try {
     const head = await file.slice(0, STORE_FORMAT_SNIFF_BYTES).arrayBuffer()
+    // Non-fatal by default, so a multi-byte sequence cut at the slice
+    // boundary — or a mislabelled binary — yields replacement characters
+    // rather than throwing. Both then fail the schema match below and
+    // buffer, which is the outcome we want for bytes we cannot read.
     const header = new TextDecoder('utf-8').decode(new Uint8Array(head))
-    if (!FILE_SCHEMA_PRESENT.test(header)) {
+    // Require a schema NAME, not merely a FILE_SCHEMA entry.
+    // `classifyStepFamily` answers 'ifc' whenever it cannot parse one, and
+    // an empty `FILE_SCHEMA(( ))` would otherwise inherit that default and
+    // send an unidentified file down the IFC-only store path.
+    if (Filetype.stepSchemaName(header) === null) {
       return false
     }
     return Filetype.classifyStepFamily(header) === 'ifc'

--- a/src/loader/Loader.js
+++ b/src/loader/Loader.js
@@ -82,6 +82,24 @@ import {markIfOutOfMemory} from '../utils/oom'
 const SCHEDULE_IDLE_TIMEOUT_MS = 5_000
 const LFS_POINTER_PROBE_BYTES = 256
 
+// Matches conway's own `STORE_DETECT_PREFIX_BYTES`
+// (`compat/web-ifc/ifc_api_model_passthrough_factory.js`) — the window its
+// store-backed open sniffs the format in. Reading the same amount means our
+// answer to "will `fromStore` take this?" comes from the same bytes it will
+// look at, rather than from a smaller window that could disagree.
+const STORE_FORMAT_SNIFF_BYTES = 65_536
+
+// The formats `findLoader` routes to conway via `parseIfcWithConway`. All
+// three are ISO-10303-21 part-21 files sharing one loader; only FILE_SCHEMA
+// separates IFC from STEP, so the suffix is not evidence either way.
+const PART21_LOADER_TYPES = new Set(['ifc', 'step', 'stp'])
+
+// Presence check for the classifier's input. `classifyStepFamily` answers
+// 'ifc' when FILE_SCHEMA is absent — the right default for naming an upload,
+// the wrong one here, where a false 'ifc' burns a model handle. Require the
+// entry to actually be in the sniffed window before trusting the verdict.
+const FILE_SCHEMA_PRESENT = /FILE_SCHEMA\s*\(/i
+
 
 /**
  * @param {Function} fn
@@ -99,29 +117,58 @@ function scheduleIdleWork(fn) {
  * True when Conway can parse an OPFS File through `OpenModelStream`
  * (M1b) so we never allocate a full-source ArrayBuffer.
  *
- * Gated on the resolved format (`loader.type`, the extension
- * `findLoader` settled on — sniffed for extension-less uploads), NOT on
- * `isIfc`: `isIfc` is true for STEP too, but Conway's store-backed open
- * is IFC-only (`IfcApiModelPassthroughFactory.fromStore` returns
- * `undefined` for AP214/AP203/AP242), and it reserves the model handle
- * before it sniffs. Offering it a STEP file therefore burns handle 0
- * on a model that never opens, and the buffered `OpenModelStreamed`
- * retry parses as handle 1 — which silently broke every Share call site
- * that passes the scene-level id 0 (`CadView.jsx` pins
- * `model.modelID = 0`), the GLB writer's spatial-tree and
- * element-properties captures among them (#1776). Buffering STEP here
- * costs nothing: the store path had no STEP implementation to lose.
+ * Decided by the file's own FILE_SCHEMA, because neither `isIfc` nor the
+ * suffix is evidence of the format and both are wrong in a different
+ * direction. Conway's store-backed open is IFC-only
+ * (`IfcApiModelPassthroughFactory.fromStore` returns `undefined` for
+ * AP214/AP203/AP242) and it reserves the model handle before it sniffs:
+ *
+ *   - `isIfc` is true for STEP as well, so it offered STEP files a path
+ *     that always refuses them. That burned handle 0 on a model which
+ *     never opened, and the buffered `OpenModelStreamed` retry parsed as
+ *     handle 1 — misaddressing every Share call site that passes the
+ *     scene-level id 0 (`CadView.jsx#loadModel` pins `model.modelID` to
+ *     it), the GLB writer's spatial-tree and element-properties captures
+ *     among them (#1776).
+ *   - A suffix test is wrong the other way: `findLoader` takes
+ *     `loader.type` from the filename, so an IFC payload named `.step`
+ *     would be denied the windowed parse and buffer its whole source —
+ *     re-introducing on a mislabelled large model exactly the
+ *     hundreds-of-MB allocation M3 removed.
+ *
+ * An absent or unrecognised FILE_SCHEMA buffers rather than gambling: a
+ * wrong "yes" costs a burned handle and a broken cache artifact, a wrong
+ * "no" costs one load's memory win. Within conway's own 64 KiB sniff
+ * window every real part-21 file carries FILE_SCHEMA, so that branch is
+ * a corrupt-or-truncated-file path, not a format we are giving up on.
  *
  * @param {object} viewer
  * @param {string} loaderType resolved format tag, i.e. `loader.type`
- * @return {boolean}
+ * @param {Blob} file the source handle, sniffed for its part-21 header
+ * @return {Promise<boolean>}
  */
-function canOpenFromStore(viewer, loaderType) {
-  if (loaderType !== 'ifc' || isFeatureEnabled('disableStreamOpen')) {
+async function canOpenFromStore(viewer, loaderType, file) {
+  if (!PART21_LOADER_TYPES.has(loaderType) || isFeatureEnabled('disableStreamOpen')) {
     return false
   }
   const ifcAPI = viewer?.IFC?.loader?.ifcManager?.ifcAPI
-  return typeof ifcAPI?.OpenModelStream === 'function'
+  if (typeof ifcAPI?.OpenModelStream !== 'function') {
+    return false
+  }
+  if (file === null || file === undefined || typeof file.slice !== 'function') {
+    return false
+  }
+  try {
+    const head = await file.slice(0, STORE_FORMAT_SNIFF_BYTES).arrayBuffer()
+    const header = new TextDecoder('utf-8').decode(new Uint8Array(head))
+    if (!FILE_SCHEMA_PRESENT.test(header)) {
+      return false
+    }
+    return Filetype.classifyStepFamily(header) === 'ifc'
+  } catch (e) {
+    debug().warn('Loader#canOpenFromStore: header sniff failed; buffering:', e)
+    return false
+  }
 }
 
 
@@ -372,6 +419,14 @@ export async function load(
       // separate JS copy. An OPFS File pins nothing.
       const opfsSourceFile = file
 
+      // One sniff, two decisions: whether to hash the File in slices
+      // instead of buffering it (below) and whether to hand conway the
+      // File itself rather than an ArrayBuffer (further below). Computed
+      // from the SOURCE handle, before any GLB cache hit can swap `file`
+      // for the artifact; the second call site additionally guards on
+      // `cameFromGlbCache` so a hit never takes the store path.
+      const canStreamOpen = await canOpenFromStore(viewer, loader.type, opfsSourceFile)
+
       // Non-GitHub sources have no upstream sha. Hash the parse buffer
       // itself so we do not materialise the file twice (once for SHA-1,
       // once for Conway) — ~860 MB on PSB. sha1Hex only reads; it does
@@ -392,7 +447,7 @@ export async function load(
           // M1b: when Conway can parse from the OPFS File store, hash
           // the File in slices and skip the full-source ArrayBuffer —
           // ~860 MB on PSB. Older engines fall through to buffering.
-          if (canOpenFromStore(viewer, loader.type)) {
+          if (canStreamOpen) {
             onProgress('Hashing model...')
           } else {
             onProgress('Buffering model bytes...')
@@ -433,9 +488,7 @@ export async function load(
         glbExportContext = {kindLabel, cacheKeyArgs, sourceFile: opfsSourceFile}
       }
 
-      if (modelData === undefined &&
-          canOpenFromStore(viewer, loader.type) &&
-          !cameFromGlbCache) {
+      if (modelData === undefined && canStreamOpen && !cameFromGlbCache) {
         const head = await file.slice(0, LFS_POINTER_PROBE_BYTES).arrayBuffer()
         if (looksLikeLfsPointer(head)) {
           modelData = head

--- a/src/loader/bldrsSpatialTree.js
+++ b/src/loader/bldrsSpatialTree.js
@@ -40,7 +40,7 @@
 // writer is in-browser and trusted; the full pass lands with the share
 // flow.
 import * as pako from 'pako'
-import {glbInfo, glbVerbose} from './glbLog'
+import {glbInfo, glbVerbose, glbWarn} from './glbLog'
 
 
 export const BLDRS_SPATIAL_TREE_EXTENSION_NAME = 'BLDRS_spatial_tree'
@@ -206,6 +206,18 @@ export async function captureBldrsSpatialTree(ifcManager, modelID) {
         modelID, includeProperties, {includeSolids: true}) :
       await ifcManager.getSpatialStructure(modelID, includeProperties)
     if (!root || root.expressID === undefined) {
+      // Loud, because the failure it hides is invisible everywhere else:
+      // Conway's `properties.*` shim optional-chains through
+      // `getPassthrough(modelID)`, so a capture addressed to a handle it
+      // never opened resolves to `undefined` rather than throwing. The
+      // writer then drops both the tree and (seeded from it) the
+      // element-properties extension, the write still reports success,
+      // and the loss only shows up a load later as an empty NavTree and
+      // Properties panel on the cache hit (#1776).
+      glbWarn(
+        `${BLDRS_SPATIAL_TREE_EXTENSION_NAME}: no spatial structure for ` +
+        `modelID=${modelID}; the cached GLB will have no NavTree and no ` +
+        'Properties. Check that this is the handle the model parsed under.')
       return null
     }
     if (canEnrichSync) {

--- a/src/loader/bldrsSpatialTree.test.js
+++ b/src/loader/bldrsSpatialTree.test.js
@@ -33,6 +33,20 @@ describe('loader/bldrsSpatialTree', () => {
       expect(await captureBldrsSpatialTree(mgr, 0)).toBeNull()
     })
 
+    it('warns when the manager has no model under that handle (#1776)', async () => {
+      // Conway's `properties.*` shim optional-chains through
+      // `getPassthrough(modelID)`, so a capture aimed at a handle it never
+      // opened resolves to `undefined` rather than throwing. Returning a
+      // silent null there is how bldrs-ai/Share#1776 stayed invisible: the
+      // writer dropped both BLDRS_* extensions, reported a successful write,
+      // and the loss only surfaced a load later as an empty NavTree and
+      // Properties panel on the cache hit.
+      const mgr = {getSpatialStructure: jest.fn(() => Promise.resolve(undefined))}
+      expect(await captureBldrsSpatialTree(mgr, 7)).toBeNull()
+      expect(getGlbLogs().some((l) =>
+        l.level === 'warn' && l.text.includes('no spatial structure for modelID=7'))).toBe(true)
+    })
+
     it('returns null and swallows the error when the manager throws', async () => {
       const mgr = {
         getSpatialStructure: () => {

--- a/src/loader/glbExport.js
+++ b/src/loader/glbExport.js
@@ -190,9 +190,19 @@ function modelHasBatchedMesh(model) {
  *   so cache-hit GLBs render NavTree and Properties panel without
  *   re-parsing. Pass `null` for non-IFC sources or when no live
  *   parser state is available.
+ * @param {number} [args.modelID] Conway's engine handle for this parse,
+ *   which every capture below is addressed to. Pass it explicitly:
+ *   `model.modelID` is the SCENE-level id by the time the (idle-
+ *   scheduled) writer runs — `CadView.jsx` pins that property to 0 as
+ *   soon as `load()` resolves — and the two numbers differ whenever
+ *   Conway did not hand this parse handle 0. Aiming a capture at a
+ *   handle Conway never opened returns `undefined` from every
+ *   `properties.*` call, which reaches here as "no tree, no
+ *   properties" and cached an artifact with neither (#1776). Falls
+ *   back to `model.modelID` for call sites that predate the argument.
  * @return {Promise<boolean>}
  */
-export async function exportAndCacheGlb({model, kindLabel, cacheKeyArgs, ifcManager = null}) {
+export async function exportAndCacheGlb({model, kindLabel, cacheKeyArgs, ifcManager = null, modelID = null}) {
   const startMs = Date.now()
   try {
     // BatchedMesh render path (`?feature=batchedMesh`): `GLTFExporter` can't
@@ -254,7 +264,7 @@ export async function exportAndCacheGlb({model, kindLabel, cacheKeyArgs, ifcMana
     // Element properties depend on the spatial tree (the slow-path BFS
     // uses tree expressIDs as BFS seeds; the fast path ignores it), so
     // the two captures are sequential rather than parallel.
-    const modelId = model?.modelID ?? 0
+    const modelId = modelID ?? model?.modelID ?? 0
     // Capture per-triangle element IDs from the pristine raw bytes
     // BEFORE any compression. The vertex-level `_EXPRESSID` /
     // `_INSTANCEID` attributes are still intact here; we read them

--- a/src/loader/glbExport.test.js
+++ b/src/loader/glbExport.test.js
@@ -425,6 +425,50 @@ describe('loader/glbExport', () => {
       expect(faceIdsExt.data.geometryItemIdentities).toBeUndefined()
     })
 
+    it('captures against the engine modelID, not the scene id on the model (#1776)', async () => {
+      // `CadView.jsx` pins `model.modelID = 0` (the scene-level id every
+      // ShareViewer call site passes) the moment `load()` resolves, and this
+      // writer runs later, from an idle callback. So the property no longer
+      // holds Conway's engine handle by the time we read it — the Loader
+      // latches that handle at parse time and hands it in. Reading
+      // `model.modelID` instead aimed every capture at a model Conway never
+      // opened, and the artifact cached with no NavTree and no Properties.
+      mockExporterParse.mockImplementation((_input, onDone) => onDone(fakeGlbBytes.buffer))
+      const ifcManager = {
+        getSpatialStructure: jest.fn(() => Promise.resolve({
+          expressID: 5, type: 'product', children: [],
+        })),
+        getItemProperties: jest.fn(() => Promise.resolve({expressID: 5, type: 'product'})),
+        getPropertySets: jest.fn(() => Promise.resolve([])),
+      }
+
+      const ok = await exportAndCacheGlb({
+        model: {fake: 'model', modelID: 0},
+        ...ctx,
+        ifcManager,
+        modelID: 3,
+      })
+
+      expect(ok).toBe(true)
+      expect(ifcManager.getSpatialStructure).toHaveBeenCalledWith(3, true)
+    })
+
+    it('falls back to model.modelID when no engine modelID is passed', async () => {
+      // Call sites that predate the explicit argument keep working.
+      mockExporterParse.mockImplementation((_input, onDone) => onDone(fakeGlbBytes.buffer))
+      const ifcManager = {
+        getSpatialStructure: jest.fn(() => Promise.resolve({
+          expressID: 5, type: 'product', children: [],
+        })),
+        getItemProperties: jest.fn(() => Promise.resolve({expressID: 5, type: 'product'})),
+        getPropertySets: jest.fn(() => Promise.resolve([])),
+      }
+
+      await exportAndCacheGlb({model: {fake: 'model', modelID: 2}, ...ctx, ifcManager})
+
+      expect(ifcManager.getSpatialStructure).toHaveBeenCalledWith(2, true)
+    })
+
     it('returns false (no throw) when the exporter produces no bytes', async () => {
       mockExporterParse.mockImplementation((_input, _onDone, onError) => onError(new Error('nope')))
       const ok = await exportAndCacheGlb({model: {}, ...ctx})


### PR DESCRIPTION
## Summary

Fixes #1776: a STEP model's second load — the one served from the GLB cache — came back with no NavTree and no Properties. Expanding the tree just repeated the model root a couple of times.

Conway's store-backed open (`OpenModelStream`, the M1b path picked up with the 1.588.1550 bump in #1753) reserves the model handle **before** it sniffs the format, and `IfcApiModelPassthroughFactory.fromStore` is IFC-only. Share offered it every file where `isIfc` was true — which includes STEP. So a STEP load burned handle 0 on a model that never opened, and the buffered `OpenModelStreamed` retry parsed as **handle 1**.

Nothing failed loudly. The parse succeeded and the model rendered, because the closures `decorateConwayDirectIfcModel` binds carry the right handle — which is why the *first* load looked perfect. What broke is everything addressing the scene-level id `0`, including the idle GLB writer, which reads `model.modelID` — a property `CadView.jsx#loadModel` pins to `0` the moment `load()` resolves (its issue-#91 hack, whose "somehow this is getting incremented to 1" comment turns out to describe exactly this mechanism). Conway's `properties.*` shim optional-chains through `getPassthrough(modelID)`, so the spatial-tree and element-properties captures resolved `undefined` rather than throwing; the writer dropped both extensions and still reported a successful write. The next load hit that artifact, found no `BLDRS_spatial_tree`, and fell back to `Loader.js`'s `ifcManager.getSpatialStructure = () => model` — walking the GLB scene graph, which is the repeated-root tree in the issue's screenshot.

## Key changes

- **`Loader.js` — `canOpenFromStore` decides from the file's own FILE_SCHEMA**, not from `isIfc` and not from the suffix. Those two are wrong in opposite directions: `isIfc` is true for STEP, so it offered STEP a path that always refuses it; a suffix test would deny IFC content named `.step` a path that would take it. The sniff reads 64 KiB, matching conway's `STORE_DETECT_PREFIX_BYTES`. An unparseable or absent schema buffers rather than gambling — a wrong "yes" burns a handle and caches a broken artifact; a wrong "no" costs one load's memory win.
- **`Loader.js` — the engine handle is latched before the model leaves `load()`** and handed to the writer explicitly. The same handle now drives `spillModelSource` and `ReleaseModelGeometry`, which were hardcoded to `0` and had been silently no-oping on STEP.
- **`Filetype.js` — `stepSchemaName` extracted** from `classifyStepFamily`, returning the parsed schema or null, so the loader can tell "said STEP" from "did not say" (the classifier folds both into `'ifc'`, which is right for naming an upload and wrong where a false `'ifc'` burns a handle). It reads the **last** FILE_SCHEMA in the **HEADER section** of comment-masked text, with the entity name anchored — each of those four qualifiers is a review finding, listed below.
- **`glbExport.js` — `exportAndCacheGlb` takes an explicit `modelID`,** falling back to `model.modelID` for call sites that predate the argument.
- **`bldrsSpatialTree.js` — an empty spatial-tree capture is now a `glbWarn`** instead of a silent null, so the next instance of this failure says so during the load that causes it rather than a load later.

## Review

Four codex rounds, six findings, every one on the store-open gate. All fixed, answered and resolved.

| # | finding | direction | fix |
|---|---|---|---|
| 1 | Suffix gating denied the store open to IFC content named `.step` | perf | sniff FILE_SCHEMA (`1d0b2f3`) |
| — | *(self-found)* presence guard let `FILE_SCHEMA(())` inherit the `'ifc'` default | **correctness** | require a parsed name (`49a7e71`) |
| 2 | Sniff did not skip Part-21 comments, which conway treats as whitespace | perf | comment-aware gap (`54911ef`) |
| 3 | A whole FILE_SCHEMA entity *inside* a comment was read as the schema | **correctness** | mask comments before scanning (`b5c1a0f`) |
| 4 | Console noise: 10 stack traces per run from the rejection tests | hygiene | divert + assert (`b5c1a0f`) |
| — | *(self-found)* duplicate FILE_SCHEMA — conway's header map is last-wins | **correctness** | take the last, bound to HEADER (`850253b`) |
| 5 | `NOT_FILE_SCHEMA(('IFC4'))` matched inside a longer identifier | **correctness** | anchor the entity name (`5ea8b22`) |

Findings 5 and the duplicate one interact: last-wins is what made the lookalike reachable in its dangerous ordering, which is the argument for anchoring rather than leaning on ordering.

**Two known divergences from `ModelFormatDetector` are deliberately left** and tracked in #1780: conway scans every quoted FILE_SCHEMA entry (we read the first), and compares after stripping all spaces (our capture stops at the first non-word character). Both make us answer "not IFC" where conway answers IFC — costing the windowed parse, never sending a STEP file down the IFC-only path.

## Tests

Each mutation-checked against the code it replaces:

- `Loader.cover.test.js` — a STEP upload buffers; IFC content with a STEP suffix keeps the store open; a part-21 file declaring no schema name buffers.
- `Filetype.test.js` — `stepSchemaName` across both families, whitespace, comments at every legal gap, an unterminated comment, a `/*` inside a string literal, a commented-out entity, duplicate declarations, a lookalike past `ENDSEC`, a `NOT_FILE_SCHEMA` identifier, and the null cases.
- `glbExport.test.js` — captures use the passed engine handle, not the scene id; plus the fallback.
- `bldrsSpatialTree.test.js` — the empty-capture warning fires.

`NavTree.cacheHit.spec.ts` gains a STEP sibling, but as a **`test.fixme` that never executes** — the GLB cache round-trip needs OPFS, which the Playwright config disables. It records the scenario rather than guarding it. That gap is why this bug shipped and is now tracked in #1779.

## Verification

| check | result |
|---|---|
| husky gate (eslint + typecheck + Jest) | green on every commit |
| `yarn build-prod` | exit 0 |
| `yarn test-ci` (coverage gate) | 244/244 suites, thresholds held |
| manual browser repro, OPFS on | before/after below, re-run on every head |

Against the issue's own model (`as1-oc-214.stp`): **before**, the reload's NavTree read `["as1", "as1", "as1_1"]` with `parsed modelID=1` and `injected 1 extension(s)`; **after**, it matches the fresh parse's nine rows, with `parsed modelID=0`, `injected 3 extension(s)`, and both `hydrated NavTree from BLDRS_spatial_tree` and `hydrated Properties panel from BLDRS_element_properties` on the cache hit. Re-checked against `index.ifc` on every head too — it must keep taking the store path (`Hashing model`, no buffering) and does.

**Gaps worth stating.** The browser check went through the `local`/`external` source kind, not the `github` kind the issue reports; the shared code path is upstream of any source-kind branching, so I expect no difference, but that is inference. The sandbox could not reach `*.netlify.app`, so the deploy preview was not clicked through.

## Follow-ups filed

- **#1778** — stop assuming conway's modelID is always 0; thread the real handle through `ShareViewer` and `IfcIsolator`. This is the durable fix: it makes a burned handle harmless, after which this PR's sniff can be relaxed or deleted. Groundwork for viewing multiple models.
- **[conway#620](https://github.com/bldrs-ai/conway/issues/620)** — the engine half: reserve the handle *after* the format sniff, so a refusal costs nothing.
- **#1779** — E2E coverage for the GLB cache-hit round-trip (OPFS under Playwright).
- **#1780** — the two remaining FILE_SCHEMA divergences.
- **#1781** — a swappable sink for the conway-direct load logs.

https://claude.ai/code/session_01NuTsqJu1rqoz8f4FSQ9vbE