### PR TITLE
Bump @bldrs-ai/conway to 1.1585.676 — Orbiter epic geometry + shading release

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@babel/plugin-syntax-import-assertions": "7.18.6",
     "@babel/preset-env": "7.18.10",
     "@babel/preset-react": "7.18.6",
-    "@bldrs-ai/conway": "1.1567.608-g929a0aa2",
+    "@bldrs-ai/conway": "1.1573.644-ga7002fd2",
     "@bldrs-ai/ifclib": "5.3.3",
     "@emotion/react": "11.10.0",
     "@emotion/styled": "11.10.0",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@babel/plugin-syntax-import-assertions": "7.18.6",
     "@babel/preset-env": "7.18.10",
     "@babel/preset-react": "7.18.6",
-    "@bldrs-ai/conway": "1.1573.644-ga7002fd2",
+    "@bldrs-ai/conway": "1.1576.647-g8f0c3963",
     "@bldrs-ai/ifclib": "5.3.3",
     "@emotion/react": "11.10.0",
     "@emotion/styled": "11.10.0",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@babel/plugin-syntax-import-assertions": "7.18.6",
     "@babel/preset-env": "7.18.10",
     "@babel/preset-react": "7.18.6",
-    "@bldrs-ai/conway": "1.1584.674-g470b4923",
+    "@bldrs-ai/conway": "1.1585.676-g80859a4d",
     "@bldrs-ai/ifclib": "5.3.3",
     "@emotion/react": "11.10.0",
     "@emotion/styled": "11.10.0",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@babel/plugin-syntax-import-assertions": "7.18.6",
     "@babel/preset-env": "7.18.10",
     "@babel/preset-react": "7.18.6",
-    "@bldrs-ai/conway": "1.1579.668-g7e5a9cf8",
+    "@bldrs-ai/conway": "1.1584.674-g470b4923",
     "@bldrs-ai/ifclib": "5.3.3",
     "@emotion/react": "11.10.0",
     "@emotion/styled": "11.10.0",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@babel/plugin-syntax-import-assertions": "7.18.6",
     "@babel/preset-env": "7.18.10",
     "@babel/preset-react": "7.18.6",
-    "@bldrs-ai/conway": "1.1576.647-g8f0c3963",
+    "@bldrs-ai/conway": "1.1578.666-g39d59784",
     "@bldrs-ai/ifclib": "5.3.3",
     "@emotion/react": "11.10.0",
     "@emotion/styled": "11.10.0",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@babel/plugin-syntax-import-assertions": "7.18.6",
     "@babel/preset-env": "7.18.10",
     "@babel/preset-react": "7.18.6",
-    "@bldrs-ai/conway": "1.1565.608-g18366f01",
+    "@bldrs-ai/conway": "1.1567.608-g929a0aa2",
     "@bldrs-ai/ifclib": "5.3.3",
     "@emotion/react": "11.10.0",
     "@emotion/styled": "11.10.0",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@babel/plugin-syntax-import-assertions": "7.18.6",
     "@babel/preset-env": "7.18.10",
     "@babel/preset-react": "7.18.6",
-    "@bldrs-ai/conway": "1.1578.666-g39d59784",
+    "@bldrs-ai/conway": "1.1579.668-g7e5a9cf8",
     "@bldrs-ai/ifclib": "5.3.3",
     "@emotion/react": "11.10.0",
     "@emotion/styled": "11.10.0",

--- a/src/loader/glbCacheKey.js
+++ b/src/loader/glbCacheKey.js
@@ -20,6 +20,19 @@
  * it (`BLDRS_GLB_BATCHED_SCHEMA_VERSION` below) — deliberately, since that
  * is the slot most users actually read. Nothing extra to do here; the note
  * exists so the coupling is visible from where the bump gets written.
+ * 0.17.0 — retires artifacts baked by pre-1.1585 engines, releasing the
+ *         #641-epic geometry + shading train (conway#666/#668/#674/#676:
+ *         wrong-sheet inverse-solve recovery, ribbon-sweep chain side,
+ *         analytic vertex normals + normals in the GLB, v-monotone
+ *         decomposition). Geometry AND shading normals are baked into the
+ *         artifact and nothing in the cache key identifies the engine, so
+ *         without this bump a returning user's cache hit bypasses conway
+ *         entirely and keeps serving the damaged faces and mis-grouped
+ *         seam normals these releases fix — cache-miss users see the new
+ *         output, cache-hit users never do. Same failure shape and same
+ *         remedy as 0.15.0/0.16.0; found by review on the release PR
+ *         (Share#1797). Older 0.16.0 artifacts read as miss; next miss
+ *         rewrites with the new engine's output.
  * 0.16.0 — retires artifacts baked in the old coordination frame. conway
  *         1.501.1426 (bldrs-ai/conway#501, issue conway#87) stopped anchoring
  *         `COORDINATE_TO_ORIGIN` on whichever element a file happens to
@@ -161,7 +174,7 @@
  * 0.2.0 — generalised cache key from GitHub-only (owner/repo/branch) to a
  *         per-source-kind 3-level namespace (ns1/ns2/ns3).
  */
-export const BLDRS_GLB_SCHEMA_VERSION = '0.16.0'
+export const BLDRS_GLB_SCHEMA_VERSION = '0.17.0'
 
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -2473,10 +2473,10 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@bldrs-ai/conway@1.1578.666-g39d59784":
-  version "1.1578.666-g39d59784"
-  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.1578.666-g39d59784.tgz#81958dd7cd26c4906107671c17408588d3405fef"
-  integrity sha512-+5Cu1be+joFGzgQc23TZCyOiFryTYjxVtrhg83ahZN2/btZuZrGtprAf5dL9HflGNSH39RQOcDWHWLzfL4TLrw==
+"@bldrs-ai/conway@1.1579.668-g7e5a9cf8":
+  version "1.1579.668-g7e5a9cf8"
+  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.1579.668-g7e5a9cf8.tgz#16c92995fcc1fa93e435bf203f340f77fd68b035"
+  integrity sha512-2dKiA/JhuBO6MdFpljdO2fy8eWP2cSmXR0oAj+j/q52Sp5cB0CPoAWK63Ggf2yeyUcJhGskdhxJmt3moYS/WZw==
   dependencies:
     gl-matrix "3.4.3"
     seedrandom "3.0.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2473,10 +2473,10 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@bldrs-ai/conway@1.1567.608-g929a0aa2":
-  version "1.1567.608-g929a0aa2"
-  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.1567.608-g929a0aa2.tgz#401e18ca7d319249c1929b076d4949bf20e00585"
-  integrity sha512-EwW6msRvUQKGsdI+cjDJiyJ+G3crDrC3tFTbDNGcswscGEv1dbWtmUvIINYtHqAY5P1mMkTd2RyDLC64qvCorA==
+"@bldrs-ai/conway@1.1573.644-ga7002fd2":
+  version "1.1573.644-ga7002fd2"
+  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.1573.644-ga7002fd2.tgz#5955a3f0912e02180bef2e9c14990ca378c2d144"
+  integrity sha512-jAFU1Os4Ov/YBbQSGntjO5jIeYnXMXOnes1dtUZCLhZJK8//0xCVRbyJzAHZfg5338Mh/LncL7Hsxxdi69fyuw==
   dependencies:
     gl-matrix "3.4.3"
     seedrandom "3.0.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2473,10 +2473,10 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@bldrs-ai/conway@1.1576.647-g8f0c3963":
-  version "1.1576.647-g8f0c3963"
-  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.1576.647-g8f0c3963.tgz#8fa6741c49879ddda6ef3f723f13fd566a5c6145"
-  integrity sha512-IlFjp5UuSzKbE3RFnYlfMygoSxIHy8xOJtwSZp2mOpEQx7l9kh6U5l5f9+t7Hy5pXV0xsckAIm95J/h2awLUSg==
+"@bldrs-ai/conway@1.1578.666-g39d59784":
+  version "1.1578.666-g39d59784"
+  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.1578.666-g39d59784.tgz#81958dd7cd26c4906107671c17408588d3405fef"
+  integrity sha512-+5Cu1be+joFGzgQc23TZCyOiFryTYjxVtrhg83ahZN2/btZuZrGtprAf5dL9HflGNSH39RQOcDWHWLzfL4TLrw==
   dependencies:
     gl-matrix "3.4.3"
     seedrandom "3.0.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2473,10 +2473,10 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@bldrs-ai/conway@1.1579.668-g7e5a9cf8":
-  version "1.1579.668-g7e5a9cf8"
-  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.1579.668-g7e5a9cf8.tgz#16c92995fcc1fa93e435bf203f340f77fd68b035"
-  integrity sha512-2dKiA/JhuBO6MdFpljdO2fy8eWP2cSmXR0oAj+j/q52Sp5cB0CPoAWK63Ggf2yeyUcJhGskdhxJmt3moYS/WZw==
+"@bldrs-ai/conway@1.1584.674-g470b4923":
+  version "1.1584.674-g470b4923"
+  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.1584.674-g470b4923.tgz#7f96ef001418829a572fee34561250aaa2d1cba0"
+  integrity sha512-AS4PuqaTtc8PIs+in5/UDz7eKPUXDojAaWgeqAhtgt01M6tc907vEzupU7Qw8TmkO4yqCpudyTlb5IYdPgidqw==
   dependencies:
     gl-matrix "3.4.3"
     seedrandom "3.0.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2473,10 +2473,10 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@bldrs-ai/conway@1.1584.674-g470b4923":
-  version "1.1584.674-g470b4923"
-  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.1584.674-g470b4923.tgz#7f96ef001418829a572fee34561250aaa2d1cba0"
-  integrity sha512-AS4PuqaTtc8PIs+in5/UDz7eKPUXDojAaWgeqAhtgt01M6tc907vEzupU7Qw8TmkO4yqCpudyTlb5IYdPgidqw==
+"@bldrs-ai/conway@1.1585.676-g80859a4d":
+  version "1.1585.676-g80859a4d"
+  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.1585.676-g80859a4d.tgz#8eb0bac476b7e7467e4fae7a6b6240bd8893cda4"
+  integrity sha512-p1MiWQyMk4+lbpq6V/z9T4Cb7nElqlnLBGfsJbb+WPmqhscE2ILBv2eIhU2IKocdKJQM8i0ZXIm2HwT50rgkRw==
   dependencies:
     gl-matrix "3.4.3"
     seedrandom "3.0.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2473,10 +2473,10 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@bldrs-ai/conway@1.1565.608-g18366f01":
-  version "1.1565.608-g18366f01"
-  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.1565.608-g18366f01.tgz#5118ab02f17ac01b8a926bebd11f1f7057955629"
-  integrity sha512-N5s34rO+4NdNzyzRxDqIJ+HN0bmzjSafCnoGbCwXLYyxiiVAnDzAV1tuSD+QtVJBox/QeJbZ39u201xp3L8tEw==
+"@bldrs-ai/conway@1.1567.608-g929a0aa2":
+  version "1.1567.608-g929a0aa2"
+  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.1567.608-g929a0aa2.tgz#401e18ca7d319249c1929b076d4949bf20e00585"
+  integrity sha512-EwW6msRvUQKGsdI+cjDJiyJ+G3crDrC3tFTbDNGcswscGEv1dbWtmUvIINYtHqAY5P1mMkTd2RyDLC64qvCorA==
   dependencies:
     gl-matrix "3.4.3"
     seedrandom "3.0.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2473,10 +2473,10 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@bldrs-ai/conway@1.1573.644-ga7002fd2":
-  version "1.1573.644-ga7002fd2"
-  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.1573.644-ga7002fd2.tgz#5955a3f0912e02180bef2e9c14990ca378c2d144"
-  integrity sha512-jAFU1Os4Ov/YBbQSGntjO5jIeYnXMXOnes1dtUZCLhZJK8//0xCVRbyJzAHZfg5338Mh/LncL7Hsxxdi69fyuw==
+"@bldrs-ai/conway@1.1576.647-g8f0c3963":
+  version "1.1576.647-g8f0c3963"
+  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.1576.647-g8f0c3963.tgz#8fa6741c49879ddda6ef3f723f13fd566a5c6145"
+  integrity sha512-IlFjp5UuSzKbE3RFnYlfMygoSxIHy8xOJtwSZp2mOpEQx7l9kh6U5l5f9+t7Hy5pXV0xsckAIm95J/h2awLUSg==
   dependencies:
     gl-matrix "3.4.3"
     seedrandom "3.0.5"


### PR DESCRIPTION
Bumps `@bldrs-ai/conway` `1.1583.660-g93378e5f` → **`1.1585.676-g80859a4d`**. The functional diff is the pin and its lockfile entry; the rest of the branch is a merge of `main`.

This PR opened as the epic's smoke instance and stacked seven rounds against it. **It is now the release bump for bldrs-ai/conway#641 — the Orbiter epic — taken at the blessed release candidate.**

## Release state

- **rc run [33334338558](https://github.com/bldrs-ai/conway/actions/runs/33334338558)** — full public + private corpus at conway `main` `80859a4d`, the exact commit this pin resolves to.
- **Baselines re-blessed:** bldrs-ai/test-models#64 and bldrs-ai/test-models-private#96, both merged. From here a per-PR smoke diff in conway means "this PR moved geometry" again, not accumulated drift.

## What this pin adds over Share `main`

Share `main` already carries most of the epic train, absorbed by the intermediate bumps in #1800 / #1802 / #1804: conway#646, #652, #655, #666, #668, plus #673 (AP242 tessellated parts) and #672 (the #660 async whole-model ask). **Two conway commits remain**, and they are the epic's last two.

### conway#674 — analytic shading normals, and normals in the GLB (conway-geom#200)

`Geometry::Reify()` averaged **face** normals inside a 40° smoothing group, comparing each candidate against the *first* triangle's normal rather than the running average — so grouping depended on triangle order, and one near-degenerate sliver could capture or exclude a whole fan. Along a trimmed face's boundary the triangulator leaves exactly such slivers. The normal is now taken from the surface the tessellator already evaluates, recorded per triangle **corner** at emission.

| fastener dome, per corner vs. the analytic sphere normal | before | after |
|---|---|---|
| seam-row p50 / p90 / p99 / max | 2.34 / 42.11 / 79.48 / 90.00° | **0.00 / 6.86 / 8.61 / 8.61°** |
| corners > 10° | 176 / 979 | **0** |
| interior max | 1.65° | **0.00°** |

Separately, the GLB writer emitted **POSITION only, on every primitive**. glTF says a primitive without NORMAL is flat-shaded and three.js implements that literally, so every conway GLB rendered fully faceted in every external consumer — and *denser, more correct* tessellation read as **worse**, because the facets got smaller and the shading noise higher-frequency. Both writers now emit the reified stream, Draco included: **NORMAL on 13/13 primitives** in both paths.

The interleaved wasm vertex stream is unchanged (`[px,py,pz,nx,ny,nz]`, stride 6), so Share's conway-direct loader reads the same buffer with the same stride — better values in the same slots, **no viewer change needed**.

### conway#676 — v-monotone decomposition of non-monotone trimmed boundaries (conway-geom#201)

`tryRibbonLoft` refused any boundary whose v-monotone break count wasn't exactly two. The private thread model's largest remaining damaged face is a boundary with **six** breaks — four from a 43-point cap, the other 785 points forming two clean legs — so the ribbon was thrown away with the cap and the face fell to the ear-clipper, whose slivers are chords across the part. Such boundaries are now cut into v-monotone pieces **along diagonals between existing boundary vertices**: no interior point introduced, no boundary vertex moved, no T-vertex possible. Two-break boundaries take the identical path they took before.

| the face (829 boundary points) | ear-clipped | decomposed |
|---|---|---|
| sagRel | 4.635e-1 | **5.688e-4 (815×)** |
| badArea | 0.9783 | **0.0000** |
| coverage | 1.0000 | 1.0000 (unchanged) |
| longest seed chord, as a fraction of face extent | 0.617 | **0.064** |

**Faces above 10% of extent on that model: 1 → 0.** Above 1%: 7 → 6. A decomposition always *succeeds* on a non-monotone boundary and succeeding is not the same as helping, so the decomposed seed is kept only where its worst chord is materially shorter than the ear-clipper's — 55 of the 511 corpus faces that reach the branch.

## The epic train, as smoked here

Each round was bumped onto this branch and clicked through on its own deploy preview before the next was stacked on it.

| round | pin | via | fix | measured |
|---|---|---|---|---|
| 1 | `1.1567.608` | conway#646 (conway-geom#190), conway#643 | monotone two-chain sweep replaces ear-clipping on trimmed b-spline ribbons; five diagnostics/selection fixes | the spring renders as a 7-turn coil, not a fan of sheets; picked STEP parts resolve their own express id through the `SHAPE_REPRESENTATION_RELATIONSHIP` chain |
| 2 | `1.1573.644` | conway#652 (conway-geom#191, #193) | single unwrapped chart for spherical trims — the button-head dome | complete dome with a clean hex socket |
| 3 | `1.1576.647` | conway#655 (conway-geom#194, #195) | closed-trim head re-seed; the thread flank cold-start, plus a stated-closure gate | the two flanks of the target thread symmetric at **49.04 vs 49.06 mm²**, where a chord across the shank had shown as a 5.7 mm² sliver |
| 4 | `1.1578.666` | conway#666 (conway-geom#196) | **#642** — wrong-sheet inverse solve on b-spline faces whose support surface passes near itself; the true minimum is recovered from the seed the solve had discarded | 28 of 28 probes; coverage → 1.0000 on every affected face; boundary residual up to **765×** better; shipped GLB triangles **−18.9%** |
| 5 | `1.1579.668` | conway#668 (conway-geom#199) | chain-side sign in the ribbon sweep, taken from the leg's direction | worst thread face **49% → 0.42%** shipped deviation; a second **37% → 1.1%** |
| 6 | `1.1584.674` | conway#674 (conway-geom#200) | analytic shading normals + GLB normals — above | dome/pedestal seam reads as a clean ring; all six STEP corpus digests moved **hash-only**, IFC digests **unmoved** exactly as predicted and CI-confirmed |
| 7 | `1.1585.676` | conway#676 (conway-geom#201) | v-monotone decomposition — above | last damaged face **815×**; **>10%-deviation count reaches zero** |

## Payload and performance, stated plainly

- **GLB grows.** Adding normals took the reference export **11.05 MB → 15.35 MB (+38.9%)**, and Draco **0.91 → 1.39 MB (+52.8%)**. Round 4's wrong-sheet fix had earlier cut shipped GLB triangles **−18.9%**, so the two partly offset each other, but **the net for GLB export is up** — the added bytes buy correct shading in every external consumer, which flat-shaded conway's exports until now.
- **Triangle counts move slightly on the decomposed faces**: the private thread model **+4.62%**, `Right_Hand` **+0.40%**, `nist_ctc_02_e2` **+0.76%**. Face 829 itself *sheds* 25,063 triangles; the growth is ~53k added across other changed faces where the decomposed seed stops converging and `tesselate` spends its full 32× budget. One face goes 1,126 → 2,880 triangles and lands *slightly worse*. That is a real cost with an open question, filed with its attribution table as **bldrs-ai/conway#675**, against #641's standing amplification-budget question.
- **Watertightness not regressed**: unpaired half-edges 844 → 844 (thread), 2,692 → 2,689 (`Right_Hand`), 414 → 414 (`nist_ctc_02`) — the metric conway-geom#188 used to certify the spring fix.
- The rc's per-model timings are in `benchmarks/conway-ci_/` in test-models#64, with a delta against the previous blessed snapshot.

## Accepted residual state, documented rather than chased

- **One `Right_Hand` face at sagRel 1.7e-1** — 46 v-breaks in 97 points, a genuinely oscillating chart. Its decomposed seed's worst chord (0.958 of extent) is *worse* than the ear-clipper's (0.918), so decomposing it is ear-clipping with extra steps. Boundary resampling is the only remaining lever and it moves already-solved trim vertices — a stop condition throughout this epic.
- **Two thread faces at ~1.7% peak deviation** — below visibility, short of conway#665's exit criterion.
- **The marginal-face amplification cost** — bldrs-ai/conway#675.

Two epic items are *closed* rather than residual: the head-seam shading artifact, conway#667, is what round 6 fixes; conway#665 is closed-by-merge, with its thread-model residue completed by round 7.

## What to look at

- **The private thread model** — the fasteners' flanks and the button-head dome should both read cleanly, and the dome/pedestal seam should be a clean ring rather than a broken dark line. Thread-flank improvements live at **thread zoom**; whole-model pixel diffs are small by design.
- **`Right_Hand.step`** — visibly smoother curved faces; damaged faces went 21 → 7 back in round 4.
- **`index.ifc`** — expect unchanged. IFC digests did not move across the whole train: only `IfcAdvancedBrep` faces reach the analytic triangulators, and architectural IFC takes the no-surface path.
- **GLB export** — models exported from Share now carry vertex normals, so external viewers stop flat-shading them.

## Verification on this branch

Per CLAUDE.md's pre-ready checklist, run locally before the ready-flip:

- **`yarn build-prod`** — clean.
- **`yarn test-ci`** — **259 suites, 2,666 passed / 5 skipped**, coverage thresholds met (statements 71.08%, branches 65.85%, functions 72.85%, lines 70.40%).
- **husky pre-commit gate forced onto the `main` merge commit** with `git commit --amend --no-edit` — a merge is not otherwise hooked.
- **`yarn test-flows-build-and-serve` + `yarn test-flows`** — 162 passed, 41 skipped, 21 failed **in a network-restricted sandbox**. Attributed, not waved through: the same subset was re-run against `origin/main` at the *old* pin in the same container, and the same failure families fail there — all five `GoogleDriveConnect` cases, `Login` (Auth0), `SynchronizedView`, `sceneHighlightPermalink`. The signatures are environmental (Auth0/Google/msw hosts refused by the egress proxy, `Page.captureScreenshot` "session closed", and a load-timing bound missed at 1179 ms against 1000 ms), and this branch touches only `package.json` and `yarn.lock`. **Pre-existing, not from the pin** — CI is the real signal.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EEbApNYfjEPWeGAYjXVhcT)_