### PR TITLE
Bump conway to 1.1578.666-g39d59784, activating STREAMING_CONSUMER

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@babel/plugin-syntax-import-assertions": "7.18.6",
     "@babel/preset-env": "7.18.10",
     "@babel/preset-react": "7.18.6",
-    "@bldrs-ai/conway": "1.1575.649-gdeabdf16",
+    "@bldrs-ai/conway": "1.1578.666-g39d59784",
     "@bldrs-ai/ifclib": "5.3.3",
     "@emotion/react": "11.10.0",
     "@emotion/styled": "11.10.0",

--- a/src/viewer/ifc/IfcItemsMap.js
+++ b/src/viewer/ifc/IfcItemsMap.js
@@ -284,13 +284,13 @@ export function itemsMapFromOrderedRanges(ranges, opts = {}) {
  * is no prior walk to collide with.
  *
  * conway#657 closes this at the source for models opened with
- * `STREAMING_CONSUMER` (which `conwayDirectIfcLoader` now declares on every
- * deferred open): there is no cache for the walk to re-push into, so
- * conway's own re-walk clears and rebuilds instead of appending and the
- * second call returns what the first did. It stays true on the pinned
- * engine and on every non-streaming open, so this entry point is not going
- * away — but a doubling seen after the pin bump is a bug rather than the
- * documented behaviour.
+ * `STREAMING_CONSUMER` (which `conwayDirectIfcLoader` declares on every
+ * deferred open, and which this pin now carries): there is no cache for the
+ * walk to re-push into, so conway's own re-walk clears and rebuilds instead
+ * of appending and the second call returns what the first did. Doubling
+ * still happens on every non-streaming open, so this entry point is not
+ * going away — but a doubling seen on a `STREAMING_CONSUMER` open is now a
+ * bug rather than the documented behaviour.
  *
  * @param {object|Array} flatMeshes FlatMesh source (size()/get(i) or Array)
  * @param {object} api Conway-compatible IfcAPI (needs GetGeometry)

--- a/src/viewer/ifc/conwayDirectIfcLoader.js
+++ b/src/viewer/ifc/conwayDirectIfcLoader.js
@@ -169,11 +169,10 @@ export async function parseIfcWithConway(
       // pointers, because the other holders keep the 475 MB graph alive.
       // This is the Share half of that; conway's is the flag's other end.
       //
-      // Ignored as an unknown key by the pinned engine (verified: no
-      // `STREAMING_CONSUMER` in node_modules/@bldrs-ai/conway), so it is
-      // inert until the pin bumps past conway#657 and then activates the
-      // no-retention contract with no further change here. Ordering
-      // against that bump therefore does not matter.
+      // Live on this pin (conway#657 landed at 1.1578.666-g39d59784):
+      // conway now honours `STREAMING_CONSUMER` and keeps no reference to
+      // the pumped stream, so the no-retention contract above is in effect
+      // with no further change needed here.
       STREAMING_CONSUMER: true,
     }
     if (onPreviewMesh) {
@@ -231,11 +230,11 @@ export async function parseIfcWithConway(
     //      drains through the SYNCHRONOUS `ExtractGeometryBatch` — and that
     //      throws outright on a windowed source ("ExtractGeometryBatch is
     //      synchronous and cannot page a windowed source", pinned engine
-    //      `compiled/src/compat/web-ifc/ifc_api_proxy_ifc.js:1509`, reached
-    //      from `streamAllMeshes`' deferred drain loop at `:2632`).
+    //      `compiled/src/compat/web-ifc/ifc_api_proxy_ifc.js:1527`, reached
+    //      from `streamAllMeshes`' deferred drain loop at `:2771`).
     //      conway#657 does
-    //      not change that: its re-walk hangs off the same drain, and there
-    //      is no async whole-model entry point on either version.
+    //      not change that: its re-walk (`recaptureWholeModel_`) hangs off
+    //      the same drain, and there is no async whole-model entry point.
     //      `ExtractGeometryBatchAsync` cannot substitute — after a full
     //      drain its cursor is exhausted and there is no public rewind.
     //      So on a windowed open there is nothing to re-extract WITH, and
@@ -392,7 +391,8 @@ export async function parseIfcWithConway(
       // frame — silently mis-framed geometry, worse than a refusal; and
       // `getFlatMesh` is per-entity and would need an ID enumeration this
       // loader does not have. conway#657 routes the first and third through
-      // `streamAllMeshes` so they refuse properly after the pin bump.
+      // `streamAllMeshes`, and this pin carries that fix, so they now refuse
+      // properly instead of silently mis-framing.
       //
       // No onMeshBatch here: extraction is already complete, so a
       // preview would just double the geometry conversion right before

--- a/src/viewer/ifc/conwayDirectIfcLoader.test.js
+++ b/src/viewer/ifc/conwayDirectIfcLoader.test.js
@@ -392,10 +392,10 @@ describe('viewer/ifc/conwayDirectIfcLoader', () => {
       }
 
       it('declares STREAMING_CONSUMER on the deferred open', async () => {
-        // Inert on the pinned engine (an unknown setting is dropped); after
-        // the pin bumps past conway#657 it is what stops conway retaining
-        // the other two spines. Share must send it either way — the two
-        // halves land independently.
+        // Live on this pin (conway#657, 1.1578.666-g39d59784): this is what
+        // stops conway retaining the other two spines. Jest mocks the
+        // engine, so this test only asserts Share sends the setting — the
+        // engine-side contract is verified against the real pin separately.
         mockIsFeatureEnabled.mockImplementation((name) => name === 'demandGeometry')
         const ifcAPI = makeDemandAPI(10)
         await parseIfcWithConway(new ArrayBuffer(4), ifcAPI)
@@ -450,12 +450,12 @@ describe('viewer/ifc/conwayDirectIfcLoader', () => {
 
       it('retains the stream on a WINDOWED open, where re-extraction throws', async () => {
         // Verified against the pinned engine
-        // (compiled/src/compat/web-ifc/ifc_api_proxy_ifc.js:1482):
+        // (compiled/src/compat/web-ifc/ifc_api_proxy_ifc.js:1527):
         // `streamAllMeshes` on a deferred model drains through the
         // SYNCHRONOUS `ExtractGeometryBatch`, which refuses a windowed
         // source outright. conway#657 does not change that — its re-walk
-        // hangs off the same drain — so there is nothing to re-extract with
-        // here and the contents must be kept.
+        // (`recaptureWholeModel_`) hangs off the same drain — so there is
+        // nothing to re-extract with here and the contents must be kept.
         mockIsFeatureEnabled.mockImplementation((name) => name === 'demandGeometry')
         const ifcAPI = makeWindowedDemandAPI(20)
         ifcAPI.StreamAllMeshes = jest.fn(() => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2473,10 +2473,10 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@bldrs-ai/conway@1.1575.649-gdeabdf16":
-  version "1.1575.649-gdeabdf16"
-  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.1575.649-gdeabdf16.tgz#b623303a393a6f00b2dc39b3fed2c0f362d46249"
-  integrity sha512-gJymVIhsj9fXxvqjG5U/n9lccXPpOfGTJK8jDWsXYL6dOrbbl3xpiqbbkoZy6eIMgds6lfa4wUUd4EJFrOZDyQ==
+"@bldrs-ai/conway@1.1578.666-g39d59784":
+  version "1.1578.666-g39d59784"
+  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.1578.666-g39d59784.tgz#81958dd7cd26c4906107671c17408588d3405fef"
+  integrity sha512-+5Cu1be+joFGzgQc23TZCyOiFryTYjxVtrhg83ahZN2/btZuZrGtprAf5dL9HflGNSH39RQOcDWHWLzfL4TLrw==
   dependencies:
     gl-matrix "3.4.3"
     seedrandom "3.0.5"


### PR DESCRIPTION
## What this bump carries

`@bldrs-ai/conway` `1.1575.649-gdeabdf16` → `1.1578.666-g39d59784` (npm latest; version chain `deabdf16 → 8f0c3963 → fa964db6 → 39d59784`, nothing else in between).

1. **conway#657 — `STREAMING_CONSUMER` activates for the first time on Share's pin.** #1800 declared `STREAMING_CONSUMER: true` in `conwayDirectIfcLoader.js`'s `deferSettings` while the pinned engine didn't understand the key (an inert unknown setting). This pin is the first to carry conway#657, so the no-retention contract is now live: a `STREAMING_CONSUMER` deferred open keeps no reference to the meshes the pump delivers (this loader's `captured`/`recapture` spine is the sole owner), and `loadAllGeometry`/`getFlatMesh` on such a model now route through `streamAllMeshes`'s re-walk instead of silently mis-framing from `model[5]`.
2. Two conway-geom fixes that can legitimately shift vertex/triangle counts on curved models: **#655** (closed-trim b-spline re-seed) and **#666** (wrong-sheet inverse solve recovery).

## Comments updated

Reworded the "inert until the pin bumps past conway#657" comments in `conwayDirectIfcLoader.js`, `conwayDirectIfcLoader.test.js`, and `IfcItemsMap.js` to state the pin now carries the contract, and refreshed the `ifc_api_proxy_ifc.js` line-number citations that moved in the new build (`:1509`→`:1527`, `:2632`→`:2771`).

## Verification — the flag's first contact with the real engine

- `yarn lint`: clean.
- `yarn test`: **259 suites / 2662 tests — 2657 passed, 5 skipped, 13 snapshots** — identical to the pre-bump baseline (Jest mocks the engine, so this was expected to be unaffected).
- `yarn build-prod`: succeeded.
- `yarn test-ci`: same counts as `yarn test` above, coverage thresholds met.
- `yarn test-flows --workers=1` on the three specs from #1800 (`src/loader/conwayDirect.spec.ts`, `src/Containers/indexStepLogo.spec.ts`, `src/viewer/loadTiming.spec.ts`): **13/13 passed.** `demandGeometry` is default-on, so every one of these already exercises the demand pump under `STREAMING_CONSUMER` against the real engine — no test needed a flag override.
- Captured the `[conwayDirect] demand pump:` boundary log directly against the built `docs/` bundle to confirm the flag's real-engine behavior:
  - `index.ifc` (buffered/resident open): `demand pump: batches=1 meshes=7 onMeshBatch=yes onPreviewMesh=yes retained=yes`, parsed `vertices=168 triangles=84 instances=7 parents=7 materials=1`.
  - GitHub-hosted `171210AISC_Sculpture_param.ifc` (the `loadTiming.spec.ts` fixture): `demand pump: batches=59 meshes=343 onMeshBatch=yes onPreviewMesh=yes retained=yes`, parsed `vertices=5689 triangles=3326 instances=539 parents=343 materials=1` — identical vertex/triangle counts across desktop, mobile, and CPU-throttled variants in the Playwright run, with no console errors and no progressive-render-then-geometry-loss at end-of-load.

No count needed re-blessing: nothing in the exercised fixtures (index.ifc, the sculpture model) hit a curved/trimmed-surface path that #655/#666 touch, and the vertex/triangle counts above matched across every repeated run.

`package.json`'s `version` field is restored to main's value (`tools/updateVersion.mjs` stamps it on every build; only the `@bldrs-ai/conway` dependency line and `yarn.lock` carry the real change).

Part of bldrs-ai/conway#638.


---
_Generated by [Claude Code](https://claude.ai/code/session_01ScPZ6RarXvYmSdz6BUXF78)_