### PR TITLE
Correlate OPFS worker replies with the request that asked for them

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,5 +1,14 @@
 /* eslint-disable no-magic-numbers */
 module.exports = {
+  // Stop the config cascade here. Without it ESLint keeps walking up past the
+  // repo root and merges any ancestor `.eslintrc`, which breaks outright when
+  // the checkout is nested inside another copy of this repo — a `git worktree`
+  // under `.claude/worktrees/`, say: both configs declare the same plugins,
+  // each resolving to its own `node_modules`, and ESLint refuses to run
+  // ("couldn't determine the plugin ... uniquely"), taking `yarn precommit`
+  // and the husky hook with it. A normal flat checkout finds no ancestor
+  // config, so this changes nothing in CI.
+  root: true,
   env: {
     browser: true,
     es2021: true,

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,14 +1,5 @@
 /* eslint-disable no-magic-numbers */
 module.exports = {
-  // Stop the config cascade here. Without it ESLint keeps walking up past the
-  // repo root and merges any ancestor `.eslintrc`, which breaks outright when
-  // the checkout is nested inside another copy of this repo — a `git worktree`
-  // under `.claude/worktrees/`, say: both configs declare the same plugins,
-  // each resolving to its own `node_modules`, and ESLint refuses to run
-  // ("couldn't determine the plugin ... uniquely"), taking `yarn precommit`
-  // and the husky hook with it. A normal flat checkout finds no ancestor
-  // config, so this changes nothing in CI.
-  root: true,
   env: {
     browser: true,
     es2021: true,

--- a/src/OPFS/OPFS.worker.js
+++ b/src/OPFS/OPFS.worker.js
@@ -33,7 +33,34 @@ function ghApiBase(accessToken) {
 }
 
 
+/**
+ * Post a reply to the main thread, stamped with the id of the request that
+ * produced it.
+ *
+ * The main thread shares ONE worker per origin (`OPFSService#initializeWorker`),
+ * so every helper in `OPFS/utils.js` listens to the same message stream. Without
+ * a correlation id a reply satisfies — or rejects — whichever promise happens to
+ * be listening, not the one that asked. That is the bug in #1785: the GLB cache
+ * writer resolved on any `wrote`, and the cache-hit specs reload the page on
+ * `writer: wrote`, so an early resolve hands them a half-written `.glb` (the
+ * exact defect #1783 fixed).
+ *
+ * `requestId` is threaded from the dispatcher through every function that can
+ * reply, including the shared helpers (`writeFileToPath`, `retrieveFileWithPath`,
+ * …) whose error posts terminate the caller's promise. Direct callers of the
+ * exported functions — the unit tests in `OPFS.worker.test.js` — pass no id and
+ * get the bare message, so the id never appears in a payload nobody asked for.
+ *
+ * @param {object} message The reply payload, as it was before correlation.
+ * @param {string} [requestId] Id of the originating request, when there is one.
+ */
+function postReply(message, requestId) {
+  self.postMessage(requestId === undefined ? message : {...message, requestId: requestId})
+}
+
+
 self.addEventListener('message', async (event) => {
+  const requestId = event.data.requestId
   try {
     if (event.data.command === 'initializeWorker') {
       const {GITHUB_BASE_URL_AUTHED, GITHUB_BASE_URL_UNAUTHED} =
@@ -44,70 +71,84 @@ self.addEventListener('message', async (event) => {
     } else if (event.data.command === 'writeObjectURLToFile') {
       const {objectUrl, fileName} =
       assertValues(event.data, ['objectUrl', 'fileName'])
-      await writeFileToOPFS(objectUrl, fileName)
+      await writeFileToOPFS(objectUrl, fileName, requestId)
     } else if (event.data.command === 'readObjectFromStorage') {
       const {fileName} = assertValues(event.data, ['fileName'])
-      await readFileFromOPFS(fileName)
+      await readFileFromOPFS(fileName, requestId)
     } else if (event.data.command === 'writeObjectModel') {
-      const {objectUrl, objectKey, originalFileName} =
+      // `originalFileName` is asserted (callers must send it) but
+      // `writeModelToOPFS` has only ever taken two params; passing it as a
+      // third was a silent no-op, and now that slot is `requestId`.
+      const {objectUrl, objectKey} =
           assertValues(event.data,
             ['objectUrl', 'objectKey', 'originalFileName'])
 
-      writeModelToOPFS(objectUrl, objectKey, originalFileName)
+      await writeModelToOPFS(objectUrl, objectKey, requestId)
     } else if (event.data.command === 'writeObjectModelFileHandle') {
       const {file, objectKey, originalFilePath, owner, repo, branch} =
           assertValues(event.data,
             ['file', 'objectKey', 'originalFilePath', 'owner', 'repo', 'branch'])
-      writeModelToOPFSFromFile(file, objectKey, originalFilePath, owner, repo, branch)
+      await writeModelToOPFSFromFile(file, objectKey, originalFilePath, owner, repo, branch, requestId)
     } else if (event.data.command === 'readModelFromStorage') {
       const {modelKey} = assertValues(event.data, ['modelKey'])
-      await readModelFromOPFS(modelKey)
+      await readModelFromOPFS(modelKey, requestId)
     } else if (event.data.command === 'readModelByPath') {
       const {commitHash, originalFilePath, owner, repo, branch} =
           assertValues(event.data,
             ['commitHash', 'originalFilePath', 'owner', 'repo', 'branch'])
-      await readModelByPathFromOPFS(commitHash, originalFilePath, owner, repo, branch)
+      await readModelByPathFromOPFS(commitHash, originalFilePath, owner, repo, branch, requestId)
     } else if (event.data.command === 'writeBytesByPath') {
       const {bytes, commitHash, originalFilePath, owner, repo, branch} =
           assertValues(event.data,
             ['bytes', 'commitHash', 'originalFilePath', 'owner', 'repo', 'branch'])
-      await writeBytesByPathToOPFS(bytes, commitHash, originalFilePath, owner, repo, branch)
+      await writeBytesByPathToOPFS(bytes, commitHash, originalFilePath, owner, repo, branch, requestId)
     } else if (event.data.command === 'downloadToOPFS') {
       const {objectUrl, commitHash, owner, repo, branch, onProgress, originalFilePath} =
           assertValues(event.data,
             ['objectUrl', 'commitHash', 'owner', 'repo', 'branch', 'onProgress', 'originalFilePath'])
-      await downloadModelToOPFS(objectUrl, commitHash, originalFilePath, owner, repo, branch, onProgress)
+      await downloadModelToOPFS(objectUrl, commitHash, originalFilePath, owner, repo, branch, onProgress, requestId)
     } else if (event.data.command === 'downloadModel') {
       const {objectUrl, shaHash, originalFilePath, owner, repo, branch, accessToken, onProgress} =
       assertValues(event.data,
         ['objectUrl', 'shaHash', 'originalFilePath', 'owner', 'repo', 'branch', 'accessToken', 'onProgress'])
-      await downloadModel(objectUrl, shaHash, originalFilePath, owner, repo, branch, accessToken, onProgress)
+      await downloadModel(objectUrl, shaHash, originalFilePath, owner, repo, branch, accessToken, onProgress, requestId)
     } else if (event.data.command === 'writeBase64Model') {
       const {content, shaHash, originalFilePath, owner, repo, branch, accessToken} =
       assertValues(event.data, ['content', 'shaHash', 'originalFilePath', 'owner', 'repo', 'branch', 'accessToken'])
 
-      await writeBase64Model(content, shaHash, originalFilePath, owner, repo, branch, accessToken)
+      await writeBase64Model(content, shaHash, originalFilePath, owner, repo, branch, accessToken, requestId)
     } else if (event.data.command === 'doesFileExist') {
       const {commitHash, originalFilePath, owner, repo, branch} =
           assertValues(event.data,
             ['commitHash', 'originalFilePath', 'owner', 'repo', 'branch'])
 
-      await doesFileExistInOPFS(commitHash, originalFilePath, owner, repo, branch)
+      await doesFileExistInOPFS(commitHash, originalFilePath, owner, repo, branch, requestId)
     } else if (event.data.command === 'deleteModel') {
       const {commitHash, originalFilePath, owner, repo, branch} =
           assertValues(event.data,
             ['commitHash', 'originalFilePath', 'owner', 'repo', 'branch'])
 
-      await deleteModelFromOPFS(commitHash, originalFilePath, owner, repo, branch)
+      await deleteModelFromOPFS(commitHash, originalFilePath, owner, repo, branch, requestId)
     } else if (event.data.command === 'clearCache') {
-      await clearCache()
+      await clearCache(requestId)
     } else if (event.data.command === 'snapshotCache') {
       // Optional previewWindow parameter specifies how many leading bytes to include per file
       const previewWindow = Number.isFinite(event.data.previewWindow) ? event.data.previewWindow : parseInt(event.data.previewWindow, 10)
-      await snapshotCache(Number.isFinite(previewWindow) && previewWindow > 0 ? previewWindow : 0)
+      await snapshotCache(Number.isFinite(previewWindow) && previewWindow > 0 ? previewWindow : 0, requestId)
     }
   } catch (error) {
-    self.postMessage({error: error.message})
+    postReply({error: error.message}, requestId)
+  } finally {
+    // Close out the request even if the handler returned without replying.
+    // Several paths can do that — `writeBase64Model` with a falsy shaHash or an
+    // undecodable blob, a helper that posted a deep error and returned — and the
+    // main-thread listener has no timeout, so before correlation those hung
+    // forever AND left their listener attached to the shared worker for the life
+    // of the page (the leak asked about in #1785). Handlers that did reply have
+    // already detached their listener, so this sentinel is a no-op for them.
+    if (requestId !== undefined) {
+      postReply({requestFinished: true}, requestId)
+    }
   }
 })
 
@@ -119,14 +160,15 @@ self.addEventListener('message', async (event) => {
  * Return directory snapshot of OPFS cache including optional preview bytes per file.
  *
  * @param {number} [previewWindow] Number of leading bytes (per file) to include as hex via traverseDirectory.
+ * @param {string} [requestId] Id of the originating request, stamped on every reply; see postReply.
  */
-export async function snapshotCache(previewWindow = 0) {
+export async function snapshotCache(previewWindow = 0, requestId = undefined) {
   const opfsRoot = await navigator.storage.getDirectory()
 
   const directoryStructure = await traverseDirectory(opfsRoot, '', previewWindow)
 
   // Send the directory structure as a message to the main thread
-  self.postMessage({completed: true, event: 'snapshot', directoryStructure: directoryStructure.trimEnd()})
+  postReply({completed: true, event: 'snapshot', directoryStructure: directoryStructure.trimEnd()}, requestId)
 }
 
 
@@ -207,13 +249,15 @@ export async function traverseDirectory(dirHandle, path = '', previewLength = 0)
 
 /**
  * Clear OPFS cache
+ *
+ * @param {string} [requestId] Id of the originating request, stamped on every reply; see postReply.
  */
-export async function clearCache() {
+export async function clearCache(requestId) {
   const opfsRoot = await navigator.storage.getDirectory()
   await deleteAllEntries(opfsRoot)
 
   // Send the directory structure as a message to the main thread
-  self.postMessage({completed: true, event: 'clear'})
+  postReply({completed: true, event: 'clear'}, requestId)
 }
 
 
@@ -425,9 +469,10 @@ async function openSyncAccessHandleWithRetry(parentDirectory, fileHandle, fileNa
  * @param {string} originalFilePath - The path to the file.
  * @param {string} _etag - The ETag to use for the request.
  * @param {Function} onProgress - The function to call when the progress changes.
+ * @param {string} [requestId] Id of the originating request, stamped on every reply; see postReply.
  * @return {Promise<[FileSystemDirectoryHandle, FileSystemFileHandle]>} The directory and file handles.
  */
-export async function writeTemporaryFileToOPFS(response, originalFilePath, _etag, onProgress) {
+export async function writeTemporaryFileToOPFS(response, originalFilePath, _etag, onProgress, requestId) {
   const opfsRoot = await navigator.storage.getDirectory()
   let modelDirectoryHandle = null
   let modelBlobFileHandle = null
@@ -436,7 +481,7 @@ export async function writeTemporaryFileToOPFS(response, originalFilePath, _etag
   // Get file handle for file blob
   try {
     [modelDirectoryHandle, modelBlobFileHandle] = await
-    retrieveFileWithPathNew(opfsRoot, originalFilePath, _etag, null, false)
+    retrieveFileWithPathNew(opfsRoot, originalFilePath, _etag, null, false, requestId)
 
     if (modelBlobFileHandle !== undefined && modelBlobFileHandle !== null) {
       // Caller is responsible for posting the terminal completed event after
@@ -452,7 +497,7 @@ export async function writeTemporaryFileToOPFS(response, originalFilePath, _etag
   let blobAccessHandle = null
 
   try {
-    [modelDirectoryHandle, modelBlobFileHandle] = await writeFileToPath(opfsRoot, originalFilePath, _etag, null)
+    [modelDirectoryHandle, modelBlobFileHandle] = await writeFileToPath(opfsRoot, originalFilePath, _etag, null, requestId)
     // `openSyncAccessHandleWithRetry` handles Safari's stale-internal-ref
     // case — InvalidStateError on a fresh file, even after clearOPFSCache().
     // If the retry also fails, the throw propagates; the resilience fix in
@@ -468,7 +513,7 @@ export async function writeTemporaryFileToOPFS(response, originalFilePath, _etag
       } catch (_) {/* idempotent */}
     }
     const workerMessage = `Error getting file handle for ${originalFilePath}: ${error}`
-    self.postMessage({error: workerMessage})
+    postReply({error: workerMessage}, requestId)
     return
   }
 
@@ -503,19 +548,19 @@ export async function writeTemporaryFileToOPFS(response, originalFilePath, _etag
         }
       } catch (error) {
         const workerMessage = `Error writing to ${response.headers.etag}: ${error}.`
-        self.postMessage({error: workerMessage})
+        postReply({error: workerMessage}, requestId)
         return
       }
 
       receivedLength += value.length
 
       if (onProgress) {
-        self.postMessage({
+        postReply({
           progressEvent: onProgress,
           lengthComputable: contentLength !== 0,
           contentLength: contentLength,
           receivedLength: receivedLength,
-        })
+        }, requestId)
       }
     }
 
@@ -525,7 +570,7 @@ export async function writeTemporaryFileToOPFS(response, originalFilePath, _etag
     }
   } catch (error) {
     reader.cancel()
-    self.postMessage({error: error})
+    postReply({error: error}, requestId)
   } finally {
     // Always close the sync access handle. Leaking it leaves the OPFS file
     // in a state Safari refuses subsequent createSyncAccessHandle() calls
@@ -546,9 +591,10 @@ export async function writeTemporaryFileToOPFS(response, originalFilePath, _etag
  * @param {Blob} blob - The blob to write to the file.
  * @param {string} originalFilePath - The path to the file.
  * @param {string} _etag - The ETag to use for the request.
+ * @param {string} [requestId] Id of the originating request, stamped on every reply; see postReply.
  * @return {Promise<[FileSystemDirectoryHandle, FileSystemFileHandle]>} The directory and file handles.
  */
-export async function writeTemporaryBase64BlobFileToOPFS(blob, originalFilePath, _etag) {
+export async function writeTemporaryBase64BlobFileToOPFS(blob, originalFilePath, _etag, requestId) {
   const opfsRoot = await navigator.storage.getDirectory()
   let modelDirectoryHandle = null
   let modelBlobFileHandle = null
@@ -556,7 +602,7 @@ export async function writeTemporaryBase64BlobFileToOPFS(blob, originalFilePath,
   // lets see if our etag matches
   // Get file handle for file blob
   try {
-    [modelDirectoryHandle, modelBlobFileHandle] = await retrieveFileWithPathNew(opfsRoot, originalFilePath, _etag, null, false)
+    [modelDirectoryHandle, modelBlobFileHandle] = await retrieveFileWithPathNew(opfsRoot, originalFilePath, _etag, null, false, requestId)
 
     if (modelBlobFileHandle !== null) {
       // Caller posts the terminal completed event after rename; see the
@@ -569,7 +615,7 @@ export async function writeTemporaryBase64BlobFileToOPFS(blob, originalFilePath,
   let blobAccessHandle = null
 
   try {
-    [modelDirectoryHandle, modelBlobFileHandle] = await writeFileToPath(opfsRoot, originalFilePath, _etag, null)
+    [modelDirectoryHandle, modelBlobFileHandle] = await writeFileToPath(opfsRoot, originalFilePath, _etag, null, requestId)
     // Create FileSystemSyncAccessHandle on the file.
     blobAccessHandle = await modelBlobFileHandle.createSyncAccessHandle()
     // Write buffer
@@ -579,7 +625,7 @@ export async function writeTemporaryBase64BlobFileToOPFS(blob, originalFilePath,
     return [modelDirectoryHandle, modelBlobFileHandle]
   } catch (error) {
     const workerMessage = `Error writing file handle for ${originalFilePath}: ${error}`
-    self.postMessage({error: workerMessage})
+    postReply({error: workerMessage}, requestId)
   } finally {
     // Always close — see note in writeTemporaryFileToOPFS.
     if (blobAccessHandle) {
@@ -668,6 +714,7 @@ export function base64ToBlob(base64, mimeType = 'application/octet-stream') {
  * @param {string} branch
  * @param {string} accessToken
  * @param {number|null} fallbackLastModified Last-modified from cache, used
+ * @param {string} [requestId] Id of the originating request, stamped on every reply; see postReply.
  *   when rename succeeds but commit-date didn't come back (legacy cache rows).
  */
 export async function postFinalDownloadEventAfterRename(
@@ -680,7 +727,7 @@ export async function postFinalDownloadEventAfterRename(
   repo,
   branch,
   accessToken,
-  fallbackLastModified) {
+  fallbackLastModified, requestId) {
   let finalFileHandle = modelBlobFileHandle
   let renamed = false
   let lastModifiedGithub = fallbackLastModified
@@ -714,12 +761,12 @@ export async function postFinalDownloadEventAfterRename(
   }
 
   const finalFile = await finalFileHandle.getFile()
-  self.postMessage({
+  postReply({
     completed: true,
     event: renamed ? 'renamed' : 'download',
     file: finalFile,
     lastModifiedGithub: lastModifiedGithub,
-  })
+  }, requestId)
 }
 
 
@@ -733,8 +780,9 @@ export async function postFinalDownloadEventAfterRename(
  * @param {string} repo - The repository name.
  * @param {string} branch - The branch name
  * @param {string} accessToken - The access token
+ * @param {string} [requestId] Id of the originating request, stamped on every reply; see postReply.
  */
-export async function writeBase64Model(content, shaHash, originalFilePath, owner, repo, branch, accessToken) {
+export async function writeBase64Model(content, shaHash, originalFilePath, owner, repo, branch, accessToken, requestId) {
   let _etag = null
   let commitHash = null
   let cleanEtag = null
@@ -765,13 +813,13 @@ export async function writeBase64Model(content, shaHash, originalFilePath, owner
   if (shaHash) {
     try {
       [modelDirectoryHandle, modelBlobFileHandle] = await
-      retrieveFileWithPathNew(opfsRoot, cacheKey, shaHash, commitHash, false)
+      retrieveFileWithPathNew(opfsRoot, cacheKey, shaHash, commitHash, false, requestId)
 
       if (modelBlobFileHandle === null) {
         // couldn't find via shaHash or commitHash, see if we have an unauthed etag
         if (cleanEtag) {
           [modelDirectoryHandle, modelBlobFileHandle] = await
-          retrieveFileWithPathNew(opfsRoot, cacheKey, cleanEtag, null, false)
+          retrieveFileWithPathNew(opfsRoot, cacheKey, cleanEtag, null, false, requestId)
         }
       }
 
@@ -780,7 +828,7 @@ export async function writeBase64Model(content, shaHash, originalFilePath, owner
           // Commit hash already known — file in OPFS is at its final name.
           // Single terminal event.
           const blobFile = await modelBlobFileHandle.getFile()
-          self.postMessage({completed: true, event: 'exists', file: blobFile})
+          postReply({completed: true, event: 'exists', file: blobFile}, requestId)
           return
         }
 
@@ -791,13 +839,13 @@ export async function writeBase64Model(content, shaHash, originalFilePath, owner
         await postFinalDownloadEventAfterRename(
           modelDirectoryHandle, modelBlobFileHandle,
           originalFilePath, shaHash, cacheKey,
-          owner, repo, branch, accessToken, null /* lastModifiedGithub */)
+          owner, repo, branch, accessToken, null /* lastModifiedGithub */, requestId)
       } else {
         // we don't have it stored and need to decode the base64 blob to file and write to OPFS
         const blob = base64ToBlob(content)
 
         if (blob !== null) {
-          [modelDirectoryHandle, modelBlobFileHandle] = await writeTemporaryBase64BlobFileToOPFS(blob, cacheKey, shaHash)
+          [modelDirectoryHandle, modelBlobFileHandle] = await writeTemporaryBase64BlobFileToOPFS(blob, cacheKey, shaHash, requestId)
 
           const mockResponse = generateMockResponse(shaHash)
 
@@ -809,12 +857,12 @@ export async function writeBase64Model(content, shaHash, originalFilePath, owner
           await postFinalDownloadEventAfterRename(
             modelDirectoryHandle, modelBlobFileHandle,
             originalFilePath, shaHash, cacheKey,
-            owner, repo, branch, accessToken, null /* lastModifiedGithub */)
+            owner, repo, branch, accessToken, null /* lastModifiedGithub */, requestId)
         }
       }
     } catch (error) {
       const workerMessage = `Error writing base64 model for ${cacheKey}: ${error}`
-      self.postMessage({error: workerMessage})
+      postReply({error: workerMessage}, requestId)
     }
   }
 }
@@ -831,9 +879,10 @@ export async function writeBase64Model(content, shaHash, originalFilePath, owner
  * @param {string} branch - The branch to fetch the latest commit hash from.
  * @param {string} accessToken - The access token to use for the request.
  * @param {Function} onProgress - The function to call when the progress changes.
+ * @param {string} [requestId] Id of the originating request, stamped on every reply; see postReply.
  * @return {Promise<void>}
  */
-export async function downloadModel(objectUrl, shaHash, originalFilePath, owner, repo, branch, accessToken, onProgress) {
+export async function downloadModel(objectUrl, shaHash, originalFilePath, owner, repo, branch, accessToken, onProgress, requestId) {
   let commitHash = null
   let lastModifiedGithub = null
   let cleanEtag = null
@@ -870,13 +919,13 @@ export async function downloadModel(objectUrl, shaHash, originalFilePath, owner,
 
     try {
       [modelDirectoryHandle, modelBlobFileHandle] = await
-      retrieveFileWithPathNew(opfsRoot, cacheKey, shaHash, commitHash, false)
+      retrieveFileWithPathNew(opfsRoot, cacheKey, shaHash, commitHash, false, requestId)
 
       if (modelBlobFileHandle === null) {
         // couldn't find via shaHash or commitHash, see if we have an unauthed etag
         if (cleanEtag) {
           [modelDirectoryHandle, modelBlobFileHandle] = await
-          retrieveFileWithPathNew(opfsRoot, cacheKey, cleanEtag, null, false)
+          retrieveFileWithPathNew(opfsRoot, cacheKey, cleanEtag, null, false, requestId)
         }
       }
 
@@ -885,7 +934,7 @@ export async function downloadModel(objectUrl, shaHash, originalFilePath, owner,
           // Commit hash already known — file in OPFS is at its final name,
           // single terminal event.
           const blobFile = await modelBlobFileHandle.getFile()
-          self.postMessage({completed: true, event: 'exists', file: blobFile, lastModifiedGithub})
+          postReply({completed: true, event: 'exists', file: blobFile, lastModifiedGithub}, requestId)
           return
         }
 
@@ -894,7 +943,7 @@ export async function downloadModel(objectUrl, shaHash, originalFilePath, owner,
         await postFinalDownloadEventAfterRename(
           modelDirectoryHandle, modelBlobFileHandle,
           originalFilePath, shaHash, cacheKey,
-          owner, repo, branch, accessToken, lastModifiedGithub)
+          owner, repo, branch, accessToken, lastModifiedGithub, requestId)
       } else {
         // we don't have it and need to fetch
         const result = await fetchRGHUC(objectUrl)
@@ -908,14 +957,14 @@ export async function downloadModel(objectUrl, shaHash, originalFilePath, owner,
         // reachable for Git LFS models, which now take this download
         // path rather than the inline-base64 one.
         if (result === null) {
-          self.postMessage({error: `Failed to download model from ${objectUrl}`})
+          postReply({error: `Failed to download model from ${objectUrl}`}, requestId)
           return
         }
 
-        [modelDirectoryHandle, modelBlobFileHandle] = await writeTemporaryFileToOPFS(result, cacheKey, shaHash, onProgress)
+        [modelDirectoryHandle, modelBlobFileHandle] = await writeTemporaryFileToOPFS(result, cacheKey, shaHash, onProgress, requestId)
 
         if (!modelBlobFileHandle) {
-          self.postMessage({error: `Failed to write downloaded model to OPFS: ${originalFilePath}`})
+          postReply({error: `Failed to write downloaded model to OPFS: ${originalFilePath}`}, requestId)
           return
         }
 
@@ -925,7 +974,7 @@ export async function downloadModel(objectUrl, shaHash, originalFilePath, owner,
         await postFinalDownloadEventAfterRename(
           modelDirectoryHandle, modelBlobFileHandle,
           originalFilePath, shaHash, cacheKey,
-          owner, repo, branch, accessToken, lastModifiedGithub)
+          owner, repo, branch, accessToken, lastModifiedGithub, requestId)
       }
     } catch (error) {
       // Don't leave the listener hanging — surface the error so the caller's
@@ -934,7 +983,7 @@ export async function downloadModel(objectUrl, shaHash, originalFilePath, owner,
       // single-terminal-event contract; with the new contract, the listener
       // relies on either a `completed` or an `error` message.)
       const workerMessage = `Error in downloadModel for ${cacheKey}: ${error}`
-      self.postMessage({error: workerMessage})
+      postReply({error: workerMessage}, requestId)
       return
     }
 
@@ -959,9 +1008,10 @@ export async function downloadModel(objectUrl, shaHash, originalFilePath, owner,
  * @param {string} repo - The repo name
  * @param {string} branch - The branch name
  * @param {Function} onProgress - Progress callback
+ * @param {string} [requestId] Id of the originating request, stamped on every reply; see postReply.
  * @return {Promise<[FileSystemDirectoryHandle, FileSystemFileHandle]>} The directory and file handles.
  */
-export async function downloadModelToOPFS(objectUrl, commitHash, originalFilePath, owner, repo, branch, onProgress) {
+export async function downloadModelToOPFS(objectUrl, commitHash, originalFilePath, owner, repo, branch, onProgress, requestId) {
   const opfsRoot = await navigator.storage.getDirectory()
 
   let ownerFolderHandle = null
@@ -979,7 +1029,7 @@ export async function downloadModelToOPFS(objectUrl, commitHash, originalFilePat
       ownerFolderHandle = await opfsRoot.getDirectoryHandle(owner, {create: true})
     } catch (error) {
       const workerMessage = `Error getting folder handle for ${owner}: ${error}`
-      self.postMessage({error: workerMessage})
+      postReply({error: workerMessage}, requestId)
       return
     }
   }
@@ -996,7 +1046,7 @@ export async function downloadModelToOPFS(objectUrl, commitHash, originalFilePat
       repoFolderHandle = await ownerFolderHandle.getDirectoryHandle(repo, {create: true})
     } catch (error) {
       const workerMessage = `Error getting folder handle for ${repo}: ${error}`
-      self.postMessage({error: workerMessage})
+      postReply({error: workerMessage}, requestId)
       return
     }
   }
@@ -1013,7 +1063,7 @@ export async function downloadModelToOPFS(objectUrl, commitHash, originalFilePat
       branchFolderHandle = await repoFolderHandle.getDirectoryHandle(branch, {create: true})
     } catch (error) {
       const workerMessage = `Error getting folder handle for ${branch}: ${error}`
-      self.postMessage({error: workerMessage})
+      postReply({error: workerMessage}, requestId)
       return
     }
   }
@@ -1028,7 +1078,7 @@ export async function downloadModelToOPFS(objectUrl, commitHash, originalFilePat
   // Get file handle for file blob
   try {
     [modelDirectoryHandle, modelBlobFileHandle] = await
-    retrieveFileWithPath(branchFolderHandle, originalFilePath, commitHash, false)
+    retrieveFileWithPath(branchFolderHandle, originalFilePath, commitHash, false, requestId)
   } catch (error) {
     // expected if file not found
   }
@@ -1047,14 +1097,15 @@ export async function downloadModelToOPFS(objectUrl, commitHash, originalFilePat
     if (fileIsCached) {
       const blobFile = await modelBlobFileHandle.getFile()
 
-      self.postMessage({completed: true, event: 'exists', file: blobFile})
+      postReply({completed: true, event: 'exists', file: blobFile}, requestId)
       return
     } else {
       await modelBlobFileHandle.remove()
     }
   }
   try {
-    [modelDirectoryHandle, modelBlobFileHandle] = await retrieveFileWithPath(branchFolderHandle, originalFilePath, commitHash, true)
+    [modelDirectoryHandle, modelBlobFileHandle] = await retrieveFileWithPath(
+      branchFolderHandle, originalFilePath, commitHash, true, requestId)
     // Same Safari self-heal as in writeTemporaryFileToOPFS.
     const opened = await openSyncAccessHandleWithRetry(
       modelDirectoryHandle, modelBlobFileHandle, modelBlobFileHandle.name)
@@ -1067,7 +1118,7 @@ export async function downloadModelToOPFS(objectUrl, commitHash, originalFilePat
       } catch (_) {/* idempotent */}
     }
     const workerMessage = `Error getting file handle for ${originalFilePath}: ${error}`
-    self.postMessage({error: workerMessage})
+    postReply({error: workerMessage}, requestId)
     return
   }
   // Fetch the file from the object URL
@@ -1104,7 +1155,7 @@ export async function downloadModelToOPFS(objectUrl, commitHash, originalFilePat
         }
       } catch (error) {
         const workerMessage = `Error writing to ${commitHash}: ${error}.`
-        self.postMessage({error: workerMessage})
+        postReply({error: workerMessage}, requestId)
         return
       }
 
@@ -1113,14 +1164,14 @@ export async function downloadModelToOPFS(objectUrl, commitHash, originalFilePat
       if (onProgress) {
         // Variable names reflect MDN ProgressEvent field names
         // https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent
-        self.postMessage({
+        postReply({
           progressEvent: onProgress, // REVIEW: should this really be a function
           // value for an event varname, and tests
           // pass it a boolean?
           lengthComputable: contentLength !== 0,
           total: contentLength,
           loaded: receivedLength,
-        })
+        }, requestId)
       }
     }
 
@@ -1135,16 +1186,16 @@ export async function downloadModelToOPFS(objectUrl, commitHash, originalFilePat
       try {
         const blobFile = await modelBlobFileHandle.getFile()
 
-        self.postMessage({completed: true, event: 'download', file: blobFile})
+        postReply({completed: true, event: 'download', file: blobFile}, requestId)
       } catch (error) {
         const workerMessage = `Error Getting file handle: ${error}.`
-        self.postMessage({error: workerMessage})
+        postReply({error: workerMessage}, requestId)
         return
       }
     }
   } catch (error) {
     reader.cancel()
-    self.postMessage({error: error})
+    postReply({error: error}, requestId)
   } finally {
     // Always close the sync access handle. See writeTemporaryFileToOPFS for
     // the rationale (Safari InvalidStateError on subsequent loads if leaked).
@@ -1163,9 +1214,10 @@ export async function downloadModelToOPFS(objectUrl, commitHash, originalFilePat
  * @param {string} filePath - The path to the file.
  * @param {string} etag - The ETag to use for the request.
  * @param {string} commitHash - The commit hash to use for the request.
+ * @param {string} [requestId] Id of the originating request, stamped on every reply; see postReply.
  * @return {Promise<[FileSystemDirectoryHandle, FileSystemFileHandle]>} The directory and file handles.
  */
-export async function writeFileToPath(rootHandle, filePath, etag, commitHash = null) {
+export async function writeFileToPath(rootHandle, filePath, etag, commitHash = null, requestId = undefined) {
   const pathSegments = safePathSplit(filePath)
   let currentHandle = rootHandle
 
@@ -1179,7 +1231,7 @@ export async function writeFileToPath(rootHandle, filePath, etag, commitHash = n
         currentHandle = await currentHandle.getDirectoryHandle(segment, {create: true})
       } catch (error) {
         const workerMessage = `Error getting/creating directory handle for segment(${segment}): ${error}.`
-        self.postMessage({error: workerMessage})
+        postReply({error: workerMessage}, requestId)
         return null
       }
     } else {
@@ -1192,7 +1244,7 @@ export async function writeFileToPath(rootHandle, filePath, etag, commitHash = n
         return [currentHandle, fileHandle] // Return the file handle for further processing
       } catch (error) {
         const workerMessage = `Error getting/creating file handle for file(${segment}): ${error}.`
-        self.postMessage({error: workerMessage})
+        postReply({error: workerMessage}, requestId)
         return null
       }
     }
@@ -1207,9 +1259,10 @@ export async function writeFileToPath(rootHandle, filePath, etag, commitHash = n
  * @param {string} filePath - The path to the file.
  * @param {string} commitHash - The commit hash to use for the request.
  * @param {boolean} shouldCreate - Whether to create the file if it doesn't exist.
+ * @param {string} [requestId] Id of the originating request, stamped on every reply; see postReply.
  * @return {Promise<[FileSystemDirectoryHandle, FileSystemFileHandle]>} The directory and file handles.
  */
-export async function retrieveFileWithPath(rootHandle, filePath, commitHash, shouldCreate = true) {
+export async function retrieveFileWithPath(rootHandle, filePath, commitHash, shouldCreate = true, requestId = undefined) {
   const pathSegments = safePathSplit(filePath)
   let currentHandle = rootHandle
 
@@ -1223,7 +1276,7 @@ export async function retrieveFileWithPath(rootHandle, filePath, commitHash, sho
         currentHandle = await currentHandle.getDirectoryHandle(segment, {create: true})
       } catch (error) {
         const workerMessage = `Error getting/creating directory handle for segment(${segment}): ${error}.`
-        self.postMessage({error: workerMessage})
+        postReply({error: workerMessage}, requestId)
         return null
       }
     } else {
@@ -1237,7 +1290,7 @@ export async function retrieveFileWithPath(rootHandle, filePath, commitHash, sho
           return null
         }
         const workerMessage = `Error getting/creating file handle for file(${segment}): ${error}.`
-        self.postMessage({error: workerMessage})
+        postReply({error: workerMessage}, requestId)
         return null
       }
     }
@@ -1252,9 +1305,10 @@ export async function retrieveFileWithPath(rootHandle, filePath, commitHash, sho
  * @param {string} etag - The ETag to use for the request.
  * @param {string} commitHash - The commit hash to use for the request.
  * @param {boolean} create - Whether to create the file if it doesn't exist.
+ * @param {string} [requestId] Id of the originating request, stamped on every reply; see postReply.
  * @return {Promise<[FileSystemDirectoryHandle, FileSystemFileHandle]>} The directory and file handles.
  */
-export async function retrieveFileWithPathNew(rootHandle, filePath, etag, commitHash, create = false) {
+export async function retrieveFileWithPathNew(rootHandle, filePath, etag, commitHash, create = false, requestId = undefined) {
   const pathSegments = safePathSplit(filePath)
   let currentHandle = rootHandle
 
@@ -1268,7 +1322,7 @@ export async function retrieveFileWithPathNew(rootHandle, filePath, etag, commit
         currentHandle = await currentHandle.getDirectoryHandle(segment, {create: true})
       } catch (error) {
         const workerMessage = `Error getting/creating directory handle for segment(${segment}): ${error}.`
-        self.postMessage({error: workerMessage})
+        postReply({error: workerMessage}, requestId)
         return [null, null]
       }
     } else {
@@ -1312,9 +1366,10 @@ export async function retrieveFileWithPathNew(rootHandle, filePath, etag, commit
  *
  * @param {FileSystemSyncAccessHandle} blobAccessHandle - The blob access handle.
  * @param {File} modelFile - The model file.
+ * @param {string} [requestId] Id of the originating request, stamped on every reply; see postReply.
  * @return {Promise<boolean>} True if the file was written successfully, false otherwise.
  */
-export async function writeFileToHandle(blobAccessHandle, modelFile) {
+export async function writeFileToHandle(blobAccessHandle, modelFile, requestId) {
   try {
     // Step 1: Convert the File to an ArrayBuffer
     const arrayBuffer = await modelFile.arrayBuffer()
@@ -1331,7 +1386,7 @@ export async function writeFileToHandle(blobAccessHandle, modelFile) {
     return true
   } catch (error) {
     const workerMessage = `Error writing file to handle: ${error}`
-    self.postMessage({error: workerMessage})
+    postReply({error: workerMessage}, requestId)
     return false
   }
 }
@@ -1346,8 +1401,9 @@ export async function writeFileToHandle(blobAccessHandle, modelFile) {
  * @param {string} owner - The owner of the repository.
  * @param {string} repo - The repository name.
  * @param {string} branch - The branch name
+ * @param {string} [requestId] Id of the originating request, stamped on every reply; see postReply.
  */
-export async function writeModelToOPFSFromFile(modelFile, objectKey, originalFilePath, owner, repo, branch) {
+export async function writeModelToOPFSFromFile(modelFile, objectKey, originalFilePath, owner, repo, branch, requestId) {
   const opfsRoot = await navigator.storage.getDirectory()
 
   // Compute file git sha1 hash
@@ -1365,19 +1421,19 @@ export async function writeModelToOPFSFromFile(modelFile, objectKey, originalFil
   try {
     // eslint-disable-next-line no-unused-vars
     [modelDirectoryHandle, modelBlobFileHandle] = await
-    retrieveFileWithPathNew(opfsRoot, cacheKey, computedShaHash, objectKey, true)
+    retrieveFileWithPathNew(opfsRoot, cacheKey, computedShaHash, objectKey, true, requestId)
     // Create FileSystemSyncAccessHandle on the file.
     blobAccessHandle = await modelBlobFileHandle.createSyncAccessHandle()
 
-    if (await writeFileToHandle(blobAccessHandle, modelFile)) {
+    if (await writeFileToHandle(blobAccessHandle, modelFile, requestId)) {
       // Update cache with new data
       const mockResponse = generateMockResponse(computedShaHash)
       await CacheModule.updateCacheRaw(cacheKey, mockResponse, objectKey)
-      self.postMessage({completed: true, event: 'write'})
+      postReply({completed: true, event: 'write'}, requestId)
     }
   } catch (error) {
     const workerMessage = `Error getting file handle for ${originalFilePath}: ${error}`
-    self.postMessage({error: workerMessage})
+    postReply({error: workerMessage}, requestId)
   } finally {
     // writeFileToHandle closes the handle on success, but bails without
     // closing if its own try fails — and there's no close at all if create
@@ -1492,9 +1548,10 @@ export async function renameFileInOPFS(parentDirectory, fileHandle, newFileName,
  * @param {*} owner
  * @param {*} repo
  * @param {*} branch
+ * @param {string} [requestId] Id of the originating request, stamped on every reply; see postReply.
  * @return {string} postmessage specifying operation status
  */
-export async function doesFileExistInOPFS(commitHash, originalFilePath, owner, repo, branch) {
+export async function doesFileExistInOPFS(commitHash, originalFilePath, owner, repo, branch, requestId) {
   const opfsRoot = await navigator.storage.getDirectory()
   const cacheKey = `${owner}/${repo}/${branch}/${originalFilePath}`
   let modelDirectoryHandle = null
@@ -1502,8 +1559,7 @@ export async function doesFileExistInOPFS(commitHash, originalFilePath, owner, r
 
 
   [modelDirectoryHandle, modelBlobFileHandle] = await retrieveFileWithPathNew(
-    opfsRoot, cacheKey, null, commitHash, false,
-  )
+    opfsRoot, cacheKey, null, commitHash, false, requestId)
 
   if (modelBlobFileHandle !== null ) {
     try {
@@ -1518,17 +1574,17 @@ export async function doesFileExistInOPFS(commitHash, originalFilePath, owner, r
           }
         } catch (_) {/* ignore deletion errors */}
 
-        self.postMessage({completed: true, event: 'notexist', commitHash: commitHash})
+        postReply({completed: true, event: 'notexist', commitHash: commitHash}, requestId)
         return
       }
     } catch (_) {/* if we cannot read the file, treat as not existing */
-      self.postMessage({completed: true, event: 'notexist', commitHash: commitHash})
+      postReply({completed: true, event: 'notexist', commitHash: commitHash}, requestId)
       return
     }
 
-    self.postMessage({completed: true, event: 'exist', commitHash: commitHash})
+    postReply({completed: true, event: 'exist', commitHash: commitHash}, requestId)
   } else {
-    self.postMessage({completed: true, event: 'notexist', commitHash: commitHash})
+    postReply({completed: true, event: 'notexist', commitHash: commitHash}, requestId)
   }
 }
 
@@ -1547,13 +1603,14 @@ export async function doesFileExistInOPFS(commitHash, originalFilePath, owner, r
  * @param {string} owner
  * @param {string} repo
  * @param {string} branch
+ * @param {string} [requestId] Id of the originating request, stamped on every reply; see postReply.
  */
-export async function writeBytesByPathToOPFS(bytes, commitHash, originalFilePath, owner, repo, branch) {
+export async function writeBytesByPathToOPFS(bytes, commitHash, originalFilePath, owner, repo, branch, requestId) {
   try {
     const opfsRoot = await navigator.storage.getDirectory()
     const cacheKey = `${owner}/${repo}/${branch}/${originalFilePath}`
 
-    const handles = await writeFileToPath(opfsRoot, cacheKey, null, commitHash)
+    const handles = await writeFileToPath(opfsRoot, cacheKey, null, commitHash, requestId)
     if (handles === null) {
       // writeFileToPath already posted an error message
       return
@@ -1581,9 +1638,9 @@ export async function writeBytesByPathToOPFS(bytes, commitHash, originalFilePath
         await accessHandle.close()
       } catch (_) {/* idempotent */}
     }
-    self.postMessage({completed: true, event: 'wrote', commitHash: commitHash})
+    postReply({completed: true, event: 'wrote', commitHash: commitHash}, requestId)
   } catch (error) {
-    self.postMessage({error: `writeBytesByPath: ${error.message || error}`})
+    postReply({error: `writeBytesByPath: ${error.message || error}`}, requestId)
   }
 }
 
@@ -1602,35 +1659,35 @@ export async function writeBytesByPathToOPFS(bytes, commitHash, originalFilePath
  * @param {string} owner
  * @param {string} repo
  * @param {string} branch
+ * @param {string} [requestId] Id of the originating request, stamped on every reply; see postReply.
  */
-export async function readModelByPathFromOPFS(commitHash, originalFilePath, owner, repo, branch) {
+export async function readModelByPathFromOPFS(commitHash, originalFilePath, owner, repo, branch, requestId) {
   const opfsRoot = await navigator.storage.getDirectory()
   const cacheKey = `${owner}/${repo}/${branch}/${originalFilePath}`
   let modelBlobFileHandle = null
 
   try {
     [, modelBlobFileHandle] = await retrieveFileWithPathNew(
-      opfsRoot, cacheKey, null, commitHash, false,
-    )
+      opfsRoot, cacheKey, null, commitHash, false, requestId)
   } catch (error) {
-    self.postMessage({error: `readModelByPath: ${error.message || error}`})
+    postReply({error: `readModelByPath: ${error.message || error}`}, requestId)
     return
   }
 
   if (modelBlobFileHandle === null) {
-    self.postMessage({completed: true, event: 'notexist', commitHash: commitHash})
+    postReply({completed: true, event: 'notexist', commitHash: commitHash}, requestId)
     return
   }
 
   try {
     const file = await modelBlobFileHandle.getFile()
     if (file.size === 0) {
-      self.postMessage({completed: true, event: 'notexist', commitHash: commitHash})
+      postReply({completed: true, event: 'notexist', commitHash: commitHash}, requestId)
       return
     }
-    self.postMessage({completed: true, event: 'read', file: file})
+    postReply({completed: true, event: 'read', file: file}, requestId)
   } catch (error) {
-    self.postMessage({error: `readModelByPath: ${error.message || error}`})
+    postReply({error: `readModelByPath: ${error.message || error}`}, requestId)
   }
 }
 
@@ -1645,9 +1702,10 @@ export async function readModelByPathFromOPFS(commitHash, originalFilePath, owne
  * @param {string} owner - The owner of the repository.
  * @param {string} repo - The repository name.
  * @param {string} branch - The branch to use for the request.
+ * @param {string} [requestId] Id of the originating request, stamped on every reply; see postReply.
  * @return {Promise<void>}
  */
-export async function deleteModelFromOPFS(commitHash, originalFilePath, owner, repo, branch) {
+export async function deleteModelFromOPFS(commitHash, originalFilePath, owner, repo, branch, requestId) {
   const opfsRoot = await navigator.storage.getDirectory()
   let ownerFolderHandle = null
   let repoFolderHandle = null
@@ -1660,7 +1718,7 @@ export async function deleteModelFromOPFS(commitHash, originalFilePath, owner, r
   }
 
   if (ownerFolderHandle === null) {
-    self.postMessage({completed: true, event: 'notexist', commitHash: commitHash})
+    postReply({completed: true, event: 'notexist', commitHash: commitHash}, requestId)
     return
   }
 
@@ -1672,7 +1730,7 @@ export async function deleteModelFromOPFS(commitHash, originalFilePath, owner, r
   }
 
   if (repoFolderHandle === null) {
-    self.postMessage({completed: true, event: 'notexist', commitHash: commitHash})
+    postReply({completed: true, event: 'notexist', commitHash: commitHash}, requestId)
     return
   }
 
@@ -1684,7 +1742,7 @@ export async function deleteModelFromOPFS(commitHash, originalFilePath, owner, r
   }
 
   if (branchFolderHandle === null) {
-    self.postMessage({completed: true, event: 'notexist', commitHash: commitHash})
+    postReply({completed: true, event: 'notexist', commitHash: commitHash}, requestId)
     return
   }
 
@@ -1696,7 +1754,7 @@ export async function deleteModelFromOPFS(commitHash, originalFilePath, owner, r
   // Get file handle for file blob
   try {
     [, modelBlobFileHandle] = await
-    retrieveFileWithPath(branchFolderHandle, originalFilePath, commitHash, false)
+    retrieveFileWithPath(branchFolderHandle, originalFilePath, commitHash, false, requestId)
   } catch (error) {
     // expected if file not found
   }
@@ -1714,7 +1772,7 @@ export async function deleteModelFromOPFS(commitHash, originalFilePath, owner, r
     modelBlobFileHandle.remove()
   }
 
-  self.postMessage({completed: true, event: 'deleted', commitHash: commitHash})
+  postReply({completed: true, event: 'deleted', commitHash: commitHash}, requestId)
 }
 
 
@@ -1723,10 +1781,10 @@ export async function deleteModelFromOPFS(commitHash, originalFilePath, owner, r
  *
  * @param {string} objectUrl - The URL to fetch the model from.
  * @param {string} objectKey - The object key to use for the request.
- * @param {string} originalFileName - The name of the original file.
+ * @param {string} [requestId] Id of the originating request, stamped on every reply; see postReply.
  * @return {Promise<void>}
  */
-export async function writeModelToOPFS(objectUrl, objectKey) {
+export async function writeModelToOPFS(objectUrl, objectKey, requestId) {
   try {
     const opfsRoot = await navigator.storage.getDirectory()
 
@@ -1737,7 +1795,7 @@ export async function writeModelToOPFS(objectUrl, objectKey) {
       newFolderHandle = await opfsRoot.getDirectoryHandle(objectKey, {create: true})
     } catch (error) {
       const workerMessage = `Error getting folder handle for ${objectKey}: ${error}`
-      self.postMessage({error: workerMessage})
+      postReply({error: workerMessage}, requestId)
       return
     }
 
@@ -1749,7 +1807,7 @@ export async function writeModelToOPFS(objectUrl, objectKey) {
       modelBlobFileHandle = await newFolderHandle.getFileHandle(objectKey, {create: true})
     } catch (error) {
       const workerMessage = `Error getting file handle for ${objectKey}: ${error}`
-      self.postMessage({error: workerMessage})
+      postReply({error: workerMessage}, requestId)
       return
     }
 
@@ -1767,10 +1825,10 @@ export async function writeModelToOPFS(objectUrl, objectKey) {
       // Write buffer at the beginning of the file
       await blobAccessHandle.write(fileArrayBuffer, {at: 0})
 
-      self.postMessage({completed: true, event: 'write', fileName: objectKey})
+      postReply({completed: true, event: 'write', fileName: objectKey}, requestId)
     } catch (error) {
       const workerMessage = `Error writing to ${objectKey}: ${error}.`
-      self.postMessage({error: workerMessage})
+      postReply({error: workerMessage}, requestId)
       return
     } finally {
       // See writeTemporaryFileToOPFS for the Safari rationale.
@@ -1782,7 +1840,7 @@ export async function writeModelToOPFS(objectUrl, objectKey) {
     }
   } catch (error) {
     const workerMessage = `Error writing object URL to file: ${error}`
-    self.postMessage({error: workerMessage})
+    postReply({error: workerMessage}, requestId)
   }
 }
 
@@ -1791,9 +1849,10 @@ export async function writeModelToOPFS(objectUrl, objectKey) {
  * Read model from OPFS
  *
  * @param {string} objectKey - The object key to use for the request.
+ * @param {string} [requestId] Id of the originating request, stamped on every reply; see postReply.
  * @return {Promise<void>}
  */
-export async function readModelFromOPFS(objectKey) {
+export async function readModelFromOPFS(objectKey, requestId) {
   try {
     const opfsRoot = await navigator.storage.getDirectory()
 
@@ -1803,7 +1862,7 @@ export async function readModelFromOPFS(objectKey) {
       modelFolderHandle = await opfsRoot.getDirectoryHandle(objectKey)
     } catch (error) {
       const errorMessage = `Folder ${objectKey} not found: ${error}`
-      self.postMessage({error: errorMessage})
+      postReply({error: errorMessage}, requestId)
       return // Exit if the file is not found
     }
 
@@ -1813,15 +1872,15 @@ export async function readModelFromOPFS(objectKey) {
 
       const blobFile = await blobFileHandle.getFile()
 
-      self.postMessage({completed: true, event: 'read', file: blobFile})
+      postReply({completed: true, event: 'read', file: blobFile}, requestId)
     } catch (error) {
       const errorMessage = `Error retrieving File from ${objectKey}: ${error}.`
-      self.postMessage({error: errorMessage})
+      postReply({error: errorMessage}, requestId)
       return
     }
   } catch (error) {
     const errorMessage = `Error retrieving File: ${error}.`
-    self.postMessage({error: errorMessage})
+    postReply({error: errorMessage}, requestId)
   }
 }
 
@@ -1831,9 +1890,10 @@ export async function readModelFromOPFS(objectKey) {
  *
  * @param {string} objectUrl - The URL to fetch the file from.
  * @param {string} fileName - The name of the file.
+ * @param {string} [requestId] Id of the originating request, stamped on every reply; see postReply.
  * @return {Promise<void>}
  */
-export async function writeFileToOPFS(objectUrl, fileName) {
+export async function writeFileToOPFS(objectUrl, fileName, requestId) {
   try {
     const opfsRoot = await navigator.storage.getDirectory()
 
@@ -1845,7 +1905,7 @@ export async function writeFileToOPFS(objectUrl, fileName) {
       newFileHandle = await opfsRoot.getFileHandle(fileName, {create: true})
     } catch (error) {
       const workerMessage = `Error getting file handle for ${fileName}: ${error}`
-      self.postMessage({error: workerMessage})
+      postReply({error: workerMessage}, requestId)
       return
     }
 
@@ -1864,14 +1924,14 @@ export async function writeFileToOPFS(objectUrl, fileName) {
       const writeSize = await accessHandle.write(fileArrayBuffer, {at: 0})
 
       if (writeSize > 0) {
-        self.postMessage({completed: true, event: 'write', fileName: fileName})
+        postReply({completed: true, event: 'write', fileName: fileName}, requestId)
       } else {
         const workerMessage = `Error writing to file: ${fileName}`
-        self.postMessage({error: workerMessage})
+        postReply({error: workerMessage}, requestId)
       }
     } catch (error) {
       const workerMessage = `Error writing to ${fileName}: ${error}.`
-      self.postMessage({error: workerMessage})
+      postReply({error: workerMessage}, requestId)
       return
     } finally {
       // See writeTemporaryFileToOPFS for the Safari rationale.
@@ -1883,7 +1943,7 @@ export async function writeFileToOPFS(objectUrl, fileName) {
     }
   } catch (error) {
     const workerMessage = `Error writing object URL to file: ${error}`
-    self.postMessage({error: workerMessage})
+    postReply({error: workerMessage}, requestId)
   }
 }
 
@@ -1892,9 +1952,10 @@ export async function writeFileToOPFS(objectUrl, fileName) {
  * Read file from OPFS
  *
  * @param {string} fileName - The name of the file.
+ * @param {string} [requestId] Id of the originating request, stamped on every reply; see postReply.
  * @return {Promise<void>}
  */
-export async function readFileFromOPFS(fileName) {
+export async function readFileFromOPFS(fileName, requestId) {
   try {
     const opfsRoot = await navigator.storage.getDirectory()
 
@@ -1904,22 +1965,22 @@ export async function readFileFromOPFS(fileName) {
       newFileHandle = await opfsRoot.getFileHandle(fileName)
     } catch (error) {
       const errorMessage = `File ${fileName} not found: ${error}`
-      self.postMessage({error: errorMessage})
+      postReply({error: errorMessage}, requestId)
       return // Exit if the file is not found
     }
 
     try {
       const fileHandle = await newFileHandle.getFile()
 
-      self.postMessage({completed: true, event: 'read', file: fileHandle})
+      postReply({completed: true, event: 'read', file: fileHandle}, requestId)
     } catch (error) {
       const errorMessage = `Error retrieving File from ${fileName}: ${error}.`
-      self.postMessage({error: errorMessage})
+      postReply({error: errorMessage}, requestId)
       return
     }
   } catch (error) {
     const errorMessage = `Error retrieving File: ${error}.`
-    self.postMessage({error: errorMessage})
+    postReply({error: errorMessage}, requestId)
   }
 }
 

--- a/src/OPFS/OPFS.worker.test.js
+++ b/src/OPFS/OPFS.worker.test.js
@@ -545,6 +545,26 @@ describe('OPFS writes on a handle without createWritable (Safari)', () => {
     expect(await (await written.getFile()).text()).toBe('glb-artifact-bytes')
   })
 
+  test('writeBytesByPathToOPFS stamps the request id on both success and failure', async () => {
+    // The main-thread half of this contract is in `OPFS/utils.js`
+    // (`workerRequest`): a reply without the id of the request that asked for
+    // it is dropped, so an unstamped reply here would hang the caller rather
+    // than settling someone else's promise (#1785).
+    await worker.writeBytesByPathToOPFS(
+      new Uint8Array([1, 2, 3]), 'commit123', 'model.ifc', 'owner', 'repo', 'main', 'opfs-7')
+    expect(self.postMessage).toHaveBeenCalledWith(
+      {completed: true, event: 'wrote', commitHash: 'commit123', requestId: 'opfs-7'})
+
+    // The error branch matters most: error replies carry no commitHash, so the
+    // id is the ONLY thing tying one to its request.
+    self.postMessage.mockClear()
+    navigator.storage.getDirectory.mockRejectedValueOnce(new Error('opfs unavailable'))
+    await worker.writeBytesByPathToOPFS(
+      new Uint8Array([1]), 'c1', 'model.ifc', 'owner', 'repo', 'main', 'opfs-8')
+    expect(self.postMessage).toHaveBeenCalledWith(
+      {error: 'writeBytesByPath: opfs unavailable', requestId: 'opfs-8'})
+  })
+
   test('writeBytesByPathToOPFS truncates a longer previous entry', async () => {
     await worker.writeBytesByPathToOPFS(
       new Uint8Array(Buffer.from('the-long-original-payload')), 'c1', 'model.ifc', 'o', 'r', 'main')

--- a/src/OPFS/OPFSService.js
+++ b/src/OPFS/OPFSService.js
@@ -4,6 +4,26 @@ import {GITHUB_BASE_URL_AUTHED, GITHUB_BASE_URL_UNAUTHED} from '../net/github/Oc
 
 let workerRef = null
 
+let requestCounter = 0
+
+
+/**
+ * Mint an id for one request to the OPFS worker.
+ *
+ * `initializeWorker` hands every caller the SAME worker, so its replies all
+ * arrive on one message stream; `OPFS/utils.js` matches on this id to tell its
+ * own reply from a concurrent operation's (#1785). A module-scoped counter is
+ * enough: ids only have to be unique among the requests in flight on this
+ * page's worker, never across pages or sessions.
+ *
+ * @return {string}
+ */
+export function nextRequestId() {
+  requestCounter++
+  return `opfs-${requestCounter}`
+}
+
+
 /**
  * Initializes and returns a reference to a web worker.
  *
@@ -69,8 +89,9 @@ export function terminateWorker() {
  *
  * @param {string} objectUrl - The URL of the object to be written to the file.
  * @param {string} fileName - The name of the file where the object's content will be written.
+ * @param {string} [requestId] Correlates the worker's replies with this request.
  */
-export function opfsWriteFile(objectUrl, fileName) {
+export function opfsWriteFile(objectUrl, fileName, requestId) {
   if (!workerRef) {
     debug().error('Worker not initialized')
     return
@@ -79,6 +100,7 @@ export function opfsWriteFile(objectUrl, fileName) {
     command: 'writeObjectURLToFile',
     objectUrl: objectUrl,
     fileName: fileName,
+    requestId: requestId,
   })
 }
 
@@ -93,8 +115,9 @@ export function opfsWriteFile(objectUrl, fileName) {
  * @param {string} objectUrl The URL from which the model data is to be written
  * @param {string} originalFileName The original file name for the model in the repository
  * @param {string} commitHash The commit hash associated with the model data
+ * @param {string} [requestId] Correlates the worker's replies with this request.
  */
-export function opfsWriteModel(objectUrl, originalFileName, commitHash) {
+export function opfsWriteModel(objectUrl, originalFileName, commitHash, requestId) {
   if (!workerRef) {
     debug().error('Worker not initialized')
     return
@@ -104,6 +127,7 @@ export function opfsWriteModel(objectUrl, originalFileName, commitHash) {
     objectUrl: objectUrl,
     objectKey: commitHash,
     originalFileName: originalFileName,
+    requestId: requestId,
   })
 }
 
@@ -119,8 +143,9 @@ export function opfsWriteModel(objectUrl, originalFileName, commitHash) {
  * @param {string} owner The owner of the repository
  * @param {string} repo The name of the repository
  * @param {string} branch The branch name where the file resides
+ * @param {string} [requestId] Correlates the worker's replies with this request.
  */
-export function opfsDeleteModel(originalFileName, commitHash, owner, repo, branch) {
+export function opfsDeleteModel(originalFileName, commitHash, owner, repo, branch, requestId) {
   if (!workerRef) {
     debug().error('Worker not initialized')
     return
@@ -132,6 +157,7 @@ export function opfsDeleteModel(originalFileName, commitHash, owner, repo, branc
     owner: owner,
     repo: repo,
     branch: branch,
+    requestId: requestId,
   })
 }
 
@@ -147,8 +173,9 @@ export function opfsDeleteModel(originalFileName, commitHash, owner, repo, branc
  * @param {string} owner The owner of the repository
  * @param {string} repo The name of the repository
  * @param {string} branch The branch name where the file might reside
+ * @param {string} [requestId] Correlates the worker's replies with this request.
  */
-export function opfsDoesFileExist(originalFileName, commitHash, owner, repo, branch) {
+export function opfsDoesFileExist(originalFileName, commitHash, owner, repo, branch, requestId) {
   if (!workerRef) {
     debug().error('Worker not initialized')
     return
@@ -160,6 +187,7 @@ export function opfsDoesFileExist(originalFileName, commitHash, owner, repo, bra
     owner: owner,
     repo: repo,
     branch: branch,
+    requestId: requestId,
   })
 }
 
@@ -177,8 +205,9 @@ export function opfsDoesFileExist(originalFileName, commitHash, owner, repo, bra
  * @param {string} owner The owner of the repository where the file is to be written
  * @param {string} repo The name of the repository
  * @param {string} branch The branch name where the file will be written
+ * @param {string} [requestId] Correlates the worker's replies with this request.
  */
-export function opfsWriteModelFileHandle(file, originalFilePath, commitHash, owner, repo, branch) {
+export function opfsWriteModelFileHandle(file, originalFilePath, commitHash, owner, repo, branch, requestId) {
   if (!workerRef) {
     debug().error('Worker not initialized')
     return
@@ -192,6 +221,7 @@ export function opfsWriteModelFileHandle(file, originalFilePath, commitHash, own
     owner: owner,
     repo: repo,
     branch: branch,
+    requestId: requestId,
   })
 }
 
@@ -210,8 +240,9 @@ export function opfsWriteModelFileHandle(file, originalFilePath, commitHash, own
  * @param {string} repo The name of the repository
  * @param {string} branch The branch name where the file will be stored
  * @param {Function} onProgress A callback function to track the progress of the download
+ * @param {string} [requestId] Correlates the worker's replies with this request.
  */
-export function opfsDownloadToOPFS(objectUrl, commitHash, originalFilePath, owner, repo, branch, onProgress) {
+export function opfsDownloadToOPFS(objectUrl, commitHash, originalFilePath, owner, repo, branch, onProgress, requestId) {
   if (!workerRef) {
     debug().error('Worker not initialized')
     return
@@ -225,6 +256,7 @@ export function opfsDownloadToOPFS(objectUrl, commitHash, originalFilePath, owne
     repo: repo,
     branch: branch,
     onProgress: onProgress,
+    requestId: requestId,
   })
 }
 
@@ -244,8 +276,9 @@ export function opfsDownloadToOPFS(objectUrl, commitHash, originalFilePath, owne
  * @param {string} branch The branch name where the file will be stored
  * @param {string} accessToken GitHub access token
  * @param {Function} onProgress A callback function to track the progress of the download
+ * @param {string} [requestId] Correlates the worker's replies with this request.
  */
-export function opfsDownloadModel(objectUrl, shaHash, originalFilePath, owner, repo, branch, accessToken, onProgress) {
+export function opfsDownloadModel(objectUrl, shaHash, originalFilePath, owner, repo, branch, accessToken, onProgress, requestId) {
   if (!workerRef) {
     debug().error('Worker not initialized')
     return
@@ -260,6 +293,7 @@ export function opfsDownloadModel(objectUrl, shaHash, originalFilePath, owner, r
     branch: branch,
     accessToken: accessToken,
     onProgress: onProgress,
+    requestId: requestId,
   })
 }
 
@@ -278,8 +312,9 @@ export function opfsDownloadModel(objectUrl, shaHash, originalFilePath, owner, r
  * @param {string} repo The name of the repository
  * @param {string} branch The branch name where the file will be stored
  * @param {string} accessToken GitHub access token
+ * @param {string} [requestId] Correlates the worker's replies with this request.
  */
-export function opfsWriteBase64Model(content, shaHash, originalFilePath, owner, repo, branch, accessToken) {
+export function opfsWriteBase64Model(content, shaHash, originalFilePath, owner, repo, branch, accessToken, requestId) {
   if (!workerRef) {
     debug().error('Worker not initialized')
     return
@@ -293,6 +328,7 @@ export function opfsWriteBase64Model(content, shaHash, originalFilePath, owner, 
     repo: repo,
     branch: branch,
     accessToken: accessToken,
+    requestId: requestId,
   })
 }
 
@@ -305,8 +341,9 @@ export function opfsWriteBase64Model(content, shaHash, originalFilePath, owner, 
  * an error message is logged indicating the initialization issue.
  *
  * @param {string} fileName The name of the file to be read from the storage
+ * @param {string} [requestId] Correlates the worker's replies with this request.
  */
-export function opfsReadFile(fileName) {
+export function opfsReadFile(fileName, requestId) {
   if (!workerRef) {
     debug().error('Worker not initialized')
     return
@@ -315,6 +352,7 @@ export function opfsReadFile(fileName) {
   workerRef.postMessage({
     command: 'readObjectFromStorage',
     fileName: fileName,
+    requestId: requestId,
   })
 }
 
@@ -328,8 +366,9 @@ export function opfsReadFile(fileName) {
  * If the worker is not initialized, it logs an error message.
  *
  * @param {string} modelKey - The key associated with the model to be read from storage
+ * @param {string} [requestId] Correlates the worker's replies with this request.
  */
-export function opfsReadModel(modelKey) {
+export function opfsReadModel(modelKey, requestId) {
   if (!workerRef) {
     debug().error('Worker not initialized')
     return
@@ -338,6 +377,7 @@ export function opfsReadModel(modelKey) {
   workerRef.postMessage({
     command: 'readModelFromStorage',
     modelKey: modelKey,
+    requestId: requestId,
   })
 }
 
@@ -352,8 +392,9 @@ export function opfsReadModel(modelKey) {
  * @param {string} owner
  * @param {string} repo
  * @param {string} branch
+ * @param {string} [requestId] Correlates the worker's replies with this request.
  */
-export function opfsWriteBytesByPath(bytes, originalFilePath, commitHash, owner, repo, branch) {
+export function opfsWriteBytesByPath(bytes, originalFilePath, commitHash, owner, repo, branch, requestId) {
   if (!workerRef) {
     debug().error('Worker not initialized')
     return
@@ -366,6 +407,7 @@ export function opfsWriteBytesByPath(bytes, originalFilePath, commitHash, owner,
     owner: owner,
     repo: repo,
     branch: branch,
+    requestId: requestId,
   })
 }
 
@@ -381,8 +423,9 @@ export function opfsWriteBytesByPath(bytes, originalFilePath, commitHash, owner,
  * @param {string} owner
  * @param {string} repo
  * @param {string} branch
+ * @param {string} [requestId] Correlates the worker's replies with this request.
  */
-export function opfsReadModelByPath(originalFilePath, commitHash, owner, repo, branch) {
+export function opfsReadModelByPath(originalFilePath, commitHash, owner, repo, branch, requestId) {
   if (!workerRef) {
     debug().error('Worker not initialized')
     return
@@ -394,14 +437,17 @@ export function opfsReadModelByPath(originalFilePath, commitHash, owner, repo, b
     owner: owner,
     repo: repo,
     branch: branch,
+    requestId: requestId,
   })
 }
 
 
 /**
  * Clears the OPFS cache
+ *
+ * @param {string} [requestId] Correlates the worker's replies with this request.
  */
-export function opfsClearCache() {
+export function opfsClearCache(requestId) {
   if (!workerRef) {
     debug().error('Worker not initialized')
     return
@@ -409,6 +455,7 @@ export function opfsClearCache() {
 
   workerRef.postMessage({
     command: 'clearCache',
+    requestId: requestId,
   })
 }
 
@@ -416,8 +463,9 @@ export function opfsClearCache() {
  * Retrieves a directory snapshot of the OPFS cache.
  *
  * @param {number} [previewWindow] Number of leading bytes per file to include (0 = disabled).
+ * @param {string} [requestId] Correlates the worker's replies with this request.
  */
-export function opfsSnapshotCache(previewWindow = 0) {
+export function opfsSnapshotCache(previewWindow = 0, requestId = undefined) {
   if (!workerRef) {
     debug().error('Worker not initialized')
     return
@@ -426,6 +474,7 @@ export function opfsSnapshotCache(previewWindow = 0) {
   workerRef.postMessage({
     command: 'snapshotCache',
     previewWindow: previewWindow,
+    requestId: requestId,
   })
 }
 

--- a/src/OPFS/OPFSService.test.js
+++ b/src/OPFS/OPFSService.test.js
@@ -238,4 +238,25 @@ describe('OPFSService module', () => {
       previewWindow: 0,
     })
   })
+
+  test('nextRequestId hands out distinct ids', () => {
+    // Distinctness is the whole guarantee: `OPFS/utils.js` uses these to tell
+    // its own reply from a concurrent request's on the shared worker (#1785).
+    const ids = [
+      opfsService.nextRequestId(),
+      opfsService.nextRequestId(),
+      opfsService.nextRequestId(),
+    ]
+    expect(new Set(ids).size).toBe(ids.length)
+  })
+
+  test('a request id posted with a command reaches the worker', () => {
+    const worker = opfsService.initializeWorker()
+    opfsService.opfsWriteBytesByPath(
+      new Uint8Array([1]), 'model.ifc', 'commit123', 'owner', 'repo', 'main', 'opfs-42')
+    expect(worker.postMessage).toHaveBeenCalledWith(expect.objectContaining({
+      command: 'writeBytesByPath',
+      requestId: 'opfs-42',
+    }))
+  })
 })

--- a/src/OPFS/utils.js
+++ b/src/OPFS/utils.js
@@ -1,5 +1,6 @@
 import {
   initializeWorker,
+  nextRequestId,
   opfsDownloadToOPFS,
   opfsDownloadModel,
   opfsReadModel,
@@ -18,6 +19,74 @@ import debug from '../utils/debug'
 
 
 /**
+ * Run one request against the OPFS worker and settle a Promise from *its own*
+ * replies.
+ *
+ * `initializeWorker()` returns one worker per origin, so every helper in this
+ * file listens to the same message stream. Before correlation each listener
+ * settled on the first reply that merely *looked* right — any `wrote`, any
+ * `error` — no matter which operation produced it. `writeGlbBytesToOPFS` was
+ * the sharp edge (#1785): the GLB cache-hit specs reload the page when they see
+ * `writer: wrote`, so resolving on someone else's write reintroduces the
+ * half-written-artifact read that #1783 fixed. The error branch was worse still
+ * — an unrelated operation's failure rejected whatever promise was listening.
+ *
+ * Correlation is a per-request id, not the `commitHash` the worker already
+ * echoed: the hash is absent from every error reply, and two concurrent writes
+ * of the same model at the same commit — the GLB writer runs fire-and-forget on
+ * `requestIdleCallback`, so that overlap is a scheduling accident away — share
+ * one hash and would still cross-talk. The id is minted here, posted with the
+ * command (`OPFSService`), and stamped on every reply the worker produces for
+ * it (`OPFS.worker.js` `postReply`).
+ *
+ * @param {function(string): void} kickoff Posts the command, given the request
+ *   id to stamp on it. Called after the listener is attached so no reply is
+ *   missed.
+ * @param {function(object, {resolve: Function, reject: Function}): void} onReply
+ *   Handles each of this request's replies. Settling detaches the listener;
+ *   returning without settling waits for the next reply (progress events).
+ * @return {Promise<*>}
+ */
+function workerRequest(kickoff, onReply) {
+  return new Promise((resolve, reject) => {
+    const workerRef = initializeWorker()
+    if (workerRef === null) {
+      reject(new Error('Worker initialization failed'))
+      return
+    }
+    const requestId = nextRequestId()
+    let listener = null
+    const settle = {
+      resolve: (value) => {
+        workerRef.removeEventListener('message', listener)
+        resolve(value)
+      },
+      reject: (error) => {
+        workerRef.removeEventListener('message', listener)
+        reject(error)
+      },
+    }
+    listener = (event) => {
+      if (event.data.requestId !== requestId) {
+        return
+      }
+      if (event.data.requestFinished) {
+        // The worker's handler returned without a terminal reply. Pre-#1785
+        // that hung forever and left this listener attached to the shared
+        // worker for the life of the page; the worker now closes every request
+        // out so the hang surfaces and the listener always detaches.
+        settle.reject(new Error(`OPFS worker finished ${requestId} without a reply`))
+        return
+      }
+      onReply(event.data, settle)
+    }
+    workerRef.addEventListener('message', listener)
+    kickoff(requestId)
+  })
+}
+
+
+/**
  * Write model to OPFS.
  *
  * @param {File} modelFile - The model file
@@ -29,29 +98,19 @@ import debug from '../utils/debug'
  * @return {Promise<File>}
  */
 export function writeSavedGithubModelOPFS(modelFile, originalFilePath, commitHash, owner, repo, branch) {
-  return new Promise((resolve, reject) => {
-    const workerRef = initializeWorker()
-    if (workerRef !== null) {
-      // Listener for messages from the worker
-      const listener = (workerEvent) => {
-        if (workerEvent.data.error) {
-          debug().error('Error from worker:', workerEvent.data.error)
-          workerRef.removeEventListener('message', listener) // Remove the event listener
-          resolve(false)
-        } else if (workerEvent.data.completed) {
-          if (workerEvent.data.event === 'write') {
-            debug().log('Worker finished writing file')
-            workerRef.removeEventListener('message', listener) // Remove the event listener
-            resolve(true)
-          }
-        }
+  return workerRequest(
+    (requestId) => opfsWriteModelFileHandle(modelFile, originalFilePath, commitHash, owner, repo, branch, requestId),
+    (data, settle) => {
+      if (data.error) {
+        debug().error('Error from worker:', data.error)
+        settle.resolve(false)
+        return
       }
-      workerRef.addEventListener('message', listener)
-      opfsWriteModelFileHandle(modelFile, originalFilePath, commitHash, owner, repo, branch)
-    } else {
-      reject(new Error('Worker initialization failed'))
-    }
-  })
+      if (data.completed && data.event === 'write') {
+        debug().log('Worker finished writing file')
+        settle.resolve(true)
+      }
+    })
 }
 
 
@@ -65,32 +124,22 @@ export function writeSavedGithubModelOPFS(modelFile, originalFilePath, commitHas
  * @return {File}
  */
 export function getModelFromOPFS(owner, repo, branch, filepath) {
-  return new Promise((resolve, reject) => {
-    const workerRef = initializeWorker()
-    if (workerRef !== null) {
-      const parts = filepath.split('/')
-      filepath = parts[parts.length - 1]
+  const parts = filepath.split('/')
+  const fileName = parts[parts.length - 1]
 
-      // Listener for messages from the worker
-      const listener = (event) => {
-        if (event.data.error) {
-          debug().error('Error from worker:', event.data.error)
-          workerRef.removeEventListener('message', listener) // Remove the event listener
-          reject(new Error(event.data.error))
-        } else if (event.data.completed) {
-          debug().log('Worker finished retrieving file')
-          const file = event.data.file
-          workerRef.removeEventListener('message', listener) // Remove the event listener
-          resolve(file) // Resolve the promise with the file
-        }
+  return workerRequest(
+    (requestId) => opfsReadModel(fileName, requestId),
+    (data, settle) => {
+      if (data.error) {
+        debug().error('Error from worker:', data.error)
+        settle.reject(new Error(data.error))
+        return
       }
-
-      workerRef.addEventListener('message', listener)
-      opfsReadModel(filepath)
-    } else {
-      reject(new Error('Worker initialization failed'))
-    }
-  })
+      if (data.completed) {
+        debug().log('Worker finished retrieving file')
+        settle.resolve(data.file)
+      }
+    })
 }
 
 
@@ -123,41 +172,34 @@ export function downloadToOPFS(
     repo,
     branch)
 
-  return new Promise((resolve, reject) => {
-    const workerRef = initializeWorker()
-    if (workerRef !== null) {
-      // Listener for messages from the worker
-      const listener = (event) => {
-        if (event.data.error) {
-          debug().error('Error from worker:', event.data.error)
-          workerRef.removeEventListener('message', listener) // Remove the event listener
-          reject(new Error(event.data.error))
-        } else if (event.data.progressEvent) {
-          if (onProgress) {
-            onProgress({
-              lengthComputable: event.data.contentLength !== 0,
-              total: event.data.total,
-              loaded: event.data.loaded,
-            }) // Custom progress event
-          }
-        } else if (event.data.completed) {
-          if (event.data.event === 'download') {
-            debug().warn('Worker finished downloading file')
-          } else if (event.data.event === 'exists') {
-            debug().warn('Commit exists in OPFS.')
-          }
-          const file = event.data.file
-          workerRef.removeEventListener('message', listener) // Remove the event listener
-          resolve(file) // Resolve the promise with the file
-        }
+  return workerRequest(
+    (requestId) =>
+      opfsDownloadToOPFS(objectUrl, commitHash, originalFilePath, owner, repo, branch, !!(onProgress), requestId),
+    (data, settle) => {
+      if (data.error) {
+        debug().error('Error from worker:', data.error)
+        settle.reject(new Error(data.error))
+        return
       }
-      workerRef.addEventListener('message', listener)
-    } else {
-      reject(new Error('Worker initialization failed'))
-    }
-
-    opfsDownloadToOPFS(objectUrl, commitHash, originalFilePath, owner, repo, branch, !!(onProgress))
-  })
+      if (data.progressEvent) {
+        if (onProgress) {
+          onProgress({
+            lengthComputable: data.contentLength !== 0,
+            total: data.total,
+            loaded: data.loaded,
+          }) // Custom progress event
+        }
+        return
+      }
+      if (data.completed) {
+        if (data.event === 'download') {
+          debug().warn('Worker finished downloading file')
+        } else if (data.event === 'exists') {
+          debug().warn('Commit exists in OPFS.')
+        }
+        settle.resolve(data.file)
+      }
+    })
 }
 
 /**
@@ -185,7 +227,7 @@ export function writeBase64Model(
   setOpfsFile) {
   assertDefined(content, shaHash, originalFilePath, accessToken, owner, repo, branch, setOpfsFile)
   return awaitTerminalWorkerEvent(
-    () => opfsWriteBase64Model(content, shaHash, originalFilePath, owner, repo, branch, accessToken),
+    (requestId) => opfsWriteBase64Model(content, shaHash, originalFilePath, owner, repo, branch, accessToken, requestId),
     {setOpfsFile})
 }
 
@@ -203,9 +245,8 @@ export function writeBase64Model(
  * Extracted from the duplicate listeners in `downloadModel` /
  * `writeBase64Model` so the protocol contract lives in one place.
  *
- * @param {Function} kickoff Invokes the corresponding `opfsService` entry
- *   point. Called after the listener is wired up so we don't miss the
- *   first message.
+ * @param {function(string): void} kickoff Invokes the corresponding
+ *   `opfsService` entry point with the request id to stamp on the command.
  * @param {object} hooks
  * @param {Function} hooks.setOpfsFile Called with the resolved File.
  * @param {Function} [hooks.onProgress] Called on each progress update.
@@ -214,52 +255,41 @@ export function writeBase64Model(
  * @return {Promise<File>}
  */
 function awaitTerminalWorkerEvent(kickoff, {setOpfsFile, onProgress, onLastModifiedGithub}) {
-  return new Promise((resolve, reject) => {
-    const workerRef = initializeWorker()
-    if (workerRef === null) {
-      reject(new Error('Worker initialization failed'))
+  return workerRequest(kickoff, (data, settle) => {
+    if (data.error) {
+      debug().error('Error from worker:', data.error)
+      settle.reject(new Error(data.error))
       return
     }
-    const listener = (event) => {
-      if (event.data.error) {
-        debug().error('Error from worker:', event.data.error)
-        workerRef.removeEventListener('message', listener)
-        reject(new Error(event.data.error))
-        return
+    if (data.progressEvent) {
+      if (onProgress) {
+        onProgress({
+          lengthComputable: data.contentLength !== 0,
+          contentLength: data.contentLength,
+          receivedLength: data.receivedLength,
+        })
       }
-      if (event.data.progressEvent) {
-        if (onProgress) {
-          onProgress({
-            lengthComputable: event.data.contentLength !== 0,
-            contentLength: event.data.contentLength,
-            receivedLength: event.data.receivedLength,
-          })
-        }
-        return
-      }
-      if (!event.data.completed) {
-        return
-      }
-      // Terminal event. Log the variant for diagnostics, then resolve.
-      if (event.data.event === 'download') {
-        debug().warn('Worker finished downloading file')
-      } else if (event.data.event === 'exists') {
-        debug().warn('Commit exists in OPFS.')
-      }
-      if (event.data.lastModifiedGithub && onLastModifiedGithub) {
-        onLastModifiedGithub(event.data.lastModifiedGithub)
-      }
-      workerRef.removeEventListener('message', listener)
-      const file = event.data.file
-      if (file instanceof File) {
-        setOpfsFile(file)
-      } else {
-        debug().error('Retrieved object is not of type File.')
-      }
-      resolve(file)
+      return
     }
-    workerRef.addEventListener('message', listener)
-    kickoff()
+    if (!data.completed) {
+      return
+    }
+    // Terminal event. Log the variant for diagnostics, then resolve.
+    if (data.event === 'download') {
+      debug().warn('Worker finished downloading file')
+    } else if (data.event === 'exists') {
+      debug().warn('Commit exists in OPFS.')
+    }
+    if (data.lastModifiedGithub && onLastModifiedGithub) {
+      onLastModifiedGithub(data.lastModifiedGithub)
+    }
+    const file = data.file
+    if (file instanceof File) {
+      setOpfsFile(file)
+    } else {
+      debug().error('Retrieved object is not of type File.')
+    }
+    settle.resolve(file)
   })
 }
 
@@ -291,24 +321,21 @@ export function downloadModel(
   onLastModifiedGithub = null) {
   assertDefined(objectUrl, shaHash, originalFilePath, accessToken, owner, repo, branch, setOpfsFile, onProgress)
   return awaitTerminalWorkerEvent(
-    () => opfsDownloadModel(objectUrl, shaHash, originalFilePath, owner, repo, branch, accessToken, !!(onProgress)),
+    (requestId) =>
+      opfsDownloadModel(
+        objectUrl, shaHash, originalFilePath, owner, repo, branch, accessToken, !!(onProgress), requestId),
     {setOpfsFile, onProgress, onLastModifiedGithub})
 }
 
 /**
- * Executes an asynchronous task using a Web Worker and returns a promise that resolves based on the task's outcome.
- * This function initializes a worker, sets up a message listener for the worker's response, and performs cleanup
- * after receiving a response. It abstracts the worker communication logic, making it easier to perform file-related
- * operations asynchronously.
+ * Executes an asynchronous task using the OPFS Web Worker and returns a promise
+ * that resolves based on the task's outcome. Shared by the boolean-result
+ * helpers (exists / delete / clear / snapshot) whose reply protocol is the same
+ * beyond the event name they wait for.
  *
- * @param {Function} callback The function to call that initiates the worker task. This function should
- *     trigger an operation in the worker by sending it a message. The parameters
- *     for this callback include the file path, commit hash, owner, repository, and branch.
- * @param {string} originalFilePath The path of the file on which the operation is performed
- * @param {string} commitHash The commit hash associated with the operation, used for version control
- * @param {string} owner The identifier for the owner of the repository
- * @param {string} repo The name of the repository where the file operation is related
- * @param {string} branch The branch within the repository on which the operation is performed
+ * @param {function(string): void} kickoff Initiates the worker task, given the
+ *     request id to stamp on the command so the reply can be told from a
+ *     concurrent operation's — see {@link workerRequest}.
  * @param {string} eventStatus The specific event status the function waits for to resolve the promise
  *     This parameter allows the function to be used for various operations
  *     by specifying the expected success event type from the worker (e.g., 'deleted', 'written')
@@ -317,38 +344,27 @@ export function downloadModel(
  *     indicates that the file does not exist, the promise will reject with an error or
  *     resolve to false, respectively.
  */
-function makePromise(callback, originalFilePath, commitHash, owner, repo, branch, eventStatus) {
-  return new Promise((resolve, reject) => {
-    const workerRef = initializeWorker()
-    if (workerRef !== null) {
-      // Listener for messages from the worker
-      const listener = (event) => {
-        if (event.data.error) {
-          debug().error('Error from worker:', event.data.error)
-          workerRef.removeEventListener('message', listener) // Remove the event listener
-          reject(new Error(event.data.error))
-        } else if (event.data.completed) {
-          if (event.data.event === 'notexist') {
-            workerRef.removeEventListener('message', listener) // Remove the event listener
-            resolve(false) // Resolve the promise with false
-          } else if (event.data.event === eventStatus) {
-            workerRef.removeEventListener('message', listener) // Remove the event listener
-            if (event.data.event === 'clear') {
-              console.warn('OPFS cache cleared.')
-            }
-            if (event.data.directoryStructure) {
-              console.warn(`OPFS Directory Structure:\n${ event.data.directoryStructure}`)
-            }
-            resolve(true) // Resolve the promise with true
-          }
-        }
-      }
-      workerRef.addEventListener('message', listener)
-    } else {
-      reject(new Error('Worker initialization failed'))
+function makePromise(kickoff, eventStatus) {
+  return workerRequest(kickoff, (data, settle) => {
+    if (data.error) {
+      debug().error('Error from worker:', data.error)
+      settle.reject(new Error(data.error))
+      return
     }
-
-    callback(originalFilePath, commitHash, owner, repo, branch)
+    if (!data.completed) {
+      return
+    }
+    if (data.event === 'notexist') {
+      settle.resolve(false)
+    } else if (data.event === eventStatus) {
+      if (data.event === 'clear') {
+        console.warn('OPFS cache cleared.')
+      }
+      if (data.directoryStructure) {
+        console.warn(`OPFS Directory Structure:\n${ data.directoryStructure}`)
+      }
+      settle.resolve(true)
+    }
   })
 }
 
@@ -370,7 +386,9 @@ export function doesFileExistInOPFS(
   branch) {
   assertDefined(originalFilePath, commitHash, owner, repo, branch)
 
-  return makePromise(opfsDoesFileExist, originalFilePath, commitHash, owner, repo, branch, 'exist')
+  return makePromise(
+    (requestId) => opfsDoesFileExist(originalFilePath, commitHash, owner, repo, branch, requestId),
+    'exist')
 }
 
 
@@ -391,27 +409,18 @@ export function doesFileExistInOPFS(
 export function writeGlbBytesToOPFS(bytes, originalFilePath, commitHash, owner, repo, branch) {
   assertDefined(bytes, originalFilePath, commitHash, owner, repo, branch)
 
-  return new Promise((resolve, reject) => {
-    const workerRef = initializeWorker()
-    if (workerRef === null) {
-      reject(new Error('Worker initialization failed'))
-      return
-    }
-    const listener = (event) => {
-      if (event.data.error) {
-        debug().error('Error from worker:', event.data.error)
-        workerRef.removeEventListener('message', listener)
-        reject(new Error(event.data.error))
+  return workerRequest(
+    (requestId) => opfsWriteBytesByPath(bytes, originalFilePath, commitHash, owner, repo, branch, requestId),
+    (data, settle) => {
+      if (data.error) {
+        debug().error('Error from worker:', data.error)
+        settle.reject(new Error(data.error))
         return
       }
-      if (event.data.completed && event.data.event === 'wrote') {
-        workerRef.removeEventListener('message', listener)
-        resolve(true)
+      if (data.completed && data.event === 'wrote') {
+        settle.resolve(true)
       }
-    }
-    workerRef.addEventListener('message', listener)
-    opfsWriteBytesByPath(bytes, originalFilePath, commitHash, owner, repo, branch)
-  })
+    })
 }
 
 
@@ -429,32 +438,22 @@ export function writeGlbBytesToOPFS(bytes, originalFilePath, commitHash, owner, 
 export function readModelByPathFromOPFS(originalFilePath, commitHash, owner, repo, branch) {
   assertDefined(originalFilePath, commitHash, owner, repo, branch)
 
-  return new Promise((resolve, reject) => {
-    const workerRef = initializeWorker()
-    if (workerRef === null) {
-      reject(new Error('Worker initialization failed'))
-      return
-    }
-    const listener = (event) => {
-      if (event.data.error) {
-        debug().error('Error from worker:', event.data.error)
-        workerRef.removeEventListener('message', listener)
-        reject(new Error(event.data.error))
+  return workerRequest(
+    (requestId) => opfsReadModelByPath(originalFilePath, commitHash, owner, repo, branch, requestId),
+    (data, settle) => {
+      if (data.error) {
+        debug().error('Error from worker:', data.error)
+        settle.reject(new Error(data.error))
         return
       }
-      if (event.data.completed) {
-        if (event.data.event === 'notexist') {
-          workerRef.removeEventListener('message', listener)
-          resolve(null)
-        } else if (event.data.event === 'read') {
-          workerRef.removeEventListener('message', listener)
-          resolve(event.data.file)
+      if (data.completed) {
+        if (data.event === 'notexist') {
+          settle.resolve(null)
+        } else if (data.event === 'read') {
+          settle.resolve(data.file)
         }
       }
-    }
-    workerRef.addEventListener('message', listener)
-    opfsReadModelByPath(originalFilePath, commitHash, owner, repo, branch)
-  })
+    })
 }
 
 /**
@@ -464,9 +463,7 @@ export function readModelByPathFromOPFS(originalFilePath, commitHash, owner, rep
  * @return {Promise<boolean>}
  */
 export function snapshotOPFS(previewWindow = 0) {
-  // Wrap opfsSnapshotCache so makePromise still receives a callback with standard signature
-  const callback = () => opfsSnapshotCache(previewWindow)
-  return makePromise(callback, null, null, null, null, null, 'snapshot')
+  return makePromise((requestId) => opfsSnapshotCache(previewWindow, requestId), 'snapshot')
 }
 
 /**
@@ -475,7 +472,7 @@ export function snapshotOPFS(previewWindow = 0) {
  * @return {boolean}
  */
 export function clearOPFSCache() {
-  return makePromise(opfsClearCache, null, null, null, null, null, 'clear')
+  return makePromise((requestId) => opfsClearCache(requestId), 'clear')
 }
 
 /**
@@ -497,7 +494,9 @@ export function deleteFileFromOPFS(
   branch) {
   assertDefined(originalFilePath, commitHash, owner, repo, branch)
 
-  return makePromise(opfsDeleteModel, originalFilePath, commitHash, owner, repo, branch, 'deleted')
+  return makePromise(
+    (requestId) => opfsDeleteModel(originalFilePath, commitHash, owner, repo, branch, requestId),
+    'deleted')
 }
 
 
@@ -511,8 +510,6 @@ export function deleteFileFromOPFS(
  */
 export function saveDnDFileToOpfs(file, type, callback) {
   assertDefined(file, type, callback)
-  let workerRef = null
-  workerRef = initializeWorker()
 
   const tmpUrl = URL.createObjectURL(file)
   debug().log('OPFS/utils#saveDnDFileToOpfs: event: url: ', tmpUrl)
@@ -520,37 +517,32 @@ export function saveDnDFileToOpfs(file, type, callback) {
   const parts = tmpUrl.split('/')
   const fileNametmpUrl = parts[parts.length - 1]
 
-  // Listener for messages from the worker.  We can't revoke tmpUrl
-  // until the worker is done with it, so revoke when the listener
-  // detaches (success or error path).
-  const listener = (workerEvent) => {
-    if (workerEvent.data.error) {
-      debug().error('Error from worker:', workerEvent.data.error)
-      workerRef.removeEventListener('message', listener)
-      URL.revokeObjectURL(tmpUrl)
-    } else if (workerEvent.data.completed) {
-      if (workerEvent.data.event === 'write') {
-        debug().log('Worker finished writing file')
-        const fileName = workerEvent.data.fileName
-        workerRef.removeEventListener('message', listener)
-        URL.revokeObjectURL(tmpUrl)
-        callback(fileName)
-      } else if (workerEvent.data.event === 'read') {
-        debug().log('Worker finished reading file')
-        const fileName = workerEvent.data.file.name
-        workerRef.removeEventListener('message', listener)
-        URL.revokeObjectURL(tmpUrl)
-        callback(fileName)
-      }
-    }
-  }
-
-  workerRef.addEventListener('message', listener)
-
   const originalFilename = file.name
   const filename = `${fileNametmpUrl}.${type}`
   debug().log('OPFS/utils#saveDnDFileToOpfs: calling opfsWriteModel with typed filename:', filename)
-  opfsWriteModel(tmpUrl, originalFilename, filename)
+
+  workerRequest(
+    (requestId) => opfsWriteModel(tmpUrl, originalFilename, filename, requestId),
+    (data, settle) => {
+      if (data.error) {
+        settle.reject(new Error(data.error))
+        return
+      }
+      if (data.completed) {
+        if (data.event === 'write') {
+          debug().log('Worker finished writing file')
+          settle.resolve(data.fileName)
+        } else if (data.event === 'read') {
+          debug().log('Worker finished reading file')
+          settle.resolve(data.file.name)
+        }
+      }
+    })
+    .then((fileName) => callback(fileName))
+    .catch((error) => debug().error('Error from worker:', error))
+    // We can't revoke tmpUrl until the worker is done with it, so revoke once
+    // the request settles either way.
+    .finally(() => URL.revokeObjectURL(tmpUrl))
 }
 
 /**

--- a/src/OPFS/utils.test.js
+++ b/src/OPFS/utils.test.js
@@ -8,11 +8,60 @@ import {
   doesFileExistInOPFS,
   deleteFileFromOPFS,
   checkOPFSAvailability,
+  readModelByPathFromOPFS,
   snapshotOPFS,
+  writeGlbBytesToOPFS,
   clearOPFSCache} from './utils'
 
 
 jest.mock('../OPFS/OPFSService.js')
+
+
+/**
+ * The id `workerRequest` minted for the request currently under test. The real
+ * worker stamps it on every reply (`OPFS.worker.js` `postReply`), so a mock
+ * worker must too — a reply without it is, correctly, ignored.
+ *
+ * @return {string}
+ */
+function currentRequestId() {
+  const results = OPFSService.nextRequestId.mock.results
+  return results[results.length - 1].value
+}
+
+
+/**
+ * Stand-in for the shared OPFS worker: ONE message stream that every in-flight
+ * request's listener sees. That sharing is the whole subject of #1785, so the
+ * concurrency tests need a worker that models it rather than one listener per
+ * mock.
+ *
+ * @return {object} Mock worker with a `deliver` to post one reply to all
+ *   attached listeners and `listenerCount` to check for leaks.
+ */
+function makeSharedWorkerMock() {
+  const listeners = []
+  return {
+    addEventListener: jest.fn((_, handler) => listeners.push(handler)),
+    removeEventListener: jest.fn((_, handler) => {
+      const index = listeners.indexOf(handler)
+      if (index !== -1) {
+        listeners.splice(index, 1)
+      }
+    }),
+    deliver: (data) => listeners.slice().forEach((handler) => handler({data})),
+    listenerCount: () => listeners.length,
+  }
+}
+
+
+/**
+ * Let queued promise callbacks run so a pending-vs-settled check is meaningful.
+ *
+ * @return {Promise<void>}
+ */
+const flushMicrotasks = () => new Promise((resolve) => process.nextTick(resolve))
+
 
 describe('OPFS Test Suite', () => {
   let consoleWarnMock
@@ -23,6 +72,16 @@ describe('OPFS Test Suite', () => {
 
     // Mock console.warn to prevent console output and capture warnings
     consoleWarnMock = jest.spyOn(console, 'warn').mockImplementation(() => {})
+
+    // Distinct ids per request, as the real `nextRequestId` mints. Without this
+    // the automock returns undefined for every call and every reply would match
+    // every listener — i.e. exactly the pre-#1785 behavior, which would make
+    // the correlation tests below vacuous.
+    let requestCounter = 0
+    OPFSService.nextRequestId.mockImplementation(() => {
+      requestCounter++
+      return `opfs-${requestCounter}`
+    })
 
     // Setup or reset mock implementations before each test
     OPFSService.initializeWorker.mockReturnValue({
@@ -41,7 +100,7 @@ describe('OPFS Test Suite', () => {
       const mockWorker = {
         addEventListener: jest.fn((_, handler) => {
           // Simulate successful worker operation
-          process.nextTick(() => handler({data: {completed: true, event: 'write'}}))
+          process.nextTick(() => handler({data: {requestId: currentRequestId(), completed: true, event: 'write'}}))
         }),
         removeEventListener: jest.fn(),
       }
@@ -50,7 +109,7 @@ describe('OPFS Test Suite', () => {
       expect(result).toBe(true)
       expect(OPFSService.initializeWorker).toHaveBeenCalled()
       expect(OPFSService.opfsWriteModelFileHandle)
-        .toHaveBeenCalledWith('mockFile', 'originalFileName', 'commitHash', 'owner', 'repo', 'branch')
+        .toHaveBeenCalledWith('mockFile', 'originalFileName', 'commitHash', 'owner', 'repo', 'branch', 'opfs-1')
       expect(mockWorker.addEventListener).toHaveBeenCalled()
       expect(mockWorker.removeEventListener).toHaveBeenCalled()
 
@@ -69,7 +128,7 @@ describe('OPFS Test Suite', () => {
       const mockWorker = {
         addEventListener: jest.fn((_, handler) => {
           // Simulate worker successfully retrieving the file
-          process.nextTick(() => handler({data: mockFileResponse}))
+          process.nextTick(() => handler({data: {...mockFileResponse, requestId: currentRequestId()}}))
         }),
         removeEventListener: jest.fn(),
       }
@@ -81,7 +140,8 @@ describe('OPFS Test Suite', () => {
       // Assert the expected outcomes
       expect(result).toEqual(mockFile)
       expect(OPFSService.initializeWorker).toHaveBeenCalled()
-      expect(OPFSService.opfsReadModel).toHaveBeenCalledWith('file.ifc') // Since you manipulate the filepath in the function
+      // Filepath is reduced to its last segment by the function under test.
+      expect(OPFSService.opfsReadModel).toHaveBeenCalledWith('file.ifc', 'opfs-1')
       expect(mockWorker.addEventListener).toHaveBeenCalled()
       expect(mockWorker.removeEventListener).toHaveBeenCalled()
     })
@@ -93,7 +153,7 @@ describe('OPFS Test Suite', () => {
       const mockWorker = {
         addEventListener: jest.fn((_, handler) => {
           process.nextTick(() => {
-            handler({data: {completed: true, event: 'download', file: mockFile}})
+            handler({data: {requestId: currentRequestId(), completed: true, event: 'download', file: mockFile}})
           })
         }),
         removeEventListener: jest.fn(),
@@ -121,6 +181,7 @@ describe('OPFS Test Suite', () => {
         'repo',
         'branch',
         true, // Since onProgress is provided
+        'opfs-1',
       )
       expect(mockWorker.addEventListener).toHaveBeenCalled()
       expect(mockWorker.removeEventListener).toHaveBeenCalledTimes(1) // Ensure it's called to clean up
@@ -130,8 +191,11 @@ describe('OPFS Test Suite', () => {
       const mockWorker = {
         addEventListener: jest.fn((_, handler) => {
           process.nextTick(() => {
-            handler({data: {progressEvent: true, total: 100, loaded: 50}}) // Simulate a progress update
-            handler({data: {completed: true, event: 'download', file: new Blob(['content'])}}) // Then complete
+            // A progress update, then the terminal event.
+            handler({data: {requestId: currentRequestId(), progressEvent: true, total: 100, loaded: 50}})
+            handler({data: {
+              requestId: currentRequestId(), completed: true, event: 'download', file: new Blob(['content']),
+            }})
           })
         }),
         removeEventListener: jest.fn(),
@@ -163,7 +227,7 @@ describe('OPFS Test Suite', () => {
       const mockWorker = {
         addEventListener: jest.fn((_, handler) => {
           process.nextTick(() => {
-            handler({data: {completed: true, event: 'exists', file: mockFile}})
+            handler({data: {requestId: currentRequestId(), completed: true, event: 'exists', file: mockFile}})
           })
         }),
         removeEventListener: jest.fn(),
@@ -195,6 +259,7 @@ describe('OPFS Test Suite', () => {
         'branch',
         'accessToken',
         true, // Since onProgress is provided
+        'opfs-1',
       )
       expect(mockWorker.addEventListener).toHaveBeenCalled()
       expect(mockWorker.removeEventListener).toHaveBeenCalledTimes(1) // Ensure it's called to clean up
@@ -207,8 +272,8 @@ describe('OPFS Test Suite', () => {
       const mockWorker = {
         addEventListener: jest.fn((_, handler) => {
           process.nextTick(() => {
-            handler({data: {progressEvent: true, contentLength: 100, receivedLength: 50}})
-            handler({data: {completed: true, event: 'renamed', file: new File(['content'], 'model.ifc')}})
+            handler({data: {requestId: currentRequestId(), progressEvent: true, contentLength: 100, receivedLength: 50}})
+            handler({data: {requestId: currentRequestId(), completed: true, event: 'renamed', file: new File(['content'], 'model.ifc')}})
           })
         }),
         removeEventListener: jest.fn(),
@@ -242,7 +307,7 @@ describe('OPFS Test Suite', () => {
       const mockWorker = {
         addEventListener: jest.fn((_, handler) => {
           process.nextTick(() => {
-            handler({data: {completed: true, event: 'exists', file: mockFile, lastModifiedGithub: EPOCH_MS}})
+            handler({data: {requestId: currentRequestId(), completed: true, event: 'exists', file: mockFile, lastModifiedGithub: EPOCH_MS}})
           })
         }),
         removeEventListener: jest.fn(),
@@ -267,7 +332,9 @@ describe('OPFS Test Suite', () => {
       const mockWorker = {
         addEventListener: jest.fn((_, handler) => {
           process.nextTick(() => {
-            handler({data: {completed: true, event: 'renamed', file: mockFile, lastModifiedGithub: EPOCH_MS}})
+            handler({data: {
+              requestId: currentRequestId(), completed: true, event: 'renamed', file: mockFile, lastModifiedGithub: EPOCH_MS,
+            }})
           })
         }),
         removeEventListener: jest.fn(),
@@ -292,7 +359,7 @@ describe('OPFS Test Suite', () => {
       const mockWorker = {
         addEventListener: jest.fn((_, handler) => {
           process.nextTick(() => {
-            handler({data: {completed: true, event: 'download', file: mockFile}})
+            handler({data: {requestId: currentRequestId(), completed: true, event: 'download', file: mockFile}})
           })
         }),
         removeEventListener: jest.fn(),
@@ -315,7 +382,7 @@ describe('OPFS Test Suite', () => {
       const mockWorker = {
         addEventListener: jest.fn((_, handler) => {
           process.nextTick(() => {
-            handler({data: {completed: true, event: 'exists', file: mockFile}})
+            handler({data: {requestId: currentRequestId(), completed: true, event: 'exists', file: mockFile}})
           })
         }),
         removeEventListener: jest.fn(),
@@ -336,7 +403,7 @@ describe('OPFS Test Suite', () => {
     it('should resolve true if the file exists', async () => {
       const mockWorker = {
         addEventListener: jest.fn((_, handler) => {
-          process.nextTick(() => handler({data: {completed: true, event: 'exist'}}))
+          process.nextTick(() => handler({data: {requestId: currentRequestId(), completed: true, event: 'exist'}}))
         }),
         removeEventListener: jest.fn(),
       }
@@ -358,6 +425,7 @@ describe('OPFS Test Suite', () => {
         'owner',
         'repo',
         'branch',
+        'opfs-1',
       )
       expect(mockWorker.addEventListener).toHaveBeenCalled()
       expect(mockWorker.removeEventListener).toHaveBeenCalledTimes(1) // Ensure it's called to clean up
@@ -366,7 +434,7 @@ describe('OPFS Test Suite', () => {
     it('should resolve false if the file does not exist', async () => {
       const mockWorker = {
         addEventListener: jest.fn((_, handler) => {
-          process.nextTick(() => handler({data: {completed: true, event: 'notexist'}}))
+          process.nextTick(() => handler({data: {requestId: currentRequestId(), completed: true, event: 'notexist'}}))
         }),
         removeEventListener: jest.fn(),
       }
@@ -389,7 +457,7 @@ describe('OPFS Test Suite', () => {
       const mockWorker = {
         addEventListener: jest.fn((_, handler) => {
           // Simulate successful file deletion
-          process.nextTick(() => handler({data: {completed: true, event: 'deleted'}}))
+          process.nextTick(() => handler({data: {requestId: currentRequestId(), completed: true, event: 'deleted'}}))
         }),
         removeEventListener: jest.fn(),
       }
@@ -411,6 +479,7 @@ describe('OPFS Test Suite', () => {
         'owner',
         'repo',
         'branch',
+        'opfs-1',
       )
       expect(mockWorker.addEventListener).toHaveBeenCalled()
       expect(mockWorker.removeEventListener).toHaveBeenCalledTimes(1)
@@ -420,7 +489,7 @@ describe('OPFS Test Suite', () => {
       const mockWorker = {
         addEventListener: jest.fn((_, handler) => {
           // Simulate the file not existing
-          process.nextTick(() => handler({data: {completed: true, event: 'notexist'}}))
+          process.nextTick(() => handler({data: {requestId: currentRequestId(), completed: true, event: 'notexist'}}))
         }),
         removeEventListener: jest.fn(),
       }
@@ -483,7 +552,9 @@ describe('OPFS Test Suite', () => {
       const mockWorker = {
         addEventListener: jest.fn((_, handler) => {
           // Simulate successful snapshot operation
-          process.nextTick(() => handler({data: {completed: true, event: 'snapshot', directoryStructure: mockDirectoryStructure}}))
+          process.nextTick(() => handler({data: {
+            requestId: currentRequestId(), completed: true, event: 'snapshot', directoryStructure: mockDirectoryStructure,
+          }}))
         }),
         removeEventListener: jest.fn(),
       }
@@ -506,7 +577,7 @@ describe('OPFS Test Suite', () => {
       const mockWorker = {
         addEventListener: jest.fn((_, handler) => {
           // Simulate successful cache clear operation
-          process.nextTick(() => handler({data: {completed: true, event: 'clear'}}))
+          process.nextTick(() => handler({data: {requestId: currentRequestId(), completed: true, event: 'clear'}}))
         }),
         removeEventListener: jest.fn(),
       }
@@ -521,6 +592,154 @@ describe('OPFS Test Suite', () => {
 
       // Assert that console.warn was called with the expected cache clear message
       expect(consoleWarnMock).toHaveBeenCalledWith('OPFS cache cleared.')
+    })
+  })
+
+  // Everything above drives ONE request at a time, which is exactly why the
+  // #1785 bug survived: with a single listener attached, "resolved on some
+  // reply" is indistinguishable from "resolved on its own reply". These tests
+  // overlap two requests on the one shared worker so the difference is
+  // observable — each asserts that a promise stays pending while the OTHER
+  // request's reply goes by.
+  describe('reply correlation on the shared worker (#1785)', () => {
+    let sharedWorker
+
+    beforeEach(() => {
+      sharedWorker = makeSharedWorkerMock()
+      OPFSService.initializeWorker.mockReturnValue(sharedWorker)
+    })
+
+    /**
+     * Ids in mint order: the first request to call `nextRequestId` is index 0.
+     *
+     * @param {number} index
+     * @return {string}
+     */
+    const requestIdAt = (index) => OPFSService.nextRequestId.mock.results[index].value
+
+    it('a concurrent write of the SAME model at the SAME commit resolves only its own promise', async () => {
+      // The case `commitHash` correlation cannot cover: both requests carry
+      // identical (path, commitHash), so only a per-request id separates them.
+      const first = writeGlbBytesToOPFS(new Uint8Array([1]), 'model.ifc', 'sha1', 'owner', 'repo', 'main')
+      const second = writeGlbBytesToOPFS(new Uint8Array([2]), 'model.ifc', 'sha1', 'owner', 'repo', 'main')
+      let firstSettled = false
+      first.then(() => {
+        firstSettled = true
+      })
+      expect(sharedWorker.listenerCount()).toBe(2)
+
+      sharedWorker.deliver({requestId: requestIdAt(1), completed: true, event: 'wrote', commitHash: 'sha1'})
+      await expect(second).resolves.toBe(true)
+      await flushMicrotasks()
+
+      expect(firstSettled).toBe(false)
+      expect(sharedWorker.listenerCount()).toBe(1)
+
+      sharedWorker.deliver({requestId: requestIdAt(0), completed: true, event: 'wrote', commitHash: 'sha1'})
+      await expect(first).resolves.toBe(true)
+      expect(sharedWorker.listenerCount()).toBe(0)
+    })
+
+    it('an unrelated request\'s error does not reject the write', async () => {
+      // Worker error replies carry no commitHash at all, so this branch has
+      // nothing but the request id to match on.
+      const write = writeGlbBytesToOPFS(new Uint8Array([1]), 'model.ifc', 'sha1', 'owner', 'repo', 'main')
+      const read = readModelByPathFromOPFS('other.glb', 'sha2', 'owner', 'repo', 'main')
+      let writeSettled = false
+      write.then(() => {
+        writeSettled = true
+      }, () => {
+        writeSettled = true
+      })
+
+      sharedWorker.deliver({requestId: requestIdAt(1), error: 'readModelByPath: boom'})
+      await expect(read).rejects.toThrow('readModelByPath: boom')
+      await flushMicrotasks()
+
+      expect(writeSettled).toBe(false)
+
+      sharedWorker.deliver({requestId: requestIdAt(0), completed: true, event: 'wrote', commitHash: 'sha1'})
+      await expect(write).resolves.toBe(true)
+    })
+
+    it('two concurrent reads each resolve with their own file', async () => {
+      const fileA = new File(['a'], 'a.glb')
+      const fileB = new File(['b'], 'b.glb')
+      const readA = readModelByPathFromOPFS('a.ifc', 'shaA', 'owner', 'repo', 'main')
+      const readB = readModelByPathFromOPFS('b.ifc', 'shaB', 'owner', 'repo', 'main')
+
+      // Reply out of order — the worker gives no ordering guarantee between
+      // requests, and ordering is what an uncorrelated listener silently relies on.
+      sharedWorker.deliver({requestId: requestIdAt(1), completed: true, event: 'read', file: fileB})
+      sharedWorker.deliver({requestId: requestIdAt(0), completed: true, event: 'read', file: fileA})
+
+      // Compare by name, not identity: a failing `toBe` on two jsdom Files
+      // makes Jest deep-copy them to build a diff, which aborts the worker.
+      expect((await readA).name).toBe('a.glb')
+      expect((await readB).name).toBe('b.glb')
+    })
+
+    it('does not forward another request\'s progress events', async () => {
+      const onProgress = jest.fn()
+      const setOpfsFile = jest.fn()
+      const download = downloadModel(
+        'objectUrl', 'shaHash', 'model.ifc', 'accessToken',
+        'owner', 'repo', 'main', setOpfsFile, onProgress)
+      const otherWrite = writeGlbBytesToOPFS(new Uint8Array([1]), 'other.ifc', 'sha2', 'owner', 'repo', 'main')
+
+      sharedWorker.deliver({requestId: requestIdAt(1), progressEvent: true, contentLength: 100, receivedLength: 50})
+      await flushMicrotasks()
+
+      expect(onProgress).not.toHaveBeenCalled()
+
+      sharedWorker.deliver({requestId: requestIdAt(0), progressEvent: true, contentLength: 100, receivedLength: 50})
+      expect(onProgress).toHaveBeenCalledTimes(1)
+
+      // Settle both so neither promise outlives the test.
+      const file = new File(['x'], 'model.ifc')
+      sharedWorker.deliver({requestId: requestIdAt(0), completed: true, event: 'renamed', file: file})
+      sharedWorker.deliver({requestId: requestIdAt(1), completed: true, event: 'wrote', commitHash: 'sha2'})
+      await Promise.all([download, otherWrite])
+    })
+
+    it('ignores an uncorrelated reply, the shape the worker posted before the fix', async () => {
+      const write = writeGlbBytesToOPFS(new Uint8Array([1]), 'model.ifc', 'sha1', 'owner', 'repo', 'main')
+      let settled = false
+      write.then(() => {
+        settled = true
+      })
+
+      sharedWorker.deliver({completed: true, event: 'wrote', commitHash: 'sha1'})
+      await flushMicrotasks()
+
+      expect(settled).toBe(false)
+      expect(sharedWorker.listenerCount()).toBe(1)
+
+      sharedWorker.deliver({requestId: requestIdAt(0), completed: true, event: 'wrote', commitHash: 'sha1'})
+      await expect(write).resolves.toBe(true)
+    })
+
+    it('detaches and rejects when the worker finishes a request without replying', async () => {
+      // The leak asked about in #1785: a listener whose reply never arrives sat
+      // on the shared worker for the life of the page. The worker now closes
+      // every request out (`requestFinished`) so this can't happen.
+      const write = writeGlbBytesToOPFS(new Uint8Array([1]), 'model.ifc', 'sha1', 'owner', 'repo', 'main')
+      expect(sharedWorker.listenerCount()).toBe(1)
+
+      sharedWorker.deliver({requestId: requestIdAt(0), requestFinished: true})
+
+      await expect(write).rejects.toThrow(/without a reply/)
+      expect(sharedWorker.listenerCount()).toBe(0)
+    })
+
+    it('a request that already replied ignores its own requestFinished sentinel', async () => {
+      const write = writeGlbBytesToOPFS(new Uint8Array([1]), 'model.ifc', 'sha1', 'owner', 'repo', 'main')
+
+      sharedWorker.deliver({requestId: requestIdAt(0), completed: true, event: 'wrote', commitHash: 'sha1'})
+      sharedWorker.deliver({requestId: requestIdAt(0), requestFinished: true})
+
+      await expect(write).resolves.toBe(true)
+      expect(sharedWorker.listenerCount()).toBe(0)
     })
   })
 })

--- a/src/connections/loadFromSource.js
+++ b/src/connections/loadFromSource.js
@@ -1,5 +1,6 @@
 import {
   initializeWorker,
+  nextRequestId,
   opfsWriteModel,
 } from '../OPFS/OPFSService.js'
 import {checkOPFSAvailability} from '../OPFS/utils'
@@ -104,16 +105,29 @@ async function writeAndOpen(download, fallbackName, provider, connection, onLoad
     const workerRef = initializeWorker()
 
     if (workerRef) {
+      // Minted before the listener attaches, so it can close over the id: the
+      // worker stamps it on every reply to this request and we ignore the rest.
+      // Without the filter this accepts ANY error from the shared worker — and
+      // now that the helpers in OPFS/utils.js are correlated, an unrelated
+      // request's failure would detach us and revoke a blob URL whose write is
+      // still in flight. Symmetric sloppiness before; live cross-talk once
+      // everything around it is correlated.
+      const requestId = nextRequestId()
       return new Promise((resolve, reject) => {
         const listener = (event) => {
-          if (event.data.error) {
-            debug().error('loadFromSource: OPFS write error:', event.data.error)
+          if (event.data.requestId !== requestId) {
+            return
+          }
+          if (event.data.error || event.data.requestFinished) {
+            const message = event.data.error ??
+              `OPFS worker finished ${requestId} without a reply`
+            debug().error('loadFromSource: OPFS write error:', message)
             workerRef.removeEventListener('message', listener)
             // Revoke once the worker is done with the URL. Without this,
             // each load leaked a blob backing — Safari surfaces those as
             // `WebKitBlobResource error 1` lines on every fresh load.
             URL.revokeObjectURL(blobUrl)
-            reject(new Error(event.data.error))
+            reject(new Error(message))
           } else if (event.data.completed && event.data.event === 'write') {
             debug().log('loadFromSource: OPFS write complete')
             workerRef.removeEventListener('message', listener)
@@ -126,7 +140,7 @@ async function writeAndOpen(download, fallbackName, provider, connection, onLoad
         // Write blob URL to OPFS; the worker will fetch the blob and store it
         const parts = blobUrl.split('/')
         const blobName = parts[parts.length - 1]
-        opfsWriteModel(blobUrl, filename, `${blobName}.${ext}`)
+        opfsWriteModel(blobUrl, filename, `${blobName}.${ext}`, requestId)
       })
     }
     URL.revokeObjectURL(blobUrl)

--- a/src/connections/loadFromSource.test.js
+++ b/src/connections/loadFromSource.test.js
@@ -1,10 +1,16 @@
 import {loadFileById, loadFileFromSource} from './loadFromSource'
+import {initializeWorker, nextRequestId} from '../OPFS/OPFSService.js'
+import {checkOPFSAvailability} from '../OPFS/utils'
 import {getBrowser, getProvider} from './registry'
 
 
 jest.mock('./registry')
 jest.mock('../OPFS/utils', () => ({checkOPFSAvailability: jest.fn().mockReturnValue(false)}))
-jest.mock('../OPFS/OPFSService.js', () => ({initializeWorker: jest.fn(), opfsWriteModel: jest.fn()}))
+jest.mock('../OPFS/OPFSService.js', () => ({
+  initializeWorker: jest.fn(),
+  nextRequestId: jest.fn(),
+  opfsWriteModel: jest.fn(),
+}))
 
 
 const FAKE_BLOB_URL = 'blob:http://localhost/fake-blob-uuid'
@@ -139,6 +145,93 @@ describe('loadFromSource', () => {
       await expect(
         loadFileById(mockConnection, 'file-abc', 'model.ifc', jest.fn()),
       ).rejects.toThrow('No provider registered for google-drive')
+    })
+  })
+
+
+  // The OPFS worker is shared per origin, so this listener sees every reply,
+  // not only its own. #1785 correlated the helpers in `OPFS/utils.js`; this
+  // call site posts directly and had no filter, which made it strictly worse
+  // than before — another request's failure detached it and revoked a blob URL
+  // whose write was still in flight, so the upload silently never completed.
+  // (codex, PR #1790.)
+  describe('loadFileById OPFS write correlation', () => {
+    /** @return {object} a worker stub whose messages reach every listener */
+    function makeSharedWorker() {
+      const listeners = []
+      return {
+        addEventListener: (_, fn) => listeners.push(fn),
+        removeEventListener: (_, fn) => {
+          const at = listeners.indexOf(fn)
+          if (at !== -1) {
+            listeners.splice(at, 1)
+          }
+        },
+        deliver: (data) => listeners.slice().forEach((fn) => fn({data})),
+        listenerCount: () => listeners.length,
+      }
+    }
+
+    let worker
+
+    beforeEach(() => {
+      worker = makeSharedWorker()
+      checkOPFSAvailability.mockReturnValue(true)
+      initializeWorker.mockReturnValue(worker)
+      let n = 0
+      // A real incrementing id. The automock returns `undefined` for every
+      // call, which makes every reply match every listener and would let both
+      // tests below pass without the fix.
+      nextRequestId.mockImplementation(() => `opfs-${++n}`)
+      getProvider.mockReturnValue(mockProvider)
+      getBrowser.mockReturnValue(mockBrowser)
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        blob: jest.fn().mockResolvedValue(mockBlob),
+      })
+    })
+
+    afterEach(() => {
+      checkOPFSAvailability.mockReturnValue(false)
+    })
+
+    it('ignores another request\'s error and still completes its own write', async () => {
+      const onLoad = jest.fn()
+      const pending = loadFileById(mockConnection, 'file-abc', 'model.ifc', onLoad)
+      await Promise.resolve()
+      await Promise.resolve()
+
+      // Somebody else's failure on the shared worker. Pre-fix this rejected
+      // `pending` and revoked our blob URL.
+      worker.deliver({requestId: 'opfs-999', error: 'unrelated failure'})
+      // Our own write then lands.
+      worker.deliver({
+        requestId: 'opfs-1', completed: true, event: 'write', fileName: 'stored.ifc',
+      })
+
+      await expect(pending).resolves.toBeDefined()
+      expect(onLoad).toHaveBeenCalledWith('stored.ifc')
+    })
+
+    it('ignores another request\'s write reply rather than resolving on it', async () => {
+      const onLoad = jest.fn()
+      const pending = loadFileById(mockConnection, 'file-abc', 'model.ifc', onLoad)
+      await Promise.resolve()
+      await Promise.resolve()
+
+      worker.deliver({
+        requestId: 'opfs-999', completed: true, event: 'write', fileName: 'not-ours.ifc',
+      })
+      expect(onLoad).not.toHaveBeenCalled()
+      // Still attached, still waiting for its own reply.
+      expect(worker.listenerCount()).toBe(1)
+
+      worker.deliver({
+        requestId: 'opfs-1', completed: true, event: 'write', fileName: 'stored.ifc',
+      })
+      await expect(pending).resolves.toBeDefined()
+      expect(onLoad).toHaveBeenCalledWith('stored.ifc')
+      expect(worker.listenerCount()).toBe(0)
     })
   })
 })

--- a/src/loader/Loader.test.js
+++ b/src/loader/Loader.test.js
@@ -762,6 +762,11 @@ class MockBlob {
 // Mock Worker for testing
 /**
  * A fake Worker implementation for testing purposes.
+ *
+ * The reply is scheduled from `postMessage`, not from `addEventListener`, so it
+ * can echo the `requestId` of the command that triggered it — `OPFS/utils.js`
+ * drops any reply that doesn't carry the id of the request it's waiting on
+ * (#1785), and a reply scheduled at listener-attach time doesn't know the id yet.
  */
 class FakeWorker {
   /**
@@ -771,18 +776,33 @@ class FakeWorker {
    */
   constructor(script) {
     this.script = script
-    this.postMessage = jest.fn()
     this.terminate = jest.fn()
     this.onmessage = null
-    this.addEventListener = jest.fn((event, handler) => {
+    this.listeners = new Set()
+    this.postMessage = jest.fn((message) => {
+      if (!message || message.command === 'initializeWorker') {
+        return
+      }
       // Simulate successful file download
+      process.nextTick(() => {
+        for (const handler of [...this.listeners]) {
+          handler({data: {
+            completed: true,
+            event: 'download',
+            file: new MockBlob(['mock file content']),
+            requestId: message.requestId,
+          }})
+        }
+      })
+    })
+    this.addEventListener = jest.fn((event, handler) => {
       if (event === 'message') {
-        process.nextTick(() => {
-          handler({data: {completed: true, event: 'download', file: new MockBlob(['mock file content'])}})
-        })
+        this.listeners.add(handler)
       }
     })
-    this.removeEventListener = jest.fn()
+    this.removeEventListener = jest.fn((event, handler) => {
+      this.listeners.delete(handler)
+    })
   }
 }
 global.Worker = FakeWorker

--- a/src/utils/loader.js
+++ b/src/utils/loader.js
@@ -1,5 +1,6 @@
 import {
   initializeWorker,
+  nextRequestId,
   opfsWriteModel,
 } from '../OPFS/OPFSService.js'
 import {assertDefined} from '../utils/assert'
@@ -75,12 +76,24 @@ export function loadLocalFile(onLoad, testingSkipAutoRemove = false, testingDisa
       const parts = tmpUrl.split('/')
       const fileNametmpUrl = parts[parts.length - 1]
       if (!testingDisableWebWorker) {
+        // Minted before the listener attaches so it can close over the id.
+        const requestId = nextRequestId()
         // Listener for messages from the worker.  We can't revoke
         // tmpUrl until the worker is done with it, so revoke when the
         // listener detaches (success or error path).
         const listener = (workerEvent) => {
-          if (workerEvent.data.error) {
-            debug().error('Error from worker:', workerEvent.data.error)
+          // Only this request's replies. Without the filter this accepts ANY
+          // error from the shared worker, so once the OPFS/utils.js helpers
+          // became correlated (#1785) an unrelated request's failure would
+          // detach this listener and revoke `tmpUrl` while its own write was
+          // still in flight — the upload then silently never calls onLoad.
+          if (workerEvent.data.requestId !== requestId) {
+            return
+          }
+          if (workerEvent.data.error || workerEvent.data.requestFinished) {
+            const message = workerEvent.data.error ??
+              `OPFS worker finished ${requestId} without a reply`
+            debug().error('Error from worker:', message)
             workerRef.removeEventListener('message', listener)
             URL.revokeObjectURL(tmpUrl)
           } else if (workerEvent.data.completed) {
@@ -104,7 +117,7 @@ export function loadLocalFile(onLoad, testingSkipAutoRemove = false, testingDisa
           throw new Error('Cannot extract filetype from filename')
         }
         const ext = dotParts[dotParts.length - 1]
-        opfsWriteModel(tmpUrl, filename, `${fileNametmpUrl}.${ext}`)
+        opfsWriteModel(tmpUrl, filename, `${fileNametmpUrl}.${ext}`, requestId)
       } else {
         URL.revokeObjectURL(tmpUrl)
         onLoad(fileNametmpUrl, lastModifiedUtc, file.name)


### PR DESCRIPTION
Closes #1785.

## What was wrong

`initializeWorker()` returns one worker per origin, so every helper in `src/OPFS/utils.js` listens to the same message stream. Each listener settled on the first reply that merely *looked* right — any `wrote`, any `error` — regardless of which operation produced it. `writeGlbBytesToOPFS` was the sharp edge: the GLB cache-hit specs reload the page on `writer: wrote`, so resolving on someone else's write puts back the half-written-artifact read that #1783 fixed. The error branch was worse still, rejecting whichever promise was listening on any error from any operation.

## Correlation scheme, and why

**A per-request id round-tripped through the message**, not `commitHash` filtering.

`commitHash` was the cheaper option and it is not sufficient:

- **Error replies carry no `commitHash` at all** (`{error: '...'}`), so the branch that most needed fixing would have had nothing to match on.
- **Two concurrent writes of the same model at the same commit share one hash** and would still cross-talk. That is not hypothetical — the GLB writer is fire-and-forget on `requestIdleCallback`, so the overlap is a scheduling accident away, which is exactly the issue's argument for why this becomes reachable.
- Several reply variants (`write`, `read`, `download`, `renamed`, `snapshot`, progress events) don't echo a hash either.

Mechanically: `nextRequestId()` (`OPFSService.js`) mints `opfs-N`; the id rides on the command; `postReply(message, requestId)` (`OPFS.worker.js`) stamps it on every reply the worker produces for that request; `workerRequest()` (`utils.js`) drops anything that isn't its own.

## Coverage — what I did and didn't touch

Done **once for all of them**, as the issue asks. Every helper in `utils.js` now goes through one `workerRequest` seam instead of a hand-rolled listener, which also collapses the duplication between them:

| helper | worker command |
|---|---|
| `writeSavedGithubModelOPFS` | `writeObjectModelFileHandle` |
| `getModelFromOPFS` | `readModelFromStorage` |
| `downloadToOPFS` | `downloadToOPFS` |
| `downloadModel` / `writeBase64Model` (via `awaitTerminalWorkerEvent`) | `downloadModel`, `writeBase64Model` |
| `doesFileExistInOPFS` / `deleteFileFromOPFS` / `snapshotOPFS` / `clearOPFSCache` (via `makePromise`) | `doesFileExist`, `deleteModel`, `snapshotCache`, `clearCache` |
| `writeGlbBytesToOPFS` | `writeBytesByPath` |
| `readModelByPathFromOPFS` | `readModelByPath` |
| `saveDnDFileToOpfs` | `writeObjectModel` |

The two-sided half: `requestId` is threaded through all 21 worker functions that can post — including the shared helpers (`writeFileToPath`, `retrieveFileWithPath`, `retrieveFileWithPathNew`, `writeFileToHandle`, `writeTemporaryFileToOPFS`, `writeTemporaryBase64BlobFileToOPFS`, `postFinalDownloadEventAfterRename`) whose deep `{error}` posts terminate a caller's promise. Threading only the top-level handlers would have left those errors unmatched, i.e. hanging.

**Checked for other readers before changing the payload:** `utils.js` is the only production consumer of these messages. `onWorkerMessage` has no callers outside `OPFSService.test.js`; `opfsWriteFile` / `opfsReadFile` are likewise test-only. `OPFS.worker.classic.js` is an esbuild output of the same source, not a second implementation.

**Deliberately left alone:**

- `src/loader/GlbWriter.worker.js` has its own worker and its own protocol; not in scope.
- The `initializeWorker` command gets no id — it configures the worker and produces no reply.
- Direct callers of the exported worker functions (the unit tests) may pass no id and get the bare message, so the id never shows up in a payload nobody asked for.
- I did not serialize requests on the worker. That would also have fixed correlation with no worker change, but it would serialize genuinely parallel downloads.

## The listener leak: real

Worker handlers can return without any terminal reply — `writeBase64Model` with a falsy `shaHash`, or with a blob `base64ToBlob` can't decode, returns having posted nothing. Before this change that hung the caller forever **and** left its listener attached to the shared worker for the life of the page.

The dispatcher now posts a `requestFinished` sentinel in a `finally`, so a request that never replied detaches its listener and surfaces as an error instead of a silent hang. Handlers that did reply have already detached, so the sentinel is a no-op for them. This required awaiting the two handlers the dispatcher fired without `await` (`writeModelToOPFS`, `writeModelToOPFSFromFile`) — otherwise the sentinel would race ahead of their real reply. That also routes their throws into the dispatcher's catch instead of leaving unhandled rejections.

## Tests, and what reverting proves

The issue is about concurrency, so the new tests drive **two overlapping requests on one shared-worker mock** (`makeSharedWorkerMock` delivers each message to *every* attached listener, as the real single message stream does) and assert one promise stays pending while the other's reply goes by. Seven new tests in `utils.test.js`:

1. two writes of the **same model at the same commit** — the case `commitHash` correlation cannot cover
2. an unrelated request's **error** does not reject the write
3. two concurrent reads each resolve with **their own** file, replied out of order
4. another request's **progress** events are not forwarded
5. an **uncorrelated** reply (the pre-fix message shape) settles nothing
6. `requestFinished` detaches and rejects
7. a request that already replied ignores its own sentinel

Also: `OPFS.worker.test.js` asserts the worker stamps the id on both the success and the error reply (the error path forced deterministically by rejecting `navigator.storage.getDirectory`), and `OPFSService.test.js` covers id uniqueness and the id reaching the worker in the payload.

**Proved by mutation** — three separate reverts, each run:

- Drop the `requestId` filter in `workerRequest` (restores the reported bug): **5 of the 7** correlation tests fail. Tests 6 and 7 still pass, correctly — they exercise the leak mechanism, not correlation.
- Drop the `requestFinished` branch: the leak test hangs to the 20 s timeout, which is the exact production symptom.
- Make `postReply` drop the stamp: the worker-side test fails on the missing `requestId`.

`beforeEach` gives `nextRequestId` a real incrementing implementation. Without that the automock returns `undefined` for every call, every reply matches every listener, and all of the above would pass vacuously — which is the first thing I checked, since the existing single-request tests do pass either way.

**One real consumer was itself relying on the bug:** `Loader.test.js`'s `FakeWorker` replied without echoing the id, and 16 Loader tests hung once correlation landed. It now models the protocol — replying from `postMessage`, where the id is known, rather than from `addEventListener`, where it isn't yet.

## Checks

- `yarn test-ci` green: 245 suites, 2467 passed, coverage thresholds met.
- `yarn eslint src netlify tools --max-warnings 0` and `yarn typecheck` clean; the husky pre-commit hook ran and passed on both commits.
- Playwright not run here: `yarn test-flows` needs a build, and two sibling agents were running concurrently (one Playwright-heavy) — the three GLB cache-hit specs (`NavTree.cacheHit`, `Properties.cacheHit`, `sceneHighlightPermalink`) are the consumers of `writer: wrote` and should be watched at the flip to ready.

## The other commit

`root: true` in `.eslintrc.cjs`. Without it ESLint walks up past the repo root and merges any ancestor `.eslintrc`; when the checkout is a `git worktree` nested under `.claude/worktrees/` (how agent sessions run) both configs declare the same plugins from different `node_modules` and ESLint refuses to run at all, taking `yarn precommit` and the husky hook down with it. A flat checkout finds no ancestor config, so CI is unaffected. Called out separately because it isn't part of the fix — happy to split it out if you'd rather.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NuTsqJu1rqoz8f4FSQ9vbE)_