### PR TITLE
Stop the ESLint config cascade at the repo root

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,5 +1,18 @@
 /* eslint-disable no-magic-numbers */
 module.exports = {
+  // Stop the config cascade at the repo root. Without this ESLint keeps
+  // walking up the filesystem and merges every ancestor `.eslintrc` it finds,
+  // so anything in a parent directory silently becomes part of this project's
+  // lint config — and a plugin named there that this repo cannot resolve makes
+  // eslint fail outright rather than degrade, taking `yarn precommit` and the
+  // husky hook down with it.
+  //
+  // Normally there is no ancestor config and this is a no-op, which is why it
+  // went unnoticed. It stops being a no-op the moment the checkout is nested
+  // inside another one — a `git worktree` under `.claude/worktrees/` for an
+  // agent session is how it surfaced, three times independently, each time as
+  // an unrunnable commit gate.
+  root: true,
   env: {
     browser: true,
     es2021: true,

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,9 @@ deno.lock
 # no LFS bandwidth; the generated thumbnails in src/assets/thumbnails ARE
 # committed, these source models are not.
 tools/thumbnails/cache/
+
+# Sandboxes for agent sessions (`git worktree` checkouts under .claude/).
+# Transient and machine-local: the branch inside one is pushed like any other,
+# but the working copy itself is never part of the repo. Untracked they show up
+# as pending changes in every session that dispatches an agent.
+.claude/worktrees/


### PR DESCRIPTION
Split out of #1788 / #1789 / #1790, which each carried this same line. Landing it once here and dropping it from those three keeps each of them to its own subject and removes a three-way conflict.

## The bug

`.eslintrc.cjs` never set `root: true`, so ESLint walks up the filesystem and merges **every ancestor `.eslintrc` it finds** into this project's config. Anything in a parent directory silently becomes part of how this repo lints.

Demonstrated directly rather than inferred. With a config one level above the checkout declaring a plugin this repo cannot resolve:

```
### WITHOUT root:true (main today)
$ yarn eslint src/Filetype.js
The plugin "eslint-plugin-this-plugin-does-not-exist" was referenced from the
config file in "../.eslintrc.cjs".

### WITH root:true (this PR)
$ yarn eslint src/Filetype.js
$          # clean
```

The failure mode is what makes it worth fixing: eslint **hard-stops** rather than degrading, so it takes `yarn precommit` and the husky pre-commit hook with it. The commit gate doesn't get weaker — it becomes unrunnable.

## How it surfaced

Normally there is no ancestor config, so this is a no-op — which is why it went unnoticed. It stops being a no-op the moment the checkout is nested inside another one.

Three agent sessions running in `git worktree` checkouts under `.claude/worktrees/` each hit an unrunnable commit gate, and each patched this line locally and independently. That's the whole reason it's three-way duplicated across #1788, #1789 and #1790.

It is not only an agent concern, though: any contributor with a stray `.eslintrc` anywhere above their checkout — a home directory, a shared parent for several repos — gets the same hard stop, and the error message points at a file outside the repo.

## Also: gitignore `.claude/worktrees/`

Those checkouts are transient and machine-local. The branch inside one is pushed like any other, but the working copy is not part of the repo, and while untracked it reports as pending changes in every session that dispatches an agent.

## What this does *not* fix

The agents also reported that files inside a worktree read as `File ignored by default`. **`root: true` does not fix that** — I checked, and the warning persists either way. It's a separate ESLint behaviour about paths under dot-directories, so it isn't claimed here and isn't addressed.

## Checks

- The before/after above, run both ways.
- Husky pre-commit gate on this commit: eslint clean, typecheck clean, **246 suites / 2477 passed**.
- No behaviour change for a flat checkout or for CI — there is no ancestor config in either, which is exactly why this is safe to land on its own.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NuTsqJu1rqoz8f4FSQ9vbE)_