### PR TITLE
Bump @bldrs-ai/conway to 1.1575.649-gdeabdf16 (SHARE-1NK engine fix)

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@babel/plugin-syntax-import-assertions": "7.18.6",
     "@babel/preset-env": "7.18.10",
     "@babel/preset-react": "7.18.6",
-    "@bldrs-ai/conway": "1.1565.608-g18366f01",
+    "@bldrs-ai/conway": "1.1575.649-gdeabdf16",
     "@bldrs-ai/ifclib": "5.3.3",
     "@emotion/react": "11.10.0",
     "@emotion/styled": "11.10.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2473,10 +2473,10 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@bldrs-ai/conway@1.1565.608-g18366f01":
-  version "1.1565.608-g18366f01"
-  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.1565.608-g18366f01.tgz#5118ab02f17ac01b8a926bebd11f1f7057955629"
-  integrity sha512-N5s34rO+4NdNzyzRxDqIJ+HN0bmzjSafCnoGbCwXLYyxiiVAnDzAV1tuSD+QtVJBox/QeJbZ39u201xp3L8tEw==
+"@bldrs-ai/conway@1.1575.649-gdeabdf16":
+  version "1.1575.649-gdeabdf16"
+  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.1575.649-gdeabdf16.tgz#b623303a393a6f00b2dc39b3fed2c0f362d46249"
+  integrity sha512-gJymVIhsj9fXxvqjG5U/n9lccXPpOfGTJK8jDWsXYL6dOrbbl3xpiqbbkoZy6eIMgds6lfa4wUUd4EJFrOZDyQ==
   dependencies:
     gl-matrix "3.4.3"
     seedrandom "3.0.5"


### PR DESCRIPTION
Engine pin bump carrying bldrs-ai/conway#654 (fixes bldrs-ai/conway#649 / Sentry [SHARE-1NK](https://bldrs-ai.sentry.io/issues/7699115915/)): the demand pump now evicts at the **start** of a pump call — everything call N delivers stays resident until call N+1 begins, so the copy window `onMeshBatch` relies on is safe — and `GetGeometry` degrades to the dummy not-found path instead of cloning a freed embind handle.

With this pin, #1798's per-placement skip hardening becomes belt-and-suspenders rather than the only line of defense, and large-model loads under `GEOMETRY_BUDGET_MB` (the SHARE-1NK cohort: 1–2 GB Revit IFCs) stop losing geometry. This is the last piece of the SHARE-1NK chain; the Sentry issue gets resolved once this deploys.

**Diff:** one dependency line in `package.json` + the matching `yarn.lock` entries.

**Validated against the new engine locally:** `build-prod` ✓, `test-ci` ✓ (258 suites / 2639 tests, coverage thresholds enforced), `test-flows src/loader/conwayDirect.spec.ts` 3/3 ✓ — the flows build bundles the new conway wasm, so the E2E exercised `1.1575.649-gdeabdf16` end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WFte6WW6bqxxL7VPAMTr1g

---
_Generated by [Claude Code](https://claude.ai/code/session_01WFte6WW6bqxxL7VPAMTr1g)_