### PR TITLE
Give the conway-direct load logs a swappable sink

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,13 +1,5 @@
 /* eslint-disable no-magic-numbers */
 module.exports = {
-  // Stop the config cascade here. Agent worktrees live under
-  // `.claude/worktrees/<id>/` inside a second checkout, so without this ESLint
-  // walks up to the outer checkout's config: plugins then resolve from two
-  // node_modules trees ("couldn't determine the plugin … uniquely"), and the
-  // ignore base path becomes the outer root, under which every worktree file
-  // sits below a dot-directory and is "ignored by default" — i.e. the husky
-  // pre-commit gate can't lint anything.
-  root: true,
   env: {
     browser: true,
     es2021: true,

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,5 +1,13 @@
 /* eslint-disable no-magic-numbers */
 module.exports = {
+  // Stop the config cascade here. Agent worktrees live under
+  // `.claude/worktrees/<id>/` inside a second checkout, so without this ESLint
+  // walks up to the outer checkout's config: plugins then resolve from two
+  // node_modules trees ("couldn't determine the plugin … uniquely"), and the
+  // ignore base path becomes the outer root, under which every worktree file
+  // sits below a dot-directory and is "ignored by default" — i.e. the husky
+  // pre-commit gate can't lint anything.
+  root: true,
   env: {
     browser: true,
     es2021: true,

--- a/PLAYBOOK.md
+++ b/PLAYBOOK.md
@@ -280,12 +280,19 @@ design — don't let it reach the console and don't silently swallow it either.
 Route it through a swappable sink and assert the expected line is present, so
 the diagnostic becomes a *tested signal* instead of spam:
 
-- `src/loader/glbLog.js` — the emit side. `glbInfo/glbWarn/glbVerbose` call an
-  active sink (default: console) that tests can swap via `setGlbLogSink`. The
-  sink lives on `globalThis` so it survives `jest.resetModules()`.
-- `tools/jest/glbLogCapture.js` — the test side. `installGlbLogCapture()`
-  (wired once in `setupTests.js`, cleared per test) buffers everything; a spec
-  reads it with `getGlbLogs()`:
+- `src/utils/logSink.js` — the mechanism. `createLogChannel(prefix, sinkKey)`
+  returns `{emit, setSink}`: `emit` writes `<prefix> <args>` to the console
+  until a sink is installed. The sink lives on `globalThis` (under `sinkKey`)
+  so it survives `jest.resetModules()`.
+- `src/loader/glbLog.js` — the `[glb]` emit side. `glbInfo/glbWarn/glbVerbose`
+  emit on that channel; tests swap the sink via `setGlbLogSink`.
+  `src/viewer/ifc/conwayDirectLog.js` is the same for the `[conwayDirect]` IFC
+  parse summary and parse-failure error.
+- `tools/jest/logCapture.js` + its per-channel wrappers
+  (`glbLogCapture.js`, `conwayDirectLogCapture.js`) — the test side.
+  `installGlbLogCapture()` / `installConwayDirectLogCapture()` (wired once in
+  `setupTests.js`, cleared per test) buffer everything; a spec reads a buffer
+  with `getGlbLogs()` / `getConwayDirectLogs()`:
 
 ```js
 import {getGlbLogs} from '../../tools/jest/glbLogCapture'
@@ -294,8 +301,14 @@ expect(getGlbLogs().some((l) => l.text.includes('out-of-range bufferView 99')))
   .toBe(true)
 ```
 
+Pin values, not presence: `Loader.test.js` asserts the whole
+`parsed modelID=0 — vertices=3 triangles=1 …` text, so a regression that
+silently drops geometry fails the test — `some(l => l.text.includes('parsed'))`
+would not have.
+
 Apply this pattern to any subsystem with intentional, assertable logging:
-give it a swappable sink rather than calling `console.*` directly.
+build it a channel with `createLogChannel` rather than calling `console.*`
+directly.
 
 **3. Suppress only what you genuinely can't reach — narrowly, and restore it.**
 Some updates fire outside any `act` scope RTL can enclose: a mocked model load

--- a/STYLE.md
+++ b/STYLE.md
@@ -127,8 +127,10 @@ this priority order:
   mute it. Keep flush helpers timer-agnostic (a single microtask, never
   `setTimeout` — it hangs under fake timers).
 - **Divert expected output and assert on it.** Code that logs *by design*
-  (the `[glb]` diagnostics) routes through a swappable sink and is checked via
-  `getGlbLogs()` — a tested signal, not console spam.
+  (the `[glb]` and `[conwayDirect]` diagnostics) routes through a swappable
+  sink — `createLogChannel` (`src/utils/logSink.js`) — and is checked via
+  `getGlbLogs()` / `getConwayDirectLogs()`: a tested signal, not console spam.
+  Assert the line's values, not just that some line was logged.
 - **Suppress only what you can't reach** — narrowly (`suppressActWarnings()`
   swallows just the one line), scoped to one test, restored in `try/finally`.
 - **Back any global mute with a static test** — e.g. three's muted "Multiple

--- a/src/loader/Loader.cover.test.js
+++ b/src/loader/Loader.cover.test.js
@@ -223,13 +223,38 @@ const EXPECTED_LOADER_ERRORS = /open failed|is not a function/i
 
 
 /**
- * Every `[conwayDirect]` line a rejection test produced must be one of the
- * failures that test induced. Call from an afterEach.
+ * Every `[conwayDirect]` line a test produced must be one of the failures that
+ * test induced. Call from an afterEach.
+ *
+ * This is a NEGATIVE guard only — it catches an unexpected diagnostic, and an
+ * empty buffer passes it by running zero assertions. That is correct here (most
+ * tests induce no parse failure and should log nothing) but it means this
+ * cannot notice the diagnostic disappearing. {@link expectInducedLoaderError}
+ * is the positive half; the two are not interchangeable.
  */
 function expectOnlyInducedLoaderErrors() {
   for (const {text} of getConwayDirectLogs()) {
     expect(text).toMatch(EXPECTED_LOADER_ERRORS)
   }
+}
+
+
+/**
+ * A `[conwayDirect]` diagnostic was actually captured for this test, and it is
+ * one of the failures the test induced.
+ *
+ * Call from the five tests whose mocked parse throws. Without it the suite has
+ * no assertion that the channel emits at all: `ShareIfcLoader#parse` logs
+ * through `conwayDirectError` and then rethrows, so the rejection these tests
+ * await is raised by the rethrow and satisfied whether or not anything was
+ * logged. Silence the channel — or break the jest capture — and every one of
+ * them stays green while the diagnostic it exists to protect is gone.
+ * (codex, PR #1789.)
+ */
+function expectInducedLoaderError() {
+  const logs = getConwayDirectLogs()
+  expect(logs.length).toBeGreaterThan(0)
+  expect(logs.some(({text}) => EXPECTED_LOADER_ERRORS.test(text))).toBe(true)
 }
 
 
@@ -588,6 +613,8 @@ describe('load() error/edge paths with OPFS enabled', () => {
     expect(arrayBufferSpy).not.toHaveBeenCalled()
     expect(sliceSpy).toHaveBeenCalled()
     expect(onProgress).toHaveBeenCalledWith('Hashing model...')
+    // The parse this test induced also emitted its diagnostic.
+    expectInducedLoaderError()
   })
 
 
@@ -620,6 +647,8 @@ describe('load() error/edge paths with OPFS enabled', () => {
     expect(arrayBufferSpy).toHaveBeenCalledTimes(1)
     expect(onProgress).toHaveBeenCalledWith('Buffering model bytes...')
     expect(onProgress).not.toHaveBeenCalledWith('Hashing model...')
+    // The parse this test induced also emitted its diagnostic.
+    expectInducedLoaderError()
   })
 
 
@@ -649,6 +678,8 @@ describe('load() error/edge paths with OPFS enabled', () => {
 
     expect(arrayBufferSpy).not.toHaveBeenCalled()
     expect(onProgress).toHaveBeenCalledWith('Hashing model...')
+    // The parse this test induced also emitted its diagnostic.
+    expectInducedLoaderError()
   })
 
 
@@ -682,6 +713,8 @@ describe('load() error/edge paths with OPFS enabled', () => {
 
     expect(arrayBufferSpy).toHaveBeenCalledTimes(1)
     expect(onProgress).toHaveBeenCalledWith('Buffering model bytes...')
+    // The parse this test induced also emitted its diagnostic.
+    expectInducedLoaderError()
   })
 
 
@@ -706,6 +739,8 @@ describe('load() error/edge paths with OPFS enabled', () => {
 
     expect(arrayBufferSpy).toHaveBeenCalledTimes(1)
     expect(onProgress).toHaveBeenCalledWith('Buffering model bytes...')
+    // The parse this test induced also emitted its diagnostic.
+    expectInducedLoaderError()
   })
 
 

--- a/src/loader/Loader.cover.test.js
+++ b/src/loader/Loader.cover.test.js
@@ -6,6 +6,7 @@
 // error shapes.
 
 import axios from 'axios'
+import {getConwayDirectLogs} from '../../tools/jest/conwayDirectLogCapture'
 import {downloadToOPFS, downloadModel, getModelFromOPFS} from '../OPFS/utils'
 import ShareIfcLoader from '../viewer/ifc/ShareIfcLoader'
 import {constructUploadedBlobPath, load, NotFoundError} from './Loader'
@@ -212,47 +213,28 @@ describe('Loader exported helpers', () => {
 })
 
 
-// `ShareIfcLoader#parse` logs the parse failure with `console.error` before
-// rethrowing, so every rejection-based case below emits one by design. A test
-// run should print nothing unexpected (STYLE.md §"Console hygiene"), so divert
-// them into a buffer — and assert on the buffer rather than silently
-// swallowing it, per PLAYBOOK §"Keep the test console clean" move 2. Anything
-// that is NOT one of these induced failures fails the test instead of
-// scrolling past in the noise.
-const EXPECTED_LOADER_ERRORS =
-  /open failed|is not a function|Failed to fetch model data|Unknown filetype|Could not guess filetype/i
+// `ShareIfcLoader#parse` logs the parse failure through the `[conwayDirect]`
+// channel before rethrowing, so every rejection-based case below emits one by
+// design. The jest setup buffers that channel instead of printing it
+// (PLAYBOOK §"Keep the test console clean" move 2); assert on the buffer
+// rather than ignoring it, so a diagnostic that is NOT one of these induced
+// failures fails the test instead of passing unnoticed.
+const EXPECTED_LOADER_ERRORS = /open failed|is not a function/i
 
 
 /**
- * Divert `console.error` for one test. Returns the buffer plus a restore.
- *
- * @return {{lines: string[], restore: Function}}
+ * Every `[conwayDirect]` line a rejection test produced must be one of the
+ * failures that test induced. Call from an afterEach.
  */
-function divertConsoleError() {
-  const original = console.error
-  const lines = []
-  console.error = (...args) => {
-    lines.push(args.map((a) => (a instanceof Error ? `${a.name}: ${a.message}` : String(a))).join(' '))
+function expectOnlyInducedLoaderErrors() {
+  for (const {text} of getConwayDirectLogs()) {
+    expect(text).toMatch(EXPECTED_LOADER_ERRORS)
   }
-  return {lines, restore: () => {
-    console.error = original
-  }}
 }
 
 
 describe('load() with isOpfsAvailable=false (axios path)', () => {
-  let consoleError
-
-  beforeEach(() => {
-    consoleError = divertConsoleError()
-  })
-
-  afterEach(() => {
-    consoleError.restore()
-    for (const line of consoleError.lines) {
-      expect(line).toMatch(EXPECTED_LOADER_ERRORS)
-    }
-  })
+  afterEach(expectOnlyInducedLoaderErrors)
 
   let viewer
   let onProgress
@@ -406,18 +388,7 @@ describe('load() with isOpfsAvailable=false (axios path)', () => {
 
 
 describe('load() error/edge paths with OPFS enabled', () => {
-  let consoleError
-
-  beforeEach(() => {
-    consoleError = divertConsoleError()
-  })
-
-  afterEach(() => {
-    consoleError.restore()
-    for (const line of consoleError.lines) {
-      expect(line).toMatch(EXPECTED_LOADER_ERRORS)
-    }
-  })
+  afterEach(expectOnlyInducedLoaderErrors)
 
   let viewer
   let onProgress

--- a/src/loader/Loader.test.js
+++ b/src/loader/Loader.test.js
@@ -1,5 +1,6 @@
 import {Object3D, Mesh, BufferGeometry, Material, BufferAttribute} from 'three'
 import {GLTFLoader} from 'three/examples/jsm/loaders/GLTFLoader.js'
+import {getConwayDirectLogs} from '../../tools/jest/conwayDirectLogCapture'
 import ShareIfcLoader from '../viewer/ifc/ShareIfcLoader'
 import {load, readModel} from './Loader'
 
@@ -343,6 +344,71 @@ describe('Loader', () => {
         warningCount: 3,
       })
       expect(model).toMatchSnapshot()
+
+      // The `[conwayDirect] parsed …` summary is the integration-boundary
+      // signal `conwayDirect.spec.ts` gates on in a real browser; here it
+      // rides the same swappable sink (src/viewer/ifc/conwayDirectLog.js), so
+      // assert its whole text rather than letting it print. This mock's
+      // StreamAllMeshes yields nothing, so every count is the empty-model
+      // zero — the non-empty counts are pinned in the test below.
+      expect(getConwayDirectLogs()).toEqual([{
+        level: 'info',
+        text: 'parsed modelID=0 — vertices=0 triangles=0 instances=0 parents=0 materials=0 ' +
+          'skippedFlatMeshes=0 skippedPlaced=0 skippedCoincident=0',
+      }])
+    } finally {
+      restoreArrayBuffer()
+    }
+  })
+
+  it('reports the parsed element counts for a streamed FlatMesh', async () => {
+    // Same load path as above, but with one placement in the FlatMesh stream,
+    // so the summary reports what was actually assembled instead of zeros: a
+    // unit triangle is 3 vertices / 1 triangle at 1 instance under 1 parent.
+    // This is the assertion that would catch a regression that silently drops
+    // geometry — the counts are the payload, not the presence of a log line.
+    mockViewer.IFC.type = 'ifc'
+    const {ifcAPI} = mockViewer.IFC.loader.ifcManager
+    const IDENTITY_MAT = [
+      1, 0, 0, 0,
+      0, 1, 0, 0,
+      0, 0, 1, 0,
+      0, 0, 0, 1,
+    ]
+    // Interleaved position+normal, the layout Conway's GetVertexArray returns.
+    const triangleVerts = new Float32Array([
+      0, 0, 0, 0, 0, 1,
+      1, 0, 0, 0, 0, 1,
+      0, 1, 0, 0, 0, 1,
+    ])
+    const triangleIndices = new Uint32Array([0, 1, 2])
+    const GEOMETRY_EXPRESS_ID = 999
+    ifcAPI.StreamAllMeshes = jest.fn((modelID, cb) => cb({
+      expressID: 100,
+      geometries: {
+        size: () => 1,
+        get: () => ({geometryExpressID: GEOMETRY_EXPRESS_ID, flatTransformation: IDENTITY_MAT}),
+      },
+    }))
+    ifcAPI.GetGeometry = jest.fn(() => ({
+      GetVertexData: () => 0,
+      GetIndexData: () => 0,
+      GetVertexDataSize: () => triangleVerts.length,
+      GetIndexDataSize: () => triangleIndices.length,
+    }))
+    ifcAPI.GetVertexArray = jest.fn(() => triangleVerts)
+    ifcAPI.GetIndexArray = jest.fn(() => triangleIndices)
+
+    const testPath = 'ifc/index.ifc'
+    const restoreArrayBuffer = testPathToContent(testPath)
+    try {
+      const model = await load(testPathToUrl(testPath), mockViewer, jest.fn(), true, jest.fn(), '')
+      expect(model).toBeDefined()
+      expect(getConwayDirectLogs()).toEqual([{
+        level: 'info',
+        text: 'parsed modelID=0 — vertices=3 triangles=1 instances=1 parents=1 materials=1 ' +
+          'skippedFlatMeshes=0 skippedPlaced=0 skippedCoincident=0',
+      }])
     } finally {
       restoreArrayBuffer()
     }

--- a/src/loader/glbLog.js
+++ b/src/loader/glbLog.js
@@ -15,37 +15,12 @@
 // default to `glbVerbose` unless the line earns its place in every load's
 // console.
 import {isFeatureEnabled} from '../FeatureFlags'
+import {createLogChannel} from '../utils/logSink'
 
 
-/**
- * Default sink: write to the console with a stable `[glb]` prefix. `level` is
- * a console method name ('info' | 'warn' | 'error').
- *
- * @param {string} level
- * @param {Array<*>} args
- */
-function consoleSink(level, args) {
-  // eslint-disable-next-line no-console
-  console[level]('[glb]', ...args)
-}
-
-
-// The active sink lives on globalThis, not a module variable, so it survives
-// `jest.resetModules()`: a harness that resets the registry and re-imports this
-// file (e.g. GlbWriterService.test.js) still shares the one sink the test setup
-// installed — module state resets, globals don't. A module-local `sink` would
-// spring back to the console on re-import, letting that path's `[glb]` lines
-// both escape the capture buffer AND print. Unset in production ⇒ console.
-const SINK_KEY = '__bldrsGlbLogSink'
-
-
-/**
- * @return {function(string, Array<*>): void} the active sink — the installed
- *   capturing sink under test, else the console default.
- */
-function activeSink() {
-  return (typeof globalThis !== 'undefined' && globalThis[SINK_KEY]) || consoleSink
-}
+// `createLogChannel` owns the console default and the globalThis-hosted
+// swappable sink (see its docs for why the sink can't be module state).
+const channel = createLogChannel('[glb]', '__bldrsGlbLogSink')
 
 
 /**
@@ -57,9 +32,7 @@ function activeSink() {
  * @param {?function(string, Array<*>): void} fn (level, args) => void
  */
 export function setGlbLogSink(fn) {
-  if (typeof globalThis !== 'undefined') {
-    globalThis[SINK_KEY] = fn ?? undefined
-  }
+  channel.setSink(fn)
 }
 
 
@@ -71,7 +44,7 @@ export function setGlbLogSink(fn) {
  * @param {...*} args
  */
 export function glbInfo(...args) {
-  activeSink()('info', args)
+  channel.emit('info', args)
 }
 
 
@@ -84,7 +57,7 @@ export function glbInfo(...args) {
  * @param {...*} args
  */
 export function glbWarn(...args) {
-  activeSink()('warn', args)
+  channel.emit('warn', args)
 }
 
 
@@ -97,6 +70,6 @@ export function glbWarn(...args) {
  */
 export function glbVerbose(...args) {
   if (isFeatureEnabled('glbVerbose')) {
-    activeSink()('info', args)
+    channel.emit('info', args)
   }
 }

--- a/src/utils/logSink.js
+++ b/src/utils/logSink.js
@@ -1,0 +1,73 @@
+// Swappable console channels for subsystems that log by design.
+//
+// PLAYBOOK.md §"Keep the test console clean" (move 2): code that is
+// *supposed* to log — the `[glb]` pipeline's milestones, the
+// `[conwayDirect]` parse boundary — should neither spam the test console nor
+// be silently swallowed. Each such subsystem owns a channel built here: in
+// the app it writes to the console under its prefix; under jest the harness
+// swaps in a capturing sink (`tools/jest/logCapture.js`) and specs assert on
+// the buffered values, so the diagnostic becomes a tested signal instead of
+// noise.
+//
+// Consumers: `src/loader/glbLog.js` (`[glb]`),
+// `src/viewer/ifc/conwayDirectLog.js` (`[conwayDirect]`).
+
+
+/**
+ * @typedef {function(string, Array<*>): void} LogSink Receives (level, args),
+ *   where `level` is a console method name ('info' | 'warn' | 'error').
+ */
+
+
+/**
+ * Build a prefixed log channel whose sink can be swapped at runtime.
+ *
+ * The active sink lives on `globalThis` under `sinkKey`, not in a module
+ * variable, so it survives `jest.resetModules()`: a harness that resets the
+ * registry and re-imports the channel's module (e.g. GlbWriterService.test.js)
+ * still shares the one sink the test setup installed — module state resets,
+ * globals don't. A module-local sink would spring back to the console on
+ * re-import, letting that path's lines both escape the capture buffer AND
+ * print. Unset (i.e. in production) ⇒ the console sink.
+ *
+ * @param {string} prefix Tag prepended to every console line, e.g. '[glb]'.
+ *   Passed as its own console arg, so a browser's `msg.text()` still reads
+ *   `<prefix> <message>` — E2E specs grep for that joined form.
+ * @param {string} sinkKey `globalThis` property holding the active sink. Must
+ *   be unique per channel.
+ * @return {{emit: function(string, Array<*>): void, setSink: function(?LogSink): void}}
+ */
+export function createLogChannel(prefix, sinkKey) {
+  /**
+   * @param {string} level
+   * @param {Array<*>} args
+   */
+  function consoleSink(level, args) {
+    // eslint-disable-next-line no-console
+    console[level](prefix, ...args)
+  }
+
+
+  /**
+   * @param {string} level
+   * @param {Array<*>} args
+   */
+  function emit(level, args) {
+    const sink = (typeof globalThis !== 'undefined' && globalThis[sinkKey]) || consoleSink
+    sink(level, args)
+  }
+
+
+  /**
+   * Passing null/undefined restores the console sink.
+   *
+   * @param {?LogSink} fn
+   */
+  function setSink(fn) {
+    if (typeof globalThis !== 'undefined') {
+      globalThis[sinkKey] = fn ?? undefined
+    }
+  }
+
+  return {emit, setSink}
+}

--- a/src/utils/logSink.test.js
+++ b/src/utils/logSink.test.js
@@ -1,0 +1,59 @@
+import {createLogChannel} from './logSink'
+
+
+// Each test builds its own channel under a throwaway globalThis key so it
+// can't collide with the `[glb]` / `[conwayDirect]` channels the jest setup
+// has already installed capturing sinks on.
+describe('utils/logSink', () => {
+  let sinkKey
+  let infoSpy
+  let channelCount = 0
+
+  beforeEach(() => {
+    channelCount += 1
+    sinkKey = `__testLogSink_${channelCount}`
+    infoSpy = jest.spyOn(console, 'info').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    infoSpy.mockRestore()
+    delete globalThis[sinkKey]
+  })
+
+  it('writes to the console under its prefix when no sink is installed', () => {
+    const {emit} = createLogChannel('[test]', sinkKey)
+    emit('info', ['parsed modelID=0', 7])
+    // The prefix is its own console arg, so a browser's msg.text() joins it
+    // back into `[test] parsed modelID=0 7` — the form E2E specs grep for.
+    const SEVEN = 7
+    expect(infoSpy).toHaveBeenCalledWith('[test]', 'parsed modelID=0', SEVEN)
+  })
+
+  it('routes to an installed sink instead of the console', () => {
+    const {emit, setSink} = createLogChannel('[test]', sinkKey)
+    const sink = jest.fn()
+    setSink(sink)
+    emit('warn', ['careful'])
+    expect(sink).toHaveBeenCalledWith('warn', ['careful'])
+    expect(infoSpy).not.toHaveBeenCalled()
+  })
+
+  it('restores the console sink when the sink is cleared', () => {
+    const {emit, setSink} = createLogChannel('[test]', sinkKey)
+    setSink(jest.fn())
+    setSink(null)
+    emit('info', ['back on the console'])
+    expect(infoSpy).toHaveBeenCalledWith('[test]', 'back on the console')
+  })
+
+  it('shares the sink across re-imports of the channel module', () => {
+    // The reason the sink lives on globalThis: a spec that calls
+    // jest.resetModules() re-runs the channel module, and the freshly created
+    // channel must still see the sink the test setup installed.
+    const sink = jest.fn()
+    createLogChannel('[test]', sinkKey).setSink(sink)
+    createLogChannel('[test]', sinkKey).emit('info', ['second import'])
+    expect(sink).toHaveBeenCalledWith('info', ['second import'])
+    expect(infoSpy).not.toHaveBeenCalled()
+  })
+})

--- a/src/viewer/ifc/ShareIfcLoader.js
+++ b/src/viewer/ifc/ShareIfcLoader.js
@@ -21,6 +21,7 @@ import {Mesh} from 'three'
 import {assembleBatchedModel, buildBatchedConwayModel} from './buildBatchedConwayModel'
 import {IncrementalBatchedBuilder} from './incrementalBatchedBuilder'
 import {buildConwayIfcModel} from './buildConwayIfcModel'
+import {conwayDirectError, conwayDirectInfo} from './conwayDirectLog'
 import {decorateConwayDirectIfcModel, parseIfcWithConway} from './conwayDirectIfcLoader'
 import {flatMeshToBufferGeometry} from './flatMeshToBufferGeometry'
 import {flatMeshToInstancedModel} from './flatMeshToInstancedModel'
@@ -569,10 +570,12 @@ export default class ShareIfcLoader {
       // that the Conway-direct parse + assembly path completed
       // successfully on a real model. Kept at info level (not gated
       // on glbVerbose) so the signal is visible in production logs
-      // without the user opting in to the verbose channel.
-      // eslint-disable-next-line no-console
-      console.info(
-        `[conwayDirect] parsed modelID=${modelID} — ` +
+      // without the user opting in to the verbose channel. The
+      // `[conwayDirect]` tag comes from the channel's console sink, so
+      // the browser-visible line is unchanged; under jest the sink
+      // buffers it and `Loader.test.js` asserts these counts.
+      conwayDirectInfo(
+        `parsed modelID=${modelID} — ` +
         `vertices=${buildStats.vertexCount} triangles=${buildStats.triangleCount} ` +
         `instances=${buildStats.instanceCount} parents=${buildStats.parentCount} ` +
         `materials=${buildStats.materialCount} ` +
@@ -602,7 +605,7 @@ export default class ShareIfcLoader {
       if (isOutOfMemoryError(err)) {
         throw markIfOutOfMemory(err)
       }
-      console.error(err)
+      conwayDirectError(err)
       if (onError) {
         onError(err)
       }

--- a/src/viewer/ifc/conwayDirectLog.js
+++ b/src/viewer/ifc/conwayDirectLog.js
@@ -1,0 +1,59 @@
+// Visible diagnostics for the Conway-direct IFC pipeline.
+//
+// Both lines this channel carries are permanent integration-boundary
+// signals, which is why they are console.* and not `debug()` (the repo's
+// default level is WARN, so a debug() line would be invisible in the field):
+//
+//   - the per-load `parsed modelID=… vertices=…` summary — the single
+//     observable proof that parse + assembly completed on a real model;
+//     `src/loader/conwayDirect.spec.ts` and the deploy-preview smoke checks
+//     gate on it.
+//   - the parse failure — the only trace a load that returns null leaves.
+//
+// Routing them through a swappable sink keeps that production behavior
+// (`[conwayDirect] <message>` on the console, unchanged wording) while
+// letting jest divert them into a buffer and assert the values, per
+// PLAYBOOK.md §"Keep the test console clean" move 2. `src/loader/glbLog.js`
+// is the same pattern for the `[glb]` pipeline; both are built on
+// `createLogChannel`, which documents why the sink lives on `globalThis`.
+//
+// Sibling `[conwayDirect]` lines in `conwayDirectIfcLoader.js` (demand-pump
+// summary, occurrence-path mismatch) still call the console directly; move
+// them here when a test needs to assert them.
+import {createLogChannel} from '../../utils/logSink'
+
+
+const channel = createLogChannel('[conwayDirect]', '__bldrsConwayDirectLogSink')
+
+
+/**
+ * Swap the `[conwayDirect]` log sink. Tests install a capturing sink
+ * (`tools/jest/conwayDirectLogCapture.js`) so these diagnostics are asserted
+ * against a buffer instead of printed. Passing null/undefined restores the
+ * console sink.
+ *
+ * @param {?function(string, Array<*>): void} fn (level, args) => void
+ */
+export function setConwayDirectLogSink(fn) {
+  channel.setSink(fn)
+}
+
+
+/**
+ * Per-load milestone (console.info by default).
+ *
+ * @param {...*} args
+ */
+export function conwayDirectInfo(...args) {
+  channel.emit('info', args)
+}
+
+
+/**
+ * Error-path diagnostic (console.error by default).
+ *
+ * @param {...*} args
+ */
+export function conwayDirectError(...args) {
+  channel.emit('error', args)
+}

--- a/tools/jest/conwayDirectLogCapture.js
+++ b/tools/jest/conwayDirectLogCapture.js
@@ -1,0 +1,39 @@
+// Test capture for the `[conwayDirect]` IFC pipeline logs.
+//
+// `ShareIfcLoader#parse` emits a per-load parse summary and, on failure, the
+// error — both by design (see `src/viewer/ifc/conwayDirectLog.js`). In the
+// app they reach the console; under jest they land in this buffer instead, so
+// `Loader.test.js` asserts the summary's element counts and `Loader.cover.test.js`
+// asserts each induced failure, rather than either scrolling past.
+//
+// Wired up globally in `setupTests.js` (install once, clear before each test).
+// Import the getter directly in a spec to assert:
+//
+//   import {getConwayDirectLogs} from '../../tools/jest/conwayDirectLogCapture'
+//   expect(getConwayDirectLogs().map((l) => l.text)).toContain('parsed modelID=0 …')
+import {setConwayDirectLogSink} from '../../src/viewer/ifc/conwayDirectLog'
+import {createLogCapture} from './logCapture'
+
+
+const capture = createLogCapture(setConwayDirectLogSink)
+
+
+/** Install the capturing sink. Idempotent; call once from global setup. */
+export function installConwayDirectLogCapture() {
+  capture.install()
+}
+
+
+/** Drop everything captured so far (call before each test). */
+export function clearConwayDirectLogs() {
+  capture.clear()
+}
+
+
+/**
+ * @return {Array<{level: string, text: string}>} a copy of the captured
+ *   `[conwayDirect]` log entries since the last clear.
+ */
+export function getConwayDirectLogs() {
+  return capture.get()
+}

--- a/tools/jest/glbLogCapture.js
+++ b/tools/jest/glbLogCapture.js
@@ -1,12 +1,11 @@
 // Test capture for the `[glb]` pipeline logs.
 //
-// A clean load — and a clean test run — should leave a quiet console
-// (conway #301 §6). The GLB loader/writer emit `[glb]` milestone and
-// error-path diagnostics through `src/loader/glbLog.js`; in the app those go
-// to the console, but under jest we divert them into a buffer instead of
-// printing. Tests that exercise an error path assert the diagnostic fired via
-// `getGlbLogs()` (turning would-be console noise into positive coverage);
-// everything else stays silent.
+// The GLB loader/writer emit `[glb]` milestone and error-path diagnostics
+// through `src/loader/glbLog.js`; in the app those go to the console, but
+// under jest we divert them into a buffer instead of printing. Tests that
+// exercise an error path assert the diagnostic fired via `getGlbLogs()`
+// (turning would-be console noise into positive coverage); everything else
+// stays silent.
 //
 // Wired up globally in `setupTests.js` (install once, clear before each test).
 // Import the getters directly in a spec to assert:
@@ -14,45 +13,21 @@
 //   import {getGlbLogs} from '../../tools/jest/glbLogCapture'
 //   expect(getGlbLogs().some((l) => l.text.includes('out-of-range'))).toBe(true)
 import {setGlbLogSink} from '../../src/loader/glbLog'
+import {createLogCapture} from './logCapture'
 
 
-/** @type {Array<{level: string, text: string}>} */
-const captured = []
-
-
-/**
- * Stringify one sink arg for buffer matching. Errors keep their message;
- * objects fall back to a safe tag rather than throwing on a cyclic value.
- *
- * @param {*} arg
- * @return {string}
- */
-function argToText(arg) {
-  if (arg instanceof Error) {
-    return arg.message
-  }
-  if (arg === null || arg === undefined || typeof arg !== 'object') {
-    return String(arg)
-  }
-  try {
-    return JSON.stringify(arg)
-  } catch {
-    return '[object]'
-  }
-}
+const capture = createLogCapture(setGlbLogSink)
 
 
 /** Install the capturing sink. Idempotent; call once from global setup. */
 export function installGlbLogCapture() {
-  setGlbLogSink((level, args) => {
-    captured.push({level, text: args.map(argToText).join(' ')})
-  })
+  capture.install()
 }
 
 
 /** Drop everything captured so far (call before each test). */
 export function clearGlbLogs() {
-  captured.length = 0
+  capture.clear()
 }
 
 
@@ -61,5 +36,5 @@ export function clearGlbLogs() {
  *   `[glb]` log entries since the last clear.
  */
 export function getGlbLogs() {
-  return captured.slice()
+  return capture.get()
 }

--- a/tools/jest/logCapture.js
+++ b/tools/jest/logCapture.js
@@ -1,0 +1,55 @@
+// Test-side half of `src/utils/logSink.js`.
+//
+// A clean load — and a clean test run — should leave a quiet console
+// (conway #301 §6). Subsystems that log by design emit through a swappable
+// channel; under jest we install a capturing sink per channel so the lines
+// land in a buffer instead of printing, and specs assert the ones they
+// expect (turning would-be console noise into positive coverage).
+//
+// One capture per channel: `glbLogCapture.js`, `conwayDirectLogCapture.js`.
+
+
+/**
+ * Stringify one sink arg for buffer matching. Errors keep their message;
+ * objects fall back to a safe tag rather than throwing on a cyclic value.
+ *
+ * @param {*} arg
+ * @return {string}
+ */
+function argToText(arg) {
+  if (arg instanceof Error) {
+    return arg.message
+  }
+  if (arg === null || arg === undefined || typeof arg !== 'object') {
+    return String(arg)
+  }
+  try {
+    return JSON.stringify(arg)
+  } catch {
+    return '[object]'
+  }
+}
+
+
+/**
+ * Build the install/clear/get trio for one log channel.
+ *
+ * @param {function(?function(string, Array<*>): void): void} setSink The
+ *   channel's sink setter, e.g. `setGlbLogSink`.
+ * @return {{install: function(): void, clear: function(): void,
+ *   get: function(): Array<{level: string, text: string}>}}
+ */
+export function createLogCapture(setSink) {
+  /** @type {Array<{level: string, text: string}>} */
+  const captured = []
+
+  return {
+    install: () => setSink((level, args) => {
+      captured.push({level, text: args.map(argToText).join(' ')})
+    }),
+    clear: () => {
+      captured.length = 0
+    },
+    get: () => captured.slice(),
+  }
+}

--- a/tools/jest/setupTests.js
+++ b/tools/jest/setupTests.js
@@ -8,6 +8,7 @@ import 'regenerator-runtime/runtime'
 import {disableDebug} from '../../src/utils/debug'
 import {getAndExportEnvVars} from './vars.jest'
 import {installGlbLogCapture, clearGlbLogs} from './glbLogCapture'
+import {installConwayDirectLogCapture, clearConwayDirectLogs} from './conwayDirectLogCapture'
 
 
 const {initServer} = require('../../src/__mocks__/server')
@@ -15,10 +16,12 @@ const {initServer} = require('../../src/__mocks__/server')
 
 disableDebug()
 
-// Divert the GLB pipeline's `[glb]` diagnostics into a buffer so a test run
-// leaves a quiet console; specs assert on them via getGlbLogs(). Cleared
-// before each test in the beforeEach below.
+// Divert the GLB pipeline's `[glb]` diagnostics and the Conway-direct IFC
+// pipeline's `[conwayDirect]` diagnostics into buffers so a test run leaves a
+// quiet console; specs assert on them via getGlbLogs() / getConwayDirectLogs().
+// Cleared before each test in the beforeEach below.
 installGlbLogCapture()
+installConwayDirectLogCapture()
 
 const server = initServer(getAndExportEnvVars())
 
@@ -29,8 +32,11 @@ beforeAll(() => {
   })
 })
 
-// Start each test with an empty `[glb]` capture buffer.
-beforeEach(() => clearGlbLogs())
+// Start each test with empty capture buffers.
+beforeEach(() => {
+  clearGlbLogs()
+  clearConwayDirectLogs()
+})
 
 // Reset any request handlers that we may add during the tests,
 // so they don't affect other tests.


### PR DESCRIPTION
Closes #1781.

`ShareIfcLoader#parse` wrote its per-load `[conwayDirect] parsed modelID=… vertices=… triangles=…` summary and its parse-failure error straight to the console, so `src/loader/Loader.test.js` printed four summary lines per run. Both are intentional diagnostics, so per STYLE.md §"Console hygiene" / PLAYBOOK §"Keep the test console clean" (move 2) they now route through a swappable sink and the tests assert the buffer — the diagnostic becomes a tested signal instead of spam.

## The sink

`src/loader/glbLog.js` had hand-rolled this mechanism for `[glb]`. Rather than copy it, the mechanism is factored out and both channels build on it:

- **`src/utils/logSink.js`** — `createLogChannel(prefix, sinkKey)` → `{emit, setSink}`. `emit(level, args)` writes `console[level](prefix, ...args)` until a sink is installed. The active sink lives on `globalThis[sinkKey]`, not in module state, so it survives `jest.resetModules()` (a spec that resets the registry and re-imports the channel still shares the one sink the setup installed — a module-local sink would spring back to the console and both escape the buffer *and* print).
- **`src/viewer/ifc/conwayDirectLog.js`** — the `[conwayDirect]` channel: `conwayDirectInfo` (parse summary), `conwayDirectError` (parse failure), `setConwayDirectLogSink`.
- **`src/loader/glbLog.js`** — now delegates to `createLogChannel`; its exported API (`glbInfo/glbWarn/glbVerbose/setGlbLogSink`) is unchanged.
- **`tools/jest/logCapture.js`** — `createLogCapture(setSink)` → `{install, clear, get}`, with the per-channel wrappers `glbLogCapture.js` and the new `conwayDirectLogCapture.js`, both installed once in `setupTests.js` and cleared per test.

The `[conwayDirect]` prefix moves from the message into the sink, so the browser-visible line is unchanged (`msg.text()` joins the args) and `conwayDirect.spec.ts` still matches it — the same multi-arg shape the `[glb]` E2E captures already rely on.

## What is now asserted

`Loader.test.js` pins the whole summary text, not its presence:

- the existing `loads an IFC model` test — the mock's `StreamAllMeshes` yields nothing, so `vertices=0 triangles=0 instances=0 parents=0 materials=0 skipped*=0`;
- a new `reports the parsed element counts for a streamed FlatMesh` test — streams one unit triangle through the mock Conway API and asserts `vertices=3 triangles=1 instances=1 parents=1 materials=1`. This is the case that would catch a regression silently dropping geometry.

`Loader.cover.test.js` drops its local `console.error` divert (from #1777) in favour of the shared buffer: an `afterEach` asserts every captured `[conwayDirect]` line is one of the failures that test induced, so an unexpected diagnostic still fails the test.

## Proved by mutation

Every new assertion was watched fail, then restored:

1. spec-side, `vertices=3` → `vertices=4`: the streamed-FlatMesh test goes red on the exact text diff.
2. spec-side, `vertices=0` → `vertices=1`: the empty-stream test goes red.
3. **source-side**, `triangles=${buildStats.triangleCount}` → `triangleCount - 1` in `ShareIfcLoader.js`: **both** tests go red (`triangles=-1` / `triangles=0`) — i.e. the assertions catch a real count regression, not just a formatting change.
4. `Loader.cover.test.js`'s `EXPECTED_LOADER_ERRORS` regex replaced with one that matches nothing: 3 tests fail, so the buffer is genuinely non-empty and that `afterEach` has teeth.
5. `src/utils/logSink.test.js`: dropping the prefix from the console sink (`console[level](...args)`) fails 2 of its 4 tests.

Related finding: the old regex in `Loader.cover.test.js` had five alternatives; only two (`open failed`, `is not a function`) ever matched. The other three (`Failed to fetch model data`, `Unknown filetype`, `Could not guess filetype`) never fired on this path — an assertion passing for a reason other than the one it claimed — so they are gone, and the file still runs with zero console output.

## Console: before → after

| File | Before | After |
|---|---|---|
| `src/loader/Loader.test.js` | 4 × `console.info [conwayDirect] parsed modelID=…` | **0** |
| `src/loader/Loader.cover.test.js` | 0 (local divert) | **0** (shared buffer, assertions kept) |
| whole `yarn test` run | 4 `[conwayDirect]` blocks | **0**; 109 unrelated pre-existing console blocks remain in other files |

## Also in this PR

`.eslintrc.cjs` gains `root: true`. Agent worktrees live at `.claude/worktrees/<id>/` *inside* a second checkout of this repo, and without it ESLint cascades up to the outer checkout's config: every plugin then resolves from two `node_modules` trees ("ESLint couldn't determine the plugin … uniquely"), and the ignore base path becomes the outer root — under which every worktree file sits below a dot-directory and is "ignored by default". Net effect: `yarn precommit`'s eslint step could not lint a single file in a worktree, so the husky gate was silently unusable there. With `root: true` the full hook (eslint + typecheck + 246 suites) runs and passes on this commit.

## Verification

- husky `pre-commit` ran the full gate on this commit: eslint clean, `tsc` clean, 2462 passed / 5 skipped, 246 suites.
- `yarn test-ci` (coverage): statements 69.63%, branches 64.33%, functions 71.68%, lines 68.89% — all above the configured floors.
- Playwright not run (draft; `conwayDirect.spec.ts` is unaffected by design — the console text it greps is byte-identical).

---
_Generated by [Claude Code](https://claude.ai/code/session_01NuTsqJu1rqoz8f4FSQ9vbE)_