### PR TITLE
Drop dead code from navToDefault, and cover it with tests

### DIFF
--- a/src/utils/navigate.js
+++ b/src/utils/navigate.js
@@ -18,14 +18,17 @@ export function navToDefault(navigate, appPrefix) {
   // shifted by exactly (+76, 0, +11.4504) — x ∈ [-76, 10] became x ∈ [0, 86]
   // — so this hash was shifted by the same amount. Re-capture it rather than
   // hand-edit it if the model or the frame changes again.
-  const mediaSizeTabletWith = 900
   disablePageReloadApprovalCheck()
-  const defaultPath = `${appPrefix}/v/p/index.ifc${location.query || ''}`
-  const cameraHash = window.innerWidth > mediaSizeTabletWith ?
-    `#${HASH_PREFIX_CAMERA}:-57.022,131.828,173.3,37.922,22.64,9.136` :
-    `#${HASH_PREFIX_CAMERA}:-57.022,131.828,173.3,37.922,22.64,9.136`
-  navWith(navigate, defaultPath, {
-    search: location.search,
+  // Desktop and mobile deliberately share one framing. This was a ternary on
+  // window.innerWidth whose two branches held byte-identical strings from the
+  // file's first commit, so every camera re-capture had to hand-edit both
+  // copies in lockstep (318af25) with nothing to catch it if only one changed.
+  // Reintroduce the branch if the two framings ever genuinely diverge.
+  const cameraHash = `#${HASH_PREFIX_CAMERA}:-57.022,131.828,173.3,37.922,22.64,9.136`
+  // `window.location`, spelled out: this is the global, not the router's
+  // location. That distinction is what broke #1784 one level down.
+  navWith(navigate, `${appPrefix}/v/p/index.ifc`, {
+    search: window.location.search,
     hash: cameraHash,
   })
 }

--- a/src/utils/navigate.test.js
+++ b/src/utils/navigate.test.js
@@ -1,4 +1,4 @@
-import {navigateToModel, isTempModelPath, homeModelPath, reloadAfterCacheClear} from './navigate'
+import {navigateToModel, isTempModelPath, homeModelPath, navToDefault, reloadAfterCacheClear} from './navigate'
 
 
 describe('navigateToModel', () => {
@@ -119,6 +119,72 @@ describe('homeModelPath', () => {
       .mockReturnValue({pathname: '/share/v/new/uuid.ifc', search: '?feature=bot'})
     expect(homeModelPath('/share')).toBe(
       '/share/v/p/index.ifc?feature=bot#c:-57.022,131.828,173.3,37.922,22.64,9.136')
+  })
+})
+
+
+describe('navToDefault', () => {
+  const CAMERA_HASH = '#c:-57.022,131.828,173.3,37.922,22.64,9.136'
+  let locationGetter
+
+  afterEach(() => {
+    if (locationGetter) {
+      locationGetter.mockRestore()
+      locationGetter = null
+    }
+  })
+
+  /**
+   * Point `window.location` at a stub for one test.
+   *
+   * @param {string} search e.g. '?feature=bot'
+   * @return {Array<string>} Collector the fake navigate pushes into
+   */
+  function navCallsWithSearch(search) {
+    locationGetter = jest.spyOn(window, 'location', 'get')
+      .mockReturnValue({pathname: '/share', search})
+    const navCalls = []
+    navToDefault((path) => navCalls.push(path), '/share')
+    return navCalls
+  }
+
+  it('navigates to the home model with the default camera', () => {
+    expect(navCallsWithSearch('')).toEqual([`/share/v/p/index.ifc${CAMERA_HASH}`])
+  })
+
+  // The gclid bug (#1784) was this query going missing across a redirect;
+  // this is the last hop in that chain, and feature flags (`?feature=…`)
+  // ride the same query.
+  it('carries the current query string forward', () => {
+    expect(navCallsWithSearch('?gclid=TEST123&feature=bot')).toEqual([
+      `/share/v/p/index.ifc?gclid=TEST123&feature=bot${CAMERA_HASH}`,
+    ])
+  })
+
+  // Guards the removal of `location.query` — not a DOM property, so always
+  // ''. Had it ever resolved, it would have appended a second query here.
+  it('appends exactly one query string', () => {
+    const [path] = navCallsWithSearch('?feature=bot')
+    expect(path.match(/\?/g)).toHaveLength(1)
+  })
+
+  // The camera hash was a ternary on window.innerWidth with two identical
+  // branches. Both form factors must keep producing the same framing.
+  it('uses the same camera on mobile and desktop widths', () => {
+    // jsdom exposes innerWidth as a writable data property, not an
+    // accessor, so jest.spyOn(..., 'get') can't wrap it — assign directly.
+    const realWidth = window.innerWidth
+    try {
+      window.innerWidth = 1280
+      const desktop = navCallsWithSearch('')
+      locationGetter.mockRestore()
+      window.innerWidth = 390
+      const mobile = navCallsWithSearch('')
+      expect(mobile).toEqual(desktop)
+      expect(mobile).toEqual([`/share/v/p/index.ifc${CAMERA_HASH}`])
+    } finally {
+      window.innerWidth = realWidth
+    }
   })
 })
 


### PR DESCRIPTION
Follow-up to #1784. Two pieces of code in `navToDefault` that read as meaningful but aren't, both sitting directly next to that fix. **No behavior change.**

## 1. `location.query` — always `''`

```js
const defaultPath = `${appPrefix}/v/p/index.ifc${location.query || ''}`
```

`Location.query` is not a DOM property, so this always resolves to `''`. It is harmless *today* only because `navWith`'s separate `options.search` argument two lines down does the real work. The hazard is a future reader who notices the name, concludes it's a bug that it's empty, and "fixes" it into a real value — at which point the query gets appended twice. Removed.

## 2. A ternary whose branches are identical

```js
const cameraHash = window.innerWidth > mediaSizeTabletWith ?
  `#${HASH_PREFIX_CAMERA}:-57.022,131.828,173.3,37.922,22.64,9.136` :
  `#${HASH_PREFIX_CAMERA}:-57.022,131.828,173.3,37.922,22.64,9.136`
```

Both branches have held byte-identical strings since the file's first commit (3222ffb), so the ternary has never chosen anything. What it *did* do is force every camera re-capture to hand-edit two identical copies in lockstep — see 318af25, which changed both — with nothing to catch an edit that updated one and not the other. Collapsed to a single constant, with a comment saying to reintroduce the branch if the framings ever genuinely diverge.

This is the one judgement call in the PR, so it's easy to drop if you disagree: it's a separate commit's worth of change bundled here because it's the same "misleading dead code in this function" cleanup. Split it out if you'd rather.

## 3. Spell out `window.location.search`

It was already the global — but #1784 was caused by precisely this ambiguity one level down, where `navWith`'s defaults read the global `location` while the caller meant the router's. Naming it costs nothing and removes the question.

## Tests

`navToDefault` had **no test coverage at all**, despite being the last hop of the redirect chain #1784 was about. Four cases added to `src/utils/navigate.test.js`:

- navigates to the home model with the default camera
- carries the current query string forward — the `gclid`/`?feature=…` case
- appends exactly one query string — the direct guard on the `location.query` removal
- frames identically at mobile and desktop widths — pins what the collapsed ternary asserted

All 245 suites pass locally (`yarn precommit` via the husky hook).

## Not addressed

`navToDefault`'s camera hash is still a hand-captured literal with a `TODO: probe for index.ifc` above it. Out of scope here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XF7jX8CRPyRNmYvDG3mQYZ)_