### PR TITLE
Ask conway which format a file is, instead of mirroring its detector

### DIFF
--- a/src/Filetype.js
+++ b/src/Filetype.js
@@ -383,58 +383,148 @@ export function analyzeHeaderStr(header) {
  * @return {string} 'ifc' or 'step'
  */
 export function classifyStepFamily(header) {
-  const schema = stepSchemaName(header)
-  if (schema === null) {
-    return 'ifc'
-  }
-  return /^IFC/i.test(schema) ? 'ifc' : 'step'
+  return stepFamily(header) ?? 'ifc'
 }
 
 
 /**
- * The FILE_SCHEMA value of an ISO-10303-21 header, or null when the entry
- * is absent from the sniffed window or carries no parseable name — an
- * empty `FILE_SCHEMA(( ))` / `FILE_SCHEMA(( '' ))`, which is malformed but
- * does occur in the wild.
+ * The schema family an ISO-10303-21 header declares — `'ifc'` or `'step'` —
+ * or null when it declares nothing this can read (no HEADER section, no
+ * FILE_SCHEMA entity, or one carrying no schema name at all: an empty
+ * `FILE_SCHEMA(( ))` / `FILE_SCHEMA(( '' ))`, malformed but seen in the wild).
  *
- * Split out of {@link classifyStepFamily} so a caller can tell "this file
- * says STEP" apart from "this file did not say". The classifier folds both
- * into 'ifc': the right default when the answer only picks a filename, and
- * the wrong one for a caller whose false-'ifc' costs more than a false
- * 'step'. `Loader.js#canOpenFromStore` is the second kind — it gates
- * conway's IFC-only store open, where guessing 'ifc' burns a model handle
- * and caches a GLB with no NavTree (bldrs-ai/Share#1776) — so it requires a
- * non-null name here before it trusts the classification.
+ * Three-valued on purpose, so a caller can tell "this file says STEP" apart
+ * from "this file did not say". {@link classifyStepFamily} folds those
+ * together into `'ifc'`: the right default when the answer only picks a
+ * filename, and the wrong one for a caller whose false-`'ifc'` costs more
+ * than a false `'step'`. `Loader.js#canOpenFromStore` is the second kind — it
+ * gates conway's IFC-only store open, where guessing `'ifc'` burns a model
+ * handle and caches a GLB with no NavTree (bldrs-ai/Share#1776) — so it asks
+ * this function directly and treats null as "buffer".
  *
- * @param {string} header
- * @return {string|null} the schema name, e.g. 'IFC4' or 'AUTOMOTIVE_DESIGN'
+ * Mirrors conway's `ModelFormatDetector.detect`
+ * (`format_detection/model_format_detector.js`) on the points that matter,
+ * because a disagreement in the "we say IFC, conway does not" direction is
+ * exactly #1776 again: every declared entry is considered, not just the
+ * first, and each is compared with spaces stripped.
+ *
+ * One divergence remains, in the safe direction. When an entity declares no
+ * quoted entry at all, conway falls back to testing the raw block text; we
+ * report null. That fallback can only say IFC for input malformed enough to
+ * put a bare `IFC…` token where a quoted list belongs, and null makes us
+ * buffer, which costs a load's memory win and never mis-routes a STEP file.
+ *
+ * @param {string} header a Part-21 header window
+ * @return {string|null} 'ifc', 'step', or null when nothing is declared
  */
-export function stepSchemaName(header) {
-  const section = part21HeaderSection(maskPart21Comments(header))
-  if (section === null) {
+export function stepFamily(header) {
+  const entries = fileSchemaEntries(header)
+  if (entries.length === 0) {
     return null
   }
-  // LAST match, not first: conway's parser stores header entities in a Map
-  // keyed by name (`step_parser.js:193`), so a header carrying FILE_SCHEMA
-  // twice overwrites and the last one wins. Reading the first would have us
-  // answer from one entity and conway from the other — and on
-  // `FILE_SCHEMA(('IFC4')); FILE_SCHEMA(('AUTOMOTIVE_DESIGN'));` that is the
-  // dangerous direction: we say IFC, conway says AP214, and a STEP file goes
-  // down the IFC-only store open (bldrs-ai/Share#1776).
-  const matches = [...section.matchAll(FILE_SCHEMA_VALUE)]
-  return matches.length === 0 ? null : matches[matches.length - 1][1]
+  return entries.some((entry) => entry.startsWith('IFC')) ? 'ifc' : 'step'
 }
 
 
-// `\b` anchors the entity name so the scan cannot start inside a longer
-// identifier. conway parses header records under their exact names and
-// inspects only the `FILE_SCHEMA` key, so `NOT_FILE_SCHEMA(('IFC4'));` is
-// invisible to it — while an unanchored scan reads it as the schema. With
-// last-wins that is the dangerous direction whenever the lookalike follows
-// the real entity: we answer IFC, conway answers AP214. `\b` suffices
-// because `_` is a word character, so there is no boundary inside
-// `NOT_FILE_SCHEMA`.
-const FILE_SCHEMA_VALUE = /\bFILE_SCHEMA\s*\(\s*\(\s*'\s*([A-Za-z0-9_]+)/ig
+/**
+ * Every schema name the effective FILE_SCHEMA entity declares, uppercased
+ * and space-stripped — conway's own normalisation
+ * (`schema.toLocaleUpperCase()` then `rawEntry.replaceAll(' ', '')`), so
+ * `' I FC4 '` reads as `IFC4` here exactly as it does there.
+ *
+ * "Effective" is the LAST FILE_SCHEMA statement in the header section:
+ * conway stores header entities in a Map keyed by name
+ * (`step_parser.js:193`), so a header carrying the entity twice overwrites
+ * and the later one wins.
+ *
+ * @param {string} header
+ * @return {string[]} normalised schema names, empty when none are declared
+ */
+function fileSchemaEntries(header) {
+  const section = part21HeaderSection(maskPart21Comments(header))
+  if (section === null) {
+    return []
+  }
+  const statement = lastFileSchemaStatement(section)
+  if (statement === null) {
+    return []
+  }
+  // `/ /g`, not `\s`: conway strips literal spaces only (`replaceAll(' ', '')`),
+  // so a tab inside a schema name must survive here exactly as it does there.
+  // (`String.replaceAll` itself is past this project's TS lib target.)
+  return [...statement.matchAll(/'([^']*)'/g)]
+    .map((match) => match[1].toUpperCase().replace(/ /g, ''))
+    .filter((entry) => entry.length > 0)
+}
+
+
+/**
+ * The last FILE_SCHEMA statement in a header section, or null.
+ *
+ * Matching at the statement start is what keeps a longer identifier out:
+ * `NOT_FILE_SCHEMA(('IFC4'));` is its own statement and does not begin with
+ * `FILE_SCHEMA`, so it is invisible here just as it is to conway, which
+ * parses records under their exact names.
+ *
+ * @param {string} section comment-masked header-section text
+ * @return {string|null}
+ */
+function lastFileSchemaStatement(section) {
+  let found = null
+  for (const statement of part21Statements(section)) {
+    if (/^\s*FILE_SCHEMA\s*\(/i.test(statement)) {
+      found = statement
+    }
+  }
+  return found
+}
+
+
+/**
+ * Split Part-21 text on `;` into statements, ignoring semicolons inside
+ * string literals (where `;` is ordinary text, and an apostrophe is escaped
+ * by doubling it). Pass comment-masked text — a `;` inside a comment would
+ * otherwise split a statement in two.
+ *
+ * @param {string} text comment-masked Part-21 text
+ * @return {string[]} statement texts, without their terminating semicolons
+ */
+function part21Statements(text) {
+  const out = []
+  let start = 0
+  let at = 0
+  let inString = false
+  while (at < text.length) {
+    const c = text[at]
+    if (inString) {
+      if (c === `'` && text[at + 1] === `'`) {
+        at += 2
+        continue
+      }
+      if (c === `'`) {
+        inString = false
+      }
+      at++
+      continue
+    }
+    if (c === `'`) {
+      inString = true
+      at++
+      continue
+    }
+    if (c === ';') {
+      out.push(text.slice(start, at))
+      at++
+      start = at
+      continue
+    }
+    at++
+  }
+  if (start < text.length) {
+    out.push(text.slice(start))
+  }
+  return out
+}
 
 
 /**

--- a/src/Filetype.js
+++ b/src/Filetype.js
@@ -403,10 +403,20 @@ export function classifyStepFamily(header) {
  * this function directly and treats null as "buffer".
  *
  * Mirrors conway's `ModelFormatDetector.detect`
- * (`format_detection/model_format_detector.js`) on the points that matter,
- * because a disagreement in the "we say IFC, conway does not" direction is
- * exactly #1776 again: every declared entry is considered, not just the
- * first, and each is compared with spaces stripped.
+ * (`format_detection/model_format_detector.js`), because a disagreement in
+ * the "we say IFC, conway does not" direction is exactly #1776 again. Two
+ * details of that loop are load-bearing and neither is obvious:
+ *
+ *   - It returns on the FIRST entry matching ANY known schema, testing IFC,
+ *     AUTOMOTIVE_DESIGN, CONFIG_CONTROL_DESIGN/AP203 and AP242 within each
+ *     entry before moving to the next. So `(('AUTOMOTIVE_DESIGN'),('IFC4'))`
+ *     is AP214 to conway, which never sees the IFC4. Asking instead whether
+ *     ANY entry starts with IFC answers 'ifc' there — the dangerous
+ *     direction, and what codex caught on this PR.
+ *   - Entries are compared with spaces stripped, so `' I FC4'` is IFC4.
+ *
+ * An entry conway recognises nothing in is skipped, and a header whose every
+ * entry is unrecognised yields null here just as it yields no format there.
  *
  * One divergence remains, in the safe direction. When an entity declares no
  * quoted entry at all, conway falls back to testing the raw block text; we
@@ -418,11 +428,44 @@ export function classifyStepFamily(header) {
  * @return {string|null} 'ifc', 'step', or null when nothing is declared
  */
 export function stepFamily(header) {
-  const entries = fileSchemaEntries(header)
-  if (entries.length === 0) {
-    return null
+  for (const entry of fileSchemaEntries(header)) {
+    const family = schemaFamily(entry)
+    if (family !== null) {
+      return family
+    }
   }
-  return entries.some((entry) => entry.startsWith('IFC')) ? 'ifc' : 'step'
+  return null
+}
+
+
+// The schema-name prefixes conway's `ModelFormatDetector` recognises, in the
+// order it tests them, each mapped to the family Share cares about. IFC is the
+// only one that reaches conway's IFC-only store open; AP214/AP203/AP242 all
+// mean "STEP" here, and anything unrecognised means conway detects no format
+// at all.
+const SCHEMA_FAMILIES = [
+  ['IFC', 'ifc'],
+  ['AUTOMOTIVE_DESIGN', 'step'],
+  ['CONFIG_CONTROL_DESIGN', 'step'],
+  ['AP203', 'step'],
+  ['AP242', 'step'],
+]
+
+
+/**
+ * The family of one normalised schema name, or null when conway recognises
+ * no format in it.
+ *
+ * @param {string} entry uppercased, space-stripped schema name
+ * @return {string|null} 'ifc', 'step', or null
+ */
+function schemaFamily(entry) {
+  for (const [prefix, family] of SCHEMA_FAMILIES) {
+    if (entry.startsWith(prefix)) {
+      return family
+    }
+  }
+  return null
 }
 
 

--- a/src/Filetype.js
+++ b/src/Filetype.js
@@ -383,191 +383,62 @@ export function analyzeHeaderStr(header) {
  * @return {string} 'ifc' or 'step'
  */
 export function classifyStepFamily(header) {
-  return stepFamily(header) ?? 'ifc'
-}
-
-
-/**
- * The schema family an ISO-10303-21 header declares — `'ifc'` or `'step'` —
- * or null when it declares nothing this can read (no HEADER section, no
- * FILE_SCHEMA entity, or one carrying no schema name at all: an empty
- * `FILE_SCHEMA(( ))` / `FILE_SCHEMA(( '' ))`, malformed but seen in the wild).
- *
- * Three-valued on purpose, so a caller can tell "this file says STEP" apart
- * from "this file did not say". {@link classifyStepFamily} folds those
- * together into `'ifc'`: the right default when the answer only picks a
- * filename, and the wrong one for a caller whose false-`'ifc'` costs more
- * than a false `'step'`. `Loader.js#canOpenFromStore` is the second kind — it
- * gates conway's IFC-only store open, where guessing `'ifc'` burns a model
- * handle and caches a GLB with no NavTree (bldrs-ai/Share#1776) — so it asks
- * this function directly and treats null as "buffer".
- *
- * Mirrors conway's `ModelFormatDetector.detect`
- * (`format_detection/model_format_detector.js`), because a disagreement in
- * the "we say IFC, conway does not" direction is exactly #1776 again. Two
- * details of that loop are load-bearing and neither is obvious:
- *
- *   - It returns on the FIRST entry matching ANY known schema, testing IFC,
- *     AUTOMOTIVE_DESIGN, CONFIG_CONTROL_DESIGN/AP203 and AP242 within each
- *     entry before moving to the next. So `(('AUTOMOTIVE_DESIGN'),('IFC4'))`
- *     is AP214 to conway, which never sees the IFC4. Asking instead whether
- *     ANY entry starts with IFC answers 'ifc' there — the dangerous
- *     direction, and what codex caught on this PR.
- *   - Entries are compared with spaces stripped, so `' I FC4'` is IFC4.
- *
- * An entry conway recognises nothing in is skipped, and a header whose every
- * entry is unrecognised yields null here just as it yields no format there.
- *
- * One divergence remains, in the safe direction. When an entity declares no
- * quoted entry at all, conway falls back to testing the raw block text; we
- * report null. That fallback can only say IFC for input malformed enough to
- * put a bare `IFC…` token where a quoted list belongs, and null makes us
- * buffer, which costs a load's memory win and never mis-routes a STEP file.
- *
- * @param {string} header a Part-21 header window
- * @return {string|null} 'ifc', 'step', or null when nothing is declared
- */
-export function stepFamily(header) {
-  for (const entry of fileSchemaEntries(header)) {
-    const family = schemaFamily(entry)
-    if (family !== null) {
-      return family
-    }
+  const schema = stepSchemaName(header)
+  if (schema === null) {
+    return 'ifc'
   }
-  return null
-}
-
-
-// The schema-name prefixes conway's `ModelFormatDetector` recognises, in the
-// order it tests them, each mapped to the family Share cares about. IFC is the
-// only one that reaches conway's IFC-only store open; AP214/AP203/AP242 all
-// mean "STEP" here, and anything unrecognised means conway detects no format
-// at all.
-const SCHEMA_FAMILIES = [
-  ['IFC', 'ifc'],
-  ['AUTOMOTIVE_DESIGN', 'step'],
-  ['CONFIG_CONTROL_DESIGN', 'step'],
-  ['AP203', 'step'],
-  ['AP242', 'step'],
-]
-
-
-/**
- * The family of one normalised schema name, or null when conway recognises
- * no format in it.
- *
- * @param {string} entry uppercased, space-stripped schema name
- * @return {string|null} 'ifc', 'step', or null
- */
-function schemaFamily(entry) {
-  for (const [prefix, family] of SCHEMA_FAMILIES) {
-    if (entry.startsWith(prefix)) {
-      return family
-    }
-  }
-  return null
+  return /^IFC/i.test(schema) ? 'ifc' : 'step'
 }
 
 
 /**
- * Every schema name the effective FILE_SCHEMA entity declares, uppercased
- * and space-stripped — conway's own normalisation
- * (`schema.toLocaleUpperCase()` then `rawEntry.replaceAll(' ', '')`), so
- * `' I FC4 '` reads as `IFC4` here exactly as it does there.
+ * The FILE_SCHEMA value of an ISO-10303-21 header, or null when the entry
+ * is absent from the sniffed window or carries no parseable name — an
+ * empty `FILE_SCHEMA(( ))` / `FILE_SCHEMA(( '' ))`, which is malformed but
+ * does occur in the wild.
  *
- * "Effective" is the LAST FILE_SCHEMA statement in the header section:
- * conway stores header entities in a Map keyed by name
- * (`step_parser.js:193`), so a header carrying the entity twice overwrites
- * and the later one wins.
+ * Split out of {@link classifyStepFamily} so a caller can tell "this file
+ * says STEP" apart from "this file did not say". The classifier folds both
+ * into 'ifc', which is the right default when the answer only picks a
+ * filename and the wrong one for a caller whose false-'ifc' is expensive.
+ *
+ * Both of these answer a *naming* question and neither is a format oracle.
+ * The one caller whose false-'ifc' was expensive — `canOpenFromStore`, gating
+ * conway's IFC-only store open, where guessing 'ifc' burns a model handle and
+ * caches a GLB with no NavTree (bldrs-ai/Share#1776) — no longer asks here.
+ * It asks conway's own `ModelFormatDetector` instead; see
+ * `src/loader/stepFormat.js` for why a scan like this one cannot agree with
+ * that parser, and please don't route a format decision back through it.
  *
  * @param {string} header
- * @return {string[]} normalised schema names, empty when none are declared
+ * @return {string|null} the schema name, e.g. 'IFC4' or 'AUTOMOTIVE_DESIGN'
  */
-function fileSchemaEntries(header) {
+export function stepSchemaName(header) {
   const section = part21HeaderSection(maskPart21Comments(header))
   if (section === null) {
-    return []
+    return null
   }
-  const statement = lastFileSchemaStatement(section)
-  if (statement === null) {
-    return []
-  }
-  // `/ /g`, not `\s`: conway strips literal spaces only (`replaceAll(' ', '')`),
-  // so a tab inside a schema name must survive here exactly as it does there.
-  // (`String.replaceAll` itself is past this project's TS lib target.)
-  return [...statement.matchAll(/'([^']*)'/g)]
-    .map((match) => match[1].toUpperCase().replace(/ /g, ''))
-    .filter((entry) => entry.length > 0)
+  // LAST match, not first: conway's parser stores header entities in a Map
+  // keyed by name (`step_parser.js:193`), so a header carrying FILE_SCHEMA
+  // twice overwrites and the last one wins. Reading the first would have us
+  // answer from one entity and conway from the other — and on
+  // `FILE_SCHEMA(('IFC4')); FILE_SCHEMA(('AUTOMOTIVE_DESIGN'));` that is the
+  // dangerous direction: we say IFC, conway says AP214, and a STEP file goes
+  // down the IFC-only store open (bldrs-ai/Share#1776).
+  const matches = [...section.matchAll(FILE_SCHEMA_VALUE)]
+  return matches.length === 0 ? null : matches[matches.length - 1][1]
 }
 
 
-/**
- * The last FILE_SCHEMA statement in a header section, or null.
- *
- * Matching at the statement start is what keeps a longer identifier out:
- * `NOT_FILE_SCHEMA(('IFC4'));` is its own statement and does not begin with
- * `FILE_SCHEMA`, so it is invisible here just as it is to conway, which
- * parses records under their exact names.
- *
- * @param {string} section comment-masked header-section text
- * @return {string|null}
- */
-function lastFileSchemaStatement(section) {
-  let found = null
-  for (const statement of part21Statements(section)) {
-    if (/^\s*FILE_SCHEMA\s*\(/i.test(statement)) {
-      found = statement
-    }
-  }
-  return found
-}
-
-
-/**
- * Split Part-21 text on `;` into statements, ignoring semicolons inside
- * string literals (where `;` is ordinary text, and an apostrophe is escaped
- * by doubling it). Pass comment-masked text — a `;` inside a comment would
- * otherwise split a statement in two.
- *
- * @param {string} text comment-masked Part-21 text
- * @return {string[]} statement texts, without their terminating semicolons
- */
-function part21Statements(text) {
-  const out = []
-  let start = 0
-  let at = 0
-  let inString = false
-  while (at < text.length) {
-    const c = text[at]
-    if (inString) {
-      if (c === `'` && text[at + 1] === `'`) {
-        at += 2
-        continue
-      }
-      if (c === `'`) {
-        inString = false
-      }
-      at++
-      continue
-    }
-    if (c === `'`) {
-      inString = true
-      at++
-      continue
-    }
-    if (c === ';') {
-      out.push(text.slice(start, at))
-      at++
-      start = at
-      continue
-    }
-    at++
-  }
-  if (start < text.length) {
-    out.push(text.slice(start))
-  }
-  return out
-}
+// `\b` anchors the entity name so the scan cannot start inside a longer
+// identifier. conway parses header records under their exact names and
+// inspects only the `FILE_SCHEMA` key, so `NOT_FILE_SCHEMA(('IFC4'));` is
+// invisible to it — while an unanchored scan reads it as the schema. With
+// last-wins that is the dangerous direction whenever the lookalike follows
+// the real entity: we answer IFC, conway answers AP214. `\b` suffices
+// because `_` is a word character, so there is no boundary inside
+// `NOT_FILE_SCHEMA`.
+const FILE_SCHEMA_VALUE = /\bFILE_SCHEMA\s*\(\s*\(\s*'\s*([A-Za-z0-9_]+)/ig
 
 
 /**

--- a/src/Filetype.test.js
+++ b/src/Filetype.test.js
@@ -8,7 +8,7 @@ import {
   isExtensionSupported,
   pathSuffixSupported,
   splitAroundExtension,
-  stepFamily,
+  stepSchemaName,
   supportedTypes,
 } from './Filetype'
 
@@ -365,146 +365,94 @@ describe('Filetype', () => {
     })
   })
 
-  describe('stepFamily', () => {
+  describe('stepSchemaName', () => {
     // Real input, because the scan is bounded to the HEADER section: a bare
     // fragment has no section to find and correctly reads as "did not say".
     const hdr = (body) => `ISO-10303-21;\nHEADER;\n${body}\nENDSEC;\nDATA;\nENDSEC;\n`
 
-    it('reads both families', () => {
-      expect(stepFamily(hdr(`FILE_SCHEMA(('IFC4'));`))).toBe('ifc')
-      expect(stepFamily(hdr(`FILE_SCHEMA(('IFC2X3'));`))).toBe('ifc')
-      expect(stepFamily(hdr(`FILE_SCHEMA(('AUTOMOTIVE_DESIGN'));`))).toBe('step')
-      expect(stepFamily(hdr(`FILE_SCHEMA(('AP203_CONFIGURATION_CONTROLLED_3D_DESIGN'));`))).toBe('step')
-    })
-
-    it('takes the first entry conway recognises, in declaration order', () => {
-      // conway returns on the FIRST entry matching ANY known schema — it tests
-      // IFC, AUTOMOTIVE_DESIGN, CONFIG_CONTROL_DESIGN/AP203 and AP242 within
-      // each entry before moving to the next (`model_format_detector.js`). So
-      // declaration order decides, and a STEP schema listed first wins even
-      // when IFC follows it.
-      //
-      // Asking instead whether ANY entry starts with IFC answers 'ifc' for the
-      // first case below, where conway answers AP214 — we would offer a STEP
-      // file conway's IFC-only store open, burn the handle, and recreate
-      // bldrs-ai/Share#1776. This test asserted exactly that wrong answer
-      // until codex caught it on the PR.
-      expect(stepFamily(hdr(`FILE_SCHEMA(('AUTOMOTIVE_DESIGN'),('IFC4'));`))).toBe('step')
-      expect(stepFamily(hdr(`FILE_SCHEMA(('IFC4'),('AUTOMOTIVE_DESIGN'));`))).toBe('ifc')
-      expect(stepFamily(hdr(`FILE_SCHEMA(('AUTOMOTIVE_DESIGN'),('CONFIG_CONTROL_DESIGN'));`))).toBe('step')
-      // An entry conway recognises nothing in is skipped, not treated as STEP,
-      // so a later recognised entry still decides.
-      expect(stepFamily(hdr(`FILE_SCHEMA(('SOMETHING_ELSE'),('IFC4'));`))).toBe('ifc')
-      expect(stepFamily(hdr(`FILE_SCHEMA(('SOMETHING_ELSE'),('AP242_MANAGED_MODEL'));`))).toBe('step')
-    })
-
-    it('answers null when no entry names a schema conway knows', () => {
-      // conway's detector falls out of its loop and returns undefined, i.e.
-      // no format — so its store open refuses the file. Null here makes
-      // `canOpenFromStore` buffer, which is the same outcome.
-      expect(stepFamily(hdr(`FILE_SCHEMA(('SOMETHING_ELSE'));`))).toBeNull()
-    })
-
-    it('strips spaces inside an entry, as conway does', () => {
-      // conway compares after `replaceAll(' ', '')`, so a name broken by
-      // stray spaces is still IFC to it. A capture that stopped at the first
-      // non-word character read `' I FC4'` as `I` and answered STEP.
-      expect(stepFamily(hdr(`FILE_SCHEMA((' IFC4 '));`))).toBe('ifc')
-      expect(stepFamily(hdr(`FILE_SCHEMA(('I FC4'));`))).toBe('ifc')
-      expect(stepFamily(hdr(`FILE_SCHEMA(('AUTOMOTIVE _ DESIGN'));`))).toBe('step')
-    })
-
-    it('is case-insensitive on the schema name', () => {
-      expect(stepFamily(hdr(`FILE_SCHEMA(('ifc4'));`))).toBe('ifc')
+    it('returns the declared schema for both families', () => {
+      expect(stepSchemaName(hdr(`FILE_SCHEMA(('IFC4'));`))).toBe('IFC4')
+      expect(stepSchemaName(hdr(`FILE_SCHEMA(('AUTOMOTIVE_DESIGN'));`))).toBe('AUTOMOTIVE_DESIGN')
+      expect(stepSchemaName(hdr(`FILE_SCHEMA  ( ( ' IFC2X3 ' ) );`))).toBe('IFC2X3')
     })
 
     it(`skips Part-21 comments the way conway's header parser does`, () => {
-      // conway's `StepHeaderParser` consumes a comment as whitespace, so
-      // `ModelFormatDetector` calls these IFC. Reading them as "did not say"
+      // ISO-10303-21 allows a comment anywhere whitespace is allowed, and
+      // conway's `StepHeaderParser` consumes one as whitespace — so
+      // `ModelFormatDetector` calls these IFC. Reading them as "no schema"
       // would cost a large IFC its windowed parse.
-      expect(stepFamily(hdr(`FILE_SCHEMA /* exported by X */ (('IFC4'));`))).toBe('ifc')
-      expect(stepFamily(hdr(`FILE_SCHEMA((/* why */'IFC4'));`))).toBe('ifc')
-      expect(stepFamily(hdr(`FILE_SCHEMA/* a */(/* b */(/* c */'IFC4'));`))).toBe('ifc')
+      expect(stepSchemaName(hdr(`FILE_SCHEMA /* exported by X */ (('IFC4'));`))).toBe('IFC4')
+      expect(stepSchemaName(hdr(`FILE_SCHEMA((/* why */'IFC4'));`))).toBe('IFC4')
+      expect(stepSchemaName(hdr(`FILE_SCHEMA/* a */(/* b */(/* c */'IFC4'));`))).toBe('IFC4')
     })
 
     it('ignores a FILE_SCHEMA entity that is itself inside a comment', () => {
-      // The dangerous direction: the whole entity sits INSIDE the comment, so
-      // no amount of tolerance BETWEEN tokens excludes it. conway skips the
-      // comment and reads AP214; a raw-text scan would answer IFC and send a
-      // STEP file down the IFC-only store open.
+      // The dangerous direction, and the one a comment-tolerant gap pattern
+      // cannot fix: the whole entity sits INSIDE the comment, so no amount of
+      // tolerance BETWEEN tokens excludes it. conway's parser skips the
+      // comment and reads AP214; a raw-text scan would answer IFC, send a
+      // STEP file down conway's IFC-only store open, and burn a model handle.
       const body = `/* FILE_SCHEMA(('IFC4')); */\nFILE_SCHEMA(('AUTOMOTIVE_DESIGN'));`
-      expect(stepFamily(hdr(body))).toBe('step')
+      expect(stepSchemaName(hdr(body))).toBe('AUTOMOTIVE_DESIGN')
       expect(analyzeHeaderStr(hdr(body))).toBe('step')
     })
 
     it('takes the LAST FILE_SCHEMA, matching conway\'s last-wins Map', () => {
       // conway stores header entities in a Map keyed by name
-      // (`step_parser.js:193`), so a duplicated entity overwrites.
+      // (`step_parser.js:193`), so a duplicated FILE_SCHEMA overwrites.
+      // Reading the first would answer IFC here where conway answers AP214 —
+      // the dangerous direction again.
       const body = `FILE_SCHEMA(('IFC4'));\nFILE_SCHEMA(('AUTOMOTIVE_DESIGN'));`
-      expect(stepFamily(hdr(body))).toBe('step')
-      expect(analyzeHeaderStr(hdr(body))).toBe('step')
-    })
-
-    it('does not match FILE_SCHEMA inside a longer entity name', () => {
-      // conway inspects only the exact `FILE_SCHEMA` key, so `NOT_FILE_SCHEMA`
-      // is invisible to it. Matching at the statement start keeps it out here.
-      const body = `FILE_SCHEMA(('AUTOMOTIVE_DESIGN'));\nNOT_FILE_SCHEMA(('IFC4'));`
-      expect(stepFamily(hdr(body))).toBe('step')
+      expect(stepSchemaName(hdr(body))).toBe('AUTOMOTIVE_DESIGN')
       expect(analyzeHeaderStr(hdr(body))).toBe('step')
     })
 
     it('ignores a FILE_SCHEMA lookalike past ENDSEC', () => {
       // The caller sniffs a fixed 64 KiB prefix, which on any real model runs
-      // well into DATA, where a quoted string may contain anything.
+      // well into DATA, where a quoted string may contain anything. conway
+      // reads FILE_SCHEMA from the HEADER section only.
       const text = `ISO-10303-21;\nHEADER;\nFILE_SCHEMA(('AUTOMOTIVE_DESIGN'));\nENDSEC;\n` +
         `DATA;\n#1=IFCPROPERTYSINGLEVALUE('FILE_SCHEMA((''IFC4''));');\nENDSEC;\n`
-      expect(stepFamily(text)).toBe('step')
+      expect(stepSchemaName(text)).toBe('AUTOMOTIVE_DESIGN')
     })
 
     it('keeps a comment-like sequence inside a string literal', () => {
       // Inside a Part-21 string `/*` is ordinary text. Masking it would join
       // the surrounding text and could resurrect the bug it exists to fix.
-      expect(stepFamily(hdr(
+      expect(stepSchemaName(hdr(
         `FILE_NAME('/* not a comment','*/');\nFILE_SCHEMA(('AUTOMOTIVE_DESIGN'));`,
-      ))).toBe('step')
+      ))).toBe('AUTOMOTIVE_DESIGN')
       // A doubled apostrophe escapes one inside the string; the string stays
       // open across it, so the `/*` after it is still literal.
-      expect(stepFamily(hdr(
+      expect(stepSchemaName(hdr(
         `FILE_NAME('it''s /* fine');\nFILE_SCHEMA(('IFC4'));`,
-      ))).toBe('ifc')
+      ))).toBe('IFC4')
     })
 
-    it('does not let a semicolon inside a string split a statement', () => {
-      // Statement splitting is string-aware, matching conway's tokenizer: a
-      // `;` inside a string literal is ordinary text, not a terminator.
-      //
-      // The case that actually distinguishes it is a semicolon inside a schema
-      // name conway still recognises — a naive split cuts the entity in half,
-      // and the leading fragment has no closed quote pair left, so it reads as
-      // "did not say". The name must stay recognisable past the split point:
-      // `AUTO;MOTIVE_DESIGN` is unrecognised either way and proves nothing.
-      expect(stepFamily(hdr(`FILE_SCHEMA(('AUTOMOTIVE_DESIGN;2'));`))).toBe('step')
-      // Worth recording what this does NOT prove. The realistic case — a
-      // semicolon in a FILE_NAME author or description field, which is common
-      // — comes out the same either way, because the mis-split fragments
-      // never start with FILE_SCHEMA and last-wins still finds the real
-      // entity. The awareness is here so the splitter is correct for the next
-      // caller, not because this input needs it.
-      expect(stepFamily(hdr(
-        `FILE_NAME('m.stp','2024',('Acme; Corp'),(''),'','','');\nFILE_SCHEMA(('IFC4'));`,
-      ))).toBe('ifc')
+    it('does not match FILE_SCHEMA inside a longer entity name', () => {
+      // conway parses header records under their exact names and inspects
+      // only the `FILE_SCHEMA` key, so `NOT_FILE_SCHEMA` is invisible to it.
+      // An unanchored scan reads it as the schema — and with last-wins that
+      // is the dangerous direction whenever the lookalike follows the real
+      // entity: we answer IFC where conway answers AP214.
+      const body = `FILE_SCHEMA(('AUTOMOTIVE_DESIGN'));\nNOT_FILE_SCHEMA(('IFC4'));`
+      expect(stepSchemaName(hdr(body))).toBe('AUTOMOTIVE_DESIGN')
+      expect(analyzeHeaderStr(hdr(body))).toBe('step')
     })
 
-    it('answers null when the header declares nothing readable', () => {
-      // Null is "did not say", which `Loader.js#canOpenFromStore` treats as
-      // "buffer" — a wrong 'ifc' there burns a model handle.
-      expect(stepFamily('HEADER;\nENDSEC;')).toBeNull()
-      expect(stepFamily(hdr(`FILE_SCHEMA(());`))).toBeNull()
-      expect(stepFamily(hdr(`FILE_SCHEMA((''));`))).toBeNull()
+    it('separates "did not say" from "said STEP"', () => {
+      // The distinction `classifyStepFamily` cannot express, because it
+      // folds both into 'ifc'. Kept for callers that want to report what a
+      // file declared rather than pick a name for it; the format decision
+      // that used to depend on it now goes through conway's detector
+      // (`src/loader/stepFormat.js`).
+      expect(stepSchemaName('HEADER;\nENDSEC;')).toBeNull()
+      expect(stepSchemaName(hdr(`FILE_SCHEMA(());`))).toBeNull()
+      expect(stepSchemaName(hdr(`FILE_SCHEMA((''));`))).toBeNull()
       // No HEADER section at all — nothing conway would parse a schema from.
-      expect(stepFamily(`FILE_SCHEMA(('IFC4'));`)).toBeNull()
-      // The classifier folds null into 'ifc'; that default is why the loader
-      // asks `stepFamily` directly rather than going through it.
+      expect(stepSchemaName(`FILE_SCHEMA(('IFC4'));`)).toBeNull()
+      // Same inputs, classifier still answers 'ifc' — that default is why
+      // the guard above exists.
       expect(analyzeHeaderStr(hdr(`FILE_SCHEMA((''));`))).toBe('ifc')
     })
   })

--- a/src/Filetype.test.js
+++ b/src/Filetype.test.js
@@ -377,14 +377,32 @@ describe('Filetype', () => {
       expect(stepFamily(hdr(`FILE_SCHEMA(('AP203_CONFIGURATION_CONTROLLED_3D_DESIGN'));`))).toBe('step')
     })
 
-    it('considers every declared entry, not just the first', () => {
-      // conway iterates all quoted entries and answers IFC if ANY starts with
-      // IFC (`model_format_detector.js`). Reading only the first made a
-      // header listing IFC second read as STEP here — safe, since it only
-      // costs the windowed parse, but a disagreement all the same.
-      expect(stepFamily(hdr(`FILE_SCHEMA(('AUTOMOTIVE_DESIGN'),('IFC4'));`))).toBe('ifc')
+    it('takes the first entry conway recognises, in declaration order', () => {
+      // conway returns on the FIRST entry matching ANY known schema — it tests
+      // IFC, AUTOMOTIVE_DESIGN, CONFIG_CONTROL_DESIGN/AP203 and AP242 within
+      // each entry before moving to the next (`model_format_detector.js`). So
+      // declaration order decides, and a STEP schema listed first wins even
+      // when IFC follows it.
+      //
+      // Asking instead whether ANY entry starts with IFC answers 'ifc' for the
+      // first case below, where conway answers AP214 — we would offer a STEP
+      // file conway's IFC-only store open, burn the handle, and recreate
+      // bldrs-ai/Share#1776. This test asserted exactly that wrong answer
+      // until codex caught it on the PR.
+      expect(stepFamily(hdr(`FILE_SCHEMA(('AUTOMOTIVE_DESIGN'),('IFC4'));`))).toBe('step')
       expect(stepFamily(hdr(`FILE_SCHEMA(('IFC4'),('AUTOMOTIVE_DESIGN'));`))).toBe('ifc')
       expect(stepFamily(hdr(`FILE_SCHEMA(('AUTOMOTIVE_DESIGN'),('CONFIG_CONTROL_DESIGN'));`))).toBe('step')
+      // An entry conway recognises nothing in is skipped, not treated as STEP,
+      // so a later recognised entry still decides.
+      expect(stepFamily(hdr(`FILE_SCHEMA(('SOMETHING_ELSE'),('IFC4'));`))).toBe('ifc')
+      expect(stepFamily(hdr(`FILE_SCHEMA(('SOMETHING_ELSE'),('AP242_MANAGED_MODEL'));`))).toBe('step')
+    })
+
+    it('answers null when no entry names a schema conway knows', () => {
+      // conway's detector falls out of its loop and returns undefined, i.e.
+      // no format — so its store open refuses the file. Null here makes
+      // `canOpenFromStore` buffer, which is the same outcome.
+      expect(stepFamily(hdr(`FILE_SCHEMA(('SOMETHING_ELSE'));`))).toBeNull()
     })
 
     it('strips spaces inside an entry, as conway does', () => {
@@ -460,10 +478,12 @@ describe('Filetype', () => {
       // Statement splitting is string-aware, matching conway's tokenizer: a
       // `;` inside a string literal is ordinary text, not a terminator.
       //
-      // The case that actually distinguishes it is a semicolon inside the
-      // schema name — a naive split cuts the entity in half, and the leading
-      // fragment has no closed quote pair left, so it reads as "did not say".
-      expect(stepFamily(hdr(`FILE_SCHEMA(('AUTO;MOTIVE_DESIGN'));`))).toBe('step')
+      // The case that actually distinguishes it is a semicolon inside a schema
+      // name conway still recognises — a naive split cuts the entity in half,
+      // and the leading fragment has no closed quote pair left, so it reads as
+      // "did not say". The name must stay recognisable past the split point:
+      // `AUTO;MOTIVE_DESIGN` is unrecognised either way and proves nothing.
+      expect(stepFamily(hdr(`FILE_SCHEMA(('AUTOMOTIVE_DESIGN;2'));`))).toBe('step')
       // Worth recording what this does NOT prove. The realistic case — a
       // semicolon in a FILE_NAME author or description field, which is common
       // — comes out the same either way, because the mis-split fragments

--- a/src/Filetype.test.js
+++ b/src/Filetype.test.js
@@ -8,7 +8,7 @@ import {
   isExtensionSupported,
   pathSuffixSupported,
   splitAroundExtension,
-  stepSchemaName,
+  stepFamily,
   supportedTypes,
 } from './Filetype'
 
@@ -365,93 +365,126 @@ describe('Filetype', () => {
     })
   })
 
-  describe('stepSchemaName', () => {
+  describe('stepFamily', () => {
     // Real input, because the scan is bounded to the HEADER section: a bare
     // fragment has no section to find and correctly reads as "did not say".
     const hdr = (body) => `ISO-10303-21;\nHEADER;\n${body}\nENDSEC;\nDATA;\nENDSEC;\n`
 
-    it('returns the declared schema for both families', () => {
-      expect(stepSchemaName(hdr(`FILE_SCHEMA(('IFC4'));`))).toBe('IFC4')
-      expect(stepSchemaName(hdr(`FILE_SCHEMA(('AUTOMOTIVE_DESIGN'));`))).toBe('AUTOMOTIVE_DESIGN')
-      expect(stepSchemaName(hdr(`FILE_SCHEMA  ( ( ' IFC2X3 ' ) );`))).toBe('IFC2X3')
+    it('reads both families', () => {
+      expect(stepFamily(hdr(`FILE_SCHEMA(('IFC4'));`))).toBe('ifc')
+      expect(stepFamily(hdr(`FILE_SCHEMA(('IFC2X3'));`))).toBe('ifc')
+      expect(stepFamily(hdr(`FILE_SCHEMA(('AUTOMOTIVE_DESIGN'));`))).toBe('step')
+      expect(stepFamily(hdr(`FILE_SCHEMA(('AP203_CONFIGURATION_CONTROLLED_3D_DESIGN'));`))).toBe('step')
+    })
+
+    it('considers every declared entry, not just the first', () => {
+      // conway iterates all quoted entries and answers IFC if ANY starts with
+      // IFC (`model_format_detector.js`). Reading only the first made a
+      // header listing IFC second read as STEP here — safe, since it only
+      // costs the windowed parse, but a disagreement all the same.
+      expect(stepFamily(hdr(`FILE_SCHEMA(('AUTOMOTIVE_DESIGN'),('IFC4'));`))).toBe('ifc')
+      expect(stepFamily(hdr(`FILE_SCHEMA(('IFC4'),('AUTOMOTIVE_DESIGN'));`))).toBe('ifc')
+      expect(stepFamily(hdr(`FILE_SCHEMA(('AUTOMOTIVE_DESIGN'),('CONFIG_CONTROL_DESIGN'));`))).toBe('step')
+    })
+
+    it('strips spaces inside an entry, as conway does', () => {
+      // conway compares after `replaceAll(' ', '')`, so a name broken by
+      // stray spaces is still IFC to it. A capture that stopped at the first
+      // non-word character read `' I FC4'` as `I` and answered STEP.
+      expect(stepFamily(hdr(`FILE_SCHEMA((' IFC4 '));`))).toBe('ifc')
+      expect(stepFamily(hdr(`FILE_SCHEMA(('I FC4'));`))).toBe('ifc')
+      expect(stepFamily(hdr(`FILE_SCHEMA(('AUTOMOTIVE _ DESIGN'));`))).toBe('step')
+    })
+
+    it('is case-insensitive on the schema name', () => {
+      expect(stepFamily(hdr(`FILE_SCHEMA(('ifc4'));`))).toBe('ifc')
     })
 
     it(`skips Part-21 comments the way conway's header parser does`, () => {
-      // ISO-10303-21 allows a comment anywhere whitespace is allowed, and
-      // conway's `StepHeaderParser` consumes one as whitespace — so
-      // `ModelFormatDetector` calls these IFC. Reading them as "no schema"
+      // conway's `StepHeaderParser` consumes a comment as whitespace, so
+      // `ModelFormatDetector` calls these IFC. Reading them as "did not say"
       // would cost a large IFC its windowed parse.
-      expect(stepSchemaName(hdr(`FILE_SCHEMA /* exported by X */ (('IFC4'));`))).toBe('IFC4')
-      expect(stepSchemaName(hdr(`FILE_SCHEMA((/* why */'IFC4'));`))).toBe('IFC4')
-      expect(stepSchemaName(hdr(`FILE_SCHEMA/* a */(/* b */(/* c */'IFC4'));`))).toBe('IFC4')
+      expect(stepFamily(hdr(`FILE_SCHEMA /* exported by X */ (('IFC4'));`))).toBe('ifc')
+      expect(stepFamily(hdr(`FILE_SCHEMA((/* why */'IFC4'));`))).toBe('ifc')
+      expect(stepFamily(hdr(`FILE_SCHEMA/* a */(/* b */(/* c */'IFC4'));`))).toBe('ifc')
     })
 
     it('ignores a FILE_SCHEMA entity that is itself inside a comment', () => {
-      // The dangerous direction, and the one a comment-tolerant gap pattern
-      // cannot fix: the whole entity sits INSIDE the comment, so no amount of
-      // tolerance BETWEEN tokens excludes it. conway's parser skips the
-      // comment and reads AP214; a raw-text scan would answer IFC, send a
-      // STEP file down conway's IFC-only store open, and burn a model handle.
+      // The dangerous direction: the whole entity sits INSIDE the comment, so
+      // no amount of tolerance BETWEEN tokens excludes it. conway skips the
+      // comment and reads AP214; a raw-text scan would answer IFC and send a
+      // STEP file down the IFC-only store open.
       const body = `/* FILE_SCHEMA(('IFC4')); */\nFILE_SCHEMA(('AUTOMOTIVE_DESIGN'));`
-      expect(stepSchemaName(hdr(body))).toBe('AUTOMOTIVE_DESIGN')
+      expect(stepFamily(hdr(body))).toBe('step')
       expect(analyzeHeaderStr(hdr(body))).toBe('step')
     })
 
     it('takes the LAST FILE_SCHEMA, matching conway\'s last-wins Map', () => {
       // conway stores header entities in a Map keyed by name
-      // (`step_parser.js:193`), so a duplicated FILE_SCHEMA overwrites.
-      // Reading the first would answer IFC here where conway answers AP214 —
-      // the dangerous direction again.
+      // (`step_parser.js:193`), so a duplicated entity overwrites.
       const body = `FILE_SCHEMA(('IFC4'));\nFILE_SCHEMA(('AUTOMOTIVE_DESIGN'));`
-      expect(stepSchemaName(hdr(body))).toBe('AUTOMOTIVE_DESIGN')
+      expect(stepFamily(hdr(body))).toBe('step')
+      expect(analyzeHeaderStr(hdr(body))).toBe('step')
+    })
+
+    it('does not match FILE_SCHEMA inside a longer entity name', () => {
+      // conway inspects only the exact `FILE_SCHEMA` key, so `NOT_FILE_SCHEMA`
+      // is invisible to it. Matching at the statement start keeps it out here.
+      const body = `FILE_SCHEMA(('AUTOMOTIVE_DESIGN'));\nNOT_FILE_SCHEMA(('IFC4'));`
+      expect(stepFamily(hdr(body))).toBe('step')
       expect(analyzeHeaderStr(hdr(body))).toBe('step')
     })
 
     it('ignores a FILE_SCHEMA lookalike past ENDSEC', () => {
       // The caller sniffs a fixed 64 KiB prefix, which on any real model runs
-      // well into DATA, where a quoted string may contain anything. conway
-      // reads FILE_SCHEMA from the HEADER section only.
+      // well into DATA, where a quoted string may contain anything.
       const text = `ISO-10303-21;\nHEADER;\nFILE_SCHEMA(('AUTOMOTIVE_DESIGN'));\nENDSEC;\n` +
         `DATA;\n#1=IFCPROPERTYSINGLEVALUE('FILE_SCHEMA((''IFC4''));');\nENDSEC;\n`
-      expect(stepSchemaName(text)).toBe('AUTOMOTIVE_DESIGN')
+      expect(stepFamily(text)).toBe('step')
     })
 
     it('keeps a comment-like sequence inside a string literal', () => {
       // Inside a Part-21 string `/*` is ordinary text. Masking it would join
       // the surrounding text and could resurrect the bug it exists to fix.
-      expect(stepSchemaName(hdr(
+      expect(stepFamily(hdr(
         `FILE_NAME('/* not a comment','*/');\nFILE_SCHEMA(('AUTOMOTIVE_DESIGN'));`,
-      ))).toBe('AUTOMOTIVE_DESIGN')
+      ))).toBe('step')
       // A doubled apostrophe escapes one inside the string; the string stays
       // open across it, so the `/*` after it is still literal.
-      expect(stepSchemaName(hdr(
+      expect(stepFamily(hdr(
         `FILE_NAME('it''s /* fine');\nFILE_SCHEMA(('IFC4'));`,
-      ))).toBe('IFC4')
+      ))).toBe('ifc')
     })
 
-    it('does not match FILE_SCHEMA inside a longer entity name', () => {
-      // conway parses header records under their exact names and inspects
-      // only the `FILE_SCHEMA` key, so `NOT_FILE_SCHEMA` is invisible to it.
-      // An unanchored scan reads it as the schema — and with last-wins that
-      // is the dangerous direction whenever the lookalike follows the real
-      // entity: we answer IFC where conway answers AP214.
-      const body = `FILE_SCHEMA(('AUTOMOTIVE_DESIGN'));\nNOT_FILE_SCHEMA(('IFC4'));`
-      expect(stepSchemaName(hdr(body))).toBe('AUTOMOTIVE_DESIGN')
-      expect(analyzeHeaderStr(hdr(body))).toBe('step')
+    it('does not let a semicolon inside a string split a statement', () => {
+      // Statement splitting is string-aware, matching conway's tokenizer: a
+      // `;` inside a string literal is ordinary text, not a terminator.
+      //
+      // The case that actually distinguishes it is a semicolon inside the
+      // schema name — a naive split cuts the entity in half, and the leading
+      // fragment has no closed quote pair left, so it reads as "did not say".
+      expect(stepFamily(hdr(`FILE_SCHEMA(('AUTO;MOTIVE_DESIGN'));`))).toBe('step')
+      // Worth recording what this does NOT prove. The realistic case — a
+      // semicolon in a FILE_NAME author or description field, which is common
+      // — comes out the same either way, because the mis-split fragments
+      // never start with FILE_SCHEMA and last-wins still finds the real
+      // entity. The awareness is here so the splitter is correct for the next
+      // caller, not because this input needs it.
+      expect(stepFamily(hdr(
+        `FILE_NAME('m.stp','2024',('Acme; Corp'),(''),'','','');\nFILE_SCHEMA(('IFC4'));`,
+      ))).toBe('ifc')
     })
 
-    it('separates "did not say" from "said STEP"', () => {
-      // The distinction `classifyStepFamily` cannot express, because it
-      // folds both into 'ifc'. A caller whose false-'ifc' is expensive —
-      // `Loader.js#canOpenFromStore` gating conway's IFC-only store open —
-      // needs a non-null name before it trusts the classification.
-      expect(stepSchemaName('HEADER;\nENDSEC;')).toBeNull()
-      expect(stepSchemaName(hdr(`FILE_SCHEMA(());`))).toBeNull()
-      expect(stepSchemaName(hdr(`FILE_SCHEMA((''));`))).toBeNull()
+    it('answers null when the header declares nothing readable', () => {
+      // Null is "did not say", which `Loader.js#canOpenFromStore` treats as
+      // "buffer" — a wrong 'ifc' there burns a model handle.
+      expect(stepFamily('HEADER;\nENDSEC;')).toBeNull()
+      expect(stepFamily(hdr(`FILE_SCHEMA(());`))).toBeNull()
+      expect(stepFamily(hdr(`FILE_SCHEMA((''));`))).toBeNull()
       // No HEADER section at all — nothing conway would parse a schema from.
-      expect(stepSchemaName(`FILE_SCHEMA(('IFC4'));`)).toBeNull()
-      // Same inputs, classifier still answers 'ifc' — that default is why
-      // the guard above exists.
+      expect(stepFamily(`FILE_SCHEMA(('IFC4'));`)).toBeNull()
+      // The classifier folds null into 'ifc'; that default is why the loader
+      // asks `stepFamily` directly rather than going through it.
       expect(analyzeHeaderStr(hdr(`FILE_SCHEMA((''));`))).toBe('ifc')
     })
   })

--- a/src/loader/Loader.cover.test.js
+++ b/src/loader/Loader.cover.test.js
@@ -113,10 +113,14 @@ function makeIfcViewer({streamOpen = false} = {}) {
 }
 
 
-// Part-21 header fixtures. `canOpenFromStore` decides the store path from
-// FILE_SCHEMA, not from the suffix, so these tests need real headers: a body
-// of filler bytes would sniff as "no schema found" and buffer for a reason
-// the test did not intend to exercise.
+// Part-21 header fixtures. `canOpenFromStore` decides the store path by handing
+// conway's own `ModelFormatDetector` the file's first 64 KiB, so these need
+// real headers: filler bytes detect as no format and buffer for a reason the
+// test did not intend to exercise. Note that the trailing `DATA;` and
+// `END-ISO-10303-21;` are load-bearing, not decoration — conway's header
+// parser only reports a schema once it has reached `ENDSEC;` then `DATA;`, so
+// trimming the fixture to the header alone would silently flip every
+// store-path test below to the buffering path.
 /**
  * @param {string} schema the FILE_SCHEMA value, e.g. 'IFC4'
  * @return {string} a minimal ISO-10303-21 header declaring it
@@ -688,9 +692,9 @@ describe('load() error/edge paths with OPFS enabled', () => {
     // conway's 64 KiB sniff window, so this is a corrupt-file path.
     //
     // The entry is PRESENT here but empty — the case a bare "is FILE_SCHEMA in
-    // the header?" guard waves through, since `classifyStepFamily` answers
-    // 'ifc' for anything it cannot parse. The gate requires a parsed schema
-    // name (`Filetype.stepSchemaName`), so this buffers.
+    // the header?" guard waves through. conway's detector matches quoted
+    // entries with `'([^']+)'`, so an empty pair yields no entry and no
+    // format, and this buffers.
     const file = new MockFile('ISO-10303-21;\nHEADER;\nFILE_SCHEMA((\'\'));\nENDSEC;\n')
     const arrayBufferSpy = jest.spyOn(file, 'arrayBuffer')
     getModelFromOPFS.mockReset()

--- a/src/loader/Loader.js
+++ b/src/loader/Loader.js
@@ -49,6 +49,7 @@ import {activeGlbCompressionMode, activeSchemaVersion} from './glbCompress'
 import {isBldrsGlbContainer, unpackGlbContainer} from './glbContainer'
 import {glbInfo, glbVerbose, glbWarn} from './glbLog'
 import {spillModelSource} from './opfsSourceByteStore'
+import {STORE_DETECT_PREFIX_BYTES, isConwayIfcFormat} from './stepFormat'
 import {
   externalCacheKey,
   gitHubCacheKey,
@@ -81,13 +82,6 @@ import {markIfOutOfMemory} from '../utils/oom'
 // would notice "cache hasn't warmed yet."
 const SCHEDULE_IDLE_TIMEOUT_MS = 5_000
 const LFS_POINTER_PROBE_BYTES = 256
-
-// Matches conway's own `STORE_DETECT_PREFIX_BYTES`
-// (`compat/web-ifc/ifc_api_model_passthrough_factory.js`) — the window its
-// store-backed open sniffs the format in. Reading the same amount means our
-// answer to "will `fromStore` take this?" comes from the same bytes it will
-// look at, rather than from a smaller window that could disagree.
-const STORE_FORMAT_SNIFF_BYTES = 65_536
 
 // The formats `findLoader` routes to conway via `parseIfcWithConway`. All
 // three are ISO-10303-21 part-21 files sharing one loader; only FILE_SCHEMA
@@ -130,11 +124,12 @@ function scheduleIdleWork(fn) {
  *     re-introducing on a mislabelled large model exactly the
  *     hundreds-of-MB allocation M3 removed.
  *
- * An absent or unrecognised FILE_SCHEMA buffers rather than gambling: a
- * wrong "yes" costs a burned handle and a broken cache artifact, a wrong
- * "no" costs one load's memory win. Within conway's own 64 KiB sniff
- * window every real part-21 file carries FILE_SCHEMA, so that branch is
- * a corrupt-or-truncated-file path, not a format we are giving up on.
+ * The question is answered by conway's own `ModelFormatDetector`, over the
+ * same 64 KiB prefix `fromStore` will read — see
+ * {@link isConwayIfcFormat}, which explains why this must not go back to
+ * being a header scan of our own. Anything it does not read as IFC —
+ * AP214/AP203/AP242, and equally a truncated or malformed part-21 file it
+ * cannot parse at all — buffers rather than gambling.
  *
  * @param {object} viewer
  * @param {string} loaderType resolved format tag, i.e. `loader.type`
@@ -153,18 +148,12 @@ async function canOpenFromStore(viewer, loaderType, file) {
     return false
   }
   try {
-    const head = await file.slice(0, STORE_FORMAT_SNIFF_BYTES).arrayBuffer()
-    // Non-fatal by default, so a multi-byte sequence cut at the slice
-    // boundary — or a mislabelled binary — yields replacement characters
-    // rather than throwing. Both then fail the schema match below and
-    // buffer, which is the outcome we want for bytes we cannot read.
-    const header = new TextDecoder('utf-8').decode(new Uint8Array(head))
-    // `stepFamily`, not `classifyStepFamily`: the classifier answers 'ifc'
-    // for anything it cannot read, which is the right default when the answer
-    // only picks a filename and the wrong one here, where a false 'ifc' sends
-    // an unidentified file down the IFC-only store path. Null means "this
-    // file did not say" and buffers.
-    return Filetype.stepFamily(header) === 'ifc'
+    // Raw bytes, not decoded text: conway's parser reads bytes, so handing it
+    // the prefix untouched removes the last place our answer could differ
+    // from its — a multi-byte sequence cut at the slice boundary decodes to a
+    // replacement character, which is a different byte than the one it sees.
+    const head = await file.slice(0, STORE_DETECT_PREFIX_BYTES).arrayBuffer()
+    return isConwayIfcFormat(new Uint8Array(head))
   } catch (e) {
     debug().warn('Loader#canOpenFromStore: header sniff failed; buffering:', e)
     return false

--- a/src/loader/Loader.js
+++ b/src/loader/Loader.js
@@ -159,14 +159,12 @@ async function canOpenFromStore(viewer, loaderType, file) {
     // rather than throwing. Both then fail the schema match below and
     // buffer, which is the outcome we want for bytes we cannot read.
     const header = new TextDecoder('utf-8').decode(new Uint8Array(head))
-    // Require a schema NAME, not merely a FILE_SCHEMA entry.
-    // `classifyStepFamily` answers 'ifc' whenever it cannot parse one, and
-    // an empty `FILE_SCHEMA(( ))` would otherwise inherit that default and
-    // send an unidentified file down the IFC-only store path.
-    if (Filetype.stepSchemaName(header) === null) {
-      return false
-    }
-    return Filetype.classifyStepFamily(header) === 'ifc'
+    // `stepFamily`, not `classifyStepFamily`: the classifier answers 'ifc'
+    // for anything it cannot read, which is the right default when the answer
+    // only picks a filename and the wrong one here, where a false 'ifc' sends
+    // an unidentified file down the IFC-only store path. Null means "this
+    // file did not say" and buffers.
+    return Filetype.stepFamily(header) === 'ifc'
   } catch (e) {
     debug().warn('Loader#canOpenFromStore: header sniff failed; buffering:', e)
     return false

--- a/src/loader/stepFormat.js
+++ b/src/loader/stepFormat.js
@@ -1,0 +1,56 @@
+// Deep import through conway's `./src/*` export map, the same route
+// `loadProgress.js` takes to `core/progress_log`. Deliberately the detector
+// itself and not a re-implementation — see the note on `isConwayIfcFormat`.
+import ModelFormatDetector, {ModelFormatType} from '@bldrs-ai/conway/src/format_detection/model_format_detector'
+import ParsingBuffer from '@bldrs-ai/conway/src/parsing/parsing_buffer'
+import debug from '../utils/debug'
+
+
+/**
+ * The window conway's store-backed open sniffs the format in — its own
+ * `STORE_DETECT_PREFIX_BYTES` (`compat/web-ifc/ifc_api_model_passthrough_
+ * factory.js`). Reading exactly this much means our answer comes from the
+ * same bytes conway's will.
+ */
+export const STORE_DETECT_PREFIX_BYTES = 65_536
+
+
+/**
+ * True when conway's `IfcApiModelPassthroughFactory.fromStore` will accept
+ * these bytes — i.e. when its detector reads them as IFC rather than
+ * AP214/AP203/AP242 or as no format at all.
+ *
+ * **This calls conway's detector rather than mirroring it, and that is the
+ * whole point.** `fromStore` reserves the model handle BEFORE it sniffs and
+ * is IFC-only, so a "yes" it then refuses burns handle 0 and pushes the
+ * buffered retry onto handle 1 — misaddressing every Share call site that
+ * passes the scene-level id 0, the GLB writer's spatial-tree and
+ * element-properties captures among them (bldrs-ai/Share#1776). Only a
+ * false-yes is expensive; a false-no costs one load's memory win.
+ *
+ * Share did briefly carry a regex mirror of `ModelFormatDetector.detect`
+ * (#1780). Differential testing against the real detector found eleven
+ * false-yes divergences in it, and they were not a matter of polish — the
+ * detector's answer depends on conway's part-21 parser reaching `ENDSEC;` /
+ * `DATA;` under byte-exact keyword matching with its own string-escape DFA
+ * (`\S\` swallows the next byte, apostrophes included). A text scan cannot
+ * agree with that except by becoming it. Handing conway the same prefix it
+ * will read makes agreement exact by construction, so please do not
+ * reintroduce a local reimplementation of this; see
+ * `src/loader/stepFormat.test.js`, whose cases are all divergences the
+ * mirror got wrong.
+ *
+ * @param {Uint8Array} prefix the file's first {@link STORE_DETECT_PREFIX_BYTES}
+ * @return {boolean} true only when conway detects IFC
+ */
+export function isConwayIfcFormat(prefix) {
+  try {
+    return ModelFormatDetector.detect(new ParsingBuffer(prefix)) === ModelFormatType.IFC
+  } catch (e) {
+    // The detector walks unvalidated bytes; anything it throws on is a file
+    // we would not want on the store path anyway. Buffering is the safe
+    // outcome, so this never propagates.
+    debug().warn('stepFormat#isConwayIfcFormat: detect threw; buffering:', e)
+    return false
+  }
+}

--- a/src/loader/stepFormat.test.js
+++ b/src/loader/stepFormat.test.js
@@ -1,0 +1,167 @@
+import {isConwayIfcFormat} from './stepFormat'
+
+
+const bytes = (text) => new TextEncoder().encode(text)
+
+// A short run of bytes that is not part-21 and not valid UTF-8.
+const NOT_TEXT = new TextEncoder().encode('\u0000\u0001\uFFFD')
+
+const MAGIC = 'ISO-10303-21;\nHEADER;\n'
+const TAIL = '\nENDSEC;\nDATA;\nENDSEC;\nEND-ISO-10303-21;\n'
+
+/**
+ * A complete part-21 file whose HEADER section is `body`.
+ *
+ * @param {string} body header entities
+ * @return {Uint8Array}
+ */
+const part21 = (body) => bytes(MAGIC + body + TAIL)
+
+
+/**
+ * Every case here is a real divergence between conway's detector and the
+ * regex mirror Share briefly carried in its place (#1780) — differential
+ * testing against the live `ModelFormatDetector` found eleven, each in the
+ * expensive direction (Share yes, conway no) that recreates #1776. They are
+ * kept as tests of `isConwayIfcFormat` because they are exactly the inputs a
+ * future reimplementation would get wrong, so a regression to a text scan
+ * fails here loudly rather than in a burned model handle.
+ */
+describe('isConwayIfcFormat', () => {
+  describe('formats', () => {
+    it('accepts a well-formed IFC header', () => {
+      expect(isConwayIfcFormat(part21(`FILE_SCHEMA(('IFC4'));`))).toBe(true)
+      expect(isConwayIfcFormat(part21(`FILE_SCHEMA(('IFC2X3'));`))).toBe(true)
+    })
+
+    it('rejects the STEP schemas conway routes elsewhere', () => {
+      // `fromStore` is IFC-only; each of these opens through the buffered
+      // path instead, and offering it the store path burns a handle.
+      expect(isConwayIfcFormat(part21(`FILE_SCHEMA(('AUTOMOTIVE_DESIGN'));`))).toBe(false)
+      expect(isConwayIfcFormat(part21(`FILE_SCHEMA(('CONFIG_CONTROL_DESIGN'));`))).toBe(false)
+      expect(isConwayIfcFormat(part21(
+        `FILE_SCHEMA(('AP242_MANAGED_MODEL_BASED_3D_ENGINEERING'));`))).toBe(false)
+    })
+
+    it('rejects a schema conway recognises nothing in', () => {
+      expect(isConwayIfcFormat(part21(`FILE_SCHEMA(('STRUCTURAL_FRAME_SCHEMA'));`))).toBe(false)
+    })
+
+    it('takes the first entry conway recognises, in declaration order', () => {
+      // conway returns on the FIRST entry matching ANY known schema, so a
+      // STEP schema listed first wins even when IFC follows it. Asking
+      // instead whether ANY entry starts with IFC — which the mirror did —
+      // answers yes here, where conway answers AP214.
+      expect(isConwayIfcFormat(part21(`FILE_SCHEMA(('AUTOMOTIVE_DESIGN'),('IFC4'));`))).toBe(false)
+      expect(isConwayIfcFormat(part21(`FILE_SCHEMA(('IFC4'),('AUTOMOTIVE_DESIGN'));`))).toBe(true)
+    })
+
+    it('reads the last FILE_SCHEMA, matching a name-keyed header map', () => {
+      expect(isConwayIfcFormat(part21(
+        `FILE_SCHEMA(('IFC4'));\nFILE_SCHEMA(('AUTOMOTIVE_DESIGN'));`))).toBe(false)
+    })
+  })
+
+  describe('files conway cannot parse at all', () => {
+    // The detector only answers after `StepHeaderParser.parseHeader` reaches
+    // `ENDSEC;` then `DATA;`. A mirror that just finds FILE_SCHEMA in the
+    // window says IFC for every one of these, and each is a burned handle.
+    it('rejects a truncated header', () => {
+      expect(isConwayIfcFormat(bytes(`${MAGIC}FILE_SCHEMA(('IFC4'));\n`))).toBe(false)
+    })
+
+    it('rejects a file with no ISO-10303-21 magic', () => {
+      expect(isConwayIfcFormat(bytes(
+        `HEADER;\nFILE_SCHEMA(('IFC4'));\nENDSEC;\nDATA;\n`))).toBe(false)
+    })
+
+    it('rejects a missing statement terminator', () => {
+      expect(isConwayIfcFormat(bytes(
+        `${MAGIC}FILE_SCHEMA(('IFC4'))\nENDSEC;\nDATA;\n`))).toBe(false)
+    })
+
+    it('rejects a stray token after the entity', () => {
+      expect(isConwayIfcFormat(bytes(
+        `${MAGIC}FILE_SCHEMA(('IFC4')) 'x';\nENDSEC;\nDATA;\n`))).toBe(false)
+    })
+
+    it('rejects an unterminated comment', () => {
+      expect(isConwayIfcFormat(bytes(
+        `${MAGIC}FILE_SCHEMA(('IFC4'));\n/* oops\nENDSEC;\nDATA;\n`))).toBe(false)
+    })
+
+    it('rejects lowercase keywords', () => {
+      // conway compares raw bytes and looks the entity up under its exact
+      // decoded name, so none of this is part-21 to it. Every regex in the
+      // mirror was case-insensitive.
+      expect(isConwayIfcFormat(bytes(`${MAGIC}file_schema(('IFC4'));${TAIL}`))).toBe(false)
+      expect(isConwayIfcFormat(bytes(
+        `iso-10303-21;\nheader;\nFILE_SCHEMA(('IFC4'));\nendsec;\ndata;\n`))).toBe(false)
+    })
+
+    it('rejects bytes that are not part-21 at all', () => {
+      expect(isConwayIfcFormat(new Uint8Array(0))).toBe(false)
+      expect(isConwayIfcFormat(NOT_TEXT)).toBe(false)
+    })
+  })
+
+  describe('strings and comments the header scan has to get right', () => {
+    it('accepts a comment between the entity name and its arguments', () => {
+      // conway's `whitespace()` consumes a comment as whitespace, so this is
+      // a perfectly ordinary IFC file and must keep the windowed parse.
+      expect(isConwayIfcFormat(part21(`FILE_SCHEMA /* note */ (('IFC4'));`))).toBe(true)
+    })
+
+    it('accepts spaces inside the schema name', () => {
+      expect(isConwayIfcFormat(part21(`FILE_SCHEMA((' I FC4 '));`))).toBe(true)
+    })
+
+    it('ignores a commented-out IFC schema', () => {
+      expect(isConwayIfcFormat(part21(
+        `/* FILE_SCHEMA(('IFC4')); */ FILE_SCHEMA(('AUTOMOTIVE_DESIGN'));`))).toBe(false)
+    })
+
+    it('rejects an empty first quoted entry', () => {
+      // conway's entry regex is `'([^']+)'` — PLUS, not star. It cannot match
+      // the empty pair, backtracks, and pairs the empty literal's closing
+      // quote with the next entry's opening one, so it never sees IFC4 and
+      // detects no format. A mirror that matched `[^']*` and dropped empties
+      // read this as IFC.
+      expect(isConwayIfcFormat(part21(`FILE_SCHEMA(('','IFC4'));`))).toBe(false)
+      expect(isConwayIfcFormat(part21(`FILE_SCHEMA(('AB''','IFC4'));`))).toBe(false)
+    })
+
+    it('rejects an IFC decoy hidden behind a \\S\\ escape', () => {
+      // conway's string DFA swallows the byte after `\S\` even when it is an
+      // apostrophe (`\S\'` encodes a high-half character, routine in
+      // German-language headers). So this whole FILE_DESCRIPTION is one
+      // string to conway and the real schema is AP214, while a scanner that
+      // only knows the doubled-apostrophe escape has its quote parity
+      // inverted from that point on and finds the decoy IFC4.
+      expect(isConwayIfcFormat(part21(
+        `FILE_SCHEMA(('AUTOMOTIVE_DESIGN'));\n` +
+        `FILE_DESCRIPTION(('\\S\\');FILE_SCHEMA((\\S\\'IFC4\\S\\'));X(\\S\\''),'2;1');`))).toBe(false)
+    })
+
+    it('rejects an ENDSEC hidden in a header string', () => {
+      // Bounding the scan at a raw `ENDSEC;` truncates the section before the
+      // later, overriding AP214 entity — and with last-wins that RESURRECTS
+      // the earlier IFC4. Early truncation is not the safe direction it looks.
+      expect(isConwayIfcFormat(part21(
+        `FILE_SCHEMA(('IFC4'));\n` +
+        `FILE_DESCRIPTION(('ENDSEC;'),'2;1');\n` +
+        `FILE_SCHEMA(('AUTOMOTIVE_DESIGN'));`))).toBe(false)
+    })
+
+    it('ignores a FILE_SCHEMA lookalike in the DATA section', () => {
+      expect(isConwayIfcFormat(bytes(
+        `${MAGIC}FILE_SCHEMA(('AUTOMOTIVE_DESIGN'));\nENDSEC;\nDATA;\n` +
+        `#1=X();\nFILE_SCHEMA(('IFC4'));\nENDSEC;\n`))).toBe(false)
+    })
+
+    it('ignores an entity whose name merely ends in FILE_SCHEMA', () => {
+      expect(isConwayIfcFormat(part21(
+        `FILE_SCHEMA(('AUTOMOTIVE_DESIGN'));\nNOT_FILE_SCHEMA(('IFC4'));`))).toBe(false)
+    })
+  })
+})


### PR DESCRIPTION
Closes #1780. Follow-up to #1777.

## What changed, and why the approach did

This started as "close the two known divergences between Share's FILE_SCHEMA scan and conway's `ModelFormatDetector`". It ends by deleting the scan from that path entirely, because the premise turned out to be wrong.

The scan exists to answer one question: *will conway's `IfcApiModelPassthroughFactory.fromStore` accept this file?* `fromStore` reserves the model handle **before** it sniffs and is IFC-only, so a "yes" it then refuses burns handle 0 and pushes the buffered retry onto handle 1 — misaddressing every Share call site that passes the scene-level id 0, the GLB writer's spatial-tree and element-properties captures among them. That is #1776. Only a false-yes is expensive; a false-no costs one load's memory win.

Review round 1 found a real divergence and fixed it: conway returns on the **first** entry matching *any* known schema, so `FILE_SCHEMA(('AUTOMOTIVE_DESIGN'),('IFC4'))` is AP214 to conway, not IFC. My original reading — "IFC if any entry starts with IFC" — answered yes there, in the expensive direction, and the test asserted that wrong answer.

That prompted differential-testing the scan against the live detector rather than reading it again. **Eleven more divergences, every one a false-yes:**

| input | scan | conway |
|---|---|---|
| truncated header (partial download) | IFC | no format |
| header longer than the 64 KiB sniff window | IFC | no format |
| missing statement terminator | IFC | no format |
| stray token after the entity | IFC | no format |
| unterminated comment | IFC | no format |
| no `ISO-10303-21;` magic | IFC | no format |
| `file_schema((...))`, lowercase | IFC | no format |
| lowercase `iso-10303-21;` / `header;` / `endsec;` | IFC | no format |
| `FILE_SCHEMA(('','IFC4'))` — empty first entry | IFC | no format |
| `FILE_SCHEMA(('AB''','IFC4'))` — odd quote run | IFC | no format |
| IFC decoy behind a `\S\` escape in FILE_DESCRIPTION | IFC | AP214 |
| `ENDSEC;` inside a header string, IFC declared before it | IFC | AP214 |

Four mechanisms behind them, none of which a text scan can reach:

- conway only answers **after** its part-21 parser has reached `ENDSEC;` then `DATA;`. Everything malformed or truncated is "no format" to it, and the scan's own docblock claimed that branch was "a corrupt-or-truncated-file path, not a format we are giving up on" — it was the opposite.
- Its keyword matching is **byte-exact** (`ParsingBuffer.token` compares raw bytes; the header map is keyed on the exact decoded identifier). Every regex in the scan was `/i`.
- Its entry regex is `'([^']+)'` — **plus, not star**. An empty quoted entry can't match, so it backtracks and pairs the empty literal's closing quote with the next entry's opening one, never seeing what follows. The scan matched `[^']*` and filtered empties: the opposite model.
- Its string DFA swallows the byte after `\S\`, **apostrophes included** (`\S\'` encodes a high-half character — routine in German-language headers). From there the scan's quote parity is inverted relative to conway's for the rest of the header.

## So it stops mirroring and starts asking

`src/loader/stepFormat.js` hands conway's own `ModelFormatDetector` the same 64 KiB prefix `fromStore` will read. Agreement is then exact by construction rather than by maintenance. It reaches the detector through conway's `./src/*` export map — the route `loadProgress.js` already takes to `core/progress_log` — so this is an established import pattern, not a new one.

`canOpenFromStore` also passes **raw bytes** now rather than decoded text, which removes the last divergence source: a multi-byte sequence cut at the slice boundary decodes to a replacement character, which is not the byte conway sees.

`Filetype.stepSchemaName` / `classifyStepFamily` revert to their #1777 state and keep doing what they are good at — naming a file, where a wrong guess costs a label. Their doc comments no longer claim `canOpenFromStore` as a caller, and neither does `Loader.cover.test.js`, whose part-21 fixture now records that its trailing `DATA;` is load-bearing (trim it and every store-path test below silently flips to buffering).

Net: **−213 lines** of header-scanning in `Filetype.js`, +56 in `stepFormat.js`.

## Tests

`src/loader/stepFormat.test.js` is the twelve divergences as twelve tests, plus the ordering and comment/duplicate/lookalike cases the scan already had. They are exactly the inputs a reimplementation would get wrong, so a regression to a text scan fails there loudly rather than in a burned handle — which is what the docblock on `isConwayIfcFormat` asks the next reader not to do.

The mutation evidence is already in hand and did not need constructing: the harness that produced the table above ran the *previous* commit's `stepFamily` against real conway, and every row is a case the old code fails.

## The conway bump, and what it demonstrated

`fe45543` merges main, which carries the pin bump `@bldrs-ai/conway` **1.588.1550 → 1.1565.608-g18366f01** (#1772 via #1784). That is a live test of this PR's central bet: a deep import into another package's internals is only sound if those internals are stable, and a version bump is exactly where it would break. Checked against the new version:

- both deep-import paths still resolve through the `./src/*` export map;
- `ModelFormatDetector.detect` is logically unchanged;
- `STORE_DETECT_PREFIX_BYTES` is still `64 * 1024`, so the prefix `stepFormat.js` reads still matches the one `fromStore` reads;
- `fromStore` still gates on `=== ModelFormatType.IFC`, and `OpenModelStream` / `OpenModelStreamed` both still exist, so `canOpenFromStore`'s capability probe hasn't been silently switched off.

CI on `fe45543` confirms it end to end: `build-prod` proves the deep import still bundles, `test-ci` proves the detector still answers as the twelve divergence tests assert. Had any of that moved, the tests are the thing that fails — which is the argument for keeping them as tests of `isConwayIfcFormat` rather than deleting them along with the scan.

The merge also brings #1783, so `OPFS_IS_ENABLED` is on under Playwright here. That gives this gate its **first real browser coverage**: `test-flows` now drives `canOpenFromStore` through the cache-hit specs, which was impossible while OPFS was off.

## Process notes worth keeping

Both of the errors on this PR were caught by machinery, not by re-reading the diff:

- Round 1's fix landed with a test asserting the **wrong answer** — I had read conway's loop as "any entry starting with IFC" and codified that. Reading a parser and running it are different activities.
- An earlier test for the string-aware splitter was **vacuous**: the realistic case (a semicolon in a FILE_NAME field) comes out identical either way. The mutation run is what showed it proved nothing.

That is the case for this PR's shape rather than a twelfth patch to the scan: the failure mode is not any single bug, it's that a paraphrase of a parser drifts silently and is expensive in exactly one direction.

## Verification

| check | result |
|---|---|
| CI `build` on `fe45543` (build-prod + lint + test-ci) | ✅ |
| CI `test-flows` on `fe45543` — incl. cache-hit specs, OPFS on | ✅ |
| husky gate (eslint + typecheck + Jest) | green — 245 suites, 2474 passed |
| `src/loader/stepFormat.test.js` | 20 tests, pass — re-run green on conway 1.1565.608 |
| loader + Filetype suites | 472 tests, pass |
| differential vs live `ModelFormatDetector` | 0 divergences remaining (exact by construction) |
| `docs/index.js` bundle size | 14.1 mb — unchanged; the detector was already bundled |

https://claude.ai/code/session_01NuTsqJu1rqoz8f4FSQ9vbE

---
_Generated by [Claude Code](https://claude.ai/code/session_01NuTsqJu1rqoz8f4FSQ9vbE)_