### PR TITLE
Un-skip the GLB cache-hit e2e specs; the documented skip reason was wrong

### DIFF
--- a/PLAYBOOK.md
+++ b/PLAYBOOK.md
@@ -46,7 +46,8 @@ substitution explicit (and visible to the user) rather than letting
 - `yarn test-flows [spec] -g "test name"` - Run a single test by name grep
 
 **Build config**: Playwright tests use `SHARE_CONFIG=playwright` (`tools/esbuild/vars.playwright.js`).
-Key differences from production: `OPFS_IS_ENABLED=false`, `MSW_IS_ENABLED=true`, `NODE_ENV=development`.
+Key differences from production: `MSW_IS_ENABLED=true`, `NODE_ENV=development`. `OPFS_IS_ENABLED` is
+**on**, as in production — it was off until #1779, so treat any older note saying otherwise as stale.
 
 **SPA routing**: The static file server (`http-server docs`) has no SPA fallback. Missing paths return
 a 404 which serves `docs/404.html`, which redirects to `/?/the/path`. `docs/index.html` then uses
@@ -66,9 +67,23 @@ await page.evaluate(() => {
 The `OpenModelDialog` reads `loadRecentFilesBySource('local')` from localStorage whenever the dialog
 opens (`isDialogDisplayed` → true), so the entry is visible immediately without a page reload.
 
-**OPFS in tests**: With `OPFS_IS_ENABLED=false`, `saveDnDFileToOpfs` is never called; the fallback
-(`saveDnDFileToOpfsFallback`) runs instead and produces a UUID without an extension. This makes
-post-DnD navigation unreliable in tests — prefer testing the persistence→UI layer directly (see above).
+**OPFS in tests**: on since #1779, so a spec exercises the same OPFS path as production —
+`saveDnDFileToOpfs` runs rather than `saveDnDFileToOpfsFallback`, and the GLB cache round-trip
+(writer → OPFS → reader) is reachable at all. That round-trip is what the cache-hit specs guard;
+without OPFS they could only ever have tested a live parse.
+
+The flag is compile-time and all-or-nothing (`store/BrowserSlice.js` hard-gates the setter), so it
+cannot be enabled per-spec. Two consequences worth knowing:
+
+- Per-test isolation comes from Playwright's fresh `BrowserContext`, not from anything the app does.
+  A spec that populates the cache and then reloads should still `clearOpfs` in `afterEach` — see
+  `NavTree.cacheHit.spec.ts` — so an interrupted run can't leave an artifact a later test reads as a
+  hit.
+- Waiting on a `[glb]` console line is the way to observe cache state (`cache HIT`, `writer: wrote`).
+  Use `waitForGlbLog` from `src/tests/e2e/glbLogs.ts` and **not** `page.waitForFunction(pred, {logs})`
+  — that serialises its argument into the page once, so Node-side pushes never reach the predicate and
+  the wait can only succeed if the line already arrived. Three specs were `fixme`'d for years on
+  exactly that mistake (#1779).
 
 **Intercept model fetches**: For tests that navigate to a GitHub model URL, use `setupVirtualPathIntercept`
 from `src/tests/e2e/models.ts` to serve a fixture file in place of the real network request.

--- a/PLAYBOOK.md
+++ b/PLAYBOOK.md
@@ -73,20 +73,36 @@ opens (`isDialogDisplayed` → true), so the entry is visible immediately withou
 without OPFS they could only ever have tested a live parse.
 
 The flag is compile-time and all-or-nothing (`store/BrowserSlice.js` hard-gates the setter), so it
-cannot be enabled per-spec. Two consequences worth knowing:
+cannot be enabled per-spec. Four consequences worth knowing:
 
-- Per-test isolation comes from Playwright's fresh `BrowserContext`, not from anything the app does.
-  A spec that populates the cache and then reloads should still `clearOpfs` in `afterEach` — see
-  `NavTree.cacheHit.spec.ts` — so an interrupted run can't leave an artifact a later test reads as a
-  hit.
+- **It changes every model-loading spec, not just the cache-hit ones.** `Loader.js#load` gates the
+  whole OPFS block on `isOpfsAvailable`, so turning the flag on also turns on, suite-wide: the model
+  fetch moving into `OPFS.worker.js` (see "Intercept model fetches" below); a full GLTFExporter +
+  gzip + OPFS write scheduled on `requestIdleCallback` at the tail of every load, fire-and-forget and
+  often still in flight when the context closes; and `spillModelSource` + `ReleaseModelGeometry`,
+  which free Conway's native geometry mid-test. A spec that picks, isolates or screenshots late is
+  running against a materially different runtime state than it was written against. If a spec starts
+  failing after touching this flag, that is the first place to look.
+- Per-test isolation comes from Playwright's fresh `BrowserContext`, not from anything the app does —
+  Chromium partitions OPFS per context, and a retry gets a fresh context too. A spec that populates
+  the cache and then reloads can still `clearOpfs`, but put it in `beforeEach`: the case it insures
+  against is a run interrupted mid-write, which is exactly the case where an `afterEach` never runs.
 - Waiting on a `[glb]` console line is the way to observe cache state (`cache HIT`, `writer: wrote`).
   Use `waitForGlbLog` from `src/tests/e2e/glbLogs.ts` and **not** `page.waitForFunction(pred, {logs})`
   — that serialises its argument into the page once, so Node-side pushes never reach the predicate and
-  the wait can only succeed if the line already arrived. Three specs were `fixme`'d for years on
-  exactly that mistake (#1779).
+  the wait can only succeed if the line already arrived. Two specs sat `fixme`'d on exactly that
+  mistake, and a third was written already-`fixme`'d beside them, for five weeks (#1779).
+- Wait for `writer: wrote`, never for a `.glb` to appear in OPFS. The file exists from creation, so
+  the existence check is satisfied while the artifact is still half-written and the reload then reads
+  it as a `cache MISS`.
 
 **Intercept model fetches**: For tests that navigate to a GitHub model URL, use `setupVirtualPathIntercept`
-from `src/tests/e2e/models.ts` to serve a fixture file in place of the real network request.
+from `src/tests/e2e/models.ts` to serve a fixture file in place of the real network request. Note that
+with OPFS on, the model fetch is issued from `OPFS.worker.js`, not the page — so page-level
+`context.route` handlers (`setupVirtualPathIntercept`'s own, and `blockExternalNetwork`'s
+real-network guard) are not the mechanism keeping it hermetic; MSW's service worker is. Gate
+navigation on the service worker being active (`visitHomepageWaitForModel` does; a bare `page.goto`
+does not) before assuming a fixture will be served.
 
 **Screenshot goldens**: A new `expectScreen(page, 'Name.png')` test has no baseline, so it fails until
 you generate one:

--- a/design/new/viewer-replacement.md
+++ b/design/new/viewer-replacement.md
@@ -1511,31 +1511,48 @@ in #1779. They are no longer `fixme`'d and `OPFS_IS_ENABLED` is on in
 than deleting, because it cost the project #1776. This section (and the
 specs, and `vars.playwright.js`) attributed the timeouts to
 worker-context fetches escaping Playwright's `context.route`, and listed
-three un-skip paths built on that premise. None was needed. The specs
-waited with `page.waitForFunction(pred, {logs: glbLogs})`, and
-`waitForFunction` serialises its argument into the page **once**, then
-re-invokes the predicate against that frozen copy — so the Node-side
+three un-skip paths built on that premise. None was needed.
+
+The two `.cacheHit` specs waited with
+`page.waitForFunction(pred, {logs: glbLogs})`, and `waitForFunction`
+serialises its argument into the page **once**, then re-invokes the
+predicate against that frozen copy — so the Node-side
 `page.on('console')` pushes never reached it. Every line they waited for
 arrives after the wait starts, so each wait burned its full timeout by
 construction, whatever OPFS was doing. Measured: against an array
 appended at 1s, `waitForFunction` times out at 4s where `expect.poll`
 resolves at 1.2s.
 
-The ≈80-spec regression the flag flip was blamed for did not reappear
-either: the full suite with OPFS on is 161 passed / 41 skipped / 0
-failed.
+`sceneHighlightPermalink.spec.ts`'s cache-hit leg is not that bug — it
+was created already-`fixme`'d beside them, citing the same reason, and
+its wait was a page-side walk of OPFS for a `.glb`, which had no
+Node-side argument and would have worked. Its real defect was that the
+`.glb` exists from creation, so the wait passed on a half-written
+artifact and the reload read a MISS. Both are fixed in #1779; they are
+different mistakes and only one of them is the `waitForFunction` one.
+
+The ≈80-spec regression the flag flip was blamed for did not reappear in
+a local full-suite run: 161 passed / 41 skipped / 0 failed. That is one
+local run under `retries: 1`, so read it as "no regression observed",
+not as "the ≈80-spec claim is disproved" — CI on a cold runner is the
+real test, and the largest untested delta is that the flip turns the GLB
+**writer**, `spillModelSource` and `ReleaseModelGeometry` on in *every*
+model-loading spec, not only the cache-hit ones (see PLAYBOOK.md §OPFS
+in tests).
 
 Two things generalise from it:
 
-- **A `fixme`'d spec rots.** Running these turned up four assertions that
+- **A `fixme`'d spec rots.** Running these turned up five assertions that
   had quietly stopped meaning anything — a `role="treeitem"` selector the
   tree no longer emits, a count taken against a collapsed tree, two
   `glbVerbose`-gated log lines asserted without the flag, and a
-  `GlobalId` row that is not rendered on either path. None could fail, so
-  none could be noticed.
+  `GlobalId` row that is not rendered on either path — plus the
+  `.glb`-existence wait above, which could not observe the state it
+  named. None could fail, so none could be noticed.
 - **A wrong diagnosis in a comment outlives the bug.** This one was
   repeated in four places and cited as settled for long enough that the
-  coverage gap it explained became normal.
+  coverage gap it explained became normal — including onto a spec written
+  five weeks later, which inherited the skip without ever having the bug.
 
 ### 4b.3. Other recommendations from PR #1531 review
 

--- a/design/new/viewer-replacement.md
+++ b/design/new/viewer-replacement.md
@@ -1500,32 +1500,42 @@ Recommendation: try (1) first as a one-line change, then evaluate
 whether (2) is worth the memory hit. (3) only if neither lands the
 remaining responsiveness budget.
 
-### 4b.2. Cache-hit Playwright specs need OPFS-worker fetch routing
+### 4b.2. Cache-hit Playwright specs — resolved in #1779
 
-`Properties.cacheHit.spec.ts` + `NavTree.cacheHit.spec.ts` are
-`test.fixme`'d as of PR #1531. The flag flip (`OPFS_IS_ENABLED: true`
-in `vars.playwright.js`) is in place but the specs time out waiting
-for `writer: wrote` because **`downloadToOPFS` runs inside the OPFS
-Worker, and worker-context fetches are not intercepted by
-Playwright's `context.route(...)`**. Three viable un-skip paths:
+`Properties.cacheHit.spec.ts`, `NavTree.cacheHit.spec.ts` and
+`sceneHighlightPermalink.spec.ts`'s cache-hit leg ran for the first time
+in #1779. They are no longer `fixme`'d and `OPFS_IS_ENABLED` is on in
+`vars.playwright.js`.
 
-1. **MSW handler for `/index.ifc`** that fulfils worker-context
-   fetches. MSW's service worker DOES intercept worker fetches once
-   it's controlling the page; the gap is the race window before
-   activation.
-2. **Gate the first `page.goto` on `waitForServiceWorker`** so MSW
-   is guaranteed in place before any fetch (worker or main).
-3. **Pre-seed OPFS via `page.evaluate`** before the first goto so
-   the test doesn't need a download at all — the reader path
-   exercises against pre-staged bytes.
+**The diagnosis recorded here was wrong**, which is worth keeping rather
+than deleting, because it cost the project #1776. This section (and the
+specs, and `vars.playwright.js`) attributed the timeouts to
+worker-context fetches escaping Playwright's `context.route`, and listed
+three un-skip paths built on that premise. None was needed. The specs
+waited with `page.waitForFunction(pred, {logs: glbLogs})`, and
+`waitForFunction` serialises its argument into the page **once**, then
+re-invokes the predicate against that frozen copy — so the Node-side
+`page.on('console')` pushes never reached it. Every line they waited for
+arrives after the wait starts, so each wait burned its full timeout by
+construction, whatever OPFS was doing. Measured: against an array
+appended at 1s, `waitForFunction` times out at 4s where `expect.poll`
+resolves at 1.2s.
 
-(2) is the smallest change and probably the right first try. (1)
-makes the specs portable to environments where SW activation is
-slower. (3) is the most deterministic but loses the writer-side
-coverage.
+The ≈80-spec regression the flag flip was blamed for did not reappear
+either: the full suite with OPFS on is 161 passed / 41 skipped / 0
+failed.
 
-The cache-hit round-trip is currently validated manually on deploy
-preview (Snowdon, Schependomlaan).
+Two things generalise from it:
+
+- **A `fixme`'d spec rots.** Running these turned up four assertions that
+  had quietly stopped meaning anything — a `role="treeitem"` selector the
+  tree no longer emits, a count taken against a collapsed tree, two
+  `glbVerbose`-gated log lines asserted without the flag, and a
+  `GlobalId` row that is not rendered on either path. None could fail, so
+  none could be noticed.
+- **A wrong diagnosis in a comment outlives the bug.** This one was
+  repeated in four places and cited as settled for long enough that the
+  coverage gap it explained became normal.
 
 ### 4b.3. Other recommendations from PR #1531 review
 

--- a/src/Components/NavTree/NavTree.cacheHit.spec.ts
+++ b/src/Components/NavTree/NavTree.cacheHit.spec.ts
@@ -28,11 +28,16 @@ const EXPAND_SETTLE_MS = 400
  */
 async function expandTree(panel: Locator) {
   for (let round = 0; round < EXPAND_ROUNDS; round++) {
-    const toggles = panel.locator('[data-testid="NavTreeNodeToggle"]')
-    if (await toggles.count() === 0) {
+    // Only the toggles of nodes still marked collapsed. Clicking every toggle
+    // each round would re-close what the previous round opened, so the tree
+    // oscillates instead of opening monotonically and the final count depends
+    // on which round happened to land last.
+    const collapsed = panel.locator(
+      '[data-node-label][data-is-expanded="false"] [data-testid="NavTreeNodeToggle"]')
+    if (await collapsed.count() === 0) {
       break
     }
-    await toggles.evaluateAll((els) => els.forEach((e) => (e as HTMLElement).click()))
+    await collapsed.evaluateAll((els) => els.forEach((e) => (e as HTMLElement).click()))
     await panel.page().waitForTimeout(EXPAND_SETTLE_MS)
   }
 }

--- a/src/Components/NavTree/NavTree.cacheHit.spec.ts
+++ b/src/Components/NavTree/NavTree.cacheHit.spec.ts
@@ -1,13 +1,41 @@
-import {expect, test} from '@playwright/test'
+import {Locator, expect, test} from '@playwright/test'
 import {
   clearOpfs,
   homepageSetup,
   setIsReturningUser,
 } from '../../tests/e2e/utils'
 import {waitForModelReady} from '../../tests/e2e/models'
+import {captureGlbLogs, waitForGlbLog} from '../../tests/e2e/glbLogs'
 
 
 const {afterEach, beforeEach, describe} = test
+
+
+// Rounds of expansion, so a nested tree opens fully rather than one level.
+const EXPAND_ROUNDS = 6
+const EXPAND_SETTLE_MS = 400
+
+
+/**
+ * Expand every open-able NavTree node, repeatedly, so descendants render.
+ *
+ * Clicks are dispatched in-page rather than through `locator.click()`: the
+ * toggles sit over a live canvas that keeps the compositor busy, and
+ * Playwright's actionability wait times out against it on a GPU-less runner
+ * even though the element is perfectly clickable.
+ *
+ * @param panel locator for the NavTree panel
+ */
+async function expandTree(panel: Locator) {
+  for (let round = 0; round < EXPAND_ROUNDS; round++) {
+    const toggles = panel.locator('[data-testid="NavTreeNodeToggle"]')
+    if (await toggles.count() === 0) {
+      break
+    }
+    await toggles.evaluateAll((els) => els.forEach((e) => (e as HTMLElement).click()))
+    await panel.page().waitForTimeout(EXPAND_SETTLE_MS)
+  }
+}
 
 
 /**
@@ -54,13 +82,9 @@ describe('View 100: NavTree on cache-hit GLB', () => {
     await clearOpfs(page)
   })
 
-  // SKIP REASON: same as Properties.cacheHit.spec.ts —
-  // `OPFS_IS_ENABLED: true` in playwright vars isn't enough on its own
-  // because OPFS-worker fetches aren't intercepted by Playwright's
-  // `context.route(...)`; the first fetch races MSW SW activation.
-  // See the longer note in `Properties.cacheHit.spec.ts` and the
-  // followup list in design/new/viewer-replacement.md §"Followups".
-  test.fixme('cache-hit GLB renders NavTree from BLDRS_spatial_tree extension', async ({page}) => {
+  // Un-skipped in bldrs-ai/Share#1779 — see the sibling note in
+  // `Properties.cacheHit.spec.ts` and `tools/esbuild/vars.playwright.js`.
+  test('cache-hit GLB renders NavTree from BLDRS_spatial_tree extension', async ({page}) => {
     // Two `page.goto` round-trips (cache-populate + cache-hit) plus
     // the writer's async element-properties BFS can easily exceed
     // Playwright's default 30s per-test budget on CI. Bump to 120s so
@@ -71,50 +95,23 @@ describe('View 100: NavTree on cache-hit GLB', () => {
     // Capture the GLB pipeline's `[glb]` log lines so we can assert
     // on observable state transitions (cache MISS / HIT, writer wrote)
     // rather than racing on timing alone.
-    const glbLogs: string[] = []
-    page.on('console', (msg) => {
-      const text = msg.text()
-      if (text.startsWith('[glb]')) {
-        glbLogs.push(text)
-      }
-    })
+    const glbLogs = captureGlbLogs(page)
 
     // First load: cache MISS, writer populates OPFS with the
     // BLDRS_spatial_tree extension. `glb` is default-on as of the
     // Phase-5a flip; no `?feature=` needed.
     const CACHE_TIMEOUT = 30_000
-    await page.goto('/share/v/p/index.ifc')
+    await page.goto('/share/v/p/index.ifc?feature=glbVerbose')
     await waitForModelReady(page)
-    try {
-      await page.waitForFunction(
-        ({logs}) => logs.some((l: string) => l.includes('writer: wrote')),
-        {logs: glbLogs},
-        {timeout: CACHE_TIMEOUT},
-      )
-    } catch (e) {
-      // Diagnostic dump: which [glb] lines DID fire before the wait
-      // timed out? Most useful failure mode is `writer: skipped
-      // (threw)` — surfaces a writer-side exception that would
-      // otherwise be invisible (the outer try/catch in
-      // exportAndCacheGlb swallows the throw and only logs).
-      const indented = glbLogs.map((l) => `  ${l}`).join('\n')
-      console.error(
-        `[NavTree.cacheHit] writer:wrote never fired in ${CACHE_TIMEOUT}ms; ` +
-        `captured ${glbLogs.length} [glb] line(s):\n${indented}`)
-      throw e
-    }
+    await waitForGlbLog(glbLogs, 'writer: wrote', CACHE_TIMEOUT)
     expect(glbLogs.some((l) => l.includes('cache MISS'))).toBe(true)
 
     // Second load: cache HIT — spatial-tree extension provides the
     // NavTree data without a live IFC parser. Reset log buffer.
     glbLogs.length = 0
-    await page.goto('/share/v/p/index.ifc')
+    await page.goto('/share/v/p/index.ifc?feature=glbVerbose')
     await waitForModelReady(page)
-    await page.waitForFunction(
-      ({logs}) => logs.some((l: string) => l.includes('cache HIT')),
-      {logs: glbLogs},
-      {timeout: CACHE_TIMEOUT},
-    )
+    await waitForGlbLog(glbLogs, 'cache HIT', CACHE_TIMEOUT)
 
     // Open the NavTree panel. The panel renders from the model's
     // `getSpatialStructure(0, true)` closure — on cache HIT this
@@ -126,23 +123,27 @@ describe('View 100: NavTree on cache-hit GLB', () => {
     const navTreePanel = page.getByTestId('NavTreePanel')
     await expect(navTreePanel).toBeVisible()
 
-    // The tree should have at least the IfcProject root + a few
-    // descendants. A writer-side bug that captures an empty /
-    // single-node tree (e.g., recursion bottom-out wrong) would
-    // make this fail. We don't pin a specific count because tree
-    // shape depends on the fixture model (index.ifc), but anything
-    // > 1 confirms the tree is actually being traversed.
-    const treeItems = navTreePanel.locator('[role="treeitem"]')
+    // `data-node-label` is the hook `NavTreeNode.jsx` actually sets. The
+    // `role="treeitem"` this spec used predates the current tree and matched
+    // nothing — invisible while the spec was `fixme`'d.
+    const treeItems = navTreePanel.locator('[data-node-label]')
     await expect(treeItems.first()).toBeVisible()
-    // index.ifc has many storeys / spaces / elements; > 5 is a
-    // comfortable lower bound that's still well below the real count.
+
+    // The tree renders collapsed, so counting without expanding sees exactly
+    // the root — which is also what the bug this guards against produced. In
+    // bldrs-ai/Share#1776 the cache-hit tree was the GLB scene graph walked by
+    // `Loader.js`'s fallback, a root whose children repeat the root's own
+    // name. Expanding is what tells the two apart.
+    await expandTree(navTreePanel)
     const itemCount = await treeItems.count()
     const MIN_TREE_ITEMS = 5
-    expect(itemCount).toBeGreaterThan(MIN_TREE_ITEMS)
+    expect(itemCount,
+      `expanded tree had ${itemCount} node(s): ` +
+        `${JSON.stringify(await treeItems.evaluateAll(
+          (els) => els.map((e) => e.getAttribute('data-node-label'))))}`)
+      .toBeGreaterThan(MIN_TREE_ITEMS)
   })
 
-  // SKIP REASON: the OPFS/MSW harness gap above, same as its IFC sibling.
-  //
   // Worth having as its own test rather than a parameterisation of the one
   // above, because the two formats reach the writer through different Conway
   // opens and a STEP-only regression is invisible to an IFC fixture. That is
@@ -155,49 +156,31 @@ describe('View 100: NavTree on cache-hit GLB', () => {
   // cache-hit tree collapses to the model root repeated a couple of times
   // (Loader.js's `ifcManager.getSpatialStructure = () => model` fallback,
   // walking the GLB scene graph) instead of the real assembly hierarchy.
-  test.fixme('cache-hit GLB renders NavTree for a STEP model', async ({page}) => {
+  test('cache-hit GLB renders NavTree for a STEP model', async ({page}) => {
     const TEST_TIMEOUT = 120_000
     test.setTimeout(TEST_TIMEOUT)
 
-    const glbLogs: string[] = []
-    page.on('console', (msg) => {
-      const text = msg.text()
-      if (text.startsWith('[glb]')) {
-        glbLogs.push(text)
-      }
-    })
+    const glbLogs = captureGlbLogs(page)
 
     const CACHE_TIMEOUT = 30_000
-    await page.goto('/share/v/p/index.step')
+    await page.goto('/share/v/p/index.step?feature=glbVerbose')
     await waitForModelReady(page)
-    await page.waitForFunction(
-      ({logs}) => logs.some((l: string) => l.includes('writer: wrote')),
-      {logs: glbLogs},
-      {timeout: CACHE_TIMEOUT},
-    )
+    await waitForGlbLog(glbLogs, 'writer: wrote', CACHE_TIMEOUT)
     expect(glbLogs.some((l) => l.includes('cache MISS'))).toBe(true)
 
     glbLogs.length = 0
-    await page.goto('/share/v/p/index.step')
+    await page.goto('/share/v/p/index.step?feature=glbVerbose')
     await waitForModelReady(page)
-    await page.waitForFunction(
-      ({logs}) => logs.some((l: string) => l.includes('cache HIT')),
-      {logs: glbLogs},
-      {timeout: CACHE_TIMEOUT},
-    )
+    await waitForGlbLog(glbLogs, 'cache HIT', CACHE_TIMEOUT)
 
     // The tree must come from the cached extension, not the scene-graph
     // fallback. This log line IS the discriminant — without it the panel
     // still renders rows, just the wrong ones.
-    await page.waitForFunction(
-      ({logs}) => logs.some((l: string) => l.includes('hydrated NavTree from BLDRS_spatial_tree')),
-      {logs: glbLogs},
-      {timeout: CACHE_TIMEOUT},
-    )
+    await waitForGlbLog(glbLogs, 'hydrated NavTree from BLDRS_spatial_tree', CACHE_TIMEOUT)
 
     await page.getByTestId('control-button-navigation').click()
     const navTreePanel = page.getByTestId('NavTreePanel')
     await expect(navTreePanel).toBeVisible()
-    await expect(navTreePanel.locator('[role="treeitem"]').first()).toBeVisible()
+    await expect(navTreePanel.locator('[data-node-label]').first()).toBeVisible()
   })
 })

--- a/src/Components/NavTree/NavTree.cacheHit.spec.ts
+++ b/src/Components/NavTree/NavTree.cacheHit.spec.ts
@@ -5,41 +5,85 @@ import {
   setIsReturningUser,
 } from '../../tests/e2e/utils'
 import {waitForModelReady} from '../../tests/e2e/models'
-import {captureGlbLogs, waitForGlbLog} from '../../tests/e2e/glbLogs'
+import {captureGlbLogs, resetGlbLogs, waitForGlbLog} from '../../tests/e2e/glbLogs'
 
 
-const {afterEach, beforeEach, describe} = test
+const {beforeEach, describe} = test
 
 
-// Rounds of expansion, so a nested tree opens fully rather than one level.
-const EXPAND_ROUNDS = 6
-const EXPAND_SETTLE_MS = 400
+// Upper bound on toggles clicked. One click per iteration (see below), so this
+// is a click budget, not a depth: generous enough to open the whole mounted
+// window of either fixture, small enough that a runaway can't eat the timeout.
+const MAX_EXPAND_CLICKS = 40
+const EXPAND_SETTLE_MS = 150
+// Distinct labels a real hierarchy must beat. The bug this guards produces a
+// root whose children repeat the root's own name, so DISTINCT labels — not
+// rows — is the discriminant; see the count assertion for why.
+const MIN_DISTINCT_LABELS = 5
+
+
+const COLLAPSED_TOGGLE =
+  '[data-node-label][data-is-expanded="false"] [data-testid="NavTreeNodeToggle"]'
 
 
 /**
- * Expand every open-able NavTree node, repeatedly, so descendants render.
+ * Expand NavTree nodes until nothing mounted is still collapsed.
  *
- * Clicks are dispatched in-page rather than through `locator.click()`: the
- * toggles sit over a live canvas that keeps the compositor busy, and
- * Playwright's actionability wait times out against it on a GPU-less runner
- * even though the element is perfectly clickable.
+ * Two things this has to work around, neither obvious:
+ *
+ *   - **One click per turn, not a batch.** `NavTreePanel`'s `handleToggle`
+ *     closes over the render-time `expandedNodeIds` and calls
+ *     `setExpandedNodeIds([...expandedNodeIds, nodeId])`, and
+ *     `NavTreeSlice.setExpandedElements` REPLACES the array. Dispatching N
+ *     clicks in one synchronous task gives every handler the same stale
+ *     snapshot and the last write wins, so a batch of N expands exactly one
+ *     node. Clicking one at a time with a settle between lets React re-render
+ *     and the next click read fresh state.
+ *   - **Clicks are dispatched in-page** rather than through `locator.click()`:
+ *     the toggles sit over a live canvas that keeps the compositor busy, and
+ *     Playwright's actionability wait times out against it on a GPU-less
+ *     runner even though the element is perfectly clickable.
+ *
+ * Termination is bounded by what is MOUNTED: the panel renders through
+ * `react-window`'s `VariableSizeList`, so rows below the fold are absent from
+ * the DOM and their collapsed state is invisible here. This opens the visible
+ * window, which is all the assertions below need — it is not a whole-tree
+ * expansion and shouldn't be read as one.
  *
  * @param panel locator for the NavTree panel
  */
 async function expandTree(panel: Locator) {
-  for (let round = 0; round < EXPAND_ROUNDS; round++) {
-    // Only the toggles of nodes still marked collapsed. Clicking every toggle
-    // each round would re-close what the previous round opened, so the tree
-    // oscillates instead of opening monotonically and the final count depends
-    // on which round happened to land last.
-    const collapsed = panel.locator(
-      '[data-node-label][data-is-expanded="false"] [data-testid="NavTreeNodeToggle"]')
-    if (await collapsed.count() === 0) {
+  for (let click = 0; click < MAX_EXPAND_CLICKS; click++) {
+    const next = panel.locator(COLLAPSED_TOGGLE).first()
+    if (await next.count() === 0) {
       break
     }
-    await collapsed.evaluateAll((els) => els.forEach((e) => (e as HTMLElement).click()))
+    await next.evaluate((e) => (e as HTMLElement).click())
     await panel.page().waitForTimeout(EXPAND_SETTLE_MS)
   }
+}
+
+
+/**
+ * Assert the panel shows a real hierarchy rather than the #1776 fallback.
+ *
+ * Counts DISTINCT `data-node-label` values, not rows. Two reasons rows are the
+ * wrong measure: the list is virtualized, so the row count saturates at the
+ * viewport (~25-30 at the config's 1280x800) and no threshold above that is
+ * even expressible; and the failure being guarded — `Loader.js`'s
+ * `ifcManager.getSpatialStructure = () => model` fallback walking the GLB
+ * scene graph — emits a root whose children carry the root's own name, which
+ * is plenty of ROWS and one label.
+ *
+ * @param panel locator for the NavTree panel
+ */
+async function expectRealHierarchy(panel: Locator) {
+  const labels = await panel.locator('[data-node-label]')
+    .evaluateAll((els) => els.map((e) => e.getAttribute('data-node-label')))
+  const distinct = new Set(labels).size
+  expect(distinct, `expanded tree had ${distinct} distinct label(s) over ` +
+    `${labels.length} row(s): ${JSON.stringify(labels)}`)
+    .toBeGreaterThanOrEqual(MIN_DISTINCT_LABELS)
 }
 
 
@@ -77,13 +121,13 @@ describe('View 100: NavTree on cache-hit GLB', () => {
   beforeEach(async ({page}) => {
     await homepageSetup(page)
     await setIsReturningUser(page.context())
-  })
-
-  // Belt-and-suspenders: per-test BrowserContext isolation already
-  // gives fresh OPFS, but clearing after every test in this describe
-  // block defends against an interrupted run leaving a partial
-  // artifact behind that a subsequent test would read as HIT.
-  afterEach(async ({page}) => {
+    // Belt-and-suspenders, and deliberately BEFORE rather than after: each
+    // test gets a fresh `BrowserContext` and Chromium partitions OPFS per
+    // context, so this is normally a no-op. The case it is insurance against —
+    // a run interrupted mid-write — is exactly the case where an `afterEach`
+    // does not execute, so clearing afterwards could not have provided it.
+    // Clearing here guarantees the populate half starts from a known-empty
+    // store whatever preceded it.
     await clearOpfs(page)
   })
 
@@ -113,7 +157,7 @@ describe('View 100: NavTree on cache-hit GLB', () => {
 
     // Second load: cache HIT — spatial-tree extension provides the
     // NavTree data without a live IFC parser. Reset log buffer.
-    glbLogs.length = 0
+    resetGlbLogs(glbLogs)
     await page.goto('/share/v/p/index.ifc?feature=glbVerbose')
     await waitForModelReady(page)
     await waitForGlbLog(glbLogs, 'cache HIT', CACHE_TIMEOUT)
@@ -134,19 +178,13 @@ describe('View 100: NavTree on cache-hit GLB', () => {
     const treeItems = navTreePanel.locator('[data-node-label]')
     await expect(treeItems.first()).toBeVisible()
 
-    // The tree renders collapsed, so counting without expanding sees exactly
+    // The tree renders collapsed, so measuring without expanding sees exactly
     // the root — which is also what the bug this guards against produced. In
     // bldrs-ai/Share#1776 the cache-hit tree was the GLB scene graph walked by
     // `Loader.js`'s fallback, a root whose children repeat the root's own
     // name. Expanding is what tells the two apart.
     await expandTree(navTreePanel)
-    const itemCount = await treeItems.count()
-    const MIN_TREE_ITEMS = 5
-    expect(itemCount,
-      `expanded tree had ${itemCount} node(s): ` +
-        `${JSON.stringify(await treeItems.evaluateAll(
-          (els) => els.map((e) => e.getAttribute('data-node-label'))))}`)
-      .toBeGreaterThan(MIN_TREE_ITEMS)
+    await expectRealHierarchy(navTreePanel)
   })
 
   // Worth having as its own test rather than a parameterisation of the one
@@ -173,7 +211,7 @@ describe('View 100: NavTree on cache-hit GLB', () => {
     await waitForGlbLog(glbLogs, 'writer: wrote', CACHE_TIMEOUT)
     expect(glbLogs.some((l) => l.includes('cache MISS'))).toBe(true)
 
-    glbLogs.length = 0
+    resetGlbLogs(glbLogs)
     await page.goto('/share/v/p/index.step?feature=glbVerbose')
     await waitForModelReady(page)
     await waitForGlbLog(glbLogs, 'cache HIT', CACHE_TIMEOUT)
@@ -187,5 +225,14 @@ describe('View 100: NavTree on cache-hit GLB', () => {
     const navTreePanel = page.getByTestId('NavTreePanel')
     await expect(navTreePanel).toBeVisible()
     await expect(navTreePanel.locator('[data-node-label]').first()).toBeVisible()
+
+    // The log line above is the discriminant for "which source fed the tree",
+    // but it says nothing about what that source CONTAINED: a captured tree
+    // that is a bare root, or whose children `mapSpatialNode` filters out for
+    // want of an `expressID`, hydrates and logs exactly the same. Since this
+    // is the test for the regression #1776 actually was, it carries the
+    // content assertion too.
+    await expandTree(navTreePanel)
+    await expectRealHierarchy(navTreePanel)
   })
 })

--- a/src/Components/Properties/Properties.cacheHit.spec.ts
+++ b/src/Components/Properties/Properties.cacheHit.spec.ts
@@ -5,10 +5,10 @@ import {
   setIsReturningUser,
 } from '../../tests/e2e/utils'
 import {waitForModelReady} from '../../tests/e2e/models'
-import {captureGlbLogs, waitForGlbLog} from '../../tests/e2e/glbLogs'
+import {captureGlbLogs, resetGlbLogs, waitForGlbLog} from '../../tests/e2e/glbLogs'
 
 
-const {afterEach, beforeEach, describe} = test
+const {beforeEach, describe} = test
 
 
 /**
@@ -34,17 +34,14 @@ describe('View 100: Properties panel on cache-hit GLB', () => {
   beforeEach(async ({page}) => {
     await homepageSetup(page)
     await setIsReturningUser(page.context())
-  })
-
-  // Belt-and-suspenders: each test's BrowserContext is per-test under
-  // `fullyParallel: true`, so OPFS is naturally fresh — but if a test
-  // run is interrupted mid-write (kill -9, CI timeout), the next run
-  // on the same worker could see a half-written artifact. Clearing
-  // after every test in this describe block makes the populate→hit
-  // pattern's first-half always start from a known-empty state.
-  afterEach(async ({page}) => {
+    // Belt-and-suspenders, and deliberately BEFORE rather than after: each
+    // test gets a fresh `BrowserContext` and Chromium partitions OPFS per
+    // context, so this is normally a no-op. The case it is insurance against —
+    // a run interrupted mid-write — is exactly the case where an `afterEach`
+    // does not execute, so clearing afterwards could not have provided it.
     await clearOpfs(page)
   })
+
 
   // Un-skipped in bldrs-ai/Share#1779. These ran green for the first time
   // once the `expect.poll` fix above landed and OPFS was enabled under
@@ -79,7 +76,7 @@ describe('View 100: Properties panel on cache-hit GLB', () => {
     // hit AND select an element so the Properties panel has something
     // to render. Reset log buffer so the second-load assertions don't
     // see the first load's lines.
-    glbLogs.length = 0
+    resetGlbLogs(glbLogs)
     await page.goto('/share/v/p/index.ifc/81/621?feature=glbVerbose')
     await waitForModelReady(page)
     await waitForGlbLog(glbLogs, 'cache HIT', CACHE_TIMEOUT)
@@ -88,8 +85,15 @@ describe('View 100: Properties panel on cache-hit GLB', () => {
     // time — confirms the closure was attached. (The lazy-decode log
     // is gated on first call to getItemProperties; the Properties
     // panel open below triggers it.)
-    expect(glbLogs.some((l) =>
-      l.includes('hydrated Properties panel from BLDRS_element_properties'))).toBe(true)
+    //
+    // A wait, not a bare `.some()`: this line is emitted AFTER the `cache HIT`
+    // above, and console events reach the Node-side buffer asynchronously over
+    // CDP with no flush barrier — so the poll can return on `cache HIT` before
+    // this one has been dispatched. A synchronous read there is a false-failure
+    // flake, and this is the only assertion in the file guarding the
+    // element-properties closure attachment.
+    await waitForGlbLog(
+      glbLogs, 'hydrated Properties panel from BLDRS_element_properties', CACHE_TIMEOUT)
 
     // Open the Properties panel — opening triggers the first
     // `model.getItemProperties(expressID)` call, which inflates the

--- a/src/Components/Properties/Properties.cacheHit.spec.ts
+++ b/src/Components/Properties/Properties.cacheHit.spec.ts
@@ -5,6 +5,7 @@ import {
   setIsReturningUser,
 } from '../../tests/e2e/utils'
 import {waitForModelReady} from '../../tests/e2e/models'
+import {captureGlbLogs, waitForGlbLog} from '../../tests/e2e/glbLogs'
 
 
 const {afterEach, beforeEach, describe} = test
@@ -45,38 +46,11 @@ describe('View 100: Properties panel on cache-hit GLB', () => {
     await clearOpfs(page)
   })
 
-  // RE-SKIP REASON (un-fixme'd earlier in PR #1531 then put back on CI
-  // timeout — `writer: wrote` never fired within 30s in either spec).
-  // OPFS_IS_ENABLED is now `true` in vars.playwright.js, but flipping
-  // the env var alone isn't sufficient: `downloadToOPFS` runs inside
-  // the OPFS Worker, and **worker-context fetches are not intercepted
-  // by Playwright's `context.route(...)` interceptor** — those routes
-  // only apply to the main page context. MSW's service worker
-  // (`mockServiceWorker.js`) CAN intercept worker fetches once it's
-  // controlling the page, but the cacheHit spec doesn't gate on
-  // `waitForServiceWorker` before its first `page.goto` so the
-  // first OPFS fetch can race the SW activation. When the OPFS fetch
-  // misses the MSW intercept, it hits the local dev server's
-  // fixture-less `index.ifc` path and either 404s or times out,
-  // causing the OPFS `try` block in `Loader.js#load` to fall through
-  // to its outer catch which sets `glbExportContext = null` — at
-  // which point the writer is bypassed entirely and the test waits
-  // forever for a log line that will never fire.
-  //
-  // Fix path tracked in design/new/viewer-replacement.md §"Followups":
-  //   1. Add an MSW handler that fulfils OPFS-worker fetches for
-  //      `/index.ifc` (today the dev server serves it directly; the
-  //      handler would route through the test fixture).
-  //   2. Gate the cacheHit specs' first `page.goto` on
-  //      `waitForServiceWorker` so MSW is guaranteed to be
-  //      controlling the page before any fetch (worker or main).
-  //   3. Or: bypass the OPFS-worker download path entirely for these
-  //      specs by pre-seeding OPFS via `page.evaluate` before the
-  //      first goto.
-  //
-  // The cache-hit round-trip remains validated manually on deploy
-  // preview (Snowdon, Schependomlaan) until one of (1)/(2)/(3) lands.
-  test.fixme('cache-hit GLB renders Properties panel with full IFC entity fields', async ({page}) => {
+  // Un-skipped in bldrs-ai/Share#1779. These ran green for the first time
+  // once the `expect.poll` fix above landed and OPFS was enabled under
+  // Playwright; the previous skip reason (an OPFS-worker / MSW-service-worker
+  // race) is discussed in `tools/esbuild/vars.playwright.js`.
+  test('cache-hit GLB renders Properties panel with full IFC entity fields', async ({page}) => {
     // Two `page.goto` round-trips (cache-populate + cache-hit) plus the
     // writer's async element-properties BFS can easily exceed
     // Playwright's default 30s per-test budget on CI. Bump to 120s so
@@ -89,38 +63,16 @@ describe('View 100: Properties panel on cache-hit GLB', () => {
     // Capture the GLB pipeline's `[glb]` log lines so we can assert on
     // observable state transitions (cache MISS / HIT, writer wrote,
     // reader decoded) rather than racing on timing alone.
-    const glbLogs: string[] = []
-    page.on('console', (msg) => {
-      const text = msg.text()
-      if (text.startsWith('[glb]')) {
-        glbLogs.push(text)
-      }
-    })
+    const glbLogs = captureGlbLogs(page)
 
     // First load: cache MISS, writer populates OPFS. The writer is
     // fire-and-forget at the call site; we wait on the "writer: wrote"
     // log to know it actually finished before the reload. `glb` is
     // default-on as of the Phase-5a flip; no `?feature=` needed.
     const CACHE_TIMEOUT = 30_000
-    await page.goto('/share/v/p/index.ifc')
+    await page.goto('/share/v/p/index.ifc?feature=glbVerbose')
     await waitForModelReady(page)
-    try {
-      await page.waitForFunction(
-        ({logs}) => logs.some((l: string) => l.includes('writer: wrote')),
-        {logs: glbLogs},
-        {timeout: CACHE_TIMEOUT},
-      )
-    } catch (e) {
-      // Diagnostic dump: which [glb] lines DID fire before the wait
-      // timed out? Most useful failure mode is `writer: skipped (threw)`
-      // — surfaces a writer-side exception that would otherwise be
-      // invisible (the outer try/catch in exportAndCacheGlb swallows
-      // the throw and only logs).
-      const indented = glbLogs.map((l) => `  ${l}`).join('\n')
-      console.error(
-        `[cacheHit.spec] writer:wrote never fired in ${CACHE_TIMEOUT}ms; captured ${glbLogs.length} [glb] line(s):\n${indented}`)
-      throw e
-    }
+    await waitForGlbLog(glbLogs, 'writer: wrote', CACHE_TIMEOUT)
     expect(glbLogs.some((l) => l.includes('cache MISS'))).toBe(true)
 
     // Second load — same path + element permalink — to trigger a cache
@@ -128,13 +80,9 @@ describe('View 100: Properties panel on cache-hit GLB', () => {
     // to render. Reset log buffer so the second-load assertions don't
     // see the first load's lines.
     glbLogs.length = 0
-    await page.goto('/share/v/p/index.ifc/81/621')
+    await page.goto('/share/v/p/index.ifc/81/621?feature=glbVerbose')
     await waitForModelReady(page)
-    await page.waitForFunction(
-      ({logs}) => logs.some((l: string) => l.includes('cache HIT')),
-      {logs: glbLogs},
-      {timeout: CACHE_TIMEOUT},
-    )
+    await waitForGlbLog(glbLogs, 'cache HIT', CACHE_TIMEOUT)
 
     // BLDRS_element_properties hydration log fires at convertToShareModel
     // time — confirms the closure was attached. (The lazy-decode log
@@ -157,11 +105,7 @@ describe('View 100: Properties panel on cache-hit GLB', () => {
     // captured nothing, which is the failure mode this test exists
     // to catch.
     const DECODE_TIMEOUT = 5_000
-    await page.waitForFunction(
-      ({logs}) => logs.some((l: string) => l.includes('decoded payload')),
-      {logs: glbLogs},
-      {timeout: DECODE_TIMEOUT},
-    )
+    await waitForGlbLog(glbLogs, 'decoded payload', DECODE_TIMEOUT)
     const decodeLog = glbLogs.find((l) => l.includes('decoded payload'))
     expect(decodeLog).toBeDefined()
     expect(decodeLog).toMatch(/(\d+) entities/)
@@ -177,18 +121,19 @@ describe('View 100: Properties panel on cache-hit GLB', () => {
     await expect(propertiesTable).toBeVisible()
     await assertPropertyValue(propertiesPanel, 'Express Id', '621')
     await assertPropertyValue(propertiesPanel, 'Name', 'Together')
-    // GlobalId is the canary for "full entity rendered, not just the
-    // slim spatial-tree-node whitelist" — it's a typed-primitive field
-    // (`{type: 1, value: <string>}`) that the spatial-tree capture
-    // strips on write (the whitelist is `{expressID, type, Name,
-    // LongName, children}` — see `bldrsSpatialTree.js#serializeNode`),
-    // but the element-properties extension preserves verbatim. If the
-    // selection effect at `CadView.jsx`'s `selectedElements` watcher
-    // ever regresses back to setting `selectedElement` to the slim
-    // tree node (or to `null` because viewer.getProperties returned
-    // nothing on cache-hit), this assertion fails — caught before the
-    // bug ships.
-    await assertPropertyValue(propertiesPanel, 'GlobalId', '02uD5Qe8H3mek2PYnMWHk1')
+    // No GlobalId assertion, though the entity has one (`#621=
+    // IFCBUILDINGELEMENTPROXY('02uD5Qe8H3mek2PYnMWHk1',…)` in index.ifc).
+    // This spec used to assert it as a canary for "full entity rendered, not
+    // just the slim spatial-tree whitelist" — but a fresh parse of the same
+    // element renders exactly these three rows too, so it never distinguished
+    // anything. It could not have been noticed while the spec was `fixme`'d.
+    //
+    // What does the distinguishing here is the pair of log assertions above:
+    // `hydrated Properties panel from BLDRS_element_properties` proves the
+    // closure was attached, and `decoded payload … N entities` with N > 0
+    // proves the payload survived gzip + JSON and inflated. Those are what
+    // bldrs-ai/Share#1776 broke — the writer dropped the extension entirely
+    // and the reload fell back to the scene graph.
   })
 })
 

--- a/src/Containers/sceneHighlightPermalink.spec.ts
+++ b/src/Containers/sceneHighlightPermalink.spec.ts
@@ -1,6 +1,7 @@
 import {expect, test} from '@playwright/test'
 import {setupVirtualPathIntercept, waitForModelReady} from '../tests/e2e/models'
 import {homepageSetup, setIsReturningUser} from '../tests/e2e/utils'
+import {captureGlbLogs, waitForGlbLog} from '../tests/e2e/glbLogs'
 
 
 /**
@@ -32,6 +33,8 @@ const MODEL_PATH = '/share/v/gh/bldrs-ai/test-models/main/ifc/openifcmodels/1712
 const ELEMENT_PERMALINK = `${MODEL_PATH}/120010/120020/120023/4998/2867`
 const TEST_TIMEOUT_MS = 180_000
 // Cache-hit test: two full loads plus the OPFS GLB write wait between them.
+const CACHE_WRITE_TIMEOUT_MS = 120_000
+const CACHE_HIT_LOG_TIMEOUT_MS = 30_000
 const CACHE_HIT_TIMEOUT_MS = 300_000
 const SETTLE_MS = 3_000
 
@@ -100,31 +103,29 @@ describe('Element-path permalink on a digit-prefixed filename', () => {
     test.setTimeout(CACHE_HIT_TIMEOUT_MS)
     await permalinkSetup(page)
 
+    const glbLogs = captureGlbLogs(page)
     await page.goto(`${ELEMENT_PERMALINK}#n:`, {waitUntil: 'domcontentloaded'})
     await waitForModelReady(page)
     await page.waitForTimeout(SETTLE_MS)
 
-    // Wait for the GLB cache write, then reload into the cache-hit path.
-    await page.waitForFunction(async () => {
-      /* eslint-disable @typescript-eslint/no-explicit-any */
-      const walk = async (dir: any): Promise<boolean> => {
-        for await (const [name, handle] of (dir as any).entries()) {
-          if (handle.kind === 'directory') {
-            if (await walk(handle)) {
-              return true
-            }
-          } else if (name.includes('.glb')) {
-            return true
-          }
-        }
-        return false
-      }
-      return walk(await navigator.storage.getDirectory())
-      /* eslint-enable @typescript-eslint/no-explicit-any */
-    }, undefined, {timeout: 120_000})
+    // Wait for the writer to FINISH, not merely for a `.glb` to appear in
+    // OPFS. This used to walk the directory for any `.glb` name, which the
+    // entry satisfies the moment it is created — so the reload could read a
+    // half-written artifact, miss, and re-parse live. `writer: wrote` is
+    // emitted after the bytes land, and is the same signal the sibling
+    // cache-hit specs wait on.
+    await waitForGlbLog(glbLogs, 'writer: wrote', CACHE_WRITE_TIMEOUT_MS)
 
+    glbLogs.length = 0
     await page.reload({waitUntil: 'domcontentloaded'})
     await waitForModelReady(page)
+    // Prove the reload actually served the artifact. Waiting for a `.glb` to
+    // appear in OPFS only shows the writer ran; if the reader then misses it —
+    // a lookup failure, a changed key — the source is re-parsed live into an
+    // ordinary BatchedMesh, whose highlight and geometry satisfy every
+    // assertion below. Without this the test can pass while exercising none of
+    // the cache-hit behaviour its name claims.
+    await waitForGlbLog(glbLogs, 'cache HIT', CACHE_HIT_LOG_TIMEOUT_MS)
     await page.waitForTimeout(SETTLE_MS)
 
     const hit = await page.evaluate(() => {

--- a/src/Containers/sceneHighlightPermalink.spec.ts
+++ b/src/Containers/sceneHighlightPermalink.spec.ts
@@ -94,14 +94,9 @@ describe('Element-path permalink on a digit-prefixed filename', () => {
   // resolving the wrong element, highlight landing on nearby other parts,
   // face permalink losing the scene highlight): the BVH build permuted
   // geometry.index AFTER the per-triangle maps were built from
-  // BLDRS_face_ids. It can't run in this harness yet: the playwright build
-  // sets `OPFS_IS_ENABLED: false` (OPFS-worker fetches bypass the MSW
-  // service worker — see tools/esbuild/vars.playwright.js), so a reload
-  // re-parses live instead of hitting the GLB cache. fixme'd like the other
-  // cacheHit specs until that harness fix lands; until then the alignment
-  // invariant is pinned by Loader.restoreCacheHitPicking.test.js and the
-  // selection restore by the live-path test above.
-  test.fixme('cache-hit reload keeps selection, highlight, and table↔geometry alignment', async ({page}) => {
+  // BLDRS_face_ids. Un-skipped in bldrs-ai/Share#1779 along with the other
+  // cache-hit specs — see `tools/esbuild/vars.playwright.js`.
+  test('cache-hit reload keeps selection, highlight, and table↔geometry alignment', async ({page}) => {
     test.setTimeout(CACHE_HIT_TIMEOUT_MS)
     await permalinkSetup(page)
 
@@ -139,6 +134,19 @@ describe('Element-path permalink on a digit-prefixed filename', () => {
       const m = v?.IFC?.context?.items?.ifcModels?.[0]
       let meshes = 0
       let misaligned = 0
+      let batchedSelSetTotal = 0
+      let batchedMeshes = 0
+      const countBatched = (o: any) => {
+        if (o.isBatchedMesh) {
+          batchedMeshes++
+          batchedSelSetTotal += o.userData?.batchedHighlight?.selSet?.size ?? 0
+        }
+      }
+      if (m?.isBatchedMesh) {
+        countBatched(m)
+      } else {
+        m?.traverse?.(countBatched)
+      }
       m?.traverse?.((o: any) => {
         if (!o.isMesh || !o.instanceMap) {
           return
@@ -159,6 +167,8 @@ describe('Element-path permalink on a digit-prefixed filename', () => {
       return {
         selectedElements: st.selectedElements,
         mergedSubsets: v?._conwaySelectionSubsets?.length ?? 0,
+        batchedSelSetTotal,
+        batchedMeshes,
         meshes,
         misaligned,
         // Diagnostics (not asserted): which selection path can this model
@@ -172,10 +182,20 @@ describe('Element-path permalink on a digit-prefixed filename', () => {
     // Selection restored from the URL on the cache-hit load too, with a
     // live merged-path highlight.
     expect(hit.selectedElements).toEqual(['2867'])
-    expect(hit.mergedSubsets).toBeGreaterThan(0)
+    // Highlight counted across BOTH render paths, exactly as the live-path
+    // test above does. The merged path exposes it as
+    // `viewer._conwaySelectionSubsets`, the batched/incremental path — which
+    // is the default — as per-batch `userData.batchedHighlight.selSet`.
+    // Asserting only the merged counter reported 0 on a model that was
+    // highlighting perfectly well.
+    expect(hit.batchedSelSetTotal + hit.mergedSubsets).toBeGreaterThan(0)
+    // Geometry is actually present on whichever path built it.
+    expect(hit.batchedMeshes + hit.meshes).toBeGreaterThan(0)
     // The picking tables agree with the geometry on every triangle — fails
-    // if the BVH build ever goes back to permuting the index in place.
-    expect(hit.meshes).toBeGreaterThan(0)
+    // if the BVH build ever goes back to permuting the index in place. Only
+    // the merged path carries per-mesh `instanceMap`, so on the batched path
+    // this is vacuously satisfied; the invariant is additionally pinned by
+    // `Loader.restoreCacheHitPicking.test.js`.
     expect(hit.misaligned).toBe(0)
   })
 })

--- a/src/Containers/sceneHighlightPermalink.spec.ts
+++ b/src/Containers/sceneHighlightPermalink.spec.ts
@@ -1,7 +1,7 @@
 import {expect, test} from '@playwright/test'
 import {setupVirtualPathIntercept, waitForModelReady} from '../tests/e2e/models'
 import {homepageSetup, setIsReturningUser} from '../tests/e2e/utils'
-import {captureGlbLogs, waitForGlbLog} from '../tests/e2e/glbLogs'
+import {captureGlbLogs, resetGlbLogs, waitForGlbLog} from '../tests/e2e/glbLogs'
 
 
 /**
@@ -116,7 +116,7 @@ describe('Element-path permalink on a digit-prefixed filename', () => {
     // cache-hit specs wait on.
     await waitForGlbLog(glbLogs, 'writer: wrote', CACHE_WRITE_TIMEOUT_MS)
 
-    glbLogs.length = 0
+    resetGlbLogs(glbLogs)
     await page.reload({waitUntil: 'domcontentloaded'})
     await waitForModelReady(page)
     // Prove the reload actually served the artifact. Waiting for a `.glb` to
@@ -183,20 +183,28 @@ describe('Element-path permalink on a digit-prefixed filename', () => {
     // Selection restored from the URL on the cache-hit load too, with a
     // live merged-path highlight.
     expect(hit.selectedElements).toEqual(['2867'])
-    // Highlight counted across BOTH render paths, exactly as the live-path
-    // test above does. The merged path exposes it as
-    // `viewer._conwaySelectionSubsets`, the batched/incremental path — which
-    // is the default — as per-batch `userData.batchedHighlight.selSet`.
-    // Asserting only the merged counter reported 0 on a model that was
-    // highlighting perfectly well.
+    // Pin the render path FIRST, because the alignment assertion below is
+    // vacuous without it. `misaligned` only counts inside a traverse guarded
+    // by `if (!o.isMesh || !o.instanceMap) return`, so `misaligned === 0` is
+    // satisfied for free by `meshes === 0` — and an OR across both paths would
+    // permit exactly that.
+    //
+    // On a cache HIT the model comes out of `GLTFLoader` (`swapToGlbLoader`),
+    // which cannot emit a `BatchedMesh`; `restoreCacheHitPicking` then attaches
+    // one `IfcInstanceMap` per child Mesh. So this leg is the merged path, and
+    // `meshes` is the picking table this test is named after being present at
+    // all. Measured on the fixture: 16 meshes, 0 batched, 1 merged subset.
+    expect(hit.meshes, 'cache-hit model carried no per-mesh instanceMap').toBeGreaterThan(0)
+    // Selection restored on the merged path, exposed as
+    // `viewer._conwaySelectionSubsets`. (Counted together with the batched
+    // path's `userData.batchedHighlight.selSet` so this reads the same as the
+    // live-path test above, where the batched path is the one that runs.)
     expect(hit.batchedSelSetTotal + hit.mergedSubsets).toBeGreaterThan(0)
-    // Geometry is actually present on whichever path built it.
-    expect(hit.batchedMeshes + hit.meshes).toBeGreaterThan(0)
-    // The picking tables agree with the geometry on every triangle — fails
-    // if the BVH build ever goes back to permuting the index in place. Only
-    // the merged path carries per-mesh `instanceMap`, so on the batched path
-    // this is vacuously satisfied; the invariant is additionally pinned by
-    // `Loader.restoreCacheHitPicking.test.js`.
+    // The picking tables agree with the geometry on every triangle — fails if
+    // the BVH build ever goes back to permuting `geometry.index` in place
+    // after the per-triangle maps are built (#1639). The `meshes > 0` gate
+    // above is what keeps this loop from being skipped entirely; the invariant
+    // is additionally pinned by `Loader.restoreCacheHitPicking.test.js`.
     expect(hit.misaligned).toBe(0)
   })
 })

--- a/src/tests/e2e/glbLogs.ts
+++ b/src/tests/e2e/glbLogs.ts
@@ -1,0 +1,58 @@
+import {Page, expect} from '@playwright/test'
+
+
+/**
+ * Capture the GLB pipeline's `[glb]` console lines into a buffer.
+ *
+ * The pipeline's observable state transitions — cache HIT/MISS, writer wrote,
+ * reader hydrated an extension — are only reported through these lines, so a
+ * cache round-trip spec asserts on them rather than racing on timing. See
+ * `src/loader/glbLog.js` for the emit side.
+ *
+ * @param page the page to listen on
+ * @return the buffer, filled as lines arrive
+ */
+export function captureGlbLogs(page: Page): string[] {
+  const logs: string[] = []
+  page.on('console', (msg) => {
+    const text = msg.text()
+    if (text.startsWith('[glb]')) {
+      logs.push(text)
+    }
+  })
+  return logs
+}
+
+
+/**
+ * Wait for a `[glb]` line containing `needle`.
+ *
+ * `expect.poll`, and NOT `page.waitForFunction(pred, {logs})`, for a reason
+ * worth stating because the page-side form looks equivalent and is not:
+ * `waitForFunction` serialises its argument into the page ONCE and re-invokes
+ * the predicate against that frozen copy, so Node-side pushes into the array
+ * never reach it. Every line these specs wait for arrives AFTER the wait
+ * starts — `writer: wrote` fires from an idle callback well past
+ * `data-model-ready` — so the page-side form could not succeed and burned its
+ * full timeout by construction.
+ *
+ * That is what actually kept the cache-hit specs `fixme`'d, rather than the
+ * OPFS/service-worker race they were annotated with (bldrs-ai/Share#1779).
+ * Demonstrated directly: against an array appended at 1s, `waitForFunction`
+ * times out at 4s where `expect.poll` resolves at 1.2s.
+ *
+ * On failure the message carries the whole captured buffer, which is the
+ * diagnostic that matters — most usefully `writer: skipped (threw)`, a
+ * writer-side exception `exportAndCacheGlb` swallows and only logs.
+ *
+ * @param logs buffer from {@link captureGlbLogs}
+ * @param needle substring to wait for
+ * @param timeout ms to wait
+ */
+export async function waitForGlbLog(logs: string[], needle: string, timeout: number) {
+  await expect.poll(() => logs.some((l) => l.includes(needle)), {
+    timeout,
+    message: `[glb] line matching "${needle}" never arrived. Captured:\n` +
+      `${logs.map((l) => `  ${l}`).join('\n') || '  (none)'}`,
+  }).toBe(true)
+}

--- a/src/tests/e2e/glbLogs.ts
+++ b/src/tests/e2e/glbLogs.ts
@@ -24,6 +24,47 @@ export function captureGlbLogs(page: Page): string[] {
 }
 
 
+// Marker pushed by {@link resetGlbLogs}, so a later `waitForGlbLog` can tell a
+// line the current load emitted from one the previous load emitted late.
+const RESET_MARKER = '[glb] --- spec: buffer reset ---'
+
+
+/**
+ * Drop everything captured so far, before driving the next load.
+ *
+ * Not simply `logs.length = 0`. There is no barrier between a wait resolving
+ * and the navigation that follows, and Playwright keeps dispatching
+ * `Runtime.consoleAPICalled` events that the old execution context already
+ * queued — `opfsSourceByteStore.js`'s "source spill: released resident source
+ * buffer" is emitted from the writer's `.finally`, i.e. strictly after the
+ * `writer: wrote` a populate half waits on. So a stale line can land after the
+ * clear, and any needle both loads can emit would then be satisfied by load 1.
+ *
+ * Pushing a marker and having {@link waitForGlbLog} search only past the LAST
+ * marker closes that: a line racing in from the old context lands before the
+ * marker and is not counted. Today's needles happen to be load-2-only, so this
+ * is insurance against the next one that isn't (`writer: wrote` fires on both).
+ *
+ * @param logs buffer from {@link captureGlbLogs}
+ */
+export function resetGlbLogs(logs: string[]) {
+  logs.length = 0
+  logs.push(RESET_MARKER)
+}
+
+
+/**
+ * Lines captured since the last {@link resetGlbLogs}, or all of them.
+ *
+ * @param logs buffer from {@link captureGlbLogs}
+ * @return the slice after the last reset marker
+ */
+function sinceReset(logs: string[]): string[] {
+  const at = logs.lastIndexOf(RESET_MARKER)
+  return at === -1 ? logs : logs.slice(at + 1)
+}
+
+
 /**
  * Wait for a `[glb]` line containing `needle`.
  *
@@ -41,18 +82,26 @@ export function captureGlbLogs(page: Page): string[] {
  * Demonstrated directly: against an array appended at 1s, `waitForFunction`
  * times out at 4s where `expect.poll` resolves at 1.2s.
  *
- * On failure the message carries the whole captured buffer, which is the
- * diagnostic that matters — most usefully `writer: skipped (threw)`, a
- * writer-side exception `exportAndCacheGlb` swallows and only logs.
+ * The buffer dump goes in a `catch` rather than `expect.poll`'s `message`
+ * option, because that option is a plain string evaluated at CALL time — it
+ * would snapshot the buffer as it stood before the wait began and so exclude,
+ * by construction, every line the wait window produced. That is the whole
+ * diagnostic: most usefully `writer: skipped (threw)`, a writer-side exception
+ * `exportAndCacheGlb` swallows and only logs.
  *
  * @param logs buffer from {@link captureGlbLogs}
  * @param needle substring to wait for
  * @param timeout ms to wait
  */
 export async function waitForGlbLog(logs: string[], needle: string, timeout: number) {
-  await expect.poll(() => logs.some((l) => l.includes(needle)), {
-    timeout,
-    message: `[glb] line matching "${needle}" never arrived. Captured:\n` +
-      `${logs.map((l) => `  ${l}`).join('\n') || '  (none)'}`,
-  }).toBe(true)
+  try {
+    await expect.poll(() => sinceReset(logs).some((l) => l.includes(needle)), {timeout}).toBe(true)
+  } catch {
+    // `expect.poll`'s own message is only "expected true, received false", so
+    // nothing is lost by replacing it rather than chaining it as a `cause`
+    // (which is past this project's TS lib target anyway).
+    const captured = sinceReset(logs).map((l) => `  ${l}`).join('\n') || '  (none)'
+    throw new Error(
+      `[glb] line matching "${needle}" never arrived within ${timeout}ms. Captured:\n${captured}`)
+  }
 }

--- a/tools/esbuild/vars.playwright.js
+++ b/tools/esbuild/vars.playwright.js
@@ -3,22 +3,34 @@ import cypress from './vars.cypress.js'
 
 export default {
   ...cypress,
-  // OPFS_IS_ENABLED reverted to false (was flipped to true in PR #1531
-  // to unblock `Properties.cacheHit.spec.ts`). With it on, the
-  // loader's first IFC fetch goes through the OPFS worker
-  // (`downloadToOPFS` → `OPFS.worker.js` → `fetch(objectUrl)`); that
-  // worker-context fetch races MSW's service-worker activation, and
-  // when MSW isn't yet controlling the page the fetch fails to match
-  // the page-level `waitForResponse` listener in
-  // `visitHomepageWaitForModel` — ALL tests that wait for the model
-  // to load (≈80 specs) then time out at the 30s budget.
+  // OPFS on, so the GLB cache round-trip — writer → OPFS → reader — is
+  // reachable from a spec at all. Without it `Loader.js#load` skips the whole
+  // OPFS block, no artifact is ever written, and the cache-hit consumer
+  // surface (NavTree from `BLDRS_spatial_tree`, Properties from
+  // `BLDRS_element_properties`, picking from `BLDRS_face_ids`) has no
+  // coverage. bldrs-ai/Share#1776 shipped through that gap: every automated
+  // check passed on code whose second load rendered an empty NavTree.
   //
-  // The cacheHit specs that needed OPFS are still `test.fixme`'d
-  // (the OPFS-worker / MSW-SW interaction needs the proper fix
-  // tracked in design/new/viewer-replacement.md §4b.2 — gate the
-  // first `page.goto` on `waitForServiceWorker`, or add an MSW
-  // handler that fulfils worker-context fetches). Until that lands,
-  // flipping the flag is pure regression.
-  OPFS_IS_ENABLED: false,
+  // This was flipped on in PR #1531 and reverted, with the revert attributing
+  // an ≈80-spec timeout to the OPFS worker's `fetch` racing MSW's
+  // service-worker activation. That attribution does not survive checking.
+  // The cache-hit specs could not have passed either way, because they waited
+  // with `page.waitForFunction(pred, {logs: glbLogs})` — which serialises its
+  // argument into the page ONCE and re-invokes the predicate against that
+  // frozen copy, so the Node-side `page.on('console')` pushes never reached
+  // it. Every line they waited for arrives after the wait starts, so each
+  // wait burned its full timeout by construction. Demonstrated directly:
+  // against an array appended at 1s, `waitForFunction` times out at 4s while
+  // `expect.poll` resolves at 1.2s. The specs now use `expect.poll`.
+  //
+  // Whether the ≈80-spec regression was ever real is a separate question, and
+  // this flag is the way to find out — it is compile-time and all-or-nothing
+  // (`store/BrowserSlice.js` hard-gates the setter), so there is no per-spec
+  // opt-in to hide behind. If it does reappear, the fix belongs at its single
+  // source: `visitHomepageWaitForModel` and `navigateAndWaitForModel` gate
+  // navigation on a network response, where a DOM-state gate
+  // (`data-model-ready`, which `waitForModelReady` already uses) is correct
+  // whether the bytes come from the network, a worker, or a cache.
+  OPFS_IS_ENABLED: true,
   THEME_IS_ENABLED: true,
 }

--- a/tools/esbuild/vars.playwright.js
+++ b/tools/esbuild/vars.playwright.js
@@ -31,6 +31,16 @@ export default {
   // navigation on a network response, where a DOM-state gate
   // (`data-model-ready`, which `waitForModelReady` already uses) is correct
   // whether the bytes come from the network, a worker, or a cache.
+  //
+  // What the flip changes suite-wide, beyond the cache-hit specs, because
+  // `Loader.js#load` gates the whole OPFS block on `isOpfsAvailable`: the
+  // model fetch moves into `OPFS.worker.js` (so page-level `context.route`
+  // handlers are no longer what keeps a GitHub-model spec hermetic — MSW's
+  // service worker is); a GLTFExporter + gzip + OPFS write is scheduled on
+  // `requestIdleCallback` at the tail of EVERY load; and `spillModelSource`
+  // + `ReleaseModelGeometry` free Conway's native geometry mid-test. None of
+  // that ran under Playwright before. It is the first thing to suspect if a
+  // spec unrelated to caching starts failing.
   OPFS_IS_ENABLED: true,
   THEME_IS_ENABLED: true,
 }


### PR DESCRIPTION
Closes #1779. Follow-up to #1776 / #1777.

## The gap

The GLB cache-hit round-trip — writer → OPFS → reader, and the NavTree, Properties and picking surfaces hanging off it — was guarded by three specs, all `test.fixme`. That is the gap #1776 shipped through: 244 Jest suites, the coverage gate and both Playwright jobs passed on code whose second load rendered an empty NavTree.

## The skip reason was wrong

The specs, `vars.playwright.js` and `viewer-replacement.md` all attribute the skip to an OPFS-worker fetch racing MSW's service-worker activation. That is not what was stopping them.

The two `.cacheHit` specs waited with `page.waitForFunction(pred, {logs: glbLogs})`. `waitForFunction` serialises its argument into the page **once** and re-invokes the predicate against that frozen copy, so the Node-side `page.on('console')` pushes never reached it. Every line they waited for arrives *after* the wait starts — `writer: wrote` fires from an idle callback well past `data-model-ready` — so each wait burned its full timeout by construction, whatever OPFS was doing.

Measured directly, against an array appended at 1s:

```
waitForFunction: TIMED OUT after 4004ms (Node array now has 1: ["writer: wrote"])
expect.poll:        RESOLVED after 1209ms
```

`sceneHighlightPermalink.spec.ts`'s cache-hit leg is a *different* mistake that inherited the same skip note: it was created already-`fixme`'d beside the other two, and its wait was a page-side walk of OPFS for a `.glb` — no Node-side argument, so it would have worked. Its real defect was that the `.glb` exists from creation, so the wait passed on a half-written artifact and the reload read a MISS. It now waits on `writer: wrote`.

So: `expect.poll` (the house pattern, already used in three Camera/NavTree specs), `OPFS_IS_ENABLED: true`, `fixme`s off. The wait and the console capture move to `src/tests/e2e/glbLogs.ts`, since three specs need them and that directory is where shared e2e helpers live.

**The ≈80-spec regression the old comment warned about did not materialise.** Full suite with OPFS on: **161 passed, 41 skipped, 0 failed** (9.4 min), reproduced on a second clean run. That is a local result under `retries: 1`, so read it as "no regression observed" rather than a disproof — the gated `test-flows` jobs on this PR are the real test.

## Five stale assertions, found by running them

Each was checked against the *live* path before being changed — "the cached path is missing something" is exactly the bug class here, and I did not want to file a false one.

| assertion | reality |
|---|---|
| `hydrated NavTree…` / `hydrated Properties…` logs | both `glbVerbose`, feature-gated — never fired. `BLDRS_face_ids`'s twin is `glbInfo` and *did*, which made a complete artifact look half-written. Specs now pass `?feature=glbVerbose`. |
| `[role="treeitem"]` | matches nothing; `NavTreeNode.jsx` sets `data-node-label`. |
| tree has &gt; 5 rows | tree renders collapsed — 1 row, which is *also* what the #1776 bug produced. The spec now expands first, since that is what tells a real tree from the scene-graph fallback. |
| `GlobalId` row present | **not rendered on either path.** The comment called it "the canary for full entity rendered, not just the slim spatial-tree whitelist" — which reads like a live cache-hit bug. A scratch probe of the fresh-parse path returned the same three rows (Type, Express Id, Name), so there is no asymmetry. Dropped, with the reason recorded at the call site. |
| waiting for a `.glb` to exist in OPFS | true from file creation, so the reload read a half-written artifact and reported `cache MISS`. The leg named "cache-hit" had never hit the cache. |

## Does it actually catch #1776?

Coverage that would not have caught the bug is not worth a flag flip, so I reverted the fix and re-ran. This took two steps, and the intermediate result is worth recording:

1. **Reverting only `canOpenFromStore`'s gate** → the handle *is* burned (`parsed modelID=1`, `Store-backed open is IFC-only`), and the specs still **pass** — because #1777's engine-handle latch independently keeps the writer correct. That is the defence-in-depth claim in #1777's description, now demonstrated rather than asserted.
2. **Reverting the latch as well** → `injected 1 extension(s)`, 8264B: #1776 reproduced byte-for-byte against the original browser repro. The STEP cache-hit test then **fails**, with a diagnostic naming the defect:

```
[glb] line matching "hydrated NavTree from BLDRS_spatial_tree" never arrived. Captured:
  [glb] reader: external cache HIT (8264B); swapping to GLB loader
  [glb] BLDRS_face_ids: resolved 1 primitive entries — 84 triangles total
  ...
```

Fix restored, rebuilt, all five green again.

## Round 2 — assertions that still could not fail

Review round 2 went after the assertions themselves rather than the wiring, and found that fixing a wait is not the same as fixing a test:

- **`misaligned === 0` was unfalsifiable.** It only counts inside a traverse guarded by `!o.isMesh || !o.instanceMap`, so `meshes === 0` satisfies it for free — and the OR across render paths I added in round 1 permitted exactly that. Reintroducing #1639 (BVH permuting `geometry.index` after the per-triangle maps are built) would have stayed green. Now `meshes > 0` pins the path first. The round-1 note calling this check vacuous was itself wrong for this leg: on a cache HIT the model comes out of `GLTFLoader`, which cannot emit a `BatchedMesh`. Measured: 16 meshes, 0 batched, 1 merged subset.
- **The NavTree row count is bounded by the viewport.** The panel renders through `react-window`, so `count()` saturates around 25–30 rows and no threshold above that is expressible; and the failure being guarded emits a root whose children repeat the root's own name — plenty of rows, one label. Now counts *distinct* labels.
- **`expandTree` expanded one node per round, not one level.** `handleToggle` closes over the render-time id list and `setExpandedElements` replaces it, so N clicks in one task all write from the same stale snapshot and the last wins. One click per turn now.
- **The STEP test — the regression #1776 actually was — had no content assertion at all**, only the hydration log, which fires identically for a captured tree that is a bare root. It now expands and asserts like its sibling.
- **Properties' hydration line was read with a bare `.some()`** right after the `cache HIT` poll returned. It is emitted *after* that line and console delivery over CDP has no flush barrier — a false-failure flake on the file's only assertion for that closure.

Two helper bugs came out of the same pass. `waitForGlbLog` built its buffer dump in `expect.poll`'s `message` option, a plain string evaluated at *call* time, so the dump excluded by construction every line the wait window produced — which is the entire diagnostic, `writer: skipped (threw)` included. And `logs.length = 0` between loads is not a barrier; `resetGlbLogs` drops a marker instead, so a line the old execution context already queued cannot satisfy the next wait. No current needle is satisfiable by load 1, but `writer: wrote` fires on both.

`clearOpfs` moved to `beforeEach` in both specs. All three places justified it as insurance against an interrupted run — precisely when an `afterEach` does not execute.

## Docs

The router points at `PLAYBOOK.md` and `viewer-replacement.md` §4b.2 for this, so both are corrected rather than left describing the old flag. Five claims did not survive checking: the specs sat `fixme`'d for five weeks, not years; `sceneHighlightPermalink` never had the `waitForFunction` bug; five assertions had rotted, not four; the clean suite run is one local run under `retries: 1`; and all four places discussing the flag omitted its largest untested delta — OPFS on turns the GLB **writer**, `spillModelSource` and `ReleaseModelGeometry` on in *every* model-loading spec, not just the cache-hit ones, and moves the model fetch into `OPFS.worker.js`, where page-level `context.route` handlers are no longer what keeps a GitHub-model spec hermetic.

## Verification

| check | result |
|---|---|
| husky gate (eslint + typecheck + Jest) | green — 244 suites, 2454 passed |
| `yarn build-prod` | green |
| `yarn test-ci` (coverage thresholds) | green — 69.4% statements / 64.0% branches |
| full Playwright suite, OPFS on | **161 passed, 41 skipped, 0 failed** (9.4 min), twice |
| the three specs' five tests, tightened | pass, `--retries=0` |
| mutation: #1776 reproduced | STEP cache-hit test **fails**, as it must |

## Note on the mobile requirement

CLAUDE.md requires desktop *and* mobile via `describeMobileAndDesktop`. These specs are desktop-only, as they were before. The cache round-trip is form-factor independent and the panels have their own mobile coverage, so I have kept this PR to restoring the coverage rather than widening it — happy to add the mobile leg here if you would rather it land together.

https://claude.ai/code/session_01NuTsqJu1rqoz8f4FSQ9vbE

---
_Generated by [Claude Code](https://claude.ai/code/session_01NuTsqJu1rqoz8f4FSQ9vbE)_