### PR TITLE
Bump @bldrs-ai/conway to 1.1582.673 — NIST AP242 PMI crash fix + tessellated part geometry

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@babel/plugin-syntax-import-assertions": "7.18.6",
     "@babel/preset-env": "7.18.10",
     "@babel/preset-react": "7.18.6",
-    "@bldrs-ai/conway": "1.1578.666-g39d59784",
+    "@bldrs-ai/conway": "1.1582.673-g12d12550",
     "@bldrs-ai/ifclib": "5.3.3",
     "@emotion/react": "11.10.0",
     "@emotion/styled": "11.10.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2473,10 +2473,10 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@bldrs-ai/conway@1.1578.666-g39d59784":
-  version "1.1578.666-g39d59784"
-  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.1578.666-g39d59784.tgz#81958dd7cd26c4906107671c17408588d3405fef"
-  integrity sha512-+5Cu1be+joFGzgQc23TZCyOiFryTYjxVtrhg83ahZN2/btZuZrGtprAf5dL9HflGNSH39RQOcDWHWLzfL4TLrw==
+"@bldrs-ai/conway@1.1582.673-g12d12550":
+  version "1.1582.673-g12d12550"
+  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.1582.673-g12d12550.tgz#8ad51a66183dcdc2d9e4e83956d17ef3210389cb"
+  integrity sha512-+l2ebAXArtBCYh1Vz14FBW2K4up3PhR+JTsw3Sv1J40cNknj9/ZUOor99BbFjC3urRwJaU3ZcCf61J84BSpCsg==
   dependencies:
     gl-matrix "3.4.3"
     seedrandom "3.0.5"


### PR DESCRIPTION
Engine bump `1.1578.666-g39d59784` → `1.1582.673-g12d12550`, releasing two conway fixes for the NIST AP242 PMI STEP corpus:

- **[conway#671](https://github.com/bldrs-ai/conway/pull/671)** — the AP214 property walk (which AP242 files route through) no longer throws on AP242-only PMI entities, so `getSpatialStructure` survives and the NavTree builds. Previously 16 of the 17 models in `test-models/step/nist/NIST-PMI-STEP-Files/` rendered their geometry and then popped "Could not read full model structure. Only model geometry will be available." over it. Fixes [bldrs-ai/test-models#61](https://github.com/bldrs-ai/test-models/issues/61).
- **[conway#673](https://github.com/bldrs-ai/conway/pull/673)** — AP242 tessellated part geometry (`TESSELLATED_SOLID` / `COMPLEX_TRIANGULATED_FACE` / `COORDINATES_LIST`) renders; `nist_ftc_08_asme1_ap242-e1-tg.stp` goes from an empty viewport to its 3,368-triangle plate. Fixes [bldrs-ai/test-models#62](https://github.com/bldrs-ai/test-models/issues/62).

Also picks up conway-geom bumps conway#666/conway#668 (wrong-sheet inverse-solve recovery; ribbon-sweep chain side), which conway's visual-diff measured below the 0.05% pixel threshold against the previously published engine.

Diff is `package.json` + `yarn.lock` only. The pre-commit gate (eslint + typecheck + Jest) passed on the new engine locally; both conway PRs went through the full conway lifecycle (codex review + fix round, smoke regression, visual diff) before merging. Verified engine-side over the whole NIST directory via the web-ifc compat shim: all 17 models stream geometry and build their spatial structure; `as1-oc-214.stp` control unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PPEuMhqtyVjAeGoKJDbGAB

---
_Generated by [Claude Code](https://claude.ai/code/session_01PPEuMhqtyVjAeGoKJDbGAB)_