### PR TITLE
bldrs-ai/conway#638: stop retaining the pumped FlatMesh stream where something else owns it

### DIFF
--- a/src/Containers/CadView.test.jsx
+++ b/src/Containers/CadView.test.jsx
@@ -45,8 +45,13 @@ jest.mock('../search/SearchIndex')
 // wit-three-shape fake the rest of the CadView assertions expect).
 // Scoped to this test file because production unit tests for
 // `buildConwayIfcModel` need the real implementation.
+// `recapture` is part of the parse's return contract, not an optional
+// extra: since conway#638 the streaming path keeps no copy of the mesh
+// stream, so it — not `captured` — is what the degraded end-of-load builds
+// read. A double that omits it makes `ShareIfcLoader#parse` throw
+// "recapture is not a function" on the fallback path.
 jest.mock('../viewer/ifc/conwayDirectIfcLoader', () => ({
-  parseIfcWithConway: () => ({modelID: 0, captured: []}),
+  parseIfcWithConway: () => ({modelID: 0, captured: [], recapture: () => []}),
   decorateConwayDirectIfcModel: () => {},
 }))
 jest.mock('../viewer/ifc/buildConwayIfcModel', () => ({

--- a/src/viewer/ifc/IfcItemsMap.js
+++ b/src/viewer/ifc/IfcItemsMap.js
@@ -283,6 +283,15 @@ export function itemsMapFromOrderedRanges(ranges, opts = {}) {
  * (Phase 3) uses `itemsMapFromConwayStream` directly because there
  * is no prior walk to collide with.
  *
+ * conway#657 closes this at the source for models opened with
+ * `STREAMING_CONSUMER` (which `conwayDirectIfcLoader` now declares on every
+ * deferred open): there is no cache for the walk to re-push into, so
+ * conway's own re-walk clears and rebuilds instead of appending and the
+ * second call returns what the first did. It stays true on the pinned
+ * engine and on every non-streaming open, so this entry point is not going
+ * away — but a doubling seen after the pin bump is a bug rather than the
+ * documented behaviour.
+ *
  * @param {object|Array} flatMeshes FlatMesh source (size()/get(i) or Array)
  * @param {object} api Conway-compatible IfcAPI (needs GetGeometry)
  * @param {number} modelID

--- a/src/viewer/ifc/ShareIfcLoader.degraded.test.js
+++ b/src/viewer/ifc/ShareIfcLoader.degraded.test.js
@@ -1,0 +1,298 @@
+// conway#638: the demand pump's FlatMesh stream is no longer retained once
+// something else takes delivery, so `ShareIfcLoader#parse`'s DEGRADED
+// end-of-load builds read `recapture()` — a whole-model accessor that
+// re-extracts at the moment of failure — instead of the parse's `captured`
+// array. These pin the wiring: on every degraded path the fallback build
+// must still receive the whole stream, and on the healthy path it must not
+// be asked for at all.
+//
+// The retention decision itself (which opens drop, which keep, and why a
+// windowed source cannot) lives one layer down and is pinned in
+// `conwayDirectIfcLoader.test.js`. Here `parseIfcWithConway` is mocked so
+// the two halves of its return value can disagree, which is exactly the
+// state a reader of the wrong one would get wrong.
+
+import ShareIfcLoader from './ShareIfcLoader'
+import {assembleBatchedModel, buildBatchedConwayModel} from './buildBatchedConwayModel'
+import {buildConwayIfcModel} from './buildConwayIfcModel'
+import {IncrementalBatchedBuilder} from './incrementalBatchedBuilder'
+import {parseIfcWithConway} from './conwayDirectIfcLoader'
+import {flatMeshToInstancedModel} from './flatMeshToInstancedModel'
+import {isFeatureEnabled} from '../../FeatureFlags'
+
+
+jest.mock('./conwayDirectIfcLoader', () => ({
+  parseIfcWithConway: jest.fn(),
+  decorateConwayDirectIfcModel: jest.fn(),
+}))
+jest.mock('./buildBatchedConwayModel', () => ({
+  buildBatchedConwayModel: jest.fn(),
+  assembleBatchedModel: jest.fn(),
+}))
+jest.mock('./buildConwayIfcModel', () => ({buildConwayIfcModel: jest.fn()}))
+jest.mock('./incrementalBatchedBuilder', () => ({IncrementalBatchedBuilder: jest.fn()}))
+jest.mock('./flatMeshToBufferGeometry', () => ({flatMeshToBufferGeometry: jest.fn()}))
+jest.mock('./flatMeshToInstancedModel', () => ({flatMeshToInstancedModel: jest.fn()}))
+jest.mock('./parsePreviewMesh', () => ({payloadToPreviewMesh: jest.fn(() => null)}))
+jest.mock('./ifcItemsMapParity', () => ({runIfcItemsMapParityCheck: jest.fn()}))
+jest.mock('./conwayDirectLog', () => ({
+  conwayDirectInfo: jest.fn(),
+  conwayDirectError: jest.fn(),
+}))
+jest.mock('../../FeatureFlags', () => ({isFeatureEnabled: jest.fn()}))
+jest.mock('../../utils/location', () => ({hasParams: jest.fn(() => false)}))
+
+// The session owns preview lifecycle and camera follow, none of which this
+// file exercises — but `previewGroup` being non-null is what makes
+// `ShareIfcLoader#parse` build an `onMeshBatch` at all, and that callback's
+// existence is the whole precondition for the stream being dropped.
+jest.mock('../ProgressiveLoadSession', () => jest.fn().mockImplementation(() => ({
+  previewGroup: {add: jest.fn(), remove: jest.fn(), children: []},
+  report: jest.fn(),
+  beginAssembly: jest.fn(),
+  notifyBounds: jest.fn(),
+  addPreviewMesh: jest.fn(),
+  setSummary: jest.fn(),
+  finish: jest.fn(),
+  abort: jest.fn(),
+})))
+
+
+/** The stream the pump delivered — what every degraded build must receive. */
+const PUMPED = [
+  {expressID: 101, geometries: {size: () => 1}},
+  {expressID: 102, geometries: {size: () => 1}},
+  {expressID: 103, geometries: {size: () => 1}},
+]
+
+const BUILD_STATS = {
+  vertexCount: 9,
+  triangleCount: 3,
+  instanceCount: 3,
+  parentCount: 1,
+  materialCount: 1,
+  skippedFlatMeshes: 0,
+  skippedPlacedGeometries: 0,
+}
+
+
+/**
+ * A model object shaped enough for the tail of `parse` (matrix stamp,
+ * `addIfcModel`, the summary line) to run over it untouched.
+ *
+ * @param {string} tag which build produced it
+ * @return {object}
+ */
+function makeModel(tag) {
+  return {tag, matrix: null, geometry: null, capabilities: {}}
+}
+
+
+/**
+ * A `viewer.IFC` stub with the scene `parse` needs to open a preview group.
+ *
+ * @return {object}
+ */
+function makeIfcNamespace() {
+  return {
+    ifcLastError: null,
+    addIfcModel: jest.fn(),
+    context: {
+      items: {ifcModels: []},
+      getScene: () => ({add: jest.fn(), remove: jest.fn()}),
+      ifcCamera: {cameraControls: null, perspectiveCamera: null},
+    },
+  }
+}
+
+
+/** @return {object} Conway IfcAPI stub for the post-build tail of `parse` */
+function makeIfcAPI() {
+  return {
+    GetCoordinationMatrix: jest.fn().mockResolvedValue(
+      [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]),
+    OpenModel: jest.fn(),
+    StreamAllMeshes: jest.fn(),
+    properties: {},
+  }
+}
+
+
+describe('viewer/ifc/ShareIfcLoader degraded end-of-load builds (conway#638)', () => {
+  let recapture
+  let ifcAPI
+  let ifc
+  let loader
+  // `?feature=batchedMesh` forces the instancing analysis to info level, so
+  // the two cases that flip it on would otherwise narrate an
+  // `[instancedMeshes]` line each. Diverted, not silenced globally
+  // (PLAYBOOK.md §"Keep the test console clean").
+  let infoSpy
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    infoSpy = jest.spyOn(console, 'info').mockImplementation(() => {})
+    // `demandGeometry` on is what gives the session a preview group, which
+    // is what gives `parse` an `onMeshBatch`, which is what makes the parse
+    // drop the stream. Everything else off: `batchedMesh` is flipped on
+    // per-test where that fallback is the subject.
+    isFeatureEnabled.mockImplementation((name) => name === 'demandGeometry')
+    // The shape the streaming path returns: an EMPTY `captured` beside a
+    // `recapture()` that still serves the whole model. A reader that took
+    // the array would silently build nothing — which is the regression.
+    //
+    // The mock drives `onMeshBatch` before resolving, the way the real pump
+    // does. Without that the loader's `builder` would stay null for every
+    // case, and the three degraded paths this file separates would collapse
+    // into one.
+    recapture = jest.fn(() => PUMPED)
+    parseIfcWithConway.mockImplementation(
+      // eslint-disable-next-line require-await
+      async (buffer, api, settings, onProgress, onMeshBatch) => {
+        if (onMeshBatch) {
+          onMeshBatch(PUMPED, 4)
+        }
+        return {modelID: 4, captured: [], recapture}
+      })
+    buildConwayIfcModel.mockReturnValue({mesh: makeModel('merged'), stats: BUILD_STATS})
+    buildBatchedConwayModel.mockReturnValue({model: makeModel('batched'), stats: BUILD_STATS})
+    assembleBatchedModel.mockReturnValue(makeModel('incremental'))
+    // Only read by the instancing diagnostic, which `?feature=batchedMesh`
+    // forces on in two cases below. Given a real shape so the diagnostic
+    // completes instead of throwing into its own catch and narrating the
+    // suite (PLAYBOOK.md §"Keep the test console clean").
+    flatMeshToInstancedModel.mockReturnValue({
+      stats: {
+        instanceCount: 3,
+        uniqueGeometryCount: 1,
+        sharedGeometryCount: 1,
+        singletonGeometryCount: 0,
+        mergedVertexCount: 9,
+        instancedVertexCount: 3,
+        vertexReductionRatio: 3,
+        estimatedBytesSaved: 0,
+        topInstancedGeometryID: 1,
+        topInstancedCount: 3,
+      },
+    })
+    ifcAPI = makeIfcAPI()
+    ifc = makeIfcNamespace()
+    loader = new ShareIfcLoader({ifcAPI, ifc})
+  })
+
+  afterEach(() => infoSpy.mockRestore())
+
+  /**
+   * Run the parse and hand back the meshes the merged fallback was built
+   * from, so each degraded case asserts on the same observable.
+   *
+   * @return {Promise<object>} the model `parse` resolved with
+   */
+  async function parseOnce() {
+    const model = await loader.parse(new ArrayBuffer(4), jest.fn(), jest.fn())
+    return model
+  }
+
+  it('feeds the merged fallback the whole stream when the builder never constructs', async () => {
+    // `builder === null` after a productive pump: the very first
+    // `new IncrementalBatchedBuilder` threw, so nothing was assembled and
+    // the end-of-load build is the only thing that can produce a model.
+    IncrementalBatchedBuilder.mockImplementation(() => {
+      throw new Error('builder construction failed')
+    })
+    const model = await parseOnce()
+    expect(model.tag).toBe('merged')
+    expect(buildConwayIfcModel).toHaveBeenCalledTimes(1)
+    expect(buildConwayIfcModel.mock.calls[0][0]).toEqual(PUMPED)
+  })
+
+  it('feeds the merged fallback the whole stream when the builder holds no content', async () => {
+    // Every `appendBatch` threw, so the builder exists but has nothing in
+    // it. `hasContent()` false is the gate; the fallback still has to build
+    // a complete model.
+    IncrementalBatchedBuilder.mockImplementation(() => ({
+      root: {parent: null},
+      appendBatch: jest.fn(),
+      hasContent: () => false,
+      finalize: jest.fn(),
+    }))
+    const model = await parseOnce()
+    expect(model.tag).toBe('merged')
+    expect(buildConwayIfcModel.mock.calls[0][0]).toEqual(PUMPED)
+  })
+
+  it('feeds the merged fallback the whole stream when finalize throws', async () => {
+    // The progressive-then-blank case named in conway#638's verification
+    // section: batches rendered, then the end-of-load assembly failed. The
+    // partial group is removed, so without a complete re-read the user is
+    // left with an empty scene.
+    IncrementalBatchedBuilder.mockImplementation(() => ({
+      root: {parent: null},
+      appendBatch: jest.fn(),
+      hasContent: () => true,
+      finalize: () => {
+        throw new Error('finalize failed')
+      },
+    }))
+    const model = await parseOnce()
+    expect(model.tag).toBe('merged')
+    expect(buildConwayIfcModel.mock.calls[0][0]).toEqual(PUMPED)
+  })
+
+  it('feeds the batchedMesh fallback the whole stream too', async () => {
+    // The other degraded build, reached first when `?feature=batchedMesh`
+    // is on. It reads the same accessor and must get the same meshes.
+    isFeatureEnabled.mockImplementation(
+      (name) => name === 'demandGeometry' || name === 'batchedMesh')
+    IncrementalBatchedBuilder.mockImplementation(() => {
+      throw new Error('builder construction failed')
+    })
+    const model = await parseOnce()
+    expect(model.tag).toBe('batched')
+    expect(buildBatchedConwayModel).toHaveBeenCalledTimes(1)
+    expect(buildBatchedConwayModel.mock.calls[0][0]).toEqual(PUMPED)
+    expect(buildConwayIfcModel).not.toHaveBeenCalled()
+  })
+
+  it('never asks for the stream when the incremental assembly succeeds', async () => {
+    // The healthy streaming path, and the point of the change: re-extraction
+    // is the price of a fallback, not of a load. If this fires on every load
+    // the retention has just been traded for a whole-model re-walk.
+    IncrementalBatchedBuilder.mockImplementation(() => ({
+      root: {parent: null},
+      appendBatch: jest.fn(),
+      hasContent: () => true,
+      finalize: () => ({batches: [], stats: BUILD_STATS}),
+    }))
+    const model = await parseOnce()
+    expect(model.tag).toBe('incremental')
+    expect(recapture).not.toHaveBeenCalled()
+    expect(buildConwayIfcModel).not.toHaveBeenCalled()
+    expect(buildBatchedConwayModel).not.toHaveBeenCalled()
+  })
+
+  it('serves both fallbacks off the accessor when they run in sequence', async () => {
+    // `buildBatchedConwayModel` throwing falls through to
+    // `buildConwayIfcModel`, so both degraded builds run in one load. Each
+    // must go through the accessor — a call site left reading the retained
+    // array would build from nothing while its sibling built correctly,
+    // which is the shape that makes this regression silent.
+    isFeatureEnabled.mockImplementation(
+      (name) => name === 'demandGeometry' || name === 'batchedMesh')
+    buildBatchedConwayModel.mockImplementation(() => {
+      throw new Error('batched build failed')
+    })
+    IncrementalBatchedBuilder.mockImplementation(() => {
+      throw new Error('builder construction failed')
+    })
+    const model = await parseOnce()
+    expect(model.tag).toBe('merged')
+    expect(buildBatchedConwayModel.mock.calls[0][0]).toEqual(PUMPED)
+    expect(buildConwayIfcModel.mock.calls[0][0]).toEqual(PUMPED)
+    // Every array handed out is the one object the accessor memoises, so
+    // the two builds cannot be reading different re-extractions.
+    for (const result of recapture.mock.results) {
+      expect(result.value).toBe(PUMPED)
+    }
+  })
+})

--- a/src/viewer/ifc/ShareIfcLoader.js
+++ b/src/viewer/ifc/ShareIfcLoader.js
@@ -55,15 +55,18 @@ import debug, {DEBUG, WARN, isLogEnabled} from '../../utils/debug'
  *
  * @param {object} ifcAPI Conway IfcAPI bound to the model
  * @param {number} modelID
- * @param {Array} captured FlatMeshes captured during the parse
+ * @param {Function} getCaptured returns the parse's whole FlatMesh stream.
+ *   A thunk rather than the array because on the streaming path
+ *   (conway#638) producing it costs a whole-model re-extraction, and that
+ *   must not be paid by the loads this gate turns away.
  * @param {boolean} [force] log at info level regardless of verbosity
  */
-function logInstancedModelStats(ifcAPI, modelID, captured, force = false) {
+function logInstancedModelStats(ifcAPI, modelID, getCaptured, force = false) {
   if (!force && !isLogEnabled(DEBUG)) {
     return
   }
   try {
-    const {stats} = flatMeshToInstancedModel(captured, ifcAPI, modelID)
+    const {stats} = flatMeshToInstancedModel(getCaptured(), ifcAPI, modelID)
     const reduction = stats.vertexReductionRatio.toFixed(2)
     const line =
       `[instancedMeshes] modelID=${modelID} — ` +
@@ -411,7 +414,13 @@ export default class ShareIfcLoader {
         }
       }
 
-      const {modelID, captured} =
+      // `recapture()`, not `captured`, is what the degraded builds below
+      // read. On the streaming path the parse keeps no copy of the FlatMesh
+      // stream — `onMeshBatch` above already assembled each batch into the
+      // durable model — so the fallbacks re-extract at the moment of
+      // failure rather than the parse holding 475 MB against the chance of
+      // one (conway#638). It is the identity where the stream was retained.
+      const {modelID, recapture} =
         await parseIfcWithConway(buffer, ifcAPI, undefined, onProgress, onMeshBatch, onPreviewMesh)
 
       session.beginAssembly()
@@ -422,7 +431,7 @@ export default class ShareIfcLoader {
       // Slice B1: the incrementally assembled batches only need
       // decoration — the group already on screen becomes the durable
       // model. Fallback on any error: remove the partial group and run
-      // the end-of-load builds below from `captured` as before.
+      // the end-of-load builds below off `recapture()` as before.
       if (builder !== null && builder.hasContent()) {
         try {
           const incremental = builder.finalize()
@@ -445,7 +454,7 @@ export default class ShareIfcLoader {
       // path on any construction error so the flag can never break a load.
       if (ifcModel === undefined && isFeatureEnabled('batchedMesh')) {
         try {
-          const batched = buildBatchedConwayModel(captured, ifcAPI, modelID, {scene})
+          const batched = buildBatchedConwayModel(recapture(), ifcAPI, modelID, {scene})
           ifcModel = batched.model
           buildStats = batched.stats
         } catch (e) {
@@ -453,7 +462,7 @@ export default class ShareIfcLoader {
         }
       }
       if (ifcModel === undefined) {
-        const merged = buildConwayIfcModel(captured, ifcAPI, modelID)
+        const merged = buildConwayIfcModel(recapture(), ifcAPI, modelID)
         ifcModel = merged.mesh
         buildStats = merged.stats
         decorateConwayDirectIfcModel(ifcModel, ifcAPI, modelID, {scene})
@@ -555,15 +564,27 @@ export default class ShareIfcLoader {
       // Toggle via `?feature=ifcItemsMapParity`. See
       // design/new/viewer-replacement.md §3b.ii for the per-vertex-vs-
       // per-instance story this check exposes.
+      //
+      // Both this and the instancing analysis below read the WHOLE mesh
+      // stream, which the streaming path no longer retains — so they go
+      // through `recapture()`, and on a dropped stream that is a real extra
+      // whole-model read. Deliberate: they are opt-in diagnostics, the cost
+      // lands only on the session that asked for one, and the alternative
+      // (reading the empty array) would report zeros that look like a
+      // finding. Note that on a live model this second read is exactly the
+      // conway-side double-count `IfcItemsMap.js` documents, so treat a
+      // parity diff taken this way with that caveat.
       if (isFeatureEnabled('ifcItemsMapParity')) {
-        runIfcItemsMapParityCheck(ifcAPI, ifcModel, captured)
+        runIfcItemsMapParityCheck(ifcAPI, ifcModel, recapture())
       }
       // Instanced-rendering analysis: groups the captured stream by shared
       // `geometryExpressID` and reports the GPU-instancing draw-call +
       // vertex-memory delta. Logged under verbose normally; forced to info
       // level when `?feature=batchedMesh` is on so the eval shows the
-      // numbers alongside what just rendered as a BatchedMesh.
-      logInstancedModelStats(ifcAPI, modelID, captured, isFeatureEnabled('batchedMesh'))
+      // numbers alongside what just rendered as a BatchedMesh. Passed as a
+      // thunk so the recapture happens only if the gate inside actually
+      // opens.
+      logInstancedModelStats(ifcAPI, modelID, recapture, isFeatureEnabled('batchedMesh'))
       // Always-on integration-boundary log. `conwayDirect.spec.ts`
       // (and the deploy-preview smoke checks) gate on `[conwayDirect]
       // parsed modelID=…` firing — it's the single observable signal

--- a/src/viewer/ifc/conwayDirectIfcLoader.js
+++ b/src/viewer/ifc/conwayDirectIfcLoader.js
@@ -231,8 +231,9 @@ export async function parseIfcWithConway(
     //      drains through the SYNCHRONOUS `ExtractGeometryBatch` — and that
     //      throws outright on a windowed source ("ExtractGeometryBatch is
     //      synchronous and cannot page a windowed source", pinned engine
-    //      `compiled/src/compat/web-ifc/ifc_api_proxy_ifc.js:1482`, reached
-    //      from `streamAllMeshes`' deferred drain loop). conway#657 does
+    //      `compiled/src/compat/web-ifc/ifc_api_proxy_ifc.js:1509`, reached
+    //      from `streamAllMeshes`' deferred drain loop at `:2632`).
+    //      conway#657 does
     //      not change that: its re-walk hangs off the same drain, and there
     //      is no async whole-model entry point on either version.
     //      `ExtractGeometryBatchAsync` cannot substitute — after a full
@@ -483,15 +484,22 @@ export async function parseIfcWithConway(
  *      filters out placements whose natives were freed. So on a model big
  *      enough to evict, this returns a strict SUBSET of what was pumped.
  *
- * That second one is an improvement over what it replaces, not a new loss.
- * Before this change the degraded builds ran over the RETAINED deltas,
- * which still name evicted geometry, and the pinned `getGeometry` clones
- * without guarding (`geometryObject.clone()` on a freed native) — so an
- * evicted model took an embind abort out of the load, the shape Sentry
- * SHARE-1NK records. The filtered re-extraction renders a partial model
- * instead. The residual is honest: retention is kept on the windowed path,
- * so that abort stays reachable there until conway grows an async
- * whole-model re-read.
+ * That second one costs nothing that was not already gone, and the reason
+ * is worth pinning down because it changed with the engine. On the RETAINED
+ * deltas an evicted placement still names freed geometry, and conway#654's
+ * `getGeometry` now probes `isNativeDeleted` and degrades to a dummy
+ * IfcGeometry rather than aborting inside embind as it used to (the Sentry
+ * SHARE-1NK shape). `flatMeshToBufferGeometry` then skips that dummy for
+ * zero vertex/index size and counts it in `skippedPlacedGeometries`. So on
+ * this pin BOTH routes render the same model — the geometry is gone either
+ * way, because the native was freed.
+ *
+ * What the filtered re-extraction buys is therefore accounting, not pixels:
+ * conway drops the placement before delivery and emits ONE aggregate
+ * warning naming the instance and entity counts, where the retained route
+ * logs a `[GetGeometry]` error per evicted placement and surfaces the loss
+ * only as a `skippedPlacedGeometries` bump. Worth having, and small — do
+ * not sell it as crash avoidance. The engine fixed the crash.
  *
  * Memoised because the two degraded builds are consecutive
  * (`buildBatchedConwayModel` then `buildConwayIfcModel`), and a second
@@ -561,9 +569,12 @@ function makeRecapture(ifcAPI, modelID, captured, retained) {
  * `onMeshBatch`) finishes copying it out — conway's GEOMETRY_BUDGET eviction
  * raced the very copy this comment used to treat as instantaneous, and
  * embind then throws "Cannot pass deleted object as a pointer of type
- * IfcGeometry" reading the freed wrapper (Sentry SHARE-1NK). Conway is
- * being fixed to keep call-N's delivered assets resident until call N+1
- * starts, closing that window; independently, `IncrementalBatchedBuilder`
+ * IfcGeometry" reading the freed wrapper (Sentry SHARE-1NK). That fix has
+ * since LANDED — conway#654 moved eviction to the head of the pump call, so
+ * call N's delivered assets stay resident until call N+1 begins, and
+ * `getGeometry` now probes `isNativeDeleted` and returns a dummy geometry
+ * instead of aborting. The window is closed on this pin (1.1575.649);
+ * independently, `IncrementalBatchedBuilder`
  * now degrades a boundary throw to one skipped placement (counted, logged)
  * rather than letting it escape and drop the whole batch, so the invariant
  * failing on some future engine version costs one part, not sixty-four.

--- a/src/viewer/ifc/conwayDirectIfcLoader.js
+++ b/src/viewer/ifc/conwayDirectIfcLoader.js
@@ -364,11 +364,34 @@ export async function parseIfcWithConway(
       //
       // Retention is unconditional here regardless of `retainCaptured`:
       // this branch means the streaming delivery produced nothing, so
-      // `captured` is once again the only delivery. The model is also
-      // non-deferred by construction, so `StreamAllMeshes` takes conway's
-      // classic walk over live natives rather than the deferred drain —
-      // which is why it works on a windowed source where `recapture` below
-      // could not.
+      // `captured` is once again the only delivery.
+      //
+      // Where that leaves `StreamAllMeshes`, stated precisely because the
+      // obvious shorthand is wrong. When conway really did fall back to a
+      // classic open, the model is non-deferred and this takes conway's
+      // classic scene walk over live natives — which works on a windowed
+      // source where `recapture` below could not, because it never touches
+      // the deferred drain. But `pumpedMeshes === 0` does NOT imply
+      // non-deferred: the pump loop exits on `remaining === 0 &&
+      // extracted === 0` whatever the reason, so a genuinely DEFERRED model
+      // with nothing to extract (a properties-only IFC, or one whose every
+      // product failed geometry) lands here too. On a windowed source that
+      // model's `StreamAllMeshes` takes the deferred branch and throws
+      // "cannot page a windowed source" out of the load. That is a
+      // PRE-EXISTING defect, not one this change introduces — the sentinel
+      // it replaced (`captured.length === 0`) selected exactly the same
+      // models and called exactly the same method — and it is tracked
+      // separately rather than fixed here.
+      //
+      // Nor is there a whole-model route around it. The three entry points
+      // that do NOT throw on a windowed deferred model are all worse:
+      // `loadAllGeometry` and `streamAllMeshesWithTypes` have no deferred
+      // branch at all and seed coordination from `model[5]`, which a
+      // deferred open never writes, so every instance lands in an identity
+      // frame — silently mis-framed geometry, worse than a refusal; and
+      // `getFlatMesh` is per-entity and would need an ID enumeration this
+      // loader does not have. conway#657 routes the first and third through
+      // `streamAllMeshes` so they refuse properly after the pin bump.
       //
       // No onMeshBatch here: extraction is already complete, so a
       // preview would just double the geometry conversion right before
@@ -445,6 +468,30 @@ export async function parseIfcWithConway(
  * were dropped it re-extracts at the moment of failure instead, which is
  * the whole point of dropping: 475 MB is not worth holding against a
  * fallback that almost never runs.
+ *
+ * **What comes back is equivalent, not identical**, and both differences
+ * matter to a reader comparing it against the pump's own output:
+ *
+ *   1. **Grouping.** On a deferred model the pinned `StreamAllMeshes`
+ *      serves per-entity FULL FlatMeshes out of conway's `meshMap`, not the
+ *      per-batch DELTA FlatMeshes the pump delivered. Same placement set,
+ *      different bundling. Benign for both readers here — the merged and
+ *      batched builds iterate placements and do not care how they arrive —
+ *      but a future consumer that keyed on batch identity would.
+ *   2. **Completeness under a budget.** `GEOMETRY_BUDGET_MB` is set on this
+ *      path, and once conway has evicted anything, its whole-model serve
+ *      filters out placements whose natives were freed. So on a model big
+ *      enough to evict, this returns a strict SUBSET of what was pumped.
+ *
+ * That second one is an improvement over what it replaces, not a new loss.
+ * Before this change the degraded builds ran over the RETAINED deltas,
+ * which still name evicted geometry, and the pinned `getGeometry` clones
+ * without guarding (`geometryObject.clone()` on a freed native) — so an
+ * evicted model took an embind abort out of the load, the shape Sentry
+ * SHARE-1NK records. The filtered re-extraction renders a partial model
+ * instead. The residual is honest: retention is kept on the windowed path,
+ * so that abort stays reachable there until conway grows an async
+ * whole-model re-read.
  *
  * Memoised because the two degraded builds are consecutive
  * (`buildBatchedConwayModel` then `buildConwayIfcModel`), and a second

--- a/src/viewer/ifc/conwayDirectIfcLoader.js
+++ b/src/viewer/ifc/conwayDirectIfcLoader.js
@@ -15,9 +15,13 @@
 // `ifcManager` too.
 //
 // Surface:
-//   - `parseIfcWithConway(buffer, ifcAPI, settings)` → `{modelID, captured}`
+//   - `parseIfcWithConway(buffer, ifcAPI, settings)` →
+//     `{modelID, captured, recapture}`
 //     OpenModel + StreamAllMeshes; one async-shaped sync call (the
 //     wrap is for symmetry with future move-to-worker paths).
+//     `captured` is the retained FlatMesh stream and is EMPTY on the
+//     streaming path (see `parseIfcWithConway`'s retention note);
+//     `recapture()` is the whole-model accessor degraded readers use.
 //   - `decorateConwayDirectIfcModel(ifcModel, ifcAPI, modelID, opts)`
 //     Post-build decoration: BVH, IfcInstanceMap, capability flips,
 //     subset method, property + spatial method closures. Runs on a
@@ -88,15 +92,17 @@ import {instanceMapFromGeometry} from './IfcInstanceMap'
  * @param {Function} [onMeshBatch] demand/tiled slice A: receives
  *   `(flatMeshes, modelID)` for each extracted batch as it lands (only
  *   on the `demandGeometry` deferred path) so callers can render
- *   progressively;
- *   `captured` still accumulates everything for one-shot consumers.
+ *   progressively. Passing it makes the caller the OWNER of the stream:
+ *   `captured` then stays empty and degraded readers must go through
+ *   `recapture()` — see the retention note in the body (conway#638).
  * @param {Function} [onPreviewMesh] demand/tiled slice A2: receives
  *   conway PreviewMeshPayloads WHILE THE PARSE RUNS (self-contained
  *   copied geometry, preview quality — openings/materials can be
  *   missing; replaced wholesale by the durable batches). Only on the
  *   `demandGeometry` deferred path with engines that support
  *   ON_PREVIEW_MESH; silently ignored otherwise.
- * @return {Promise<{modelID: number, captured: Array}>}
+ * @return {Promise<{modelID: number, captured: Array,
+ *   recapture: Function}>}
  */
 export async function parseIfcWithConway(
   buffer, ifcAPI, settings = undefined, onProgress = undefined, onMeshBatch = undefined, onPreviewMesh = undefined) {
@@ -138,8 +144,9 @@ export async function parseIfcWithConway(
   }
   // Demand/tiled rendering slice A (`demandGeometry` flag, #1613):
   // deferred open + batch pump. The open returns in parse time; meshes
-  // then stream in file-order batches through `onMeshBatch` (and
-  // accumulate into `captured` for the classic one-shot consumers),
+  // then stream in file-order batches through `onMeshBatch` (accumulating
+  // into `captured` only where nothing else takes delivery — see the
+  // retention note below),
   // yielding to the event loop between batches so the scene can render
   // progressively. Feature-detected; engines without the pump fall
   // through to the classic selection below.
@@ -153,6 +160,21 @@ export async function parseIfcWithConway(
       ...openSettings,
       DEFER_GEOMETRY: true,
       GEOMETRY_BUDGET_MB: GEOMETRY_BUDGET_MB,
+      // conway#638 / conway#657: declare that THIS loader owns delivery of
+      // the pumped stream, so conway keeps no reference to it. A deferred
+      // open builds each PlacedGeometry once and files that same object
+      // into three pointer spines — conway's per-entity `meshMap`, its
+      // `vectorFlatMesh`, and whatever the embedder keeps — and dropping
+      // fewer than all three frees only the ~4.4 MB of one spine's
+      // pointers, because the other holders keep the 475 MB graph alive.
+      // This is the Share half of that; conway's is the flag's other end.
+      //
+      // Ignored as an unknown key by the pinned engine (verified: no
+      // `STREAMING_CONSUMER` in node_modules/@bldrs-ai/conway), so it is
+      // inert until the pin bumps past conway#657 and then activates the
+      // no-retention contract with no further change here. Ordering
+      // against that bump therefore does not matter.
+      STREAMING_CONSUMER: true,
     }
     if (onPreviewMesh) {
       // Slice A2 (parse-time preview channel): conway emits preview
@@ -163,10 +185,20 @@ export async function parseIfcWithConway(
     }
     let modelID
     let openData = data
+    // Did the open land on a WINDOWED source — bytes paged on demand out of
+    // an OPFS/Blob store — rather than a resident buffer? Load-bearing for
+    // the retention decision below, and knowable only here: conway exposes
+    // `sourceIsExternal` on the proxy but not through the `IfcApi` shim
+    // Share holds, and Share's `OpenModelStream(store, …)` is the only way
+    // this loader produces a windowed model. Nothing later flips it — the
+    // one call that would (`spillModelSource`) runs from the GLB writer's
+    // `finally`, long after `parse` has returned.
+    let windowedSource = false
     if (store !== null) {
       // eslint-disable-next-line new-cap
       modelID = await ifcAPI.OpenModelStream(store, deferSettings)
-      if (typeof modelID !== 'number' || modelID < 0) {
+      windowedSource = typeof modelID === 'number' && modelID >= 0
+      if (!windowedSource) {
         // IFC-only store path: STEP / failed sniff falls back to a
         // buffered streamed open (conway#510 contract).
         openData = await bytesFromSource(buffer)
@@ -181,6 +213,40 @@ export async function parseIfcWithConway(
       throw new Error(`parseIfcWithConway: OpenModel returned ${modelID}`)
     }
     const captured = []
+    // Retention decision (conway#638). `captured` used to accumulate every
+    // pumped FlatMesh unconditionally, and on the streaming path that array
+    // is dead weight: `onMeshBatch` has already assembled each batch into
+    // the durable BatchedMesh by the time the next one lands, and the only
+    // remaining readers are ShareIfcLoader's DEGRADED end-of-load builds.
+    // Holding one of the three pointer spines over a 475 MB graph against
+    // the chance of a fallback is what this stops.
+    //
+    // Two states must keep the contents, and both are genuine:
+    //
+    //   1. No `onMeshBatch` — then `captured` IS the delivery, not a copy
+    //      of it. Nothing else ever sees the stream.
+    //   2. A WINDOWED deferred source. The replacement for retention is
+    //      re-extraction at the moment of failure (`recapture` below), and
+    //      re-extraction is `StreamAllMeshes`, which on a deferred model
+    //      drains through the SYNCHRONOUS `ExtractGeometryBatch` — and that
+    //      throws outright on a windowed source ("ExtractGeometryBatch is
+    //      synchronous and cannot page a windowed source", pinned engine
+    //      `compiled/src/compat/web-ifc/ifc_api_proxy_ifc.js:1482`, reached
+    //      from `streamAllMeshes`' deferred drain loop). conway#657 does
+    //      not change that: its re-walk hangs off the same drain, and there
+    //      is no async whole-model entry point on either version.
+    //      `ExtractGeometryBatchAsync` cannot substitute — after a full
+    //      drain its cursor is exhausted and there is no public rewind.
+    //      So on a windowed open there is nothing to re-extract WITH, and
+    //      dropping here would turn a rare degraded build into a blank
+    //      screen. Retention stays until conway grows an async re-read.
+    //
+    // Note the asymmetry that leaves: a GitHub/OPFS-backed load takes the
+    // windowed open by default (`Loader.js` hands `parse` the File itself),
+    // so today this frees the stream on buffered opens only. The flag above
+    // is still declared on both, which is correct — declaring it changes
+    // what CONWAY retains, and `captured` is Share's own spine.
+    const retainCaptured = onMeshBatch === undefined || windowedSource
     // Batch-pump accounting for the load log. Whether the pump actually
     // produced anything is the difference between a model that streams
     // onto the screen and one that shows nothing until the end-of-load
@@ -193,6 +259,11 @@ export async function parseIfcWithConway(
     // extractIFCGeometryData open). elapsedMs omitted: the reporter
     // stamps wall-clock so we don't fight Conway's parse-relative clock.
     let pumpedBatches = 0
+    // Counted rather than derived from `captured.length`, which is 0 on the
+    // streaming path. This is the number the permanent boundary log reports
+    // and the number the empty-pump sentinel tests, so it has to track the
+    // meshes the pump actually delivered whether or not they were kept.
+    let pumpedMeshes = 0
     let geometryTotal
     let geometryDone = 0
     const reportGeometry = (completed, total) => {
@@ -237,11 +308,19 @@ export async function parseIfcWithConway(
         reportGeometry(geometryDone, geometryTotal)
       }
       if (batch.length > 0) {
-        captured.push(...batch)
+        if (retainCaptured) {
+          captured.push(...batch)
+        }
+        pumpedMeshes += batch.length
         pumpedBatches++
         if (onMeshBatch) {
           onMeshBatch(batch, modelID)
         }
+        // `batch` itself goes out of scope on the next iteration, so on the
+        // streaming path the last reference to this batch's FlatMeshes is
+        // whatever `onMeshBatch` chose to keep — which for the incremental
+        // builder is nothing (it copies every payload at delivery, the
+        // Share#1640 invariant).
       }
       if (remaining === 0 && extracted === 0) {
         break
@@ -258,9 +337,10 @@ export async function parseIfcWithConway(
     // eslint-disable-next-line no-console
     console.info(
       `[conwayDirect] demand pump: batches=${pumpedBatches} ` +
-      `meshes=${captured.length} onMeshBatch=${onMeshBatch ? 'yes' : 'no'} ` +
-      `onPreviewMesh=${onPreviewMesh ? 'yes' : 'no'}`)
-    if (captured.length === 0) {
+      `meshes=${pumpedMeshes} onMeshBatch=${onMeshBatch ? 'yes' : 'no'} ` +
+      `onPreviewMesh=${onPreviewMesh ? 'yes' : 'no'} ` +
+      `retained=${retainCaptured ? 'yes' : 'no'}`)
+    if (pumpedMeshes === 0) {
       // Nothing pumped: conway fell back to a classic fully-extracted
       // open internally, so StreamAllMeshes below captures the whole
       // model in one go and NOTHING renders until the end-of-load build.
@@ -269,11 +349,27 @@ export async function parseIfcWithConway(
       console.warn(
         '[conwayDirect] demand pump produced no batches; ' +
         'falling back to one-shot StreamAllMeshes — no progressive render')
-      // The deferred columnar open is IFC-only: for STEP input (and any
-      // streamed-parse failure) conway falls back internally to a
-      // classic, fully-extracted open where the batch pump is a no-op —
-      // the model is fine, it just has nothing to pump. Serve the
-      // one-shot capture instead of returning an empty scene.
+      // The pump is a no-op whenever conway did not actually open the model
+      // deferred — it returns `{extracted: 0, remaining: 0}` on a
+      // fully-extracted model — which happens on any streamed-parse failure
+      // that fell back internally to a classic open. The model is fine, it
+      // just has nothing to pump. Serve the one-shot capture instead of
+      // returning an empty scene.
+      //
+      // NOT a STEP-vs-IFC split, though it used to be described as one:
+      // conway routes AP214/AP203/AP242 with DEFER_GEOMETRY through
+      // `IfcApiProxyAP214.createDeferred`
+      // (`ifc_api_model_passthrough_factory.ts`), pinned engine-side by
+      // `ap214_streamed_open.test.ts`, so STEP pumps like IFC does.
+      //
+      // Retention is unconditional here regardless of `retainCaptured`:
+      // this branch means the streaming delivery produced nothing, so
+      // `captured` is once again the only delivery. The model is also
+      // non-deferred by construction, so `StreamAllMeshes` takes conway's
+      // classic walk over live natives rather than the deferred drain —
+      // which is why it works on a windowed source where `recapture` below
+      // could not.
+      //
       // No onMeshBatch here: extraction is already complete, so a
       // preview would just double the geometry conversion right before
       // the final build renders the same thing.
@@ -281,8 +377,13 @@ export async function parseIfcWithConway(
       ifcAPI.StreamAllMeshes(modelID, (flatMesh) => {
         captured.push(flatMesh)
       })
+      return {modelID, captured, recapture: () => captured}
     }
-    return {modelID, captured}
+    return {
+      modelID,
+      captured,
+      recapture: makeRecapture(ifcAPI, modelID, captured, retainCaptured),
+    }
   }
 
   // Open-path selection, most preferred first:
@@ -327,7 +428,63 @@ export async function parseIfcWithConway(
   ifcAPI.StreamAllMeshes(modelID, (flatMesh) => {
     captured.push(flatMesh)
   })
-  return {modelID, captured}
+  // The classic path never streams, so `captured` is always whole and
+  // `recapture` is the identity — the return shape stays uniform so
+  // callers never branch on which open path ran.
+  return {modelID, captured, recapture: () => captured}
+}
+
+
+/**
+ * Build the whole-model accessor for ShareIfcLoader's DEGRADED end-of-load
+ * builds — the readers that fire when the incremental assembly could not
+ * produce a model (`builder === null`, `!builder.hasContent()`, or
+ * `finalize()`/`assembleBatchedModel` throwing).
+ *
+ * When the pump's contents were retained this is the identity. When they
+ * were dropped it re-extracts at the moment of failure instead, which is
+ * the whole point of dropping: 475 MB is not worth holding against a
+ * fallback that almost never runs.
+ *
+ * Memoised because the two degraded builds are consecutive
+ * (`buildBatchedConwayModel` then `buildConwayIfcModel`), and a second
+ * `StreamAllMeshes` on a live model re-pushes into conway's still-populated
+ * cache and doubles every triangle count — the defect
+ * `IfcItemsMap.js` §"Why this is a separate entry point" documents from the
+ * consumer side.
+ *
+ * Deliberately does NOT swallow a throw. Re-extraction is only wired up
+ * where it is known to work (see `retainCaptured`), so a throw here is a
+ * broken assumption, not an expected state; letting it reach
+ * `ShareIfcLoader.parse`'s handler surfaces a real error to the user
+ * instead of rendering an empty scene and calling it a load.
+ *
+ * @param {object} ifcAPI Conway IfcAPI bound to the model
+ * @param {number} modelID
+ * @param {Array} captured the retained stream (empty when dropped)
+ * @param {boolean} retained whether `captured` holds the whole stream
+ * @return {Function} `() => Array` of the whole model's FlatMeshes
+ */
+function makeRecapture(ifcAPI, modelID, captured, retained) {
+  let recaptured = null
+  return () => {
+    if (retained) {
+      return captured
+    }
+    if (recaptured === null) {
+      const meshes = []
+      // eslint-disable-next-line new-cap
+      ifcAPI.StreamAllMeshes(modelID, (flatMesh) => {
+        meshes.push(flatMesh)
+      })
+      // eslint-disable-next-line no-console
+      console.info(
+        `[conwayDirect] recaptured ${meshes.length} mesh(es) for a degraded ` +
+        'end-of-load build')
+      recaptured = meshes
+    }
+    return recaptured
+  }
 }
 
 

--- a/src/viewer/ifc/conwayDirectIfcLoader.test.js
+++ b/src/viewer/ifc/conwayDirectIfcLoader.test.js
@@ -193,9 +193,11 @@ describe('viewer/ifc/conwayDirectIfcLoader', () => {
         // The residency budget rides on the deferred path only, and is what
         // keeps the wasm high-water bounded (PSB: 1284 MB -> 298 MB).
         expect(settings.GEOMETRY_BUDGET_MB).toBe(64)
-        // 150 products in batches of 64 → 3 extraction rounds; all
-        // meshes accumulate AND stream incrementally.
-        expect(result.captured).toHaveLength(150)
+        // 150 products in batches of 64 → 3 extraction rounds, streamed
+        // incrementally. Nothing accumulates: `onMeshBatch` took delivery,
+        // so retaining a second reference to the same FlatMeshes is the
+        // 475 MB conway#638 exists to stop.
+        expect(result.captured).toHaveLength(0)
         expect(batches).toEqual([64, 64, 22])
         // The one-shot capture path is not used on this branch.
         expect(ifcAPI.StreamAllMeshes).not.toHaveBeenCalled()
@@ -257,11 +259,17 @@ describe('viewer/ifc/conwayDirectIfcLoader', () => {
         expect(flag.isActive).toBe(true)
       })
 
-      it('serves the one-shot capture when the pump no-ops (STEP / classic fallback)', async () => {
-        // The deferred columnar open is IFC-only: STEP input falls back
-        // internally to a classic fully-extracted open whose pump returns
-        // {0,0} immediately. The loader must serve StreamAllMeshes then,
-        // not an empty scene.
+      it('serves the one-shot capture when the pump no-ops (internal classic fallback)', async () => {
+        // Conway falls back internally to a classic fully-extracted open on
+        // any streamed-parse failure, and its pump then returns {0,0}
+        // immediately. The loader must serve StreamAllMeshes then, not an
+        // empty scene.
+        //
+        // This is NOT the STEP case it was once written as: conway routes
+        // AP214/AP203/AP242 with DEFER_GEOMETRY through
+        // `IfcApiProxyAP214.createDeferred`
+        // (`ifc_api_model_passthrough_factory.ts`), pinned engine-side by
+        // `ap214_streamed_open.test.ts`, so STEP pumps like IFC does.
         mockIsFeatureEnabled.mockImplementation((name) => name === 'demandGeometry')
         const ifcAPI = makeDemandAPI(10)
         ifcAPI.ExtractGeometryBatch = jest.fn(() => ({extracted: 0, remaining: 0}))
@@ -331,6 +339,248 @@ describe('viewer/ifc/conwayDirectIfcLoader', () => {
         const [data] = ifcAPI.OpenModelStreamed.mock.calls[0]
         expect(data).toBeInstanceOf(Uint8Array)
         expect(result.captured).toHaveLength(10)
+      })
+    })
+
+    // conway#638: the pumped FlatMesh stream is one of three pointer spines
+    // over a 475 MB graph (conway holds `meshMap` and `vectorFlatMesh`; this
+    // is Share's). Dropping it on the streaming path is only safe if the
+    // counters that read the ARRAY keep working and the degraded end-of-load
+    // readers can get the stream back — these pin both.
+    describe('streaming-consumer retention (conway#638)', () => {
+      beforeEach(() => mockIsFeatureEnabled.mockReset())
+      afterAll(() => mockIsFeatureEnabled.mockReset())
+
+      /**
+       * @param {number} products total products the fake engine holds
+       * @return {object} IfcAPI stub with the deferred pump surface
+       */
+      function makeDemandAPI(products) {
+        let cursor = 0
+        return {
+          wasmModule: {},
+          OpenModelStreamed: jest.fn(() => Promise.resolve(5)),
+          OpenModelAsync: jest.fn(() => Promise.resolve(8)),
+          OpenModel: jest.fn(() => 9),
+          StreamAllMeshes: jest.fn(),
+          ExtractGeometryBatch: jest.fn((modelID, batchSize, cb) => {
+            const take = Math.min(batchSize, products - cursor)
+            for (let i = 0; i < take; i++) {
+              cb({expressID: 1000 + cursor + i, geometries: {size: () => 1}})
+            }
+            cursor += take
+            return {extracted: take, remaining: products - cursor}
+          }),
+        }
+      }
+
+      /**
+       * A windowed (store-backed) twin of the demand API: `OpenModelStream`
+       * succeeds, which is the shape a GitHub/OPFS-backed load takes because
+       * `Loader.js` hands `parse` the File itself rather than its bytes.
+       *
+       * @param {number} products total products the fake engine holds
+       * @return {object} IfcAPI stub whose deferred open is windowed
+       */
+      function makeWindowedDemandAPI(products) {
+        const ifcAPI = makeDemandAPI(products)
+        ifcAPI.OpenModelStream = jest.fn(() => Promise.resolve(3))
+        ifcAPI.ExtractGeometryBatchAsync = jest.fn((modelID, batchSize, cb) =>
+          // eslint-disable-next-line new-cap
+          Promise.resolve(ifcAPI.ExtractGeometryBatch(modelID, batchSize, cb)))
+        return ifcAPI
+      }
+
+      it('declares STREAMING_CONSUMER on the deferred open', async () => {
+        // Inert on the pinned engine (an unknown setting is dropped); after
+        // the pin bumps past conway#657 it is what stops conway retaining
+        // the other two spines. Share must send it either way — the two
+        // halves land independently.
+        mockIsFeatureEnabled.mockImplementation((name) => name === 'demandGeometry')
+        const ifcAPI = makeDemandAPI(10)
+        await parseIfcWithConway(new ArrayBuffer(4), ifcAPI)
+        const [, settings] = ifcAPI.OpenModelStreamed.mock.calls[0]
+        expect(settings.STREAMING_CONSUMER).toBe(true)
+      })
+
+      it('does not declare STREAMING_CONSUMER on the classic open', async () => {
+        // A classic open has no pump and no accumulation to suppress, and
+        // sending the flag there would claim an ownership contract that
+        // nothing on this path honours.
+        mockIsFeatureEnabled.mockImplementation(() => false)
+        const ifcAPI = makeDemandAPI(10)
+        await parseIfcWithConway(new ArrayBuffer(4), ifcAPI)
+        const [, settings] = ifcAPI.OpenModelStreamed.mock.calls[0]
+        expect(settings.STREAMING_CONSUMER).toBeUndefined()
+      })
+
+      it('counts every pumped mesh in the boundary log while retaining none', async () => {
+        // The permanent `[conwayDirect] demand pump:` line (Share#1744) is
+        // the only signal distinguishing a streaming load from a
+        // blank-screen-then-pop one, and it used to report `captured.length`
+        // — which is now 0. It has to report the meshes actually delivered.
+        mockIsFeatureEnabled.mockImplementation((name) => name === 'demandGeometry')
+        const ifcAPI = makeDemandAPI(150)
+        const result = await parseIfcWithConway(
+          new ArrayBuffer(4), ifcAPI, undefined, undefined, jest.fn())
+        expect(result.captured).toHaveLength(0)
+        const pumpLine = infoSpy.mock.calls
+          .map(([line]) => line)
+          .find((line) => typeof line === 'string' && line.includes('demand pump:'))
+        expect(pumpLine).toContain('meshes=150')
+        expect(pumpLine).toContain('batches=3')
+        expect(pumpLine).toContain('retained=no')
+      })
+
+      it('retains the stream when nothing else takes delivery', async () => {
+        // No `onMeshBatch` means `captured` IS the delivery, not a copy of
+        // it — dropping here would hand the caller an empty model.
+        mockIsFeatureEnabled.mockImplementation((name) => name === 'demandGeometry')
+        const ifcAPI = makeDemandAPI(150)
+        const result = await parseIfcWithConway(new ArrayBuffer(4), ifcAPI)
+        expect(result.captured).toHaveLength(150)
+        expect(result.recapture()).toHaveLength(150)
+        // Retained means whole: no re-extraction is needed or performed.
+        expect(ifcAPI.StreamAllMeshes).not.toHaveBeenCalled()
+        const pumpLine = infoSpy.mock.calls
+          .map(([line]) => line)
+          .find((line) => typeof line === 'string' && line.includes('demand pump:'))
+        expect(pumpLine).toContain('retained=yes')
+      })
+
+      it('retains the stream on a WINDOWED open, where re-extraction throws', async () => {
+        // Verified against the pinned engine
+        // (compiled/src/compat/web-ifc/ifc_api_proxy_ifc.js:1482):
+        // `streamAllMeshes` on a deferred model drains through the
+        // SYNCHRONOUS `ExtractGeometryBatch`, which refuses a windowed
+        // source outright. conway#657 does not change that — its re-walk
+        // hangs off the same drain — so there is nothing to re-extract with
+        // here and the contents must be kept.
+        mockIsFeatureEnabled.mockImplementation((name) => name === 'demandGeometry')
+        const ifcAPI = makeWindowedDemandAPI(20)
+        ifcAPI.StreamAllMeshes = jest.fn(() => {
+          throw new Error(
+            'ExtractGeometryBatch is synchronous and cannot page a windowed source')
+        })
+        const file = new Blob([new Uint8Array([1, 2, 3, 4])])
+        const result = await parseIfcWithConway(
+          file, ifcAPI, undefined, undefined, jest.fn())
+        expect(ifcAPI.OpenModelStream).toHaveBeenCalledTimes(1)
+        expect(result.captured).toHaveLength(20)
+        // The degraded reader is served without ever touching the entry
+        // point that would throw.
+        expect(result.recapture()).toHaveLength(20)
+        expect(ifcAPI.StreamAllMeshes).not.toHaveBeenCalled()
+      })
+
+      it('drops the stream when a windowed open falls back to a buffered one', async () => {
+        // conway#510: an `OpenModelStream` that returns -1 (STEP, failed
+        // sniff) re-opens buffered. The model is then resident, so
+        // re-extraction works again and the retention must lift with it —
+        // otherwise the fallback silently keeps 475 MB alive.
+        mockIsFeatureEnabled.mockImplementation((name) => name === 'demandGeometry')
+        const ifcAPI = makeWindowedDemandAPI(20)
+        ifcAPI.OpenModelStream = jest.fn(() => Promise.resolve(-1))
+        const file = new Blob([new Uint8Array([1, 2, 3, 4])])
+        const result = await parseIfcWithConway(
+          file, ifcAPI, undefined, undefined, jest.fn())
+        expect(ifcAPI.OpenModelStreamed).toHaveBeenCalledTimes(1)
+        expect(result.captured).toHaveLength(0)
+      })
+
+      it('re-extracts on demand for a degraded end-of-load build', async () => {
+        // The replacement for retention: the whole stream comes back at the
+        // moment of failure instead of being held for a fallback that
+        // almost never runs.
+        mockIsFeatureEnabled.mockImplementation((name) => name === 'demandGeometry')
+        const ifcAPI = makeDemandAPI(150)
+        ifcAPI.StreamAllMeshes = jest.fn((modelID, cb) => {
+          for (let i = 0; i < 150; i++) {
+            cb({expressID: 1000 + i, geometries: {size: () => 1}})
+          }
+        })
+        const result = await parseIfcWithConway(
+          new ArrayBuffer(4), ifcAPI, undefined, undefined, jest.fn())
+        // Not paid unless a degraded reader actually asks.
+        expect(ifcAPI.StreamAllMeshes).not.toHaveBeenCalled()
+        const recaptured = result.recapture()
+        expect(recaptured).toHaveLength(150)
+        expect(recaptured[0].expressID).toBe(1000)
+        expect(ifcAPI.StreamAllMeshes).toHaveBeenCalledTimes(1)
+        expect(ifcAPI.StreamAllMeshes.mock.calls[0][0]).toBe(5)
+      })
+
+      it('re-extracts at most once across the two consecutive degraded builds', async () => {
+        // `buildBatchedConwayModel` then `buildConwayIfcModel` both ask. A
+        // second `StreamAllMeshes` on a live model re-pushes into conway's
+        // still-populated cache and doubles every triangle count — the
+        // defect IfcItemsMap.js documents from the consumer side — so the
+        // accessor has to memoise.
+        mockIsFeatureEnabled.mockImplementation((name) => name === 'demandGeometry')
+        const ifcAPI = makeDemandAPI(10)
+        ifcAPI.StreamAllMeshes = jest.fn((modelID, cb) => {
+          cb({expressID: 7, geometries: {size: () => 1}})
+        })
+        const result = await parseIfcWithConway(
+          new ArrayBuffer(4), ifcAPI, undefined, undefined, jest.fn())
+        const first = result.recapture()
+        const second = result.recapture()
+        expect(second).toBe(first)
+        expect(ifcAPI.StreamAllMeshes).toHaveBeenCalledTimes(1)
+      })
+
+      it('serves the empty-pump sentinel off the counter, not the array', async () => {
+        // The sentinel used to be `captured.length === 0`, which on the
+        // streaming path is now ALSO true after a perfectly healthy pump.
+        // Reading the counter instead is what keeps a 150-mesh streaming
+        // load from being mistaken for a no-op pump and re-extracted whole.
+        mockIsFeatureEnabled.mockImplementation((name) => name === 'demandGeometry')
+        const ifcAPI = makeDemandAPI(150)
+        await parseIfcWithConway(
+          new ArrayBuffer(4), ifcAPI, undefined, undefined, jest.fn())
+        expect(ifcAPI.StreamAllMeshes).not.toHaveBeenCalled()
+        expect(warnSpy).not.toHaveBeenCalledWith(
+          expect.stringContaining('demand pump produced no batches'))
+      })
+
+      it('still recovers a genuinely empty pump, with an onMeshBatch present', async () => {
+        // The blank-screen case the sentinel exists for: conway fell back
+        // internally to a classic non-deferred open, so the pump is a no-op
+        // and `StreamAllMeshes` — a classic walk over live natives, which
+        // works even on a windowed source — is the only delivery. This must
+        // keep filling `captured` regardless of the retention decision.
+        mockIsFeatureEnabled.mockImplementation((name) => name === 'demandGeometry')
+        const ifcAPI = makeDemandAPI(10)
+        ifcAPI.ExtractGeometryBatch = jest.fn(() => ({extracted: 0, remaining: 0}))
+        ifcAPI.StreamAllMeshes = jest.fn((modelID, cb) => {
+          for (let i = 0; i < 5; i++) {
+            cb({expressID: 2000 + i, geometries: {size: () => 1}})
+          }
+        })
+        const onMeshBatch = jest.fn()
+        const result = await parseIfcWithConway(
+          new ArrayBuffer(4), ifcAPI, undefined, undefined, onMeshBatch)
+        expect(result.captured).toHaveLength(5)
+        expect(result.recapture()).toHaveLength(5)
+        expect(onMeshBatch).not.toHaveBeenCalled()
+        // One walk, not two: `recapture` must not re-drive the engine on a
+        // path where `captured` is already whole.
+        expect(ifcAPI.StreamAllMeshes).toHaveBeenCalledTimes(1)
+        const pumpLine = infoSpy.mock.calls
+          .map(([line]) => line)
+          .find((line) => typeof line === 'string' && line.includes('demand pump:'))
+        expect(pumpLine).toContain('meshes=0')
+      })
+
+      it('recapture is the identity on the classic non-deferred path', async () => {
+        mockIsFeatureEnabled.mockImplementation(() => false)
+        const ifcAPI = makeDemandAPI(10)
+        ifcAPI.StreamAllMeshes = jest.fn((modelID, cb) => {
+          cb({expressID: 11, geometries: {size: () => 1}})
+        })
+        const result = await parseIfcWithConway(new ArrayBuffer(4), ifcAPI)
+        expect(result.recapture()).toBe(result.captured)
+        expect(ifcAPI.StreamAllMeshes).toHaveBeenCalledTimes(1)
       })
     })
 

--- a/src/viewer/ifc/conwayDirectIfcLoader.test.js
+++ b/src/viewer/ifc/conwayDirectIfcLoader.test.js
@@ -471,6 +471,46 @@ describe('viewer/ifc/conwayDirectIfcLoader', () => {
         // point that would throw.
         expect(result.recapture()).toHaveLength(20)
         expect(ifcAPI.StreamAllMeshes).not.toHaveBeenCalled()
+        // Counter fidelity is not a streaming-path-only concern: the log
+        // must report real meshes on the retained branch too, where
+        // `captured.length` would happen to agree and so hide a regression
+        // in the counter itself.
+        const pumpLine = infoSpy.mock.calls
+          .map(([line]) => line)
+          .find((line) => typeof line === 'string' && line.includes('demand pump:'))
+        expect(pumpLine).toContain('meshes=20')
+        expect(pumpLine).toContain('retained=yes')
+      })
+
+      it('surfaces the engine refusal when a DEFERRED windowed model pumps nothing', async () => {
+        // Pins CURRENT behaviour, which is a pre-existing defect this
+        // change neither introduces nor fixes.
+        //
+        // `pumpedMeshes === 0` does not imply conway fell back to a classic
+        // open: a genuinely deferred model with nothing to extract (a
+        // properties-only IFC, or one whose every product failed geometry)
+        // exits the pump loop the same way, because it breaks on
+        // `remaining === 0 && extracted === 0` whatever the reason. The
+        // sentinel's one-shot `StreamAllMeshes` then takes conway's
+        // DEFERRED branch, which drains through the synchronous
+        // `ExtractGeometryBatch` and refuses a windowed source.
+        //
+        // The sentinel it replaced (`captured.length === 0`) selected the
+        // same models and called the same method, so this is byte-equivalent
+        // to main. Pinned red-to-green for whoever fixes it engine-side.
+        mockIsFeatureEnabled.mockImplementation((name) => name === 'demandGeometry')
+        const ifcAPI = makeWindowedDemandAPI(0)
+        ifcAPI.StreamAllMeshes = jest.fn(() => {
+          throw new Error(
+            'ExtractGeometryBatch is synchronous and cannot page a windowed source')
+        })
+        const file = new Blob([new Uint8Array([1, 2, 3, 4])])
+        await expect(parseIfcWithConway(file, ifcAPI, undefined, undefined, jest.fn()))
+          .rejects.toThrow(/cannot page a windowed source/)
+        // It really did reach the sentinel rather than failing earlier.
+        expect(ifcAPI.StreamAllMeshes).toHaveBeenCalledTimes(1)
+        expect(warnSpy).toHaveBeenCalledWith(
+          expect.stringContaining('demand pump produced no batches'))
       })
 
       it('drops the stream when a windowed open falls back to a buffered one', async () => {


### PR DESCRIPTION
Part of bldrs-ai/conway#638 (and so of bldrs-ai/conway#635). **This is the Share half only** — the conway half is bldrs-ai/conway#657 (open draft), the pin bump to a conway carrying it is a separate step, and the joint three-spine measurement is still owed. So this deliberately carries no closing keyword.

Built on [#638's design comment](https://github.com/bldrs-ai/conway/issues/638#issuecomment-5455957015), not the issue body: the body says conway's `meshMap` replay backs Share's fallback, and it does not — Share's fallback fires only on an empty pump, which means conway opened the model non-deferred, where `streamAllMeshes` re-walks live natives. Re-traced against the pinned engine and confirmed.

> **Pin note.** This branch has merged `main`, so it now sits on conway **1.1575.649-gdeabdf16** (conway main with #654's eviction-timing fix, still **without** #657). Every pin-sensitive claim below was re-verified against that engine, and one of them changed — see "What the recapture improvement actually is".

## What this establishes

`parseIfcWithConway` accumulated every pumped `FlatMesh` into `captured` unconditionally. On the streaming path that array is dead weight — `onMeshBatch` has already assembled each batch into the durable `BatchedMesh` by the time the next one lands — and it is one of **three pointer spines over one shared 475 MB graph** (conway holds `meshMap` and `vectorFlatMesh`; this is Share's).

- **`captured` now accumulates only where nothing else takes delivery.**
- **The degraded end-of-load builds re-extract at the moment of failure** through a new `recapture()` accessor, instead of the parse holding the stream against the chance of a fallback that almost never runs.
- **The two readers that read the array rather than its contents move to a counter.** The permanent `[conwayDirect] demand pump: batches=… meshes=…` line (Share#1744) reports meshes actually delivered, and the empty-pump sentinel tests that counter. This is not cosmetic: reading `captured.length` after this change would mistake a healthy 150-mesh streaming load for a no-op pump and re-extract the whole model. The line gains `retained=yes|no`.
- **`STREAMING_CONSUMER: true` is declared on the deferred open**, inert on the pinned engine and activating conway#657's no-retention contract once the pin moves. Re-grepped on 1.1575.649: still absent, so still inert.

## What `recapture()` actually returns — equivalent, not identical

1. **Grouping.** On a deferred model the pinned `StreamAllMeshes` serves per-entity **full** FlatMeshes out of conway's `meshMap`, not the per-batch **delta** FlatMeshes the pump delivered. Same placement set, different bundling — benign for both readers here, since the merged and batched builds iterate placements and are indifferent to how they arrive, but a future consumer keyed on batch identity would care.
2. **Completeness under a budget.** `GEOMETRY_BUDGET_MB` is set on this path, and once conway has evicted anything its whole-model serve filters out placements whose natives were freed (`livePlacements`). So on a model large enough to evict, `recapture()` returns a strict **subset** of what was pumped.

### What the recapture improvement actually is (revised on the new pin)

An earlier revision of this PR claimed the filtered stream saved a degraded build from an **embind abort**, because the old pin's `getGeometry` cloned a freed native unguarded (the Sentry SHARE-1NK shape). **That claim is retired — conway#654, which arrived with this branch's `main` merge, fixed it engine-side.** On 1.1575.649 `getGeometry` probes `isNativeDeleted` and wraps the clone in a try/catch, degrading an evicted placement to a **dummy `IfcGeometry`** with a `[GetGeometry]` error rather than aborting. Share's `flatMeshToBufferGeometry` already skips a zero vertex/index geometry and counts it in `skippedPlacedGeometries`.

So on this pin **both routes render the same model** — the geometry is gone either way, because the native was freed. What the filtered re-extraction buys is **accounting, not pixels**: conway drops the placement before delivery and emits one aggregate warning naming instance and entity counts, where the retained route logs one `[GetGeometry]` error per evicted placement and surfaces the loss only as a `skippedPlacedGeometries` bump. Worth having, and small. It is no longer crash avoidance, and the residual on the windowed path is correspondingly milder than previously stated — noisier accounting, not a reachable abort.

## The re-extraction mechanism, and where it is not available

`recapture()` is the identity where the stream was retained, and a **memoised `StreamAllMeshes` capture** where it was dropped. Memoised because `buildBatchedConwayModel` and `buildConwayIfcModel` run in sequence and a second whole-model walk on a live model doubles every cached triangle count — the defect `IfcItemsMap.js` documents from the consumer side.

**Retention is kept in two states, and the second is the honest limitation of this PR.**

1. **No `onMeshBatch`** — `captured` *is* the delivery, not a copy of it.
2. **A windowed (store-backed) deferred open.** Re-verified on 1.1575.649: `streamAllMeshes` on a deferred model drains through the **synchronous** `extractGeometryBatch`, which throws `ExtractGeometryBatch is synchronous and cannot page a windowed source` outright when `model[0].isSourceExternal` (`compiled/src/compat/web-ifc/ifc_api_proxy_ifc.js:1509`, reached from the drain loop at `:2632` — line numbers refreshed, #654 moved them). `ExtractGeometryBatchAsync` cannot substitute: after a full drain its cursor is exhausted and there is no public rewind, and it remains the only async geometry entry point on the pin.

**This constraint is not lifted by conway#657.** Its `recaptureWholeModel_` hangs off the same `streamAllMeshes` drain loop, which that PR leaves calling the sync `extractGeometryBatch` — so its "a late whole-model ask still works" claim does not hold for windowed sources on either version.

**Nor is there a route around it.** The three whole-model entry points that do *not* refuse a windowed deferred model are all worse: `loadAllGeometry` and `streamAllMeshesWithTypes` have no deferred branch and seed coordination from `model[5]`, which a deferred open never writes, so every instance lands in an identity frame — silently mis-framed geometry, worse than a refusal; `getFlatMesh` is per-entity and needs an ID enumeration the loader does not have. This is recorded in the code so the next reader does not "discover" `LoadAllGeometry` as the escape hatch.

**Consequence:** a GitHub/OPFS-backed load takes the windowed open by default (`Loader.js` hands `parse` the `File` itself), so today this frees the stream on **buffered opens only** — not the large models that motivated #638. Post-pin-bump a windowed model is no worse than today, just no better.

## A pre-existing defect this change documents but does not fix

The empty-pump sentinel is reached whenever `pumpedMeshes === 0`, and that does **not** imply conway fell back to a classic open: the pump loop exits on `remaining === 0 && extracted === 0` whatever the reason, so a genuinely **deferred** model with nothing to extract — a properties-only IFC, or one whose every product failed geometry — lands there too. On a windowed source that model's one-shot `StreamAllMeshes` takes the deferred branch and refuses to page, throwing out of the load.

This is **byte-equivalent to `main`**: the sentinel it replaced (`captured.length === 0`) selected exactly the same models and called exactly the same method. A test pins the current rejection so an engine-side fix has a red-to-green. Not fixed here; being filed separately.

## What this only hopes

- **The bytes.** No memory number is claimed. Dropping one spine frees ~4.4 MB of the measured 475 MB, which is the *predicted* size of one 562,351-entry spine at 8 B — a confirmation of the model, not a result. The real figure needs all three spines dropped in one experiment on a Share build against a conway carrying #657, and is owed by the joint measurement.
- **That the flag does anything yet.** On this pin it is a dropped unknown key.
- **That the windowed half lands.** It does not, here.

## Falsifiability evidence

Four targeted reverts, each observed red.

**Revert A — restore the unconditional `captured.push(...batch)`.** 3 failed / 44 passed. Two tests fail on `expect(result.captured).toHaveLength(0)` — received 150 and 20.

**Revert B — point the boundary log and the sentinel back at `captured.length`.** 4 failed / 43 passed, and these are the two silent regressions named in #638's verification section:
```
counter fidelity:  Expected substring: "meshes=150"
                   Received string:    "…demand pump: batches=3 meshes=0 onMeshBatch=yes … retained=no"
sentinel misfire:  StreamAllMeshes — Expected number of calls: 0
                                     Received number of calls: 1
```
The second is a *healthy* 150-mesh streaming load being mistaken for an empty pump and re-extracted whole.

**Revert C — point the degraded builds back at `captured`.** 5 of 6 fail in `ShareIfcLoader.degraded.test.js`: every degraded build receives `[]` instead of the 3-mesh stream. That is the render-nothing regression. The healthy-path test still passes, so it pins the fallback specifically.

**Revert D — never increment `pumpedMeshes`.** 6 failed / 42 passed, confirming the counter assertions on the *retained* branch are falsifiable too (where `captured.length` would coincidentally agree).

One test is deliberately **not** falsifiable against this diff: "surfaces the engine refusal when a DEFERRED windowed model pumps nothing" characterises pre-existing behaviour, and exists so the engine-side fix has a red-to-green. It is non-vacuous — it also asserts the sentinel was actually reached (`StreamAllMeshes` called once, warning emitted).

## Numbers

- **Baseline on the untouched tree at `620af58`:** `yarn lint` clean; `yarn test` **258 suites / 2644 tests** — 2639 passed, 5 skipped, exit 0.
- **After, on the merged tree at conway 1.1575.649:** `yarn lint` clean; `yarn test` **259 suites / 2662 tests** — 2657 passed, 5 skipped, 13 snapshots, exit 0. `+1 suite, +18 tests`, nothing pre-existing red. The husky gate ran this on the merged tree.
- **Pre-flip validation** (run before the merge, on 1.1565.608): `yarn build-prod` exit 0; `yarn test-ci` exit 0 with coverage thresholds enforced; Playwright `conwayDirect.spec.ts` + `indexStepLogo.spec.ts` + `loadTiming.spec.ts` — **13 passed**, including a real GitHub-sourced IFC load through the demand pump that streamed and assembled normally (`Geometry: 0.250s`, `vertices=5689 triangles=3326`). Gated CI re-runs these against the new pin on this push.
- `package.json`'s build version stamp was restored each time; the tree is clean.

## Expectations legitimately changed (rubric #9)

- `conwayDirectIfcLoader.test.js` "opens deferred and pumps batches to completion" asserted `captured` had 150 with an `onMeshBatch` present. That is now 0 by design; the assertion was inverted and re-commented.
- `CadView.test.jsx`'s module double for `conwayDirectIfcLoader` returned `{modelID, captured}` and now returns `recapture` too. **This was a real caught defect, not a mechanical update:** the stale double made `ShareIfcLoader#parse` throw `recapture is not a function`, failing two CadView tests. It reproduced in isolation and passed on the untouched tree, so causation was confirmed before it was fixed. Every production return site carries `recapture`; no defensive `?? captured` was added, because that would convert exactly this class of bug into a silently empty model.
- The `GEOMETRY_BUDGET_MB` docstring predicted #654's copy-window fix as pending. It has landed, so the note now records it as closed on this pin rather than leaving a reader waiting for it. Pre-existing text, corrected because the merge made it false.

## Tests

`src/viewer/ifc/conwayDirectIfcLoader.test.js` — 12 new: the flag on the deferred open and its absence on the classic one; counter fidelity with zero retention *and* on the retained branch; retention where nothing takes delivery; retention on a windowed open whose `StreamAllMeshes` is stubbed with the real engine message (asserted never called); the drop when a windowed open falls back to buffered; on-demand re-extraction and its memoisation; the sentinel served off the counter; a genuinely empty pump still recovering with an `onMeshBatch` present; the deferred-windowed empty pump's current rejection; and `recapture` as the identity on the classic path.

`src/viewer/ifc/ShareIfcLoader.degraded.test.js` — 6 new, one per degraded path (`builder === null`, `!hasContent()`, `finalize()` throwing), the `batchedMesh` fallback, both fallbacks in sequence, and the healthy path asserting the accessor is **never** called — because re-extraction on every load would just trade retention for a whole-model re-walk.

## Review focus (the load-bearing claims to attack)

- **Fallback correctness on windowed sources.** The central claim: a windowed deferred model cannot serve a post-pump whole-model re-read on this pin *or* after conway#657, so retention there is necessary rather than timid. Evidence is `ifc_api_proxy_ifc.js:1509` and the unchanged drain loop in #657's diff. **Attack:** is there a path I missed — a rewind, an async whole-model entry, a `getFlatMesh` route that does not reach the sync pump?
- **Is `windowedSource` inferred correctly?** It is set from Share's own successful `OpenModelStream(store, …)` rather than asked of the engine, because `sourceIsExternal` is a proxy getter not exposed through the `IfcApi` shim. I argue nothing later flips it — `spillModelSource` runs from the GLB writer's `finally`, long after `parse` returns. Break that ordering claim and the retention decision is wrong for the window that matters.
- **Counter fidelity of the boundary log.** `pumpedMeshes` is incremented in the same branch that used to push, so it should equal the old `captured.length` exactly. Worth reading for an early `continue` or a batch counted twice.
- **Empty-pump sentinel preservation.** The sentinel moved from `captured.length === 0` to `pumpedMeshes === 0` and its branch now returns early with unconditional retention. The claim is that this is byte-equivalent in model selection, including for the deferred-windowed case documented above.
- **The revised improvement claim.** I now assert the filtered re-extraction buys accounting rather than pixels on this pin, because #654 made `getGeometry` degrade instead of abort and `flatMeshToBufferGeometry` already skips the dummy. If a dummy geometry can reach a consumer that does *not* skip it, that claim is too weak and the improvement is larger than stated.
- **The diagnostics.** `ifcItemsMapParity` and the instancing analysis now cost a real whole-model re-read on a dropped stream. I judged that better than reporting zeros that look like a finding, and gated the instancing one behind a thunk so a closed gate pays nothing.
- **`#1798`/`#1799`'s semantics are untouched.** `incrementalBatchedBuilder.js` is not in this diff at all; the staged boundary reads, `failedThisBatch` vs `badGeometry`, and `seenPlacements.add` ordering are unchanged, and the merge of `main` was clean (`package.json` + `yarn.lock` only).

## Sequencing

conway#657 publishes; then Share's pin bump to a conway carrying it; then the joint three-spine measurement. bldrs-ai/conway#638 stays open.