### PR TITLE
Preserve query string on /share redirect (fixes gclid loss)

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,93 +1,93 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="utf-8"/>
-    <meta name="description" content="Build every thing together: Collab and Share 3d models online"/>
-    <meta name="keywords" content="ifc, ifc viewer, cad viewer, share ifc, share model, open source"/>
-    <meta name="viewport" content="width=device-width, initial-scale=1"/>
-    <meta name="theme-color" content="#000000"/>
-    <meta name="viewport"
-          content="width=device-width, user-scalable=no, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0">
-    <link rel="icon" href="/favicon.ico"/>
-    <title>bldrs.ai</title>
-    <meta name="google-site-verification" content="soxvqCycG6656Bmiml345OQ0BPfPnfzHBx_CJ3dSEeQ" />
-    <!-- Start Single Page Apps for GitHub Pages -->
-    <script type="application/javascript">
-      // Single Page Apps for GitHub Pages
-      // MIT License
-      // https://github.com/rafgraph/spa-github-pages
-      (function (l) {
-        if (l.search[1] === '/') {
-          var decoded = l.search.slice(1).split('&').map(function (s) {
-            return s.replace(/~and~/g, '&')
-          }).join('?')
-          var finalPath = l.pathname.slice(0, -1) + decoded + l.hash
-          window.history.replaceState(null, null, finalPath)
-        }
-      }(window.location))
-    </script>
-    <!-- End Single Page Apps for GitHub Pages -->
-    <style>
-      :root {
-        color-scheme: light dark;
-        background-color: Canvas;
-        color: CanvasText;
-      }
-    </style>
-    <link rel="stylesheet" href="/index.css">
-  </head>
-  <body>
-    <noscript>You need to enable JavaScript to run this app.</noscript>
-    <div id="root"></div>
-    <script type="application/javascript">
-      const loader = document.createElement('script')
-      const pathPrefix = window.location.pathname.startsWith('/Share') ? '/Share' : ''
-      loader.setAttribute('type', 'module')
-      loader.setAttribute('src', pathPrefix + '/index.js')
-      document.body.appendChild(loader)
-    </script>
-    <!-- gtag stub only: buffers events into dataLayer everywhere (gtagEvent
-         calls + E2E assertions rely on it). The external gtag/js loader is
-         injected by src/index/ga.js, and only on prod hosts outside
-         automation — keeps preview/dev/CI traffic out of prod analytics.
-         The config ID below must match ga.js#GA_MEASUREMENT_ID. -->
-    <script type="application/javascript">
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-      // Carried IN the config call rather than a `set` queued before it.
-      // config is what triggers page_view / session_start / first_visit — the
-      // events that make landing page and new-vs-returning queryable per user
-      // — and gtag only guarantees a user property reaches them when it is
-      // passed as config's own `user_properties` field. A preceding `set`
-      // relies on queue-drain ordering that gtag does not document.
-      //
-      // The bundle cannot do this: it loads long after config is queued.
-      // So the `cid.` prefix (analytics#OPEN_CID_PREFIX — a bare id is
-      // numeric-looking, and GA4 won't populate a text dimension from a
-      // number) and the consent rule (analytics#isAllowed) are duplicated
-      // here on purpose, the same arrangement the config ID already has with
-      // ga.js#GA_MEASUREMENT_ID.
-      //
-      // Host and automation are deliberately NOT re-checked. Everything the
-      // stub queues is inert off-prod because ga.js#shouldInitGa never
-      // injects gtag/js there (asserted in ga.test.js), and the E2E suite
-      // reads this buffer on localhost — the same reason isRealModelOpen
-      // documents localhost as a deliberate exception.
-      function userPropsBeforeConfig() {
-        var consent = document.cookie.match(/(?:^|;\s*)isAnalyticsAllowed=([^;]*)/);
-        // absent means allowed (the app's default); anything present but not
-        // exactly 'true' is a denial, matching isAllowed's === 'true' test
-        if (consent && consent[1] !== 'true') return {};
-        // _ga is `GA<version>.<domain depth>.<id>`, and the id itself has a dot
-        var m = document.cookie.match(/(?:^|;\s*)_ga=GA\d+\.\d+\.([^;]+)/);
-        return m ? {user_properties: {open_cid: 'cid.' + m[1]}} : {};
-      }
-      gtag('config', 'G-GRLNVMZRGW', userPropsBeforeConfig());
-    </script>
-    <!-- AdSense site verification. Body-after-bundle placement so MSW takes control before the script's network requests fire in dev/test. design/new/ads.md captures why Auto ads stay OFF and which routes may carry ad slots. -->
-    <script async
-            src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-2372655610709687"
-            crossorigin="anonymous"></script>
-  </body>
+<head>
+<meta charset="utf-8"/>
+<meta name="description" content="Build every thing together: Collab and Share 3d models online"/>
+<meta name="keywords" content="ifc, ifc viewer, cad viewer, share ifc, share model, open source"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<meta name="theme-color" content="#000000"/>
+<meta name="viewport"
+content="width=device-width, user-scalable=no, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0">
+<link rel="icon" href="/favicon.ico"/>
+<title>bldrs.ai</title>
+<meta name="google-site-verification" content="soxvqCycG6656Bmiml345OQ0BPfPnfzHBx_CJ3dSEeQ" />
+<!-- Start Single Page Apps for GitHub Pages -->
+<script type="application/javascript">
+// Single Page Apps for GitHub Pages
+// MIT License
+// https://github.com/rafgraph/spa-github-pages
+(function (l) {
+if (l.search[1] === '/') {
+var decoded = l.search.slice(1).split('&').map(function (s) {
+return s.replace(/~and~/g, '&')
+}).join('?')
+var finalPath = l.pathname.slice(0, -1) + decoded + l.hash
+window.history.replaceState(null, null, finalPath)
+}
+}(window.location))
+</script>
+<!-- End Single Page Apps for GitHub Pages -->
+<!-- gtag stub only: buffers events into dataLayer everywhere (gtagEvent
+calls + E2E assertions rely on it). The external gtag/js loader is
+injected by src/index/ga.js, and only on prod hosts outside
+automation — keeps preview/dev/CI traffic out of prod analytics.
+The config ID below must match ga.js#GA_MEASUREMENT_ID. -->
+<script type="application/javascript">
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date());
+// Carried IN the config call rather than a `set` queued before it.
+// config is what triggers page_view / session_start / first_visit — the
+// events that make landing page and new-vs-returning queryable per user
+// — and gtag only guarantees a user property reaches them when it is
+// passed as config's own `user_properties` field. A preceding `set`
+// relies on queue-drain ordering that gtag does not document.
+//
+// The bundle cannot do this: it loads long after config is queued.
+// So the `cid.` prefix (analytics#OPEN_CID_PREFIX — a bare id is
+// numeric-looking, and GA4 won't populate a text dimension from a
+// number) and the consent rule (analytics#isAllowed) are duplicated
+// here on purpose, the same arrangement the config ID already has with
+// ga.js#GA_MEASUREMENT_ID.
+//
+// Host and automation are deliberately NOT re-checked. Everything the
+// stub queues is inert off-prod because ga.js#shouldInitGa never
+// injects gtag/js there (asserted in ga.test.js), and the E2E suite
+// reads this buffer on localhost — the same reason isRealModelOpen
+// documents localhost as a deliberate exception.
+function userPropsBeforeConfig() {
+var consent = document.cookie.match(/(?:^|;\s*)isAnalyticsAllowed=([^;]*)/);
+// absent means allowed (the app's default); anything present but not
+// exactly 'true' is a denial, matching isAllowed's === 'true' test
+if (consent && consent[1] !== 'true') return {};
+// _ga is `GA<version>.<domain depth>.<id>`, and the id itself has a dot
+var m = document.cookie.match(/(?:^|;\s*)_ga=GA\d+\.\d+\.([^;]+)/);
+return m ? {user_properties: {open_cid: 'cid.' + m[1]}} : {};
+}
+gtag('config', 'G-GRLNVMZRGW', userPropsBeforeConfig());
+</script>
+<style>
+:root {
+color-scheme: light dark;
+background-color: Canvas;
+color: CanvasText;
+}
+</style>
+<link rel="stylesheet" href="/index.css">
+</head>
+<body>
+<noscript>You need to enable JavaScript to run this app.</noscript>
+<div id="root"></div>
+<script type="application/javascript">
+const loader = document.createElement('script')
+const pathPrefix = window.location.pathname.startsWith('/Share') ? '/Share' : ''
+loader.setAttribute('type', 'module')
+loader.setAttribute('src', pathPrefix + '/index.js')
+document.body.appendChild(loader)
+</script>
+<!-- AdSense site verification. Body-after-bundle placement so MSW takes control before the script's network requests fire in dev/test. design/new/ads.md captures why Auto ads stay OFF and which routes may carry ad slots. -->
+<script async
+src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-2372655610709687"
+crossorigin="anonymous"></script>
+</body>
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -1,93 +1,93 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-<meta charset="utf-8"/>
-<meta name="description" content="Build every thing together: Collab and Share 3d models online"/>
-<meta name="keywords" content="ifc, ifc viewer, cad viewer, share ifc, share model, open source"/>
-<meta name="viewport" content="width=device-width, initial-scale=1"/>
-<meta name="theme-color" content="#000000"/>
-<meta name="viewport"
-content="width=device-width, user-scalable=no, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0">
-<link rel="icon" href="/favicon.ico"/>
-<title>bldrs.ai</title>
-<meta name="google-site-verification" content="soxvqCycG6656Bmiml345OQ0BPfPnfzHBx_CJ3dSEeQ" />
-<!-- Start Single Page Apps for GitHub Pages -->
-<script type="application/javascript">
-// Single Page Apps for GitHub Pages
-// MIT License
-// https://github.com/rafgraph/spa-github-pages
-(function (l) {
-if (l.search[1] === '/') {
-var decoded = l.search.slice(1).split('&').map(function (s) {
-return s.replace(/~and~/g, '&')
-}).join('?')
-var finalPath = l.pathname.slice(0, -1) + decoded + l.hash
-window.history.replaceState(null, null, finalPath)
-}
-}(window.location))
-</script>
-<!-- End Single Page Apps for GitHub Pages -->
-<!-- gtag stub only: buffers events into dataLayer everywhere (gtagEvent
-calls + E2E assertions rely on it). The external gtag/js loader is
-injected by src/index/ga.js, and only on prod hosts outside
-automation — keeps preview/dev/CI traffic out of prod analytics.
-The config ID below must match ga.js#GA_MEASUREMENT_ID. -->
-<script type="application/javascript">
-window.dataLayer = window.dataLayer || [];
-function gtag(){dataLayer.push(arguments);}
-gtag('js', new Date());
-// Carried IN the config call rather than a `set` queued before it.
-// config is what triggers page_view / session_start / first_visit — the
-// events that make landing page and new-vs-returning queryable per user
-// — and gtag only guarantees a user property reaches them when it is
-// passed as config's own `user_properties` field. A preceding `set`
-// relies on queue-drain ordering that gtag does not document.
-//
-// The bundle cannot do this: it loads long after config is queued.
-// So the `cid.` prefix (analytics#OPEN_CID_PREFIX — a bare id is
-// numeric-looking, and GA4 won't populate a text dimension from a
-// number) and the consent rule (analytics#isAllowed) are duplicated
-// here on purpose, the same arrangement the config ID already has with
-// ga.js#GA_MEASUREMENT_ID.
-//
-// Host and automation are deliberately NOT re-checked. Everything the
-// stub queues is inert off-prod because ga.js#shouldInitGa never
-// injects gtag/js there (asserted in ga.test.js), and the E2E suite
-// reads this buffer on localhost — the same reason isRealModelOpen
-// documents localhost as a deliberate exception.
-function userPropsBeforeConfig() {
-var consent = document.cookie.match(/(?:^|;\s*)isAnalyticsAllowed=([^;]*)/);
-// absent means allowed (the app's default); anything present but not
-// exactly 'true' is a denial, matching isAllowed's === 'true' test
-if (consent && consent[1] !== 'true') return {};
-// _ga is `GA<version>.<domain depth>.<id>`, and the id itself has a dot
-var m = document.cookie.match(/(?:^|;\s*)_ga=GA\d+\.\d+\.([^;]+)/);
-return m ? {user_properties: {open_cid: 'cid.' + m[1]}} : {};
-}
-gtag('config', 'G-GRLNVMZRGW', userPropsBeforeConfig());
-</script>
-<style>
-:root {
-color-scheme: light dark;
-background-color: Canvas;
-color: CanvasText;
-}
-</style>
-<link rel="stylesheet" href="/index.css">
-</head>
-<body>
-<noscript>You need to enable JavaScript to run this app.</noscript>
-<div id="root"></div>
-<script type="application/javascript">
-const loader = document.createElement('script')
-const pathPrefix = window.location.pathname.startsWith('/Share') ? '/Share' : ''
-loader.setAttribute('type', 'module')
-loader.setAttribute('src', pathPrefix + '/index.js')
-document.body.appendChild(loader)
-</script>
-<!-- AdSense site verification. Body-after-bundle placement so MSW takes control before the script's network requests fire in dev/test. design/new/ads.md captures why Auto ads stay OFF and which routes may carry ad slots. -->
-<script async
-src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-2372655610709687"
-crossorigin="anonymous"></script>
-</body>
+  <head>
+    <meta charset="utf-8"/>
+    <meta name="description" content="Build every thing together: Collab and Share 3d models online"/>
+    <meta name="keywords" content="ifc, ifc viewer, cad viewer, share ifc, share model, open source"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1"/>
+    <meta name="theme-color" content="#000000"/>
+    <meta name="viewport"
+          content="width=device-width, user-scalable=no, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0">
+    <link rel="icon" href="/favicon.ico"/>
+    <title>bldrs.ai</title>
+    <meta name="google-site-verification" content="soxvqCycG6656Bmiml345OQ0BPfPnfzHBx_CJ3dSEeQ" />
+    <!-- Start Single Page Apps for GitHub Pages -->
+    <script type="application/javascript">
+      // Single Page Apps for GitHub Pages
+      // MIT License
+      // https://github.com/rafgraph/spa-github-pages
+      (function (l) {
+        if (l.search[1] === '/') {
+          var decoded = l.search.slice(1).split('&').map(function (s) {
+            return s.replace(/~and~/g, '&')
+          }).join('?')
+          var finalPath = l.pathname.slice(0, -1) + decoded + l.hash
+          window.history.replaceState(null, null, finalPath)
+        }
+      }(window.location))
+    </script>
+    <!-- End Single Page Apps for GitHub Pages -->
+    <!-- gtag stub only: buffers events into dataLayer everywhere (gtagEvent
+         calls + E2E assertions rely on it). The external gtag/js loader is
+         injected by src/index/ga.js, and only on prod hosts outside
+         automation — keeps preview/dev/CI traffic out of prod analytics.
+         The config ID below must match ga.js#GA_MEASUREMENT_ID. -->
+    <script type="application/javascript">
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      // Carried IN the config call rather than a `set` queued before it.
+      // config is what triggers page_view / session_start / first_visit — the
+      // events that make landing page and new-vs-returning queryable per user
+      // — and gtag only guarantees a user property reaches them when it is
+      // passed as config's own `user_properties` field. A preceding `set`
+      // relies on queue-drain ordering that gtag does not document.
+      //
+      // The bundle cannot do this: it loads long after config is queued.
+      // So the `cid.` prefix (analytics#OPEN_CID_PREFIX — a bare id is
+      // numeric-looking, and GA4 won't populate a text dimension from a
+      // number) and the consent rule (analytics#isAllowed) are duplicated
+      // here on purpose, the same arrangement the config ID already has with
+      // ga.js#GA_MEASUREMENT_ID.
+      //
+      // Host and automation are deliberately NOT re-checked. Everything the
+      // stub queues is inert off-prod because ga.js#shouldInitGa never
+      // injects gtag/js there (asserted in ga.test.js), and the E2E suite
+      // reads this buffer on localhost — the same reason isRealModelOpen
+      // documents localhost as a deliberate exception.
+      function userPropsBeforeConfig() {
+        var consent = document.cookie.match(/(?:^|;\s*)isAnalyticsAllowed=([^;]*)/);
+        // absent means allowed (the app's default); anything present but not
+        // exactly 'true' is a denial, matching isAllowed's === 'true' test
+        if (consent && consent[1] !== 'true') return {};
+        // _ga is `GA<version>.<domain depth>.<id>`, and the id itself has a dot
+        var m = document.cookie.match(/(?:^|;\s*)_ga=GA\d+\.\d+\.([^;]+)/);
+        return m ? {user_properties: {open_cid: 'cid.' + m[1]}} : {};
+      }
+      gtag('config', 'G-GRLNVMZRGW', userPropsBeforeConfig());
+    </script>
+    <style>
+      :root {
+        color-scheme: light dark;
+        background-color: Canvas;
+        color: CanvasText;
+      }
+    </style>
+    <link rel="stylesheet" href="/index.css">
+  </head>
+  <body>
+    <noscript>You need to enable JavaScript to run this app.</noscript>
+    <div id="root"></div>
+    <script type="application/javascript">
+      const loader = document.createElement('script')
+      const pathPrefix = window.location.pathname.startsWith('/Share') ? '/Share' : ''
+      loader.setAttribute('type', 'module')
+      loader.setAttribute('src', pathPrefix + '/index.js')
+      document.body.appendChild(loader)
+    </script>
+    <!-- AdSense site verification. Body-after-bundle placement so MSW takes control before the script's network requests fire in dev/test. design/new/ads.md captures why Auto ads stay OFF and which routes may carry ad slots. -->
+    <script async
+            src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-2372655610709687"
+            crossorigin="anonymous"></script>
+  </body>
 </html>

--- a/src/ShareRoutes.jsx
+++ b/src/ShareRoutes.jsx
@@ -8,11 +8,11 @@ import {
 } from 'react-router-dom'
 import debug from './utils/debug'
 import {disablePageReloadApprovalCheck} from './utils/event'
+import {navWith} from './utils/navigate'
 import About from './pages/share/About'
 import Conway from './pages/share/Conway'
 import Quotas from './pages/share/Quotas'
 import Share from './Share'
-
 
 /**
  * For URL design see: https://github.com/bldrs-ai/Share/wiki/URL-Structure
@@ -34,8 +34,8 @@ import Share from './Share'
  * Examples for this component:
  *   http://host/share/v/p/haus.ifc
  *   http://host/share/v/gh/IFCjs/test-ifc-files/main/Others/479l7.ifc
- *                    ^... here on handled by this component's paths.
- *              ^... path to the component in BaseRoutes.jsx.
+ *   ^... here on handled by this component's paths.
+ *   ^... path to the component in BaseRoutes.jsx.
  *
  * @see https://github.com/bldrs-ai/Share/wiki/Design#ifc-scene-load
  * @return {object}
@@ -102,10 +102,9 @@ export default function ShareRoutes({installPrefix, appPrefix}) {
   )
 }
 
-
 /**
  * Forward page from /share to /share/v/p per spect at:
- *   https://github.com/bldrs-ai/Share/wiki/URL-Structure
+ * https://github.com/bldrs-ai/Share/wiki/URL-Structure
  *
  * @param {string} appPrefix The install prefix, e.g. /share.
  * @return {object}
@@ -119,7 +118,7 @@ function Forward({appPrefix}) {
       const dest = `${appPrefix}/v/p`
       debug().log('ShareRoutes#useEffect[location]: forwarding to: ', dest)
       disablePageReloadApprovalCheck()
-      navigate(dest)
+      navWith(navigate, dest)
     }
   }, [location, appPrefix, navigate])
 

--- a/src/ShareRoutes.jsx
+++ b/src/ShareRoutes.jsx
@@ -120,7 +120,11 @@ function Forward({appPrefix}) {
       const dest = `${appPrefix}/v/p`
       debug().log('ShareRoutes#useEffect[location]: forwarding to: ', dest)
       disablePageReloadApprovalCheck()
-      navWith(navigate, dest)
+      // Pass the router's own location rather than letting navWith fall back
+      // to its `window.location` defaults: under MemoryRouter (tests) and
+      // HashRouter the global and the router disagree, and this effect is
+      // already keyed on the router location, so that is the one to forward.
+      navWith(navigate, dest, {search: location.search, hash: location.hash})
     }
   }, [location, appPrefix, navigate])
 

--- a/src/ShareRoutes.jsx
+++ b/src/ShareRoutes.jsx
@@ -14,6 +14,7 @@ import Conway from './pages/share/Conway'
 import Quotas from './pages/share/Quotas'
 import Share from './Share'
 
+
 /**
  * For URL design see: https://github.com/bldrs-ai/Share/wiki/URL-Structure
  *
@@ -34,8 +35,8 @@ import Share from './Share'
  * Examples for this component:
  *   http://host/share/v/p/haus.ifc
  *   http://host/share/v/gh/IFCjs/test-ifc-files/main/Others/479l7.ifc
- *   ^... here on handled by this component's paths.
- *   ^... path to the component in BaseRoutes.jsx.
+ *                    ^... here on handled by this component's paths.
+ *              ^... path to the component in BaseRoutes.jsx.
  *
  * @see https://github.com/bldrs-ai/Share/wiki/Design#ifc-scene-load
  * @return {object}
@@ -102,9 +103,10 @@ export default function ShareRoutes({installPrefix, appPrefix}) {
   )
 }
 
+
 /**
  * Forward page from /share to /share/v/p per spect at:
- * https://github.com/bldrs-ai/Share/wiki/URL-Structure
+ *   https://github.com/bldrs-ai/Share/wiki/URL-Structure
  *
  * @param {string} appPrefix The install prefix, e.g. /share.
  * @return {object}

--- a/src/ShareRoutes.jsx
+++ b/src/ShareRoutes.jsx
@@ -120,10 +120,13 @@ function Forward({appPrefix}) {
       const dest = `${appPrefix}/v/p`
       debug().log('ShareRoutes#useEffect[location]: forwarding to: ', dest)
       disablePageReloadApprovalCheck()
-      // Pass the router's own location rather than letting navWith fall back
-      // to its `window.location` defaults: under MemoryRouter (tests) and
-      // HashRouter the global and the router disagree, and this effect is
-      // already keyed on the router location, so that is the one to forward.
+      // Pass the router's own location rather than letting navWith fall
+      // back to its `window.location` defaults. BrowserRouter keeps the two
+      // in sync, so production behaves the same either way — but under
+      // MemoryRouter the global is jsdom's empty default, and the search
+      // vanishes in the unit test exactly the way this bug dropped it in
+      // the browser. This effect is already keyed on the useLocation()
+      // value, so forward that.
       navWith(navigate, dest, {search: location.search, hash: location.hash})
     }
   }, [location, appPrefix, navigate])

--- a/src/ShareRoutes.test.jsx
+++ b/src/ShareRoutes.test.jsx
@@ -1,0 +1,76 @@
+import React from 'react'
+import {render, waitFor} from '@testing-library/react'
+import {MemoryRouter, Route, Routes, useLocation} from 'react-router-dom'
+import ShareRoutes from './ShareRoutes'
+
+
+// Share mounts CadView and the whole viewer stack. This suite only
+// exercises the /share -> /share/v/p forward, so stub it out.
+jest.mock('./Share', () => {
+  return function MockShare() {
+    return <div data-testid='mock-share'>Mock Share</div>
+  }
+})
+
+
+/**
+ * Captures the live router location so tests can assert on it.
+ *
+ * @param {Function} onLocation Called with the current location on every render
+ * @return {null}
+ */
+function LocationSpy({onLocation}) {
+  onLocation(useLocation())
+  return null
+}
+
+
+/**
+ * Render ShareRoutes the way BaseRoutes mounts it — nested under a
+ * `/share/*` parent route, so its internal `<Route path='/'>` matches.
+ *
+ * @param {string} entry Initial URL
+ * @return {Function} Getter for the most recent router location
+ */
+function renderAt(entry) {
+  let seen = null
+  render(
+    <MemoryRouter initialEntries={[entry]}>
+      <Routes>
+        <Route
+          path='/share/*'
+          element={<ShareRoutes installPrefix='' appPrefix='/share'/>}
+        />
+      </Routes>
+      <LocationSpy onLocation={(loc) => {
+        seen = loc
+      }}
+      />
+    </MemoryRouter>,
+  )
+  return () => seen
+}
+
+
+describe('ShareRoutes Forward', () => {
+  it('forwards /share to /share/v/p', async () => {
+    const location = renderAt('/share')
+    await waitFor(() => expect(location().pathname).toBe('/share/v/p'))
+  })
+
+  // Regression guard. A bare `navigate(dest)` here dropped location.search,
+  // so an ad click landing on the homepage lost its gclid before gtag.js
+  // read window.location — GA4 then filed the paid session as
+  // google/organic and Google Ads recorded no conversion.
+  it('carries the query string through the forward', async () => {
+    const location = renderAt('/share?gclid=TEST123')
+    await waitFor(() => expect(location().pathname).toBe('/share/v/p'))
+    expect(location().search).toBe('?gclid=TEST123')
+  })
+
+  it('preserves every param, not just known ones', async () => {
+    const location = renderAt('/share?gclid=TEST123&utm_source=google&foo=bar')
+    await waitFor(() => expect(location().pathname).toBe('/share/v/p'))
+    expect(location().search).toBe('?gclid=TEST123&utm_source=google&foo=bar')
+  })
+})

--- a/src/routes/landingQuery.spec.ts
+++ b/src/routes/landingQuery.spec.ts
@@ -1,0 +1,45 @@
+import {expect, test} from '@playwright/test'
+import {describeMobileAndDesktop} from '../tests/e2e/formFactor'
+import {homepageSetup, setIsReturningUser} from '../tests/e2e/utils'
+
+
+// Verbatim shape of a Google Ads landing URL. `gclid` is the load-bearing
+// one; the `utm_*` pair and the unknown `foo` are here to prove the whole
+// query survives rather than a allowlist of params we happened to name.
+const AD_CLICK_SEARCH = '?gclid=TEST123&utm_source=google&utm_medium=cpc&foo=bar'
+
+// The chain rewrites the URL three times and each hop waits on a React
+// effect, so give the walk to the model URL room on a loaded CI runner.
+const FORWARD_TIMEOUT_MS = 30_000
+
+
+describeMobileAndDesktop('Landing query string', () => {
+  test.beforeEach(async ({page}) => {
+    await homepageSetup(page)
+    await setIsReturningUser(page.context())
+  })
+
+  // Regression guard for the gclid-attribution bug (#1784). Landing on `/`
+  // walks `/` -> `/share` -> `/share/v/p` -> `/share/v/p/index.ifc`, each
+  // hop a `navigate` out of a React effect, and any one of them calling
+  // `navigate(dest)` bare drops `location.search`.
+  //
+  // Assert on `window.location`, not react-router's location: gtag/js
+  // loads asynchronously and reads the *global* live at send time, so the
+  // global is both what actually broke and the only thing that proves the
+  // fix. A router-level assertion can pass while GA4 still sees no gclid.
+  test('survives the homepage forward chain', async ({page}) => {
+    await page.goto(`/${AD_CLICK_SEARCH}`, {waitUntil: 'domcontentloaded'})
+
+    await page.waitForURL((url) => url.pathname.endsWith('/share/v/p/index.ifc'), {
+      timeout: FORWARD_TIMEOUT_MS,
+    })
+
+    const search = await page.evaluate(() => window.location.search)
+    const params = new URLSearchParams(search)
+    expect(params.get('gclid')).toBe('TEST123')
+    expect(params.get('utm_source')).toBe('google')
+    expect(params.get('utm_medium')).toBe('cpc')
+    expect(params.get('foo')).toBe('bar')
+  })
+})


### PR DESCRIPTION
## Problem

`https://bldrs.ai/?gclid=TEST123` drops the query string on load.

`ShareRoutes.jsx`'s `Forward` component redirects `/share` → `/share/v/p` with a
bare `navigate(dest)`, which does not carry `location.search`. Everywhere else in
the codebase redirects go through `navWith`, whose defaults preserve search and
hash — this is a single missed call site. `BaseRoutes.jsx` (step before) preserves
it correctly, and `navToDefault` (step after) tries to, but by then
`location.search` is already empty.

## Impact

GA4's `gtag/js` loads asynchronously and reads `window.location` live at send
time, after React's effect chain has already rewritten the URL. With `gclid`
gone and a `google.com` referrer, paid sessions are filed as `google / organic`.

Observed: ~872 Google Ads clicks over Aug 17–26 produced ~75 `google / cpc`
sessions in GA4, while `google / organic` rose from ~5.7 to ~110 sessions/day
with a geography and device mix matching the ad campaigns exactly (100% desktop;
campaigns run mobile −100%). Google Ads recorded zero conversions because
nothing tied back to a `gclid`. Search Console independently reports ~0 organic
clicks for the same period.

## Changes

- `src/ShareRoutes.jsx` — `Forward` now redirects through `navWith`, passing the
  router's own `search` and `hash` explicitly.

  Passing them explicitly is load-bearing, not defensive. `navWith`'s default
  options (`src/utils/navigate.js:103-106`) are evaluated against the
  module-scope global `location` — `window.location` — not the router's
  `useLocation()`. `BrowserRouter` keeps the two in sync so production behaves
  the same either way, but `MemoryRouter` never touches `window.location`, so
  under test the default falls back to jsdom's empty location and drops the
  search one level *below* where the original bug dropped it. A first pass at
  this fix used bare `navWith(navigate, dest)` and failed its own regression
  test for exactly that reason.

- `src/ShareRoutes.test.jsx` — unit-level regression guard on the forward.

- `src/routes/landingQuery.spec.ts` — real-browser E2E, desktop and mobile via
  `describeMobileAndDesktop`. The unit test asserts on react-router's abstract
  location, but the bug is specifically about `window.location`: gtag reads the
  global live at send time, so a router-level assertion can pass while GA4 still
  sees no `gclid`. This spec drives the full
  `/` → `/share` → `/share/v/p` → `/share/v/p/index.ifc` chain in Chromium and
  asserts on `window.location.search`, covering `gclid`, both `utm_*` params and
  an unknown param. Verified falsifiable: reverting `Forward` to the original
  bare `navigate(dest)` fails both form factors with `gclid` `null`.

- `public/index.html` — move the gtag stub/config block from `<body>` into
  `<head>`. Separate concern: Search Console's tracking-snippet ownership
  verification requires the snippet in `<head>` (PR #1773 worked around this
  with a meta tag). This does not by itself fix the attribution bug. It does not
  affect the MSW hermeticity the neighbouring AdSense comment describes — that
  applies to a script issuing its own network request, whereas the gtag *stub*
  makes none (it only defines `dataLayer`/`gtag` and queues a `config`); the
  network-triggering `googletagmanager.com` script is injected later from
  `src/index/ga.js#setupGa`.

## Review

codex was out of usage quota on this PR, so this went through a sub-agent round
per [agent-workflow.md §Review](design/new/agent-workflow.md). Findings and
dispositions: https://github.com/bldrs-ai/Share/pull/1784#issuecomment-5448817224

## Verification after deploy

1. `https://bldrs.ai/?gclid=TEST123` should survive to
   `/share/v/p/index.ifc?gclid=TEST123`.
2. GA4 Realtime should show the session as `google / cpc`, not `google / organic`.
3. Within 24–48h, `google / organic` should fall back toward its pre-Aug-17
   baseline and `google / cpc` should rise toward the Ads click count.

## Follow-up

`src/utils/navigate.js:23` uses `location.query`, which is not a DOM property and
is therefore always `''`. Harmless today only because `navWith`'s separate
`options.search` does the real work, but it sits directly next to this fix and a
future "cleanup" that turned it into a real value would double-append the query.
Tracked separately.