### PR TITLE
Demand-batch resilience: one evicted geometry no longer drops a whole batch (SHARE-1NK)

### DIFF
--- a/src/viewer/ifc/conwayDirectIfcLoader.js
+++ b/src/viewer/ifc/conwayDirectIfcLoader.js
@@ -349,9 +349,23 @@ export async function parseIfcWithConway(
  *
  * Safe here for one specific reason: eviction frees an asset from
  * GetGeometry until something re-extracts it, and this loader copies every
- * payload at delivery (the bldrs-ai/Share#1640 invariant). A change that
- * made it hold geometry IDs and fetch them later would break quietly, so
- * that invariant is now load-bearing rather than merely true.
+ * payload at delivery (the bldrs-ai/Share#1640 invariant) — but "at
+ * delivery" means between pump calls, in `onMeshBatch` below, after
+ * `ExtractGeometryBatchAsync` returns and before the next pump call runs.
+ * A batch delivered late in that window can still be evicted before
+ * `IncrementalBatchedBuilder.appendBatch` (called synchronously from
+ * `onMeshBatch`) finishes copying it out — conway's GEOMETRY_BUDGET eviction
+ * raced the very copy this comment used to treat as instantaneous, and
+ * embind then throws "Cannot pass deleted object as a pointer of type
+ * IfcGeometry" reading the freed wrapper (Sentry SHARE-1NK). Conway is
+ * being fixed to keep call-N's delivered assets resident until call N+1
+ * starts, closing that window; independently, `IncrementalBatchedBuilder`
+ * now degrades a boundary throw to one skipped placement (counted, logged)
+ * rather than letting it escape and drop the whole batch, so the invariant
+ * failing on some future engine version costs one part, not sixty-four.
+ * A change that made this loader hold geometry IDs and fetch them later
+ * would still break quietly, so the copy-at-delivery invariant remains
+ * load-bearing rather than merely true.
  *
  * Ignored by engines predating conway#535 — unknown settings are dropped —
  * so ordering against the conway bump does not matter.

--- a/src/viewer/ifc/incrementalBatchedBuilder.js
+++ b/src/viewer/ifc/incrementalBatchedBuilder.js
@@ -1,4 +1,5 @@
 import {BatchedMesh, Box3, DoubleSide, Group, Matrix4, Vector4} from 'three'
+import debug, {WARN} from '../../utils/debug'
 import {forEachVectorItem} from './conwayVector'
 import {makeSurfaceMaterial} from '../lookMaterial'
 import {
@@ -21,6 +22,11 @@ const INITIAL_INSTANCES = 1024
 const INITIAL_VERTICES = 1 << 18
 const INITIAL_INDICES = 1 << 19
 const GROWTH = 2
+// Console cap for per-record skip warnings (see warnBadRecord_): a model
+// with many budget-evicted geometries (conway#535) shouldn't flood the
+// console one line per id -- the load report's skipped* counts already
+// carry the full total (Sentry SHARE-1NK).
+const MAX_BAD_RECORD_WARNINGS = 5
 /* eslint-enable no-magic-numbers */
 
 
@@ -73,6 +79,8 @@ export class IncrementalBatchedBuilder {
     // Conway exactly once per model.
     this.geometryCache = new Map()
     this.badGeometry = new Set()
+    // Running count backing warnBadRecord_'s console cap.
+    this.badRecordWarnings = 0
     // coincidenceKeys already appended, across all batches — drops exact
     // duplicate placements that would z-fight (see coincidenceKey).
     this.seenPlacements = new Set()
@@ -112,20 +120,59 @@ export class IncrementalBatchedBuilder {
    * on per-record problems — mirrors the one-shot builder's skip
    * accounting.
    *
+   * Both loop bodies below are guarded individually rather than once
+   * around the whole method: conway's GEOMETRY_BUDGET eviction
+   * (conwayDirectIfcLoader.js, conway#535) can free a native asset
+   * between delivery and our reading it, and embind then throws
+   * "Cannot pass deleted object as a pointer of type IfcGeometry" from
+   * whichever wrapper touches it next — a FlatMesh's own accessors, or
+   * one of its PlacedGeometry entries inside appendPlacement_. Letting
+   * either throw escape this method would abort the whole batch (up to
+   * 64 products) instead of the one poisoned record, which is exactly
+   * the Sentry SHARE-1NK regression: don't reintroduce it here.
+   *
    * @param {object|Array} flatMeshes delta FlatMesh source
    */
   appendBatch(flatMeshes) {
     forEachVectorItem(flatMeshes, (flatMesh) => {
-      const parentExpressId = flatMesh?.expressID
-      const placedVec = flatMesh?.geometries
-      if (parentExpressId === undefined || !placedVec) {
+      try {
+        const parentExpressId = flatMesh?.expressID
+        const placedVec = flatMesh?.geometries
+        if (parentExpressId === undefined || !placedVec) {
+          this.totals.skippedFlatMeshes++
+          return
+        }
+        forEachVectorItem(placedVec, (placed) => {
+          try {
+            this.appendPlacement_(parentExpressId, placed)
+          } catch (e) {
+            this.totals.skippedPlacedGeometries++
+            this.warnBadRecord_('appendPlacement_ failed; skipping placement:', e)
+          }
+        })
+      } catch (e) {
         this.totals.skippedFlatMeshes++
-        return
+        this.warnBadRecord_('FlatMesh read failed; skipping:', e)
       }
-      forEachVectorItem(placedVec, (placed) => {
-        this.appendPlacement_(parentExpressId, placed)
-      })
     })
+  }
+
+
+  /**
+   * Log one per-record skip, deduped/capped so a model with many bad
+   * records (e.g. every geometry evicted past the budget) doesn't flood
+   * the console — see MAX_BAD_RECORD_WARNINGS. The load report's
+   * skipped* totals (finalize()) carry the full count regardless of how
+   * many lines actually printed.
+   *
+   * @param {string} message
+   * @param {Error} e underlying error, logged so a Sentry load report
+   *   still shows why geometry was skipped.
+   */
+  warnBadRecord_(message, e) {
+    if (this.badRecordWarnings++ < MAX_BAD_RECORD_WARNINGS) {
+      debug(WARN).warn(`IncrementalBatchedBuilder: ${message}`, e)
+    }
   }
 
 
@@ -288,25 +335,45 @@ export class IncrementalBatchedBuilder {
     if (this.badGeometry.has(geomExpressID)) {
       return null
     }
-    // eslint-disable-next-line new-cap
-    const geom = this.api.GetGeometry(this.modelID, geomExpressID)
-    if (!geom) {
+    let geom
+    let indexSize
+    let vertCount
+    let rawVerts
+    let rawIndices
+    try {
+      // eslint-disable-next-line new-cap
+      geom = this.api.GetGeometry(this.modelID, geomExpressID)
+      if (!geom) {
+        this.badGeometry.add(geomExpressID)
+        return null
+      }
+      // eslint-disable-next-line new-cap
+      indexSize = geom.GetIndexDataSize()
+      // eslint-disable-next-line new-cap
+      const vertSize = geom.GetVertexDataSize()
+      if (indexSize === 0 || vertSize === 0 || vertSize % VERT_STRIDE !== 0) {
+        this.badGeometry.add(geomExpressID)
+        return null
+      }
+      vertCount = (vertSize / VERT_STRIDE) | 0
+      // eslint-disable-next-line new-cap
+      rawVerts = this.api.GetVertexArray(geom.GetVertexData(), vertCount * VERT_STRIDE)
+      // eslint-disable-next-line new-cap
+      rawIndices = this.api.GetIndexArray(geom.GetIndexData(), indexSize)
+    } catch (e) {
+      // conway's GEOMETRY_BUDGET_MB (conwayDirectIfcLoader.js) evicts the
+      // least-recently-used native geometry at each pump batch (conway#535).
+      // If eviction lands between the demand pump delivering this id and
+      // our copying it out here, embind throws "Cannot pass deleted object
+      // as a pointer of type IfcGeometry" from whichever of the calls
+      // above touches the freed wrapper. Cache it as bad (so no batch
+      // retries the same doomed id) and degrade to one skipped placement
+      // — never let it escape and take the whole batch with it
+      // (Sentry SHARE-1NK).
       this.badGeometry.add(geomExpressID)
+      this.warnBadRecord_(`geometry ${geomExpressID} fetch failed; skipping:`, e)
       return null
     }
-    // eslint-disable-next-line new-cap
-    const indexSize = geom.GetIndexDataSize()
-    // eslint-disable-next-line new-cap
-    const vertSize = geom.GetVertexDataSize()
-    if (indexSize === 0 || vertSize === 0 || vertSize % VERT_STRIDE !== 0) {
-      this.badGeometry.add(geomExpressID)
-      return null
-    }
-    const vertCount = (vertSize / VERT_STRIDE) | 0
-    // eslint-disable-next-line new-cap
-    const rawVerts = this.api.GetVertexArray(geom.GetVertexData(), vertCount * VERT_STRIDE)
-    // eslint-disable-next-line new-cap
-    const rawIndices = this.api.GetIndexArray(geom.GetIndexData(), indexSize)
     const geometry = localGeometry(rawVerts, rawIndices, vertCount)
     geometry.computeBoundingBox()
     const entry = {

--- a/src/viewer/ifc/incrementalBatchedBuilder.js
+++ b/src/viewer/ifc/incrementalBatchedBuilder.js
@@ -78,7 +78,16 @@ export class IncrementalBatchedBuilder {
     // idByBatch: Map(batchState → geometryId)} — geometry fetched from
     // Conway exactly once per model.
     this.geometryCache = new Map()
+    // Permanently unusable shapes: conway handed back nothing, or handed
+    // back a degenerate buffer (zero-size, or a vertex size that isn't a
+    // whole number of VERT_STRIDE verts). Those are properties of the
+    // SHAPE, so no later batch can do better — never retried.
     this.badGeometry = new Set()
+    // Ids whose Conway-boundary fetch THREW during the batch currently
+    // being appended (GEOMETRY_BUDGET eviction, see resolveGeometry_'s
+    // catch). Unlike badGeometry this is transient: cleared at the top of
+    // every appendBatch so the next batch retries.
+    this.failedThisBatch = new Set()
     // Running count backing warnBadRecord_'s console cap.
     this.badRecordWarnings = 0
     // coincidenceKeys already appended, across all batches — drops exact
@@ -134,6 +143,13 @@ export class IncrementalBatchedBuilder {
    * @param {object|Array} flatMeshes delta FlatMesh source
    */
   appendBatch(flatMeshes) {
+    // Eviction state is a property of THIS pump call: whatever the budget
+    // freed before it stays freed for its whole duration, and conway
+    // re-extracts an evicted shape only when a later product maps it. So
+    // a boundary throw suppresses further fetches of that id within this
+    // batch (they would fail identically) and no further — see
+    // resolveGeometry_.
+    this.failedThisBatch.clear()
     forEachVectorItem(flatMeshes, (flatMesh) => {
       try {
         const parentExpressId = flatMesh?.expressID
@@ -246,6 +262,20 @@ export class IncrementalBatchedBuilder {
   /**
    * Resolve (or reject) one placement and append its instance.
    *
+   * ORDERING IS LOAD-BEARING (codex P2 on Share#1798). Every read that
+   * crosses the Conway boundary — the PlacedGeometry's own accessors and
+   * the GetGeometry/GetVertexArray/GetIndexArray calls behind
+   * resolveGeometry_ — is staged into locals BEFORE the first mutation,
+   * because any of them can throw embind's "Cannot pass deleted object"
+   * when the geometry budget evicts the native asset (see appendBatch).
+   * A throw between `addInstance` and the pick-table pushes would leave
+   * the mesh holding an instance that `cursor` and the tables never
+   * recorded, so every later instance id maps to the wrong row of
+   * selection metadata — and appendBatch's per-placement guard would
+   * cheerfully keep appending into the now-corrupt builder. Once staging
+   * is done the rest is three.js writes into preallocated buffers and
+   * JS array pushes, which don't throw in practice.
+   *
    * @param {number} parentExpressId
    * @param {object} placed Conway PlacedGeometry
    */
@@ -255,20 +285,27 @@ export class IncrementalBatchedBuilder {
       this.totals.skippedPlacedGeometries++
       return
     }
+    const color = placed.color ?? DEFAULT_COLOR
+    // One staged read of the transform serves both the dedup key and the
+    // instance matrix: Matrix4.fromArray copies element-wise, so
+    // `matrix.elements` is value-identical to the source array (and the
+    // recenter offset is only subtracted from it further down, after the
+    // key is taken — matching the one-shot builder, which keys on the raw
+    // placement).
+    const matrix = this.scratchMatrix.fromArray(placed.flatTransformation)
+    const occurrencePath = placed.occurrencePath ?? null
     const entry = this.resolveGeometry_(geomExpressID)
     if (entry === null) {
       this.totals.skippedPlacedGeometries++
       return
     }
-    const color = placed.color ?? DEFAULT_COLOR
     // Drop an exact coincident duplicate (same part + geometry + transform +
     // colour): it would z-fight the one already appended. See coincidenceKey.
-    const dedupKey = coincidenceKey(parentExpressId, geomExpressID, placed.flatTransformation, color)
+    const dedupKey = coincidenceKey(parentExpressId, geomExpressID, matrix.elements, color)
     if (this.seenPlacements.has(dedupKey)) {
       this.totals.skippedCoincidentPlacements++
       return
     }
-    this.seenPlacements.add(dedupKey)
     const isTransparent = color.w < OPAQUE_ALPHA
     const state = this.ensureBatch_(isTransparent)
     this.ensureCapacity_(state, entry)
@@ -279,14 +316,13 @@ export class IncrementalBatchedBuilder {
       entry.idByBatch.set(state, geometryId)
     }
     const batchId = state.mesh.addInstance(geometryId)
-    const matrix = this.scratchMatrix.fromArray(placed.flatTransformation)
-    // Decide the model-wide origin-recenter offset from the first placement,
-    // then subtract it from every instance so a georeferenced model renders at
-    // the origin (float32-precise) instead of at ~1e7 m. See
-    // coordinationOffsetFor. Stamped on the root for consumers that need to
-    // map a rendered point back to true world coordinates.
+    // Decide the model-wide origin-recenter offset from the first placement
+    // that actually appends, then subtract it from every instance so a
+    // georeferenced model renders at the origin (float32-precise) instead of
+    // at ~1e7 m. See coordinationOffsetFor. Stamped on the root for consumers
+    // that need to map a rendered point back to true world coordinates.
     if (this.coordination.offset === undefined) {
-      this.coordination.offset = coordinationOffsetFor(placed.flatTransformation)
+      this.coordination.offset = coordinationOffsetFor(matrix.elements)
     }
     if (this.coordination.offset !== null) {
       this.root.userData.coordinationOffset = this.coordination.offset
@@ -301,12 +337,17 @@ export class IncrementalBatchedBuilder {
     // Per-occurrence identity (STEP): NAUO path + solid geometry id, so
     // the batched consumers can narrow selection / hide to one occurrence.
     state.instanceGeometryIds.push(geomExpressID)
-    state.instanceOccurrencePaths.push(placed.occurrencePath ?? null)
+    state.instanceOccurrencePaths.push(occurrencePath)
     state.instanceGeometry.push(entry.geometry)
     state.instanceColors.push(color)
     state.cursor++
     this.occurrenceId++
     this.totals.placements++
+    // Marked seen only once the append actually landed: a placement that
+    // died mid-append must not poison the dedup set, or the identical
+    // placement conway re-emits in a later batch would be dropped as a
+    // duplicate of an instance that was never drawn.
+    this.seenPlacements.add(dedupKey)
     if (isTransparent) {
       this.totals.transparentPlacements++
     }
@@ -332,7 +373,7 @@ export class IncrementalBatchedBuilder {
     if (cached !== undefined) {
       return cached
     }
-    if (this.badGeometry.has(geomExpressID)) {
+    if (this.badGeometry.has(geomExpressID) || this.failedThisBatch.has(geomExpressID)) {
       return null
     }
     let geom
@@ -366,11 +407,21 @@ export class IncrementalBatchedBuilder {
       // If eviction lands between the demand pump delivering this id and
       // our copying it out here, embind throws "Cannot pass deleted object
       // as a pointer of type IfcGeometry" from whichever of the calls
-      // above touches the freed wrapper. Cache it as bad (so no batch
-      // retries the same doomed id) and degrade to one skipped placement
+      // above touches the freed wrapper. Degrade to one skipped placement
       // — never let it escape and take the whole batch with it
       // (Sentry SHARE-1NK).
-      this.badGeometry.add(geomExpressID)
+      //
+      // This failure is TRANSIENT, unlike the degenerate-shape branches
+      // above, so it must NOT go in badGeometry: conway's contract is
+      // that an evicted shape is gone from GetGeometry only until
+      // something re-extracts it, which happens when a later product maps
+      // it — a retry in a LATER batch can therefore succeed and recover
+      // every placement that reuses the shape. Blacklisting it
+      // permanently would drop them all. Scope the suppression to this
+      // batch instead (cleared in appendBatch): within one pump call the
+      // eviction state can't change, so re-fetching here is a guaranteed
+      // second failure and only costs another boundary throw.
+      this.failedThisBatch.add(geomExpressID)
       this.warnBadRecord_(`geometry ${geomExpressID} fetch failed; skipping:`, e)
       return null
     }

--- a/src/viewer/ifc/incrementalBatchedBuilder.test.js
+++ b/src/viewer/ifc/incrementalBatchedBuilder.test.js
@@ -22,11 +22,22 @@ function unitTriangleVerts() {
 
 /**
  * @param {object} byGeomExpressId geomExpressID → {vertexData, indexData}
- * @return {object} mock Conway IfcAPI
+ * @param {object} [opts]
+ * @param {Set<number>} [opts.deletedGeomIds] ids whose GetGeometry call
+ *   throws the embind "deleted object" error, simulating a conway#535
+ *   budget eviction that lands between delivery and our reading it.
+ * @return {object} mock Conway IfcAPI. `GetGeometry` is a jest.fn so
+ *   tests can assert it isn't retried once an id lands in badGeometry.
  */
-function makeApi(byGeomExpressId) {
+function makeApi(byGeomExpressId, opts = {}) {
+  const deletedGeomIds = opts.deletedGeomIds ?? new Set()
   return {
-    GetGeometry(_modelID, geomExpressID) {
+    GetGeometry: jest.fn((_modelID, geomExpressID) => {
+      if (deletedGeomIds.has(geomExpressID)) {
+        // Matches the real embind wording (Sentry SHARE-1NK) so a
+        // message-sniffing fallback would also see the right shape.
+        throw new Error('Cannot pass deleted object as a pointer of type IfcGeometry')
+      }
       const g = byGeomExpressId[geomExpressID]
       if (!g) {
         return null
@@ -37,7 +48,7 @@ function makeApi(byGeomExpressId) {
         GetVertexDataSize: () => g.vertexData.length,
         GetIndexDataSize: () => g.indexData.length,
       }
-    },
+    }),
     GetVertexArray(ptr) {
       return byGeomExpressId[ptr].vertexData
     },
@@ -275,5 +286,62 @@ describe('IncrementalBatchedBuilder', () => {
     const {stats} = builder.finalize()
     expect(stats.skippedPlacedGeometries).toBe(1)
     expect(builder.hasContent()).toBe(true)
+  })
+
+  it('skips one budget-evicted geometry without dropping the rest of the batch, and never retries it (SHARE-1NK)', () => {
+    // conway's GEOMETRY_BUDGET_MB eviction (conwayDirectIfcLoader.js,
+    // conway#535) can free geometry 777's native asset between the demand
+    // pump delivering it and this call reading it, so GetGeometry throws
+    // embind's "Cannot pass deleted object..." for that one id while 999
+    // and 888 are unaffected. Before the fix this propagated out of
+    // resolveGeometry_, appendBatch caught it at the batch level (or, pre
+    // Sentry SHARE-1NK, ShareIfcLoader.js dropped the whole up-to-64-product
+    // batch into the preview fallback) -- either way the healthy placements
+    // in the SAME batch were lost too. They must survive now.
+    const api = makeApi(shapes, {deletedGeomIds: new Set([777])})
+    const builder = new IncrementalBatchedBuilder(api, 0)
+
+    expect(() => builder.appendBatch([
+      flatMesh(1, [{geomExpressID: 999, color: OPAQUE}]),
+      flatMesh(2, [{geomExpressID: 777, color: OPAQUE}]),
+      flatMesh(3, [{geomExpressID: 888, color: OPAQUE}]),
+    ])).not.toThrow()
+
+    // A later batch re-referencing the same evicted id must not retry the
+    // Conway call -- resolveGeometry_ caches it in badGeometry so a model
+    // with the eviction repeating across many products doesn't repeatedly
+    // fail the same doomed fetch.
+    expect(() => builder.appendBatch([
+      flatMesh(4, [{geomExpressID: 777, color: OPAQUE}]),
+    ])).not.toThrow()
+
+    const {stats} = builder.finalize()
+    expect(stats.instanceCount).toBe(2) // 999 and 888 only
+    expect(stats.skippedPlacedGeometries).toBe(2) // 777, once per batch it appeared in
+    expect(api.GetGeometry).toHaveBeenCalledTimes(3) // 999, 777 (once), 888 -- not 4
+  })
+
+  it('skips one unreadable FlatMesh without dropping the rest of the batch', () => {
+    // The same conway eviction can free a FlatMesh's own wrapper, not just
+    // the geometry it points to -- reading `.expressID` off a deleted
+    // vector element throws the same way. appendBatch must count and skip
+    // that ONE FlatMesh and still append the healthy ones around it.
+    const poisoned = {
+      get expressID() {
+        throw new Error('Cannot pass deleted object as a pointer of type FlatMesh')
+      },
+      geometries: [],
+    }
+    const builder = new IncrementalBatchedBuilder(makeApi(shapes), 0)
+
+    expect(() => builder.appendBatch([
+      flatMesh(1, [{geomExpressID: 999, color: OPAQUE}]),
+      poisoned,
+      flatMesh(3, [{geomExpressID: 888, color: OPAQUE}]),
+    ])).not.toThrow()
+
+    const {stats} = builder.finalize()
+    expect(stats.instanceCount).toBe(2) // 999 and 888
+    expect(stats.skippedFlatMeshes).toBe(1)
   })
 })

--- a/src/viewer/ifc/incrementalBatchedBuilder.test.js
+++ b/src/viewer/ifc/incrementalBatchedBuilder.test.js
@@ -25,9 +25,11 @@ function unitTriangleVerts() {
  * @param {object} [opts]
  * @param {Set<number>} [opts.deletedGeomIds] ids whose GetGeometry call
  *   throws the embind "deleted object" error, simulating a conway#535
- *   budget eviction that lands between delivery and our reading it.
+ *   budget eviction that lands between delivery and our reading it. The
+ *   set is read per call, so a test can delete from it to model conway
+ *   re-extracting the shape for a later product.
  * @return {object} mock Conway IfcAPI. `GetGeometry` is a jest.fn so
- *   tests can assert it isn't retried once an id lands in badGeometry.
+ *   tests can assert which ids were fetched, and how often.
  */
 function makeApi(byGeomExpressId, opts = {}) {
   const deletedGeomIds = opts.deletedGeomIds ?? new Set()
@@ -73,6 +75,16 @@ function flatMesh(expressID, placements) {
       color,
     })),
   }
+}
+
+
+/**
+ * @param {object} api mock from makeApi
+ * @param {number} geomExpressID
+ * @return {number} how many times GetGeometry was called for that id
+ */
+function callsFor(api, geomExpressID) {
+  return api.GetGeometry.mock.calls.filter(([, id]) => id === geomExpressID).length
 }
 
 
@@ -288,7 +300,7 @@ describe('IncrementalBatchedBuilder', () => {
     expect(builder.hasContent()).toBe(true)
   })
 
-  it('skips one budget-evicted geometry without dropping the rest of the batch, and never retries it (SHARE-1NK)', () => {
+  it('skips one budget-evicted geometry without dropping the rest of the batch (SHARE-1NK)', () => {
     // conway's GEOMETRY_BUDGET_MB eviction (conwayDirectIfcLoader.js,
     // conway#535) can free geometry 777's native asset between the demand
     // pump delivering it and this call reading it, so GetGeometry throws
@@ -307,10 +319,9 @@ describe('IncrementalBatchedBuilder', () => {
       flatMesh(3, [{geomExpressID: 888, color: OPAQUE}]),
     ])).not.toThrow()
 
-    // A later batch re-referencing the same evicted id must not retry the
-    // Conway call -- resolveGeometry_ caches it in badGeometry so a model
-    // with the eviction repeating across many products doesn't repeatedly
-    // fail the same doomed fetch.
+    // Still evicted in the next batch, so it fails again and is skipped
+    // again -- but it IS re-fetched (see the retry test below for why the
+    // suppression stops at the batch boundary).
     expect(() => builder.appendBatch([
       flatMesh(4, [{geomExpressID: 777, color: OPAQUE}]),
     ])).not.toThrow()
@@ -318,7 +329,101 @@ describe('IncrementalBatchedBuilder', () => {
     const {stats} = builder.finalize()
     expect(stats.instanceCount).toBe(2) // 999 and 888 only
     expect(stats.skippedPlacedGeometries).toBe(2) // 777, once per batch it appeared in
-    expect(api.GetGeometry).toHaveBeenCalledTimes(3) // 999, 777 (once), 888 -- not 4
+    expect(callsFor(api, 777)).toBe(2) // once per batch, not once per placement
+  })
+
+  it('retries a transiently evicted geometry in the next batch, but not within the batch', () => {
+    // A budget eviction is TRANSIENT: conway re-extracts the shape when a
+    // later product maps it, so the id must not be blacklisted permanently
+    // (codex P1 on Share#1798) -- every later placement reusing that shape
+    // would be dropped for the rest of the load. Within ONE pump batch the
+    // eviction state can't change, so a second placement of the same id
+    // must not pay for another guaranteed-fail boundary call.
+    const evicted = new Set([777])
+    const api = makeApi({...shapes, 777: shapes[999]}, {deletedGeomIds: evicted})
+    const builder = new IncrementalBatchedBuilder(api, 0)
+
+    builder.appendBatch([
+      flatMesh(1, [{geomExpressID: 777, color: OPAQUE}]),
+      flatMesh(2, [{geomExpressID: 777, color: OPAQUE}]), // same batch, same eviction
+    ])
+    expect(callsFor(api, 777)).toBe(1)
+
+    // Conway re-extracted it for a later product: the retry now succeeds.
+    evicted.delete(777)
+    builder.appendBatch([flatMesh(3, [{geomExpressID: 777, color: OPAQUE}])])
+    expect(callsFor(api, 777)).toBe(2)
+
+    const {stats, batches} = builder.finalize()
+    expect(stats.instanceCount).toBe(1) // the recovered placement
+    expect(stats.skippedPlacedGeometries).toBe(2) // both batch-1 placements
+    expect(Array.from(batches[0].instanceParents)).toEqual([3])
+  })
+
+  it('never re-fetches a degenerate geometry, in this batch or any later one', () => {
+    // The contrast case to the retry above: a zero-size shape is a property
+    // of the SHAPE, not of eviction timing, so no later batch can do better
+    // and badGeometry keeps it permanently.
+    const degenerate = {vertexData: unitTriangleVerts(), indexData: new Uint32Array([])}
+    const api = makeApi({...shapes, 666: degenerate})
+    const builder = new IncrementalBatchedBuilder(api, 0)
+
+    builder.appendBatch([
+      flatMesh(1, [{geomExpressID: 666, color: OPAQUE}]),
+      flatMesh(2, [{geomExpressID: 666, color: OPAQUE}]),
+    ])
+    builder.appendBatch([flatMesh(3, [{geomExpressID: 666, color: OPAQUE}])])
+
+    expect(callsFor(api, 666)).toBe(1)
+    const {stats} = builder.finalize()
+    expect(stats.instanceCount).toBe(0)
+    expect(stats.skippedPlacedGeometries).toBe(3)
+  })
+
+  it('skips a placement whose boundary read throws mid-append, keeping the tables aligned', () => {
+    // Every Conway-boundary read is staged before the first mutation (codex
+    // P2 on Share#1798). If `occurrencePath` threw AFTER addInstance, the
+    // mesh would carry an instance that `cursor` and the pick tables never
+    // recorded, and every later instance id would map to the wrong row of
+    // selection metadata -- silently, since appendBatch keeps going.
+    const api = makeApi(shapes)
+    const builder = new IncrementalBatchedBuilder(api, 0)
+    const poisoned = {
+      geometryExpressID: 999,
+      flatTransformation: IDENTITY_MAT,
+      color: OPAQUE,
+      get occurrencePath() {
+        throw new Error('Cannot pass deleted object as a pointer of type PlacedGeometry')
+      },
+    }
+    const moved = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 7, 0, 0, 1]
+
+    expect(() => builder.appendBatch([
+      {expressID: 1, geometries: [poisoned]},
+      {expressID: 2, geometries: [
+        {geometryExpressID: 999, flatTransformation: moved, color: OPAQUE},
+      ]},
+      flatMesh(3, [{geomExpressID: 888, color: OPAQUE}]),
+    ])).not.toThrow()
+
+    const {stats, batches} = builder.finalize()
+    expect(stats.skippedPlacedGeometries).toBe(1)
+    expect(stats.instanceCount).toBe(2) // the two healthy placements after it
+    expect(batches).toHaveLength(1)
+    const batch = batches[0]
+    // No untracked instance: the mesh, the cursor and every pick table agree.
+    expect(batch.mesh.instanceCount).toBe(stats.instanceCount)
+    expect(builder.opaque.cursor).toBe(stats.instanceCount)
+    for (const table of [batch.instanceParents, batch.instanceOccurrenceIds,
+      batch.instanceGeometryIds, batch.instanceGeometry, batch.instanceColors]) {
+      expect(table).toHaveLength(stats.instanceCount)
+    }
+    // ...and row i really describes instance i: parent 2's translated
+    // transform sits at batchId 0, where instanceParents says it is.
+    expect(Array.from(batch.instanceParents)).toEqual([2, 3])
+    const m = new Matrix4()
+    batch.mesh.getMatrixAt(0, m)
+    expect(m.elements[12]).toBeCloseTo(7)
   })
 
   it('skips one unreadable FlatMesh without dropping the rest of the batch', () => {


### PR DESCRIPTION
Share half of Sentry [SHARE-1NK](https://bldrs-ai.sentry.io/issues/7699115915/) — see bldrs-ai/conway#649 for the full root cause and bldrs-ai/conway#654 (merged) for the engine-side fix.

## What happened

On the demand path, conway's `GEOMETRY_BUDGET_MB` eviction could free a native geometry between delivery and Share's copy of it, so `api.GetGeometry(...)` threw embind's `Cannot pass deleted object as a pointer of type IfcGeometry`. `IncrementalBatchedBuilder.appendBatch` let that throw escape — despite its doc comment promising per-record resilience — and `ShareIfcLoader` dropped the **entire batch** (up to 64 products) into the preview fallback, which hit the same error. Whole batches of geometry silently vanished from the rendered model on a 1.9 GB Revit IFC.

## The change

- **`incrementalBatchedBuilder.js`** — `resolveGeometry_` wraps the Conway-boundary calls (`GetGeometry` → `GetIndexArray`) in try/catch and degrades a throw to one skipped placement. A thrown fetch is treated as **transient** (a `failedThisBatch` set, cleared per pump call, suppresses same-batch re-fetches while later batches retry and recover the shape once conway re-extracts it); only genuinely degenerate shapes (missing / zero-size / misaligned vertex size) go in the permanent `badGeometry` set. `appendBatch` guards each FlatMesh and each placement individually. All Conway-boundary reads (`color`, `flatTransformation`, `occurrencePath`, the geometry fetch) are **staged into locals before the first mutation**, so a boundary throw can never leave the mesh holding an instance the pick tables didn't record. Warnings are deduped/capped (`MAX_BAD_RECORD_WARNINGS`); the load report's `skipped*` counts carry full totals.
- **`conwayDirectIfcLoader.js`** — the `GEOMETRY_BUDGET_MB` invariant comment now describes the real copy timing (between pump calls, in `onMeshBatch`), the eviction race that caused SHARE-1NK, and the two-sided fix.
- **Merged with #1791's `CoincidenceSet`** (85-bit numeric placement fingerprint from the #635 epic): the combined dedup test-and-set now runs on the staged matrix elements, after every boundary read and the geometry fetch, preserving both changes' guarantees.

This is engine-independent hardening: it narrows the loss to individual evicted placements on the current engine pin, and becomes belt-and-suspenders once the pin is bumped past conway#654 (the follow-up that fully resolves the Sentry issue).

## Tests

`incrementalBatchedBuilder.test.js`: one budget-evicted geometry among healthy ones → no throw, rest of batch appended, retried and recovered on the next batch, not re-fetched within a batch; degenerate-permanent contrast case; a throwing `occurrencePath` getter → mesh `instanceCount`, `cursor`, and all five pick tables stay aligned; one unreadable FlatMesh → `skippedFlatMeshes` counted, rest appended. All verified falsifiable (fix reverted → red). Codex round 1 findings fixed and resolved; round 2 clean. Pre-flip validation on the merged head: `build-prod` ✓, `test-ci` ✓ (258 suites / 2639 tests, coverage thresholds enforced), `test-flows src/loader/conwayDirect.spec.ts` 3/3 ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WFte6WW6bqxxL7VPAMTr1g