### PR TITLE
Run the GLB cache-hit E2E specs on mobile as well as desktop

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,5 +1,14 @@
 /* eslint-disable no-magic-numbers */
 module.exports = {
+  // Stop the config cascade at the repo root. Without this ESLint keeps
+  // walking up, and an agent worktree under `.claude/worktrees/` (this repo's
+  // own convention) sits INSIDE another checkout of this repo: the ancestor
+  // .eslintrc.cjs then loads a second copy of every plugin ("couldn't
+  // determine the plugin ... uniquely") and, because the ignore base moves up
+  // with it, every file under the worktree looks like it lives in a dotfolder
+  // and is "ignored by default". Both make `yarn precommit` unrunnable there.
+  // In a normal checkout nothing sits above the root, so this is a no-op.
+  root: true,
   env: {
     browser: true,
     es2021: true,

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,14 +1,5 @@
 /* eslint-disable no-magic-numbers */
 module.exports = {
-  // Stop the config cascade at the repo root. Without this ESLint keeps
-  // walking up, and an agent worktree under `.claude/worktrees/` (this repo's
-  // own convention) sits INSIDE another checkout of this repo: the ancestor
-  // .eslintrc.cjs then loads a second copy of every plugin ("couldn't
-  // determine the plugin ... uniquely") and, because the ignore base moves up
-  // with it, every file under the worktree looks like it lives in a dotfolder
-  // and is "ignored by default". Both make `yarn precommit` unrunnable there.
-  // In a normal checkout nothing sits above the root, so this is a no-op.
-  root: true,
   env: {
     browser: true,
     es2021: true,

--- a/src/Components/NavTree/NavTree.cacheHit.spec.ts
+++ b/src/Components/NavTree/NavTree.cacheHit.spec.ts
@@ -6,9 +6,10 @@ import {
 } from '../../tests/e2e/utils'
 import {waitForModelReady} from '../../tests/e2e/models'
 import {captureGlbLogs, resetGlbLogs, waitForGlbLog} from '../../tests/e2e/glbLogs'
+import {describeMobileAndDesktop} from '../../tests/e2e/formFactor'
 
 
-const {beforeEach, describe} = test
+const {beforeEach} = test
 
 
 // Upper bound on toggles clicked. One click per iteration (see below), so this
@@ -16,9 +17,16 @@ const {beforeEach, describe} = test
 // window of either fixture, small enough that a runaway can't eat the timeout.
 const MAX_EXPAND_CLICKS = 40
 const EXPAND_SETTLE_MS = 150
-// Distinct labels a real hierarchy must beat. The bug this guards produces a
+// Distinct labels a real hierarchy must reach. The bug this guards produces a
 // root whose children repeat the root's own name, so DISTINCT labels — not
 // rows — is the discriminant; see the count assertion for why.
+//
+// 5 is a ceiling, not a loose floor: both fixtures flatten to exactly
+// Bldrs / Build / Every / Thing / Together — 11 rows, 5 distinct labels, all
+// of them mounted at BOTH form factors. So there is no headroom to trade away
+// on the smaller viewport, and no honest way to raise it. Measured in
+// bldrs-ai/Share#1787 by running the suite with this constant set to 99 and
+// reading the counts out of the failure message.
 const MIN_DISTINCT_LABELS = 5
 
 
@@ -68,12 +76,18 @@ async function expandTree(panel: Locator) {
  * Assert the panel shows a real hierarchy rather than the #1776 fallback.
  *
  * Counts DISTINCT `data-node-label` values, not rows. Two reasons rows are the
- * wrong measure: the list is virtualized, so the row count saturates at the
- * viewport (~25-30 at the config's 1280x800) and no threshold above that is
- * even expressible; and the failure being guarded — `Loader.js`'s
+ * wrong measure. First, the failure being guarded — `Loader.js`'s
  * `ifcManager.getSpatialStructure = () => model` fallback walking the GLB
  * scene graph — emits a root whose children carry the root's own name, which
- * is plenty of ROWS and one label.
+ * is plenty of ROWS and one label. Second, the list is virtualized through
+ * `react-window`, so on a large model the row count saturates at whatever the
+ * viewport mounts — and since this suite runs at two viewports (1280x800, and
+ * a 390x844 phone where the panel is a 50vh bottom drawer rather than a
+ * full-height side drawer) no single row threshold would hold at both.
+ *
+ * Neither fixture is large enough for that second reason to bind today: both
+ * flatten to 11 rows and all 11 mount at either size. A label count is what
+ * keeps that from mattering if a fixture ever grows.
  *
  * @param panel locator for the NavTree panel
  */
@@ -110,6 +124,13 @@ async function expectRealHierarchy(panel: Locator) {
  *     bug that captures an empty / one-element tree would surface
  *     here (e.g., `serializeNode`'s recursion stopping early).
  *
+ * Runs at both form factors (bldrs-ai/Share#1787). The cache
+ * round-trip is form-factor blind, but the surface these assertions
+ * read is not — the panel is a full-height side drawer on desktop
+ * and a 50vh bottom drawer on a phone, and it renders through
+ * `react-window`, so what is MOUNTED (and therefore assertable) is a
+ * function of viewport height.
+ *
  * Design: design/new/viewer-replacement.md §3b.iii. The Phase 5a
  * follow-up tracked there ("NavTree on cache-hit GLB") that this
  * spec was tracking. Pairs with the §3c "regression-testing
@@ -117,7 +138,7 @@ async function expectRealHierarchy(panel: Locator) {
  * BLDRS_* payloads will eventually be golden-snapshotted; this
  * spec is the smoke gate that the round-trip is alive at all.
  */
-describe('View 100: NavTree on cache-hit GLB', () => {
+describeMobileAndDesktop('View 100: NavTree on cache-hit GLB', () => {
   beforeEach(async ({page}) => {
     await homepageSetup(page)
     await setIsReturningUser(page.context())

--- a/src/Components/Properties/Properties.cacheHit.spec.ts
+++ b/src/Components/Properties/Properties.cacheHit.spec.ts
@@ -6,9 +6,10 @@ import {
 } from '../../tests/e2e/utils'
 import {waitForModelReady} from '../../tests/e2e/models'
 import {captureGlbLogs, resetGlbLogs, waitForGlbLog} from '../../tests/e2e/glbLogs'
+import {describeMobileAndDesktop} from '../../tests/e2e/formFactor'
 
 
-const {beforeEach, describe} = test
+const {beforeEach} = test
 
 
 /**
@@ -17,6 +18,11 @@ const {beforeEach, describe} = test
  * `BLDRS_element_properties` extension's full round-trip — capture →
  * GLB cache → reload → lazy decode → Properties panel renders the
  * full IFC entity (not just the slim spatial-tree-node whitelist).
+ *
+ * Runs at both form factors (bldrs-ai/Share#1787): the round-trip
+ * itself is form-factor blind, but `control-button-properties` and
+ * the panel it opens are not — on a phone the panel is a tab in the
+ * bottom drawer (`TabbedPanels`), not a side drawer.
  *
  * Design: design/new/viewer-replacement.md §3b.iii default-on gating;
  * Phase 3 prereq for `conwayDirectIfc` default-on. Pairs with the
@@ -30,7 +36,7 @@ const {beforeEach, describe} = test
  * extension, `model.getItemProperties` from the element-properties
  * extension, `inferModelCapabilities` flips for both).
  */
-describe('View 100: Properties panel on cache-hit GLB', () => {
+describeMobileAndDesktop('View 100: Properties panel on cache-hit GLB', () => {
   beforeEach(async ({page}) => {
     await homepageSetup(page)
     await setIsReturningUser(page.context())

--- a/src/Containers/sceneHighlightPermalink.spec.ts
+++ b/src/Containers/sceneHighlightPermalink.spec.ts
@@ -2,6 +2,7 @@ import {expect, test} from '@playwright/test'
 import {setupVirtualPathIntercept, waitForModelReady} from '../tests/e2e/models'
 import {homepageSetup, setIsReturningUser} from '../tests/e2e/utils'
 import {captureGlbLogs, resetGlbLogs, waitForGlbLog} from '../tests/e2e/glbLogs'
+import {describeMobileAndDesktop} from '../tests/e2e/formFactor'
 
 
 /**
@@ -20,14 +21,16 @@ import {captureGlbLogs, resetGlbLogs, waitForGlbLog} from '../tests/e2e/glbLogs'
  * both callers to the element path below the file suffix and requires
  * whole-segment-numeric ids.
  *
+ * Runs at both form factors (bldrs-ai/Share#1787). Only the NavTree
+ * assertion below is DOM-bound and so form-factor sensitive; the rest read the
+ * store, which does not know what size the window is.
+ *
  * The scene highlight has no DOM, so the scene-side assertions read the
  * exposed store/viewer (`window.useStore` — exposed for debugging in
  * useStore.js) rather than pixels: the batched selection layer (live batched
  * model) or the merged-path selection subsets (cache-hit model), whichever
  * render path is active.
  */
-const {describe} = test
-
 const MODEL_PATH = '/share/v/gh/bldrs-ai/test-models/main/ifc/openifcmodels/171210AISC_Sculpture_param.ifc'
 // Element path written by selecting plate 'p58' — project root down to the element.
 const ELEMENT_PERMALINK = `${MODEL_PATH}/120010/120020/120023/4998/2867`
@@ -47,7 +50,7 @@ async function permalinkSetup(page: import('@playwright/test').Page) {
   await setupVirtualPathIntercept(page, MODEL_PATH, '')
 }
 
-describe('Element-path permalink on a digit-prefixed filename', () => {
+describeMobileAndDesktop('Element-path permalink on a digit-prefixed filename', () => {
   test('restores selection and keeps the scene highlight', async ({page}) => {
     test.setTimeout(TEST_TIMEOUT_MS)
     await permalinkSetup(page)


### PR DESCRIPTION
Closes #1787.

The three GLB cache-hit specs restored in #1783 were plain `test.describe`, so they only ever ran at the config's desktop viewport. They are the specs that guard #1776 — the STEP model whose *second* (cache-hit) load rendered an empty NavTree — so the missing mobile half is not a formality. This wraps all three in `describeMobileAndDesktop`.

## What changed

- `src/Components/NavTree/NavTree.cacheHit.spec.ts` (IFC + STEP)
- `src/Components/Properties/Properties.cacheHit.spec.ts`
- `src/Containers/sceneHighlightPermalink.spec.ts`

10 tests, 10 green: `yarn test-flows <the three specs> --retries=0`.

Nothing beyond the wrapper was needed to make them pass. No threshold lowered, no branch on `ff.isMobile`, no scroll or extra expansion — the mobile leg runs the identical body. Two comment corrections are the only other edits.

## What the mobile leg turned up

**The round trip is form-factor blind, and now that is measured rather than assumed.** The cache-hit permalink test prints its scene state, and mobile reports exactly what desktop does: `{"selectedElements":["2867"],"mergedSubsets":1,"batchedSelSetTotal":0,"batchedMeshes":0,"meshes":16,"misaligned":0}`.

**`expectRealHierarchy`'s stated reason was wrong, and the mobile run is what made it checkable.** The doc said rows are the wrong measure because the row count "saturates at the viewport (~25-30 at the config's 1280x800)". Both fixtures flatten to **11 rows total**, so nothing saturates at 1280x800 and nothing saturates at 390x844 either — all 11 mount at both sizes. Virtualization is a reason the assertion *stays* correct if a fixture grows; it is not the reason it is correct today. The load-bearing reason is the other one the comment gave: the #1776 fallback emits many rows carrying one label. Comment rewritten to say that, and to record the two viewports the suite now runs at.

**`MIN_DISTINCT_LABELS = 5` is a ceiling, not a floor.** `index.ifc` and `index.step` both flatten to exactly `Bldrs / Build / Every / Thing / Together` — 5 distinct labels is the *most* either fixture can offer. There was no headroom to trade away for the smaller viewport, and raising it would fail on desktop too. Noted at the constant so the next reader does not go looking for slack that is not there.

## Proving the mobile assertions can fail

Each of these was run, watched go red, and reverted.

| Break | Result |
|---|---|
| `MIN_DISTINCT_LABELS` 5 → 99 | All 4 NavTree tests red. Message: `expanded tree had 5 distinct label(s) over 11 row(s): ["Bldrs","Build","Every","Thing","Together",…]` — byte-identical on `[desktop]` and `[mobile]`. This run is where the ceiling above was measured. |
| `expandTree(navTreePanel)` removed | All 4 red at `1 distinct label(s) over 1 row(s): ["Bldrs"]`, mobile included — so expansion is load-bearing at phone height, and the collapsed root does not satisfy the threshold by accident. |
| Properties `Name` `'Together'` → `'TogetherXX'` | `[mobile]` red, reporting the real row text `"NameTogether"` — the panel genuinely rendered through `TabbedPanels` on the phone. |
| Permalink `toHaveCount(1)` → `toHaveCount(2)` | `[mobile]` red, `Received: 1` — one NavTree row really is selected on mobile, not zero. |
| Permalink `hit.meshes > 0` → `> 1000` | `[mobile]` red, `Received: 16` — the cache-hit picking tables are present on mobile. |

Final state re-run after restoring all five: 10 passed.

## Note on the eslint line

An earlier revision of this PR carried `root: true` in `.eslintrc.cjs`. Three PRs each hit the same unrunnable commit gate in an agent worktree and each patched it locally, so it has been **split out to #1792** (merged) and removed here. Main now carries it, and this branch has merged main.

## Checks

- `yarn test-flows` on all three specs, both form factors, `--retries=0`: 10 passed.
- Husky pre-commit gate on every commit here, including the merge commit (forced with `--amend`, since `pre-commit` does not fire on `git merge`): eslint + typecheck + full Jest suite green.
- CI on `5b18cff`: `build` ✅, `playwright-run` ✅, `playwright-webifc-run` ✅.
- `package.json` version stamp from the Playwright build reverted before committing (#1747).