### PR TITLE
Write down the falsifiable-assertion discipline, and the Lighthouse artefact

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,6 +95,7 @@ This file is the router for AI assistants working in this repo. Keep it small. T
 | Code style, lint rules | [STYLE.md](STYLE.md) |
 | Writing an assertion that can actually fail — the vacuous-assertion shapes seen in practice, and the break-it-and-watch-it-go-red check | [STYLE.md](STYLE.md) §"Assertions must be able to fail" |
 | Build, dev server, CI, Playwright setup | [PLAYBOOK.md](PLAYBOOK.md) |
+| Working in a `.claude/worktrees/` git worktree — why `git commit` aborts there, why `--no-verify` is the wrong fix, and which results a worktree gets wrong | [PLAYBOOK.md](PLAYBOOK.md) §"A git worktree is not a place to commit from" |
 | Where to put an E2E `*.spec.ts` (co-locate near the subject; `src/tests/e2e` is shared helpers only) | [src/tests/e2e/README.md](src/tests/e2e/README.md) |
 | Adding a new model format (`supportedTypes` + header sniffing → `findLoader` arm → `ShareModel` capabilities → fixtures/tests), what NavTree naming and raycast picking give you for free, Git LFS on GitHub-hosted models | [design/new/adding-model-formats.md](design/new/adding-model-formats.md) |
 | Asset pipeline, fonts, icons | [src/assets/README.md](src/assets/README.md) |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,6 +93,7 @@ This file is the router for AI assistants working in this repo. Keep it small. T
 | Module boundaries, top-level architecture | [DESIGN.md](DESIGN.md) |
 | Render loop, `setRenderUpdate` seam, `?feature=perf` panel | [DESIGN.md](DESIGN.md) §"Render loop & perf monitor" |
 | Code style, lint rules | [STYLE.md](STYLE.md) |
+| Writing an assertion that can actually fail — the vacuous-assertion shapes seen in practice, and the break-it-and-watch-it-go-red check | [STYLE.md](STYLE.md) §"Assertions must be able to fail" |
 | Build, dev server, CI, Playwright setup | [PLAYBOOK.md](PLAYBOOK.md) |
 | Where to put an E2E `*.spec.ts` (co-locate near the subject; `src/tests/e2e` is shared helpers only) | [src/tests/e2e/README.md](src/tests/e2e/README.md) |
 | Adding a new model format (`supportedTypes` + header sniffing → `findLoader` arm → `ShareModel` capabilities → fixtures/tests), what NavTree naming and raycast picking give you for free, Git LFS on GitHub-hosted models | [design/new/adding-model-formats.md](design/new/adding-model-formats.md) |

--- a/PLAYBOOK.md
+++ b/PLAYBOOK.md
@@ -240,9 +240,25 @@ and exits 1. That failure is at least loud. The danger is what it invites:
 linted, typechecked or tested — the exact gate CLAUDE.md tells you to trust
 instead of running by hand. **Don't.** Either `yarn install` in the worktree
 (which reinstalls `.husky/_`, and a full `node_modules`), or — cheaper, and
-what actually worked here — do the editing in the worktree, export the
-change (`git diff > /tmp/x.patch`), and `git apply` + `git commit` it in the
-main checkout, where the hook is wired.
+what actually worked here — do the editing in the worktree, export the change,
+and `git apply` + `git commit` it in the main checkout, where the hook is
+wired. Stage first and ask for binary, or the export quietly loses work:
+
+```sh
+# in the worktree
+git add -A && git diff --cached --binary > /tmp/x.patch
+# in the main checkout
+git apply /tmp/x.patch && git commit
+```
+
+A plain `git diff` shows tracked modifications only, so a **new** file — a
+module, a spec, a fixture — is simply absent from the patch, with no warning;
+`--binary` is what carries a changed image or model fixture. Measured on a
+scratch worktree: a patch made with plain `git diff` after adding one `.js`
+and one `.png` contained **zero** references to either, while the staged form
+above carried both and applied cleanly in the main checkout. The failure mode
+is the bad kind — the commit looks complete, and the missing work sits in a
+worktree that gets deleted.
 
 **2. Anything resolution-sensitive gives the wrong answer there.** A
 worktree starts with no `node_modules` at all, so the reflex is to symlink

--- a/PLAYBOOK.md
+++ b/PLAYBOOK.md
@@ -218,6 +218,49 @@ regression. **It is also not by itself evidence of nothing:**
   agent sandbox's proxy blocks `netlify.app`, which is why both fell back to a
   local A/B).
 
+## A git worktree is not a place to commit from, or to check config in
+
+Agents that work in a linked worktree (`.claude/worktrees/…`, gitignored
+since #1792) hit two problems that both present as "the repo is broken"
+rather than "this checkout is incomplete".
+
+**1. You cannot commit there, and the obvious workaround is the bad one.**
+`core.hooksPath = .husky` lives in `.git/config`, which linked worktrees
+*share*, so git looks for the hook in the worktree. `.husky/pre-commit` is
+tracked, so it is there — but it starts by sourcing `.husky/_/husky.sh`,
+which `husky install` generates and which is **untracked**, so it is not.
+Verified on a fresh worktree of this repo: the commit aborts with
+
+```
+.husky/pre-commit: 2: .: cannot open .husky/_/husky.sh: No such file
+```
+
+and exits 1. That failure is at least loud. The danger is what it invites:
+`--no-verify` clears it instantly and lands a commit that nothing has
+linted, typechecked or tested — the exact gate CLAUDE.md tells you to trust
+instead of running by hand. **Don't.** Either `yarn install` in the worktree
+(which reinstalls `.husky/_`, and a full `node_modules`), or — cheaper, and
+what actually worked here — do the editing in the worktree, export the
+change (`git diff > /tmp/x.patch`), and `git apply` + `git commit` it in the
+main checkout, where the hook is wired.
+
+**2. Anything resolution-sensitive gives the wrong answer there.** A
+worktree starts with no `node_modules` at all, so the reflex is to symlink
+or copy the main checkout's. Both make the worktree lie about anything that
+depends on *where* a module resolves from:
+
+- `singleThreeInstance.test.js` failed in a worktree and passed in the main
+  checkout, on identical source — it asserts a single resolved `three`, and
+  a symlinked tree gives it two.
+- An eslint probe run in a worktree did **not** reproduce the plugin-
+  uniqueness error that motivated #1792's `root: true`, because the config
+  cascade above the worktree is a different set of directories.
+
+So a worktree is fine for reading and editing. Confirm any result about
+module resolution, the eslint/babel config cascade, or the hook in the main
+checkout before you believe it — and before you write it into a PR body.
+
+
 ## Drive Picker fails on Brave with Shields up
 
 When testing the Drive Picker on Brave at `bldrs.ai`:

--- a/PLAYBOOK.md
+++ b/PLAYBOOK.md
@@ -190,27 +190,33 @@ ports → `net::ERR_CONNECTION_REFUSED`. Tests look "broken" when they're not.
 Pre-existing quirk; flag as a separate cleanup if it bothers you.
 
 
-## Netlify's Lighthouse Best Practices score oscillates on its own
+## Netlify's Lighthouse Best Practices score is flaky — check, don't assume
 
 The preview comment's **Best Practices** number moves between 83, 92 and 100
-across audits of unrelated commits, and reports the swing as "down 9 from
-production" / "up 8 from production". It is not a signal about the diff.
-
-Established twice, at real cost, so it does not need establishing a third time:
+across audits of unrelated commits, and presents each swing as "down 9 from
+production" / "up 8 from production". Twice it cost a real investigation:
 
 - On #1783 it read −9 on a diff of specs, docs and `vars.playwright.js` — none
   of which reach the `SHARE_CONFIG=prod` bundle the audit loads — and later read
-  +8 on the same PR with no change.
-- On #1790 it read −9 on a diff that *does* touch production code, which is the
-  case worth checking rather than dismissing. Building `main` and the branch
-  side by side under one config and capturing console errors on load gave
-  byte-identical results (two events, both sandbox artefacts, neither from the
-  changed code). The score then recovered to 92 on the next head unaided.
+  +8 on the same PR with no change in between.
+- On #1790 it read −9 on a diff that **does** touch production code. Building
+  `main` and the branch side by side under one config and capturing console
+  errors on load gave byte-identical results; the score recovered to 92 on the
+  next head unaided.
 
-So: a Best Practices delta with no console-error delta is the audit, not you.
-Worth one check if the diff reaches production code — a local A/B on console
-errors is the cheap discriminator, since that category is largely console-driven
-— and worth nothing at all if it doesn't.
+So the score is known-flaky and a delta is not by itself evidence of a
+regression. **It is also not by itself evidence of nothing:**
+
+- **If the diff cannot reach the prod bundle** (specs, docs, Playwright-only
+  config), a delta is the audit. Nothing to do.
+- **If the diff can reach it, open the audit and read which check changed.**
+  Best Practices aggregates several — console errors are only one of them, so a
+  local console A/B is a useful first cut and *not* a clearance: a production
+  change can leave the console identical and still move a legitimate check. The
+  Netlify deploy log names the failing audit; that is the artefact to look at,
+  and it is what neither investigation above actually managed to read (the
+  agent sandbox's proxy blocks `netlify.app`, which is why both fell back to a
+  local A/B).
 
 ## Drive Picker fails on Brave with Shields up
 

--- a/PLAYBOOK.md
+++ b/PLAYBOOK.md
@@ -190,6 +190,28 @@ ports → `net::ERR_CONNECTION_REFUSED`. Tests look "broken" when they're not.
 Pre-existing quirk; flag as a separate cleanup if it bothers you.
 
 
+## Netlify's Lighthouse Best Practices score oscillates on its own
+
+The preview comment's **Best Practices** number moves between 83, 92 and 100
+across audits of unrelated commits, and reports the swing as "down 9 from
+production" / "up 8 from production". It is not a signal about the diff.
+
+Established twice, at real cost, so it does not need establishing a third time:
+
+- On #1783 it read −9 on a diff of specs, docs and `vars.playwright.js` — none
+  of which reach the `SHARE_CONFIG=prod` bundle the audit loads — and later read
+  +8 on the same PR with no change.
+- On #1790 it read −9 on a diff that *does* touch production code, which is the
+  case worth checking rather than dismissing. Building `main` and the branch
+  side by side under one config and capturing console errors on load gave
+  byte-identical results (two events, both sandbox artefacts, neither from the
+  changed code). The score then recovered to 92 on the next head unaided.
+
+So: a Best Practices delta with no console-error delta is the audit, not you.
+Worth one check if the diff reaches production code — a local A/B on console
+errors is the cheap discriminator, since that category is largely console-driven
+— and worth nothing at all if it doesn't.
+
 ## Drive Picker fails on Brave with Shields up
 
 When testing the Drive Picker on Brave at `bldrs.ai`:

--- a/STYLE.md
+++ b/STYLE.md
@@ -162,9 +162,15 @@ test.skip('GitHub route (/gh) processes URL correctly', async ({page}) => {
 ```
 
 ```sh
-grep -rn "test\.skip\|describe\.skip\|it\.skip\|\.fixme" src \
-  --include=*.spec.ts --include=*.test.js --include=*.test.jsx --include=*.test.ts
+grep -rn "test\.skip\|describe\.skip\|it\.skip\|\.fixme" src netlify tools \
+  --include=*.test.* --include=*.spec.*
 ```
+
+Cover every test root and extension, not the ones you happen to remember —
+Jest's `roots` are `src`, `netlify` and `__mocks__`, `tools` has its own
+suites, and specs come in `.js`, `.jsx`, `.ts` and `.tsx` (`BotChat.test.tsx`).
+A scan narrower than that reports a clean ratchet while a skip sits in the
+directory it did not look at.
 
 That returned 31 lines when this was written — one is prose mentioning the
 word, so **30 real skips, exactly one of which named an issue** (#956). Read

--- a/STYLE.md
+++ b/STYLE.md
@@ -144,9 +144,33 @@ misread as the first, and the remedy is unrelated. Un-skipping three specs in
 #1783 surfaced a `role="treeitem"` selector the tree no longer emits, two
 `glbVerbose`-gated log waits, and a `GlobalId` row rendered on neither path —
 **each would have failed had it executed**, and none had executed for five
-weeks. A `test.fixme` spec rots against the code around it. When you un-skip
-one, expect its assertions to be stale and re-derive them from the current
-behaviour rather than trusting that they still describe it.
+weeks. A skipped spec (`test.fixme`, `test.skip`, `it.skip`) rots against the
+code around it. When you un-skip one, expect its assertions to be stale and
+re-derive them from the current behaviour rather than trusting that they still
+describe it.
+
+That remedy only helps once someone has already decided to un-skip, which
+leaves the harder half: **nothing tells you a skip has gone inert.** Jest and
+Playwright both count a skip as a non-failure, and `test-flows.yml` has no skip
+budget or expiry, so an inert spec satisfies every gate indefinitely — five
+weeks was luck, not a bound. Until that is enforced (#1796), the check is a
+convention you can grep: **a committed skip names an issue on the line above.**
+
+```js
+// SKIPPED #1234: needs setupVirtualPathIntercept for raw.githubusercontent.com
+test.skip('GitHub route (/gh) processes URL correctly', async ({page}) => {
+```
+
+```sh
+grep -rn "test\.skip\|describe\.skip\|it\.skip\|\.fixme" src \
+  --include=*.spec.ts --include=*.test.js --include=*.test.jsx --include=*.test.ts
+```
+
+That returned 31 lines when this was written — one is prose mentioning the
+word, so **30 real skips, exactly one of which named an issue** (#956). Read
+the number as a ratchet, not a clean baseline. A skip without
+an issue has no owner and no condition for coming back; it is a deleted test
+that still counts itself as coverage.
 
 **3. The assertion runs, can fail, and says something false.** #1782's
 multi-entry test asserted the *wrong answer* outright, so it would have defended

--- a/STYLE.md
+++ b/STYLE.md
@@ -118,6 +118,47 @@ Use dash-separated, converted from CamelCase:
 - **Mock implementations**: Use `() => {}` freely for Jest mocks
 - **Test descriptions**: Clear, descriptive test names
 
+### Assertions must be able to fail
+
+An assertion that cannot fail is worse than a missing one, because it reads as
+coverage. The #1776 work stream (#1777, #1782, #1783, #1788, #1789, #1790)
+turned up about a dozen, several of them inside code written to prevent exactly
+this. They come in a small number of shapes, so check for them by name:
+
+- **A negative guard doing duty as a positive one.** "Nothing unexpected
+  appeared" is not "the thing appeared", and an empty collection satisfies the
+  first while disproving the second. `expectOnlyInducedLoaderErrors` iterates a
+  captured buffer, so a buffer left empty *because the diagnostic stopped
+  emitting* ran zero assertions and passed (#1789). Assert the collection's
+  size too, or pair the guard with a positive one — and say at both which is
+  which.
+- **A mock that disables what the test discriminates on.** `jest.mock`
+  auto-mocks return `undefined`. `nextRequestId` mocked that way makes every
+  worker reply match every listener, so nine correlation tests would have
+  passed with no correlation at all (#1790). Give a mocked helper a real
+  implementation whenever its return value is the thing being tested.
+- **A selector or flag that quietly stopped matching.** `[role="treeitem"]`
+  after the tree stopped emitting it; two `glbVerbose`-gated log lines asserted
+  without the flag on; a `GlobalId` row rendered on neither path (#1783). Each
+  matched nothing, and nothing said so.
+- **A threshold with no headroom.** `MIN_DISTINCT_LABELS = 5` reads as a loose
+  floor; both fixtures offer exactly five, so it is the ceiling (#1788). If a
+  bound is the most the fixture can give, say so at the constant, or the next
+  reader goes looking for slack that isn't there.
+- **A precondition satisfied earlier than you think.** Waiting for a `.glb` to
+  exist in OPFS passes at file *creation*, so the reload read a half-written
+  artifact and a spec named "cache-hit" never hit the cache (#1783). Wait for
+  the completion signal, not for existence.
+- **A test that codifies the bug.** #1782's multi-entry case asserted the wrong
+  answer outright, which would have defended the defect against whoever noticed
+  it next.
+
+**The check is cheap: break the thing the assertion guards, watch it go red,
+restore it.** Every repair above was confirmed that way, and the mutation run is
+what caught two of them being vacuous a *second* time after a first fix. Put the
+result in the PR — "26 passed before, 5 failed after" is evidence a reviewer can
+act on; "added a test" is not.
+
 ### Console hygiene
 A test run should print **nothing unexpected** — noise buries the one new
 warning that flags a real regression. Treat a stray warning as a defect, in

--- a/STYLE.md
+++ b/STYLE.md
@@ -122,42 +122,47 @@ Use dash-separated, converted from CamelCase:
 
 An assertion that cannot fail is worse than a missing one, because it reads as
 coverage. The #1776 work stream (#1777, #1782, #1783, #1788, #1789, #1790)
-turned up about a dozen, several of them inside code written to prevent exactly
-this. They come in a small number of shapes, so check for them by name:
+produced about a dozen of these — several inside code written to prevent exactly
+that. They are **three different diseases** wearing one symptom, and they take
+different remedies, so name which one you have before reaching for a fix.
 
-- **A negative guard doing duty as a positive one.** "Nothing unexpected
-  appeared" is not "the thing appeared", and an empty collection satisfies the
-  first while disproving the second. `expectOnlyInducedLoaderErrors` iterates a
-  captured buffer, so a buffer left empty *because the diagnostic stopped
-  emitting* ran zero assertions and passed (#1789). Assert the collection's
-  size too, or pair the guard with a positive one — and say at both which is
-  which.
-- **A mock that disables what the test discriminates on.** `jest.mock`
-  auto-mocks return `undefined`. `nextRequestId` mocked that way makes every
-  worker reply match every listener, so nine correlation tests would have
-  passed with no correlation at all (#1790). Give a mocked helper a real
-  implementation whenever its return value is the thing being tested.
-- **A selector or flag that quietly stopped matching.** `[role="treeitem"]`
-  after the tree stopped emitting it; two `glbVerbose`-gated log lines asserted
-  without the flag on; a `GlobalId` row rendered on neither path (#1783). Each
-  matched nothing, and nothing said so.
-- **A threshold with no headroom.** `MIN_DISTINCT_LABELS = 5` reads as a loose
-  floor; both fixtures offer exactly five, so it is the ceiling (#1788). If a
-  bound is the most the fixture can give, say so at the constant, or the next
-  reader goes looking for slack that isn't there.
-- **A precondition satisfied earlier than you think.** Waiting for a `.glb` to
-  exist in OPFS passes at file *creation*, so the reload read a half-written
-  artifact and a spec named "cache-hit" never hit the cache (#1783). Wait for
-  the completion signal, not for existence.
-- **A test that codifies the bug.** #1782's multi-entry case asserted the wrong
-  answer outright, which would have defended the defect against whoever noticed
-  it next.
+**1. The assertion genuinely cannot fail.** No input makes it red.
 
-**The check is cheap: break the thing the assertion guards, watch it go red,
-restore it.** Every repair above was confirmed that way, and the mutation run is
-what caught two of them being vacuous a *second* time after a first fix. Put the
-result in the PR — "26 passed before, 5 failed after" is evidence a reviewer can
-act on; "added a test" is not.
+- Iterating a collection that may be empty runs zero assertions and passes.
+  `expectOnlyInducedLoaderErrors` matched each line of a captured buffer, so a
+  buffer left empty *because the diagnostic had stopped emitting* sailed through
+  (#1789). Assert the size too, or pair the guard with a positive one.
+- A mock returning `undefined` where the return value is what the test
+  discriminates on. `jest.mock` auto-mocks `nextRequestId` to `undefined`, which
+  makes every worker reply match every listener — nine correlation tests would
+  have passed with no correlation at all (#1790). Give it a real implementation.
+- Alternatives nothing can reach: an expected-error regex carried five, only two
+  of which any code path could produce (#1789).
+
+**2. The assertion is sound but never runs.** This is the one most likely to be
+misread as the first, and the remedy is unrelated. Un-skipping three specs in
+#1783 surfaced a `role="treeitem"` selector the tree no longer emits, two
+`glbVerbose`-gated log waits, and a `GlobalId` row rendered on neither path —
+**each would have failed had it executed**, and none had executed for five
+weeks. A `test.fixme` spec rots against the code around it. When you un-skip
+one, expect its assertions to be stale and re-derive them from the current
+behaviour rather than trusting that they still describe it.
+
+**3. The assertion runs, can fail, and says something false.** #1782's
+multi-entry test asserted the *wrong answer* outright, so it would have defended
+the defect against whoever noticed it next. #1788's threshold comment called
+`>= 5` a loose floor when five is the most either fixture can offer — the
+assertion was right, the explanation was not, and the next reader would have
+gone hunting for slack that does not exist. Check the claim, not just the pass;
+a green test proves nothing about the sentence above it.
+
+**For 1 and 3 the check is cheap: break the thing the assertion guards, watch it
+go red, restore it.** Every repair above was confirmed that way, and the mutation
+run is what caught two of them being vacuous a *second* time after a first fix,
+which reading alone had missed both times. Put the result in the PR — "26 passed
+before, 5 failed after" is evidence a reviewer can act on; "added a test" is not.
+Note that this check cannot reach disease 2 at all: a skipped test is not made
+honest by mutating the code it does not run against.
 
 ### Console hygiene
 A test run should print **nothing unexpected** — noise buries the one new


### PR DESCRIPTION
Docs only, `.md`-only diff (3 files, no deletions). Three things the #1776 work stream produced that currently live in PR bodies and review threads, which nothing in the router points at — so the next person rediscovers them.

**Three codex rounds have reshaped this substantially, and every round found a real defect in a claim I had made about my own evidence.** For a PR whose subject is assertions that pass for the wrong reason, that is the relevant fact about it, so each section below says what was wrong before.

## 1. STYLE.md §"Assertions must be able to fail"

Across #1777, #1782, #1783, #1788, #1789 and #1790, about a dozen assertions passed for a reason other than the one their comment claimed. Several were inside code written to prevent exactly that — #1789's was in the guard added to stop diagnostics going unnoticed, and it had the failure mode it existed to catch.

The first draft filed all of them under "assertions that cannot fail". **Round 1 showed that was wrong**, and the correction is the substance of the section: they are **three diseases with unrelated remedies**, and naming which one you have comes before reaching for a fix.

| disease | example | remedy |
|---|---|---|
| **1. Genuinely unfalsifiable** | `expectOnlyInducedLoaderErrors` iterating a buffer that may be empty (#1789); automocked `nextRequestId` returning `undefined`, so every reply matched every listener (#1790); an expected-error regex with three unreachable alternatives (#1789) | break it, watch it go red |
| **2. Sound but never executed** | three specs `test.fixme` for five weeks; un-skipping them surfaced a dead `role="treeitem"` selector, two `glbVerbose`-gated waits, a `GlobalId` row on neither path — **each would have gone red had it run** (#1783) | mutation cannot reach this one — see below |
| **3. Runs, can fail, says something false** | a test asserting the wrong answer outright (#1782); a comment calling `>= 5` a loose floor when five is the ceiling both fixtures offer — the assertion was right, the explanation was not (#1788) | check the claim, not just the pass |

**Round 2: disease 2 had no detection method.** Jest and Playwright both count a skip as a non-failure and `test-flows.yml` has no skip budget or expiry, so an inert spec satisfies every gate indefinitely — five weeks was luck, not a bound. Inventory: **30 committed skips, exactly one naming an issue** (#956). Added the convention half (a skip names an issue on the line above, plus a scan and the count as a ratchet); enforcement is CI work, filed as **#1796**.

**Round 3: that scan was itself incomplete** — it searched only `src` and four extensions, missing Jest's `netlify` root (`jest.config.js:8`), the `tools/` suites, and `.tsx` specs (`BotChat.test.tsx`). Now `src netlify tools` with `*.test.* / *.spec.*`. The count does not move — 31 lines either way — so the baseline was right by luck, not construction, and the *scan* was the defect: a future skip in a `.tsx` spec would have left the ratchet reading clean.

For diseases 1 and 3 the check is cheap and is now asked for explicitly: **break the guarded thing, watch it go red, restore.** It caught two assertions being vacuous a *second* time after a first repair, which reading alone had missed both times. Put the numbers in the PR — "26 passed before, 5 failed after" is evidence a reviewer can act on; "added a test" is not.

## 2. PLAYBOOK.md §"Netlify's Lighthouse Best Practices score is flaky — check, don't assume"

That number moves between 83, 92 and 100 across unrelated commits and presents each swing as a change "from production". It cost real investigation twice — #1783 (−9 then +8 unaided, on a diff that provably cannot reach the prod bundle) and #1790 (−9 on a diff that **does** touch production code).

The first draft turned that into a universal discriminator: "no console-error delta ⇒ it's the audit". **Round 1 was right that this overclaims** — Best Practices aggregates several audits, so a production change can leave the console byte-identical and still move a legitimate check, and the guidance as written would have talked someone out of investigating a real regression. Now split on the only distinction the evidence supports: if the diff cannot reach the prod bundle the delta is the audit; if it can, open the audit and read *which check* changed, with the console A/B described as a first cut and explicitly not a clearance.

It also records what limited both investigations, because it will limit the next one: neither actually read the audit — the agent sandbox's proxy blocks `netlify.app`. Better the next person knows the evidence is second-hand than inherits confidence in it.

## 3. PLAYBOOK.md §"A git worktree is not a place to commit from, or to check config in"

Sub-agents in this stream worked in `.claude/worktrees/` and hit two things that both present as "the repo is broken":

- **`git commit` aborts there.** `core.hooksPath = .husky` lives in `.git/config`, which linked worktrees share, and `.husky/pre-commit` is tracked — but the `.husky/_/husky.sh` it sources is generated by `husky install` and untracked. Verified on a fresh worktree: `cannot open .husky/_/husky.sh`, exit 1, no commit created. The abort is loud and therefore fine; what needed writing down is that `--no-verify` clears it in one keystroke and lands a commit nothing has gated — the exact gate AGENTS.md says to trust rather than run by hand.
- **A worktree lies about resolution.** With `node_modules` symlinked or absent, `singleThreeInstance.test.js` failed there on source that passes in the main checkout (it asserts a single resolved `three`), and an eslint probe there did not reproduce the plugin-uniqueness error that motivated #1792 — the config cascade above a worktree is a different set of directories.

**Round 3 caught the remedy losing work.** The section had said "export the change (`git diff > /tmp/x.patch`)". Measured on a scratch worktree with one new `.js` and one new `.png`: that patch contained **zero** references to either — `git diff` shows tracked modifications only, and binaries need `--binary`. `git add -A && git diff --cached --binary` carried both and applied cleanly in the main checkout. The dangerous shape, since the commit looks complete and the missing work dies with the worktree.

## Notes

- `CLAUDE.md` is a symlink to `AGENTS.md`, so the router rows land in the real file. Two rows added — the STYLE section and the worktree section — since neither "Code style, lint rules" nor "Build, dev server, CI, Playwright setup" would lead anyone to them.
- **Why a docs change got review at all:** agent-workflow.md §Review skips review on docs by default, *except where the doc is the policy*. Testing discipline is exactly that, and the exception paid for itself three times over.
- Husky gate green on each commit: eslint + typecheck + 258 suites / 2623 tests.
- **No Actions CI will run on this PR.** Both workflows carry `paths-ignore: ['**/*.md', ...]` at the `pull_request` level, so a docs-only diff produces no run — confirmed, zero runs on this branch before or after the ready flip. `build-prod` / `test-ci` / `test-flows` were not run locally either: the diff touches no source, so coverage is identical to `main` and there is nothing for esbuild or Playwright to see.