### PR TITLE
conway#660: drop windowed retention through the async whole-model ask, feature-detected

### DIFF
--- a/src/Containers/CadView.test.jsx
+++ b/src/Containers/CadView.test.jsx
@@ -50,8 +50,24 @@ jest.mock('../search/SearchIndex')
 // stream, so it — not `captured` — is what the degraded end-of-load builds
 // read. A double that omits it makes `ShareIfcLoader#parse` throw
 // "recapture is not a function" on the fallback path.
+//
+// ASYNC, matching the real seam (conway#660): `recapture()` returns a
+// Promise on every path, because a windowed re-extraction pages bytes off
+// the byte store and cannot be synchronous. The sync form passed only
+// because `await` normalises a plain array.
+//
+// Stated precisely, because the obvious stronger claim is false: making
+// this double async does NOT give this file a dropped-`await` detector.
+// Measured — with the `await` removed from the merged degraded build, this
+// whole file stays green either way, because the `buildConwayIfcModel`
+// double below ignores its argument entirely and hands back the harness
+// singleton. What guards that call site is
+// `ShareIfcLoader.degraded.test.js`, whose builder doubles assert on the
+// meshes they receive. This double is here to stop a fixture from
+// contradicting the contract it stands in for, not to catch a regression.
 jest.mock('../viewer/ifc/conwayDirectIfcLoader', () => ({
-  parseIfcWithConway: () => ({modelID: 0, captured: [], recapture: () => []}),
+  // eslint-disable-next-line require-await
+  parseIfcWithConway: () => ({modelID: 0, captured: [], recapture: async () => []}),
   decorateConwayDirectIfcModel: () => {},
 }))
 jest.mock('../viewer/ifc/buildConwayIfcModel', () => ({

--- a/src/viewer/ifc/ShareIfcLoader.degraded.test.js
+++ b/src/viewer/ifc/ShareIfcLoader.degraded.test.js
@@ -145,7 +145,14 @@ describe('viewer/ifc/ShareIfcLoader degraded end-of-load builds (conway#638)', (
     // does. Without that the loader's `builder` would stay null for every
     // case, and the three degraded paths this file separates would collapse
     // into one.
-    recapture = jest.fn(() => PUMPED)
+    // ASYNC on purpose, matching the real seam (conway#660): on a windowed
+    // source the re-extraction pages the byte window through
+    // `StreamAllMeshesAsync`, so `recapture()` returns a Promise on every
+    // path. A sync stub here would let a call site that dropped its `await`
+    // pass — the builders would receive an array either way — which is
+    // exactly the regression this file exists to catch.
+    // eslint-disable-next-line require-await
+    recapture = jest.fn(async () => PUMPED)
     parseIfcWithConway.mockImplementation(
       // eslint-disable-next-line require-await
       async (buffer, api, settings, onProgress, onMeshBatch) => {
@@ -290,9 +297,13 @@ describe('viewer/ifc/ShareIfcLoader degraded end-of-load builds (conway#638)', (
     expect(buildBatchedConwayModel.mock.calls[0][0]).toEqual(PUMPED)
     expect(buildConwayIfcModel.mock.calls[0][0]).toEqual(PUMPED)
     // Every array handed out is the one object the accessor memoises, so
-    // the two builds cannot be reading different re-extractions.
+    // the two builds cannot be reading different re-extractions. Each
+    // recorded result is the accessor's Promise, so resolve before
+    // comparing — `toBe` on the Promises themselves would pass on the
+    // memoised seam and equally on a broken one that re-drove the engine
+    // and happened to return the same array.
     for (const result of recapture.mock.results) {
-      expect(result.value).toBe(PUMPED)
+      expect(await result.value).toBe(PUMPED)
     }
   })
 })

--- a/src/viewer/ifc/ShareIfcLoader.degraded.test.js
+++ b/src/viewer/ifc/ShareIfcLoader.degraded.test.js
@@ -278,6 +278,46 @@ describe('viewer/ifc/ShareIfcLoader degraded end-of-load builds (conway#638)', (
     expect(buildBatchedConwayModel).not.toHaveBeenCalled()
   })
 
+  it('fails the load loudly when the whole-model ask rejects', async () => {
+    // conway#660/#672: on a windowed source `recapture()` drives
+    // `StreamAllMeshesAsync`, which THROWS rather than serving an empty
+    // model when a `GEOMETRY_BUDGET_MB` eviction freed everything the
+    // re-walk needs. That rejection has to end the load, not be absorbed
+    // into a blank scene reported as success — the failure mode that costs
+    // a user their file.
+    //
+    // The chain is worth naming because only half of it propagates. The
+    // FIRST degraded `await recapture()` sits inside the batchedMesh
+    // branch's try/catch, so a rejection there is swallowed into
+    // fall-through (correctly — that branch's contract is "never break a
+    // load"); it is the SECOND, unguarded await feeding the merged build
+    // that carries the failure out. This runs with `batchedMesh` off, which
+    // is the shipped default, so it exercises that unguarded await
+    // directly.
+    //
+    // "Loudly" is `ShareIfcLoader#parse`'s documented error contract, not a
+    // rejection: it catches, stashes `ifcLastError`, calls `onError` and
+    // returns null (re-throwing only on OOM, so `Loader.js#readModel` can
+    // show the tailored message). What must never happen is a model
+    // reaching the scene.
+    IncrementalBatchedBuilder.mockImplementation(() => {
+      throw new Error('builder construction failed')
+    })
+    const evicted = new Error(
+      'StreamAllMeshesAsync: this model was opened with STREAMING_CONSUMER, ' +
+      'and the re-walk resolved none of the model')
+    recapture.mockRejectedValue(evicted)
+    const onError = jest.fn()
+    const model = await loader.parse(new ArrayBuffer(4), jest.fn(), onError)
+    expect(model).toBeNull()
+    expect(onError).toHaveBeenCalledWith(evicted)
+    expect(loader.ifcLastError).toBe(evicted)
+    // The load is over, and nothing was added to the scene — no partial or
+    // empty model presented as a successful one.
+    expect(ifc.addIfcModel).not.toHaveBeenCalled()
+    expect(buildConwayIfcModel).not.toHaveBeenCalled()
+  })
+
   it('serves both fallbacks off the accessor when they run in sequence', async () => {
     // `buildBatchedConwayModel` throwing falls through to
     // `buildConwayIfcModel`, so both degraded builds run in one load. Each

--- a/src/viewer/ifc/ShareIfcLoader.js
+++ b/src/viewer/ifc/ShareIfcLoader.js
@@ -55,18 +55,23 @@ import debug, {DEBUG, WARN, isLogEnabled} from '../../utils/debug'
  *
  * @param {object} ifcAPI Conway IfcAPI bound to the model
  * @param {number} modelID
- * @param {Function} getCaptured returns the parse's whole FlatMesh stream.
- *   A thunk rather than the array because on the streaming path
- *   (conway#638) producing it costs a whole-model re-extraction, and that
- *   must not be paid by the loads this gate turns away.
+ * @param {Function} getCaptured async thunk returning the parse's whole
+ *   FlatMesh stream. A thunk rather than the array because on the streaming
+ *   path (conway#638) producing it costs a whole-model re-extraction, and
+ *   that must not be paid by the loads this gate turns away; async because
+ *   on a windowed source that re-extraction pages the window through
+ *   conway#660's `StreamAllMeshesAsync` (see `makeRecapture`).
  * @param {boolean} [force] log at info level regardless of verbosity
+ * @return {Promise<void>} resolves once the probe has logged or been gated
+ *   away — awaited by the caller only to keep the load log's line order
+ *   deterministic, not because anything depends on the result
  */
-function logInstancedModelStats(ifcAPI, modelID, getCaptured, force = false) {
+async function logInstancedModelStats(ifcAPI, modelID, getCaptured, force = false) {
   if (!force && !isLogEnabled(DEBUG)) {
     return
   }
   try {
-    const {stats} = flatMeshToInstancedModel(getCaptured(), ifcAPI, modelID)
+    const {stats} = flatMeshToInstancedModel(await getCaptured(), ifcAPI, modelID)
     const reduction = stats.vertexReductionRatio.toFixed(2)
     const line =
       `[instancedMeshes] modelID=${modelID} — ` +
@@ -93,6 +98,9 @@ function logInstancedModelStats(ifcAPI, modelID, getCaptured, force = false) {
  * @typedef {object} ConwayIfcAPI Conway-compatible IfcAPI handle.
  * @property {Function} OpenModel Open an IFC model from a Uint8Array.
  * @property {Function} StreamAllMeshes Stream FlatMeshes for a modelID.
+ * @property {Function} [StreamAllMeshesAsync] conway#660: the async twin,
+ *   and the only whole-model ask a windowed deferred model can answer.
+ *   Absent on pins predating it — feature-detect, never assume.
  * @property {Function} GetCoordinationMatrix Get the coord matrix.
  * @property {Function} getStatistics Per-load load statistics.
  * @property {Function} getConwayVersion Conway engine version string.
@@ -419,7 +427,15 @@ export default class ShareIfcLoader {
       // stream — `onMeshBatch` above already assembled each batch into the
       // durable model — so the fallbacks re-extract at the moment of
       // failure rather than the parse holding 475 MB against the chance of
-      // one (conway#638). It is the identity where the stream was retained.
+      // one (conway#638). It is the identity where the stream was retained,
+      // which after conway#660 is only "no onMeshBatch" plus a windowed open
+      // on an engine pin without `StreamAllMeshesAsync`.
+      //
+      // ALWAYS AWAIT IT. The accessor returns a Promise on every path
+      // (`makeRecapture` explains why it is uniform rather than a union):
+      // on a windowed source the re-extraction pages the byte window, so it
+      // cannot be synchronous, and a missed `await` would feed a Promise to
+      // a builder that iterates placements — an empty model, silently.
       const {modelID, recapture} =
         await parseIfcWithConway(buffer, ifcAPI, undefined, onProgress, onMeshBatch, onPreviewMesh)
 
@@ -454,7 +470,7 @@ export default class ShareIfcLoader {
       // path on any construction error so the flag can never break a load.
       if (ifcModel === undefined && isFeatureEnabled('batchedMesh')) {
         try {
-          const batched = buildBatchedConwayModel(recapture(), ifcAPI, modelID, {scene})
+          const batched = buildBatchedConwayModel(await recapture(), ifcAPI, modelID, {scene})
           ifcModel = batched.model
           buildStats = batched.stats
         } catch (e) {
@@ -462,7 +478,7 @@ export default class ShareIfcLoader {
         }
       }
       if (ifcModel === undefined) {
-        const merged = buildConwayIfcModel(recapture(), ifcAPI, modelID)
+        const merged = buildConwayIfcModel(await recapture(), ifcAPI, modelID)
         ifcModel = merged.mesh
         buildStats = merged.stats
         decorateConwayDirectIfcModel(ifcModel, ifcAPI, modelID, {scene})
@@ -575,7 +591,7 @@ export default class ShareIfcLoader {
       // conway-side double-count `IfcItemsMap.js` documents, so treat a
       // parity diff taken this way with that caveat.
       if (isFeatureEnabled('ifcItemsMapParity')) {
-        runIfcItemsMapParityCheck(ifcAPI, ifcModel, recapture())
+        runIfcItemsMapParityCheck(ifcAPI, ifcModel, await recapture())
       }
       // Instanced-rendering analysis: groups the captured stream by shared
       // `geometryExpressID` and reports the GPU-instancing draw-call +
@@ -584,7 +600,7 @@ export default class ShareIfcLoader {
       // numbers alongside what just rendered as a BatchedMesh. Passed as a
       // thunk so the recapture happens only if the gate inside actually
       // opens.
-      logInstancedModelStats(ifcAPI, modelID, recapture, isFeatureEnabled('batchedMesh'))
+      await logInstancedModelStats(ifcAPI, modelID, recapture, isFeatureEnabled('batchedMesh'))
       // Always-on integration-boundary log. `conwayDirect.spec.ts`
       // (and the deploy-preview smoke checks) gate on `[conwayDirect]
       // parsed modelID=…` firing — it's the single observable signal

--- a/src/viewer/ifc/conwayDirectIfcLoader.js
+++ b/src/viewer/ifc/conwayDirectIfcLoader.js
@@ -368,17 +368,23 @@ export async function parseIfcWithConway(
     // indistinguishable without this line (Share#1744). console.info,
     // not debug() — debug() no-ops unless the level is raised.
     //
-    // `wholeModelAsk` reports which regime the engine put this load in
-    // (conway#660): `async` means the windowed drop is live, `sync` that the
-    // pin predates the async ask. It is how a production PSB trace says
-    // which side of the pin bump it measured without reading the version.
+    // `asyncAsk` reports the ENGINE's capability, not the entry point this
+    // load would drive (conway#660): `yes` means the pin carries
+    // `StreamAllMeshesAsync`, which is what makes the windowed drop
+    // possible. It is deliberately not "which ask ran" — nothing has run
+    // yet at this point, and on a BUFFERED open `asyncAsk=yes` still drives
+    // the sync ask, because the async one is wired only where the sync one
+    // cannot serve. The entry point actually driven is named by the
+    // `recaptured N mesh(es) via …` line, and only a degraded build emits
+    // one. Read together they say which side of a pin bump a production
+    // trace measured, without anyone reading a version string.
     // eslint-disable-next-line no-console
     console.info(
       `[conwayDirect] demand pump: batches=${pumpedBatches} ` +
       `meshes=${pumpedMeshes} onMeshBatch=${onMeshBatch ? 'yes' : 'no'} ` +
       `onPreviewMesh=${onPreviewMesh ? 'yes' : 'no'} ` +
       `windowed=${windowedSource ? 'yes' : 'no'} ` +
-      `wholeModelAsk=${hasAsyncWholeModelAsk ? 'async' : 'sync'} ` +
+      `asyncAsk=${hasAsyncWholeModelAsk ? 'yes' : 'no'} ` +
       `retained=${retainCaptured ? 'yes' : 'no'}`)
     if (pumpedMeshes === 0) {
       // Nothing pumped: conway fell back to a classic fully-extracted

--- a/src/viewer/ifc/conwayDirectIfcLoader.js
+++ b/src/viewer/ifc/conwayDirectIfcLoader.js
@@ -22,6 +22,8 @@
 //     `captured` is the retained FlatMesh stream and is EMPTY on the
 //     streaming path (see `parseIfcWithConway`'s retention note);
 //     `recapture()` is the whole-model accessor degraded readers use.
+//     It ALWAYS returns a Promise — see `makeRecapture` for why the
+//     seam is uniform rather than "array here, promise there".
 //   - `decorateConwayDirectIfcModel(ifcModel, ifcAPI, modelID, opts)`
 //     Post-build decoration: BVH, IfcInstanceMap, capability flips,
 //     subset method, property + spatial method closures. Runs on a
@@ -94,7 +96,9 @@ import {instanceMapFromGeometry} from './IfcInstanceMap'
  *   on the `demandGeometry` deferred path) so callers can render
  *   progressively. Passing it makes the caller the OWNER of the stream:
  *   `captured` then stays empty and degraded readers must go through
- *   `recapture()` — see the retention note in the body (conway#638).
+ *   `recapture()` — see the retention note in the body (conway#638),
+ *   which also covers the one case that still keeps the contents (an
+ *   engine pin without `StreamAllMeshesAsync` on a windowed open).
  * @param {Function} [onPreviewMesh] demand/tiled slice A2: receives
  *   conway PreviewMeshPayloads WHILE THE PARSE RUNS (self-contained
  *   copied geometry, preview quality — openings/materials can be
@@ -102,7 +106,7 @@ import {instanceMapFromGeometry} from './IfcInstanceMap'
  *   `demandGeometry` deferred path with engines that support
  *   ON_PREVIEW_MESH; silently ignored otherwise.
  * @return {Promise<{modelID: number, captured: Array,
- *   recapture: Function}>}
+ *   recapture: function(): Promise<Array>}>}
  */
 export async function parseIfcWithConway(
   buffer, ifcAPI, settings = undefined, onProgress = undefined, onMeshBatch = undefined, onPreviewMesh = undefined) {
@@ -212,41 +216,70 @@ export async function parseIfcWithConway(
       throw new Error(`parseIfcWithConway: OpenModel returned ${modelID}`)
     }
     const captured = []
-    // Retention decision (conway#638). `captured` used to accumulate every
-    // pumped FlatMesh unconditionally, and on the streaming path that array
-    // is dead weight: `onMeshBatch` has already assembled each batch into
-    // the durable BatchedMesh by the time the next one lands, and the only
-    // remaining readers are ShareIfcLoader's DEGRADED end-of-load builds.
-    // Holding one of the three pointer spines over a 475 MB graph against
-    // the chance of a fallback is what this stops.
+    // Does this engine expose conway#660's async whole-model ask? That is
+    // the ONLY entry point that can answer a windowed deferred model, so it
+    // decides the retention question below. Feature-detected rather than
+    // version-gated: the pin this landed on (1.1578.666-g39d59784) does NOT
+    // have it, so the new regime is dormant until the next routine bump,
+    // and an engine swap (real web-ifc, an older pin, a future one) picks
+    // its regime by what it actually implements.
+    const hasAsyncWholeModelAsk = typeof ifcAPI.StreamAllMeshesAsync === 'function'
+    // Retention decision (conway#638, completed by conway#660). `captured`
+    // used to accumulate every pumped FlatMesh unconditionally, and on the
+    // streaming path that array is dead weight: `onMeshBatch` has already
+    // assembled each batch into the durable BatchedMesh by the time the next
+    // one lands, and the only remaining readers are ShareIfcLoader's
+    // DEGRADED end-of-load builds. Holding one of the three pointer spines
+    // over a 475 MB graph against the chance of a fallback is what this
+    // stops.
     //
-    // Two states must keep the contents, and both are genuine:
+    // The replacement for retention is re-extraction at the moment of
+    // failure (`recapture` below), so the contents are kept exactly where
+    // there is nothing to re-extract WITH:
     //
     //   1. No `onMeshBatch` — then `captured` IS the delivery, not a copy
-    //      of it. Nothing else ever sees the stream.
-    //   2. A WINDOWED deferred source. The replacement for retention is
-    //      re-extraction at the moment of failure (`recapture` below), and
-    //      re-extraction is `StreamAllMeshes`, which on a deferred model
-    //      drains through the SYNCHRONOUS `ExtractGeometryBatch` — and that
-    //      throws outright on a windowed source ("ExtractGeometryBatch is
-    //      synchronous and cannot page a windowed source", pinned engine
+    //      of it. Nothing else ever sees the stream. Unconditional.
+    //   2. A WINDOWED deferred source ON AN ENGINE WITHOUT THE ASYNC ASK.
+    //      `StreamAllMeshes` on a deferred model drains through the
+    //      SYNCHRONOUS `ExtractGeometryBatch`, which throws outright on a
+    //      windowed source ("ExtractGeometryBatch is synchronous and cannot
+    //      page a windowed source", pinned engine
     //      `compiled/src/compat/web-ifc/ifc_api_proxy_ifc.js:1527`, reached
     //      from `streamAllMeshes`' deferred drain loop at `:2771`).
-    //      conway#657 does
-    //      not change that: its re-walk (`recaptureWholeModel_`) hangs off
-    //      the same drain, and there is no async whole-model entry point.
-    //      `ExtractGeometryBatchAsync` cannot substitute — after a full
-    //      drain its cursor is exhausted and there is no public rewind.
-    //      So on a windowed open there is nothing to re-extract WITH, and
-    //      dropping here would turn a rare degraded build into a blank
-    //      screen. Retention stays until conway grows an async re-read.
+    //      conway#657 did not change that — its re-walk
+    //      (`recaptureWholeModel_`) hangs off the same drain — and
+    //      `ExtractGeometryBatchAsync` cannot substitute, because after a
+    //      full drain its cursor is exhausted and there is no public rewind.
+    //      Dropping there would turn a rare degraded build into a blank
+    //      screen, so on such a pin retention stays.
     //
-    // Note the asymmetry that leaves: a GitHub/OPFS-backed load takes the
-    // windowed open by default (`Loader.js` hands `parse` the File itself),
-    // so today this frees the stream on buffered opens only. The flag above
-    // is still declared on both, which is correct — declaring it changes
-    // what CONWAY retains, and `captured` is Share's own spine.
-    const retainCaptured = onMeshBatch === undefined || windowedSource
+    // conway#660 (`StreamAllMeshesAsync`, merged as conway#672) removes
+    // case 2's premise for engines that carry it: the async ask drains
+    // through `ExtractGeometryBatchAsync`, which pages the window, and then
+    // runs the SAME post-drain serve the sync entry point runs — same
+    // placements, same `STREAMING_CONSUMER` re-walk, same budget accounting.
+    // So the two regimes are:
+    //
+    //   pin WITHOUT `StreamAllMeshesAsync`: windowed retains, buffered drops
+    //   pin WITH it:                        both drop
+    //
+    // That asymmetry is the one that mattered: a GitHub/OPFS-backed load
+    // takes the windowed open by default (`Loader.js` hands `parse` the File
+    // itself), so the large models the epic is aimed at were exactly the
+    // ones still retaining — measured on PSB (860 MB) as ~zero bytes
+    // reclaimed with two of three spines dropped (conway#660's A/B comment).
+    // Whether dropping the third pays out there is the before/after that
+    // issue still owes; nothing here claims a number.
+    const retainCaptured =
+      onMeshBatch === undefined || (windowedSource && !hasAsyncWholeModelAsk)
+    // Which whole-model entry point `recapture()` will drive if a degraded
+    // build asks. The async ask is used ONLY where the sync one cannot
+    // serve — a windowed source — so a buffered open keeps driving exactly
+    // the call it drove before this change, on any pin. Narrow on purpose:
+    // it keeps the pin bump from silently re-routing the path that already
+    // worked, and the async ask is a full drain plus a full scene walk
+    // either way.
+    const recaptureViaAsyncAsk = windowedSource && hasAsyncWholeModelAsk
     // Batch-pump accounting for the load log. Whether the pump actually
     // produced anything is the difference between a model that streams
     // onto the screen and one that shows nothing until the end-of-load
@@ -334,11 +367,18 @@ export async function parseIfcWithConway(
     // that shows nothing until the end-of-load build, and the two are
     // indistinguishable without this line (Share#1744). console.info,
     // not debug() — debug() no-ops unless the level is raised.
+    //
+    // `wholeModelAsk` reports which regime the engine put this load in
+    // (conway#660): `async` means the windowed drop is live, `sync` that the
+    // pin predates the async ask. It is how a production PSB trace says
+    // which side of the pin bump it measured without reading the version.
     // eslint-disable-next-line no-console
     console.info(
       `[conwayDirect] demand pump: batches=${pumpedBatches} ` +
       `meshes=${pumpedMeshes} onMeshBatch=${onMeshBatch ? 'yes' : 'no'} ` +
       `onPreviewMesh=${onPreviewMesh ? 'yes' : 'no'} ` +
+      `windowed=${windowedSource ? 'yes' : 'no'} ` +
+      `wholeModelAsk=${hasAsyncWholeModelAsk ? 'async' : 'sync'} ` +
       `retained=${retainCaptured ? 'yes' : 'no'}`)
     if (pumpedMeshes === 0) {
       // Nothing pumped: conway fell back to a classic fully-extracted
@@ -366,47 +406,58 @@ export async function parseIfcWithConway(
       // this branch means the streaming delivery produced nothing, so
       // `captured` is once again the only delivery.
       //
-      // Where that leaves `StreamAllMeshes`, stated precisely because the
-      // obvious shorthand is wrong. When conway really did fall back to a
-      // classic open, the model is non-deferred and this takes conway's
-      // classic scene walk over live natives — which works on a windowed
-      // source where `recapture` below could not, because it never touches
-      // the deferred drain. But `pumpedMeshes === 0` does NOT imply
-      // non-deferred: the pump loop exits on `remaining === 0 &&
-      // extracted === 0` whatever the reason, so a genuinely DEFERRED model
-      // with nothing to extract (a properties-only IFC, or one whose every
-      // product failed geometry) lands here too. On a windowed source that
-      // model's `StreamAllMeshes` takes the deferred branch and throws
-      // "cannot page a windowed source" out of the load. That is a
-      // PRE-EXISTING defect, not one this change introduces — the sentinel
-      // it replaced (`captured.length === 0`) selected exactly the same
-      // models and called exactly the same method — and it is tracked
-      // separately rather than fixed here.
+      // Which entry point serves that, stated precisely because the obvious
+      // shorthand is wrong. When conway really did fall back to a classic
+      // open, the model is non-deferred and the SYNC `StreamAllMeshes` takes
+      // conway's classic scene walk over live natives, which works on a
+      // windowed source because it never touches the deferred drain. But
+      // `pumpedMeshes === 0` does NOT imply non-deferred: the pump loop
+      // exits on `remaining === 0 && extracted === 0` whatever the reason,
+      // so a genuinely DEFERRED model with nothing to extract (a
+      // properties-only IFC, or one whose every product failed geometry)
+      // lands here too — and on a windowed source THAT model's
+      // `StreamAllMeshes` takes the deferred branch and throws "cannot page
+      // a windowed source" out of the load (conway#661's Share-side
+      // symptom; #1800 pinned it as a pre-existing defect it neither
+      // introduced nor fixed).
       //
-      // Nor is there a whole-model route around it. The three entry points
-      // that do NOT throw on a windowed deferred model are all worse:
-      // `loadAllGeometry` and `streamAllMeshesWithTypes` have no deferred
-      // branch at all and seed coordination from `model[5]`, which a
-      // deferred open never writes, so every instance lands in an identity
-      // frame — silently mis-framed geometry, worse than a refusal; and
-      // `getFlatMesh` is per-entity and would need an ID enumeration this
-      // loader does not have. conway#657 routes the first and third through
-      // `streamAllMeshes`, and this pin carries that fix, so they now refuse
-      // properly instead of silently mis-framing.
+      // conway#660's async ask fixes it for the pins that carry it, and the
+      // fix is this one branch: on a windowed source `StreamAllMeshesAsync`
+      // pages the window and serves both sub-cases — the genuinely deferred
+      // model through the async drain, the internally-fallen-back classic
+      // one through the sync path it delegates to internally (conway#672's
+      // "safe on a resident source and on a non-deferred model"). A
+      // properties-only windowed IFC therefore loads instead of failing.
+      // Buffered opens keep the sync call, which already worked.
+      //
+      // The alternatives remain worse, which is why the ask is the fix and
+      // not a workaround: `loadAllGeometry` and `streamAllMeshesWithTypes`
+      // have no deferred branch at all and seed coordination from
+      // `model[5]`, which a deferred open never writes, so every instance
+      // lands in an identity frame — silently mis-framed geometry, worse
+      // than a refusal; and `getFlatMesh` is per-entity and would need an ID
+      // enumeration this loader does not have. conway#657 routes the first
+      // and third through `streamAllMeshes`, and this pin carries that fix,
+      // so they now refuse properly instead of silently mis-framing.
       //
       // No onMeshBatch here: extraction is already complete, so a
       // preview would just double the geometry conversion right before
       // the final build renders the same thing.
-      // eslint-disable-next-line new-cap
-      ifcAPI.StreamAllMeshes(modelID, (flatMesh) => {
-        captured.push(flatMesh)
-      })
-      return {modelID, captured, recapture: () => captured}
+      const pushCaptured = (flatMesh) => captured.push(flatMesh)
+      if (recaptureViaAsyncAsk) {
+        // eslint-disable-next-line new-cap
+        await ifcAPI.StreamAllMeshesAsync(modelID, pushCaptured)
+      } else {
+        // eslint-disable-next-line new-cap
+        ifcAPI.StreamAllMeshes(modelID, pushCaptured)
+      }
+      return {modelID, captured, recapture: retainedRecapture(captured)}
     }
     return {
       modelID,
       captured,
-      recapture: makeRecapture(ifcAPI, modelID, captured, retainCaptured),
+      recapture: makeRecapture(
+        ifcAPI, modelID, captured, retainCaptured, recaptureViaAsyncAsk),
     }
   }
 
@@ -455,7 +506,20 @@ export async function parseIfcWithConway(
   // The classic path never streams, so `captured` is always whole and
   // `recapture` is the identity — the return shape stays uniform so
   // callers never branch on which open path ran.
-  return {modelID, captured, recapture: () => captured}
+  return {modelID, captured, recapture: retainedRecapture(captured)}
+}
+
+
+/**
+ * The `recapture()` seam for a stream that was KEPT: hands back the array
+ * that is already whole, through the same Promise the re-extracting form
+ * returns, so no call site has to know which one it holds.
+ *
+ * @param {Array} captured the whole FlatMesh stream
+ * @return {function(): Promise<Array>}
+ */
+function retainedRecapture(captured) {
+  return () => Promise.resolve(captured)
 }
 
 
@@ -473,8 +537,8 @@ export async function parseIfcWithConway(
  * **What comes back is equivalent, not identical**, and both differences
  * matter to a reader comparing it against the pump's own output:
  *
- *   1. **Grouping.** On a deferred model the pinned `StreamAllMeshes`
- *      serves per-entity FULL FlatMeshes out of conway's `meshMap`, not the
+ *   1. **Grouping.** On a deferred model the whole-model ask serves
+ *      per-entity FULL FlatMeshes out of conway's re-walk, not the
  *      per-batch DELTA FlatMeshes the pump delivered. Same placement set,
  *      different bundling. Benign for both readers here — the merged and
  *      batched builds iterate placements and do not care how they arrive —
@@ -483,6 +547,13 @@ export async function parseIfcWithConway(
  *      path, and once conway has evicted anything, its whole-model serve
  *      filters out placements whose natives were freed. So on a model big
  *      enough to evict, this returns a strict SUBSET of what was pumped.
+ *      Identical on both entry points and on both source types: conway#672
+ *      measured the async ask serving 3 of 16 placements under a 2 KiB
+ *      budget, warning with the exact unresolved count (3 + 13 = 16), and
+ *      THROWING rather than serving an empty model when nothing at all
+ *      resolves. Windowing does not change it — the re-walk resolves
+ *      against the geometry STORE, never the byte source, so an eviction is
+ *      reported missing rather than paged back in.
  *
  * That second one costs nothing that was not already gone, and the reason
  * is worth pinning down because it changed with the engine. On the RETAINED
@@ -501,45 +572,84 @@ export async function parseIfcWithConway(
  * only as a `skippedPlacedGeometries` bump. Worth having, and small — do
  * not sell it as crash avoidance. The engine fixed the crash.
  *
+ * **Which entry point, and why the seam is async everywhere.** On a
+ * buffered model this drives the synchronous `StreamAllMeshes`, exactly as
+ * before conway#660. On a WINDOWED one that call throws ("cannot page a
+ * windowed source"), so it drives `StreamAllMeshesAsync` instead — the
+ * async twin conway#672 added, which pages the window through
+ * `ExtractGeometryBatchAsync` and then runs the same post-drain serve. One
+ * of those two is a Promise, so the accessor returns a Promise on BOTH
+ * paths and every call site awaits. A union return ("array on the old pin,
+ * Promise on the new one") would work by accident — `await` normalises
+ * either — but it makes a missing `await` invisible on the pin the
+ * developer is running and a silent wrong-type feed on the other, which is
+ * precisely the shape of bug the memoisation note below is about.
+ *
  * Memoised because the two degraded builds are consecutive
  * (`buildBatchedConwayModel` then `buildConwayIfcModel`), and a second
  * `StreamAllMeshes` on a live model re-pushes into conway's still-populated
  * cache and doubles every triangle count — the defect
  * `IfcItemsMap.js` §"Why this is a separate entry point" documents from the
- * consumer side.
+ * consumer side. The memo holds the PROMISE, not the resolved array, so two
+ * readers that ask before the first ask resolves still drive the engine
+ * once; on the async path that overlap is reachable in a way it never was
+ * synchronously. (conway#672 serialises overlapping asks internally too,
+ * but that queues a second full drain + scene walk — this avoids asking.)
  *
- * Deliberately does NOT swallow a throw. Re-extraction is only wired up
- * where it is known to work (see `retainCaptured`), so a throw here is a
- * broken assumption, not an expected state; letting it reach
- * `ShareIfcLoader.parse`'s handler surfaces a real error to the user
- * instead of rendering an empty scene and calling it a load.
+ * Deliberately does NOT swallow a throw, and a rejected ask stays memoised:
+ * re-extraction is only wired up where it is known to work (see
+ * `retainCaptured`), so a throw here is a broken assumption, not an
+ * expected state; letting it reach `ShareIfcLoader.parse`'s handler
+ * surfaces a real error to the user instead of rendering an empty scene and
+ * calling it a load, and re-driving a failed whole-model ask for the second
+ * degraded build would only pay the drain twice to fail twice.
  *
  * @param {object} ifcAPI Conway IfcAPI bound to the model
  * @param {number} modelID
  * @param {Array} captured the retained stream (empty when dropped)
  * @param {boolean} retained whether `captured` holds the whole stream
- * @return {Function} `() => Array` of the whole model's FlatMeshes
+ * @param {boolean} viaAsyncAsk drive `StreamAllMeshesAsync` (windowed
+ *   source on a conway#660 engine) rather than `StreamAllMeshes`
+ * @return {function(): Promise<Array>} the whole model's FlatMeshes
  */
-function makeRecapture(ifcAPI, modelID, captured, retained) {
+function makeRecapture(ifcAPI, modelID, captured, retained, viaAsyncAsk) {
   let recaptured = null
   return () => {
     if (retained) {
-      return captured
+      return Promise.resolve(captured)
     }
     if (recaptured === null) {
-      const meshes = []
-      // eslint-disable-next-line new-cap
-      ifcAPI.StreamAllMeshes(modelID, (flatMesh) => {
-        meshes.push(flatMesh)
-      })
-      // eslint-disable-next-line no-console
-      console.info(
-        `[conwayDirect] recaptured ${meshes.length} mesh(es) for a degraded ` +
-        'end-of-load build')
-      recaptured = meshes
+      recaptured = captureWholeModel(ifcAPI, modelID, viaAsyncAsk)
     }
     return recaptured
   }
+}
+
+
+/**
+ * One whole-model ask through whichever entry point can serve this model.
+ *
+ * @param {object} ifcAPI Conway IfcAPI bound to the model
+ * @param {number} modelID
+ * @param {boolean} viaAsyncAsk use conway#660's `StreamAllMeshesAsync`
+ * @return {Promise<Array>} every FlatMesh the ask served
+ */
+async function captureWholeModel(ifcAPI, modelID, viaAsyncAsk) {
+  const meshes = []
+  const push = (flatMesh) => meshes.push(flatMesh)
+  if (viaAsyncAsk) {
+    // eslint-disable-next-line new-cap
+    await ifcAPI.StreamAllMeshesAsync(modelID, push)
+  } else {
+    // eslint-disable-next-line new-cap
+    ifcAPI.StreamAllMeshes(modelID, push)
+  }
+  // eslint-disable-next-line no-console
+  console.info(
+    `[conwayDirect] recaptured ${meshes.length} mesh(es) via ` +
+    `${viaAsyncAsk ? 'StreamAllMeshesAsync' : 'StreamAllMeshes'} for a ` +
+    'degraded end-of-load build')
+  return meshes
 }
 
 

--- a/src/viewer/ifc/conwayDirectIfcLoader.test.js
+++ b/src/viewer/ifc/conwayDirectIfcLoader.test.js
@@ -487,7 +487,7 @@ describe('viewer/ifc/conwayDirectIfcLoader', () => {
         // The regime is reported, so a production trace says which side of
         // the pin bump it measured without anyone reading a version string.
         expect(pumpLine).toContain('windowed=yes')
-        expect(pumpLine).toContain('wholeModelAsk=sync')
+        expect(pumpLine).toContain('asyncAsk=no')
       })
 
       it('surfaces the engine refusal when a DEFERRED windowed model pumps nothing', async () => {
@@ -694,7 +694,7 @@ describe('viewer/ifc/conwayDirectIfcLoader', () => {
           const pumpLine = pumpLineFrom(infoSpy)
           expect(pumpLine).toContain('meshes=20')
           expect(pumpLine).toContain('windowed=yes')
-          expect(pumpLine).toContain('wholeModelAsk=async')
+          expect(pumpLine).toContain('asyncAsk=yes')
           expect(pumpLine).toContain('retained=no')
           // Still not paid unless a degraded reader actually asks — the ask
           // is a full drain plus a full scene walk.
@@ -757,6 +757,11 @@ describe('viewer/ifc/conwayDirectIfcLoader', () => {
           const pumpLine = pumpLineFrom(infoSpy)
           expect(pumpLine).toContain('windowed=no')
           expect(pumpLine).toContain('retained=no')
+          // The token is the ENGINE's capability, not the entry point this
+          // load drives: `yes` here beside a sync `StreamAllMeshes` below is
+          // the intended reading, and the `recaptured … via …` line is what
+          // names the ask that actually ran.
+          expect(pumpLine).toContain('asyncAsk=yes')
           expect(await result.recapture()).toHaveLength(1)
           expect(ifcAPI.StreamAllMeshes).toHaveBeenCalledTimes(1)
           expect(ifcAPI.StreamAllMeshesAsync).not.toHaveBeenCalled()

--- a/src/viewer/ifc/conwayDirectIfcLoader.test.js
+++ b/src/viewer/ifc/conwayDirectIfcLoader.test.js
@@ -439,7 +439,7 @@ describe('viewer/ifc/conwayDirectIfcLoader', () => {
         const ifcAPI = makeDemandAPI(150)
         const result = await parseIfcWithConway(new ArrayBuffer(4), ifcAPI)
         expect(result.captured).toHaveLength(150)
-        expect(result.recapture()).toHaveLength(150)
+        expect(await result.recapture()).toHaveLength(150)
         // Retained means whole: no re-extraction is needed or performed.
         expect(ifcAPI.StreamAllMeshes).not.toHaveBeenCalled()
         const pumpLine = infoSpy.mock.calls
@@ -448,14 +448,18 @@ describe('viewer/ifc/conwayDirectIfcLoader', () => {
         expect(pumpLine).toContain('retained=yes')
       })
 
-      it('retains the stream on a WINDOWED open, where re-extraction throws', async () => {
-        // Verified against the pinned engine
+      it('retains the stream on a WINDOWED open with no async ask, where re-extraction throws', async () => {
+        // The OLD-PIN regime, and the one the shipped pin
+        // (1.1578.666-g39d59784) is in: no `StreamAllMeshesAsync` on the
+        // stub, exactly as on that engine. Verified against it
         // (compiled/src/compat/web-ifc/ifc_api_proxy_ifc.js:1527):
         // `streamAllMeshes` on a deferred model drains through the
         // SYNCHRONOUS `ExtractGeometryBatch`, which refuses a windowed
         // source outright. conway#657 does not change that — its re-walk
         // (`recaptureWholeModel_`) hangs off the same drain — so there is
         // nothing to re-extract with here and the contents must be kept.
+        // conway#660 is what removes this case's premise, for pins that
+        // carry it; the nested describe below is that regime.
         mockIsFeatureEnabled.mockImplementation((name) => name === 'demandGeometry')
         const ifcAPI = makeWindowedDemandAPI(20)
         ifcAPI.StreamAllMeshes = jest.fn(() => {
@@ -469,7 +473,7 @@ describe('viewer/ifc/conwayDirectIfcLoader', () => {
         expect(result.captured).toHaveLength(20)
         // The degraded reader is served without ever touching the entry
         // point that would throw.
-        expect(result.recapture()).toHaveLength(20)
+        expect(await result.recapture()).toHaveLength(20)
         expect(ifcAPI.StreamAllMeshes).not.toHaveBeenCalled()
         // Counter fidelity is not a streaming-path-only concern: the log
         // must report real meshes on the retained branch too, where
@@ -480,6 +484,10 @@ describe('viewer/ifc/conwayDirectIfcLoader', () => {
           .find((line) => typeof line === 'string' && line.includes('demand pump:'))
         expect(pumpLine).toContain('meshes=20')
         expect(pumpLine).toContain('retained=yes')
+        // The regime is reported, so a production trace says which side of
+        // the pin bump it measured without anyone reading a version string.
+        expect(pumpLine).toContain('windowed=yes')
+        expect(pumpLine).toContain('wholeModelAsk=sync')
       })
 
       it('surfaces the engine refusal when a DEFERRED windowed model pumps nothing', async () => {
@@ -543,7 +551,7 @@ describe('viewer/ifc/conwayDirectIfcLoader', () => {
           new ArrayBuffer(4), ifcAPI, undefined, undefined, jest.fn())
         // Not paid unless a degraded reader actually asks.
         expect(ifcAPI.StreamAllMeshes).not.toHaveBeenCalled()
-        const recaptured = result.recapture()
+        const recaptured = await result.recapture()
         expect(recaptured).toHaveLength(150)
         expect(recaptured[0].expressID).toBe(1000)
         expect(ifcAPI.StreamAllMeshes).toHaveBeenCalledTimes(1)
@@ -563,8 +571,8 @@ describe('viewer/ifc/conwayDirectIfcLoader', () => {
         })
         const result = await parseIfcWithConway(
           new ArrayBuffer(4), ifcAPI, undefined, undefined, jest.fn())
-        const first = result.recapture()
-        const second = result.recapture()
+        const first = await result.recapture()
+        const second = await result.recapture()
         expect(second).toBe(first)
         expect(ifcAPI.StreamAllMeshes).toHaveBeenCalledTimes(1)
       })
@@ -601,7 +609,7 @@ describe('viewer/ifc/conwayDirectIfcLoader', () => {
         const result = await parseIfcWithConway(
           new ArrayBuffer(4), ifcAPI, undefined, undefined, onMeshBatch)
         expect(result.captured).toHaveLength(5)
-        expect(result.recapture()).toHaveLength(5)
+        expect(await result.recapture()).toHaveLength(5)
         expect(onMeshBatch).not.toHaveBeenCalled()
         // One walk, not two: `recapture` must not re-drive the engine on a
         // path where `captured` is already whole.
@@ -612,6 +620,229 @@ describe('viewer/ifc/conwayDirectIfcLoader', () => {
         expect(pumpLine).toContain('meshes=0')
       })
 
+      // conway#660 / conway#672: `StreamAllMeshesAsync` is the async twin of
+      // the whole-model ask, and the ONLY entry point a windowed deferred
+      // model can answer. The pin this landed on
+      // (1.1578.666-g39d59784) does NOT export it — verified by grep over
+      // `node_modules/@bldrs-ai/conway` — so everything in this block is
+      // DORMANT until the next routine pin bump, and the tests above pin
+      // that today's behaviour is unchanged. These are what the bump
+      // activates.
+      describe('windowed retention with the async whole-model ask (conway#660)', () => {
+        /**
+         * Add conway#660's async ask to a stub, serving a fixed answer.
+         * Async-shaped on purpose: the real one drains the pump and yields,
+         * so a call site that forgot to await gets a Promise here too.
+         *
+         * @param {object} ifcAPI stub to extend
+         * @param {number} served meshes the whole-model ask answers with
+         * @return {object} the same stub, with the async ask attached
+         */
+        function withAsyncWholeModelAsk(ifcAPI, served) {
+          ifcAPI.StreamAllMeshesAsync = jest.fn(async (modelID, cb) => {
+            await Promise.resolve()
+            for (let i = 0; i < served; i++) {
+              cb({expressID: 3000 + i, geometries: {size: () => 1}})
+            }
+          })
+          return ifcAPI
+        }
+
+        /**
+         * The sync entry point as the real engine behaves on a windowed
+         * deferred model: it refuses rather than serving.
+         *
+         * @param {object} ifcAPI stub to extend
+         * @return {object} the same stub
+         */
+        function withWindowedSyncRefusal(ifcAPI) {
+          ifcAPI.StreamAllMeshes = jest.fn(() => {
+            throw new Error(
+              'ExtractGeometryBatch is synchronous and cannot page a windowed source')
+          })
+          return ifcAPI
+        }
+
+        /**
+         * @param {object} spy the console.info spy
+         * @return {string|undefined} the demand-pump boundary line
+         */
+        function pumpLineFrom(spy) {
+          return spy.mock.calls
+            .map(([line]) => line)
+            .find((line) => typeof line === 'string' && line.includes('demand pump:'))
+        }
+
+        /** @return {Blob} a File-shaped source, which takes the windowed open */
+        function windowedFile() {
+          return new Blob([new Uint8Array([1, 2, 3, 4])])
+        }
+
+        it('drops the stream on a WINDOWED open once the engine can serve it back', async () => {
+          // The whole point of conway#660: GitHub/OPFS loads take the
+          // windowed open by default, so this branch is where the third
+          // pointer spine was still being held over the 475 MB graph. With
+          // an ask that can answer, it goes the way the buffered one already
+          // did.
+          mockIsFeatureEnabled.mockImplementation((name) => name === 'demandGeometry')
+          const ifcAPI = withAsyncWholeModelAsk(
+            withWindowedSyncRefusal(makeWindowedDemandAPI(20)), 20)
+          const result = await parseIfcWithConway(
+            windowedFile(), ifcAPI, undefined, undefined, jest.fn())
+          expect(ifcAPI.OpenModelStream).toHaveBeenCalledTimes(1)
+          expect(result.captured).toHaveLength(0)
+          const pumpLine = pumpLineFrom(infoSpy)
+          expect(pumpLine).toContain('meshes=20')
+          expect(pumpLine).toContain('windowed=yes')
+          expect(pumpLine).toContain('wholeModelAsk=async')
+          expect(pumpLine).toContain('retained=no')
+          // Still not paid unless a degraded reader actually asks — the ask
+          // is a full drain plus a full scene walk.
+          expect(ifcAPI.StreamAllMeshesAsync).not.toHaveBeenCalled()
+        })
+
+        it('serves a degraded build through the async ask, never the sync refusal', async () => {
+          // The replacement for retention, on the source type that could not
+          // have one before. The sync entry point is left in place throwing
+          // the real engine's message, so routing to it would fail loudly
+          // rather than pass by accident.
+          mockIsFeatureEnabled.mockImplementation((name) => name === 'demandGeometry')
+          const ifcAPI = withAsyncWholeModelAsk(
+            withWindowedSyncRefusal(makeWindowedDemandAPI(20)), 20)
+          const result = await parseIfcWithConway(
+            windowedFile(), ifcAPI, undefined, undefined, jest.fn())
+          const recaptured = await result.recapture()
+          expect(recaptured).toHaveLength(20)
+          expect(recaptured[0].expressID).toBe(3000)
+          expect(ifcAPI.StreamAllMeshesAsync).toHaveBeenCalledTimes(1)
+          // Bound to the windowed model's handle, not the buffered
+          // fallback's (3 vs 5) — a mis-bound ask would serve another model.
+          expect(ifcAPI.StreamAllMeshesAsync.mock.calls[0][0]).toBe(3)
+          expect(ifcAPI.StreamAllMeshes).not.toHaveBeenCalled()
+        })
+
+        it('memoises the async ask across the two consecutive degraded builds', async () => {
+          // Same defect as the sync path's memo: a second whole-model ask on
+          // a live model doubles every triangle count (IfcItemsMap.js §"Why
+          // this is a separate entry point"). The overlap case is the one
+          // only the async path can reach — `buildBatchedConwayModel`'s
+          // failure and `buildConwayIfcModel`'s ask are consecutive awaits,
+          // but nothing in the seam forces them to be, so the memo holds the
+          // PROMISE rather than the resolved array.
+          mockIsFeatureEnabled.mockImplementation((name) => name === 'demandGeometry')
+          const ifcAPI = withAsyncWholeModelAsk(
+            withWindowedSyncRefusal(makeWindowedDemandAPI(20)), 20)
+          const result = await parseIfcWithConway(
+            windowedFile(), ifcAPI, undefined, undefined, jest.fn())
+          const [first, second] = await Promise.all(
+            [result.recapture(), result.recapture()])
+          expect(second).toBe(first)
+          const third = await result.recapture()
+          expect(third).toBe(first)
+          expect(ifcAPI.StreamAllMeshesAsync).toHaveBeenCalledTimes(1)
+        })
+
+        it('keeps the SYNC ask on a buffered open even when the async one exists', async () => {
+          // Byte-identity for the path that already worked: the async ask is
+          // wired only where the sync one cannot serve. A pin bump must not
+          // silently re-route a buffered load onto a second implementation
+          // of the same answer.
+          mockIsFeatureEnabled.mockImplementation((name) => name === 'demandGeometry')
+          const ifcAPI = withAsyncWholeModelAsk(makeDemandAPI(10), 10)
+          ifcAPI.StreamAllMeshes = jest.fn((modelID, cb) => {
+            cb({expressID: 7, geometries: {size: () => 1}})
+          })
+          const result = await parseIfcWithConway(
+            new ArrayBuffer(4), ifcAPI, undefined, undefined, jest.fn())
+          const pumpLine = pumpLineFrom(infoSpy)
+          expect(pumpLine).toContain('windowed=no')
+          expect(pumpLine).toContain('retained=no')
+          expect(await result.recapture()).toHaveLength(1)
+          expect(ifcAPI.StreamAllMeshes).toHaveBeenCalledTimes(1)
+          expect(ifcAPI.StreamAllMeshesAsync).not.toHaveBeenCalled()
+        })
+
+        it('still retains a windowed stream when nothing else takes delivery', async () => {
+          // The retention case that is not about the engine at all: with no
+          // `onMeshBatch`, `captured` IS the delivery. An ask that can now
+          // serve must not be read as permission to hand back an empty
+          // model.
+          mockIsFeatureEnabled.mockImplementation((name) => name === 'demandGeometry')
+          const ifcAPI = withAsyncWholeModelAsk(
+            withWindowedSyncRefusal(makeWindowedDemandAPI(20)), 20)
+          const result = await parseIfcWithConway(windowedFile(), ifcAPI)
+          expect(result.captured).toHaveLength(20)
+          expect(await result.recapture()).toBe(result.captured)
+          expect(pumpLineFrom(infoSpy)).toContain('retained=yes')
+          expect(ifcAPI.StreamAllMeshesAsync).not.toHaveBeenCalled()
+        })
+
+        it('recovers an empty pump on a DEFERRED windowed model through the async ask', async () => {
+          // The deliberate behaviour CHANGE this brings, and the Share-side
+          // symptom of conway#661: a genuinely deferred windowed model with
+          // nothing to extract (properties-only IFC, or every product failed
+          // geometry) exits the pump loop like an internal classic fallback
+          // does, and the sentinel's one-shot sync `StreamAllMeshes` then
+          // takes conway's deferred branch and throws the load away. #1800
+          // pinned that as a pre-existing defect; on a pin with the async
+          // ask the same sentinel can serve instead, so it does — one
+          // feature-detected branch, no new machinery. The twin test above
+          // pins that the throw is unchanged on a pin without it.
+          mockIsFeatureEnabled.mockImplementation((name) => name === 'demandGeometry')
+          const ifcAPI = withAsyncWholeModelAsk(
+            withWindowedSyncRefusal(makeWindowedDemandAPI(0)), 5)
+          const result = await parseIfcWithConway(
+            windowedFile(), ifcAPI, undefined, undefined, jest.fn())
+          expect(result.captured).toHaveLength(5)
+          // Unconditionally retained here whatever the retention decision
+          // said: this branch means the streaming delivery produced nothing,
+          // so `captured` is once again the only delivery.
+          expect(await result.recapture()).toBe(result.captured)
+          expect(ifcAPI.StreamAllMeshesAsync).toHaveBeenCalledTimes(1)
+          expect(ifcAPI.StreamAllMeshes).not.toHaveBeenCalled()
+          // The blank-screen warning still fires: nothing streamed, so the
+          // user still waited for the end-of-load build.
+          expect(warnSpy).toHaveBeenCalledWith(
+            expect.stringContaining('demand pump produced no batches'))
+        })
+
+        it('serves the budget subset the ask answers with, without inventing a throw', async () => {
+          // conway#672's measured semantics: under a budget the re-walk
+          // resolves against the geometry STORE, so evicted placements are
+          // reported missing rather than paged back — the ask serves a
+          // strict SUBSET (measured there as 3 of 16 under a 2 KiB budget,
+          // warning "13 placed instance(s) could not be resolved"). Share
+          // takes what it gets; a subset still builds a model, and treating
+          // it as failure would turn a degraded build into a dead load.
+          mockIsFeatureEnabled.mockImplementation((name) => name === 'demandGeometry')
+          const ifcAPI = withAsyncWholeModelAsk(
+            withWindowedSyncRefusal(makeWindowedDemandAPI(20)), 12)
+          const result = await parseIfcWithConway(
+            windowedFile(), ifcAPI, undefined, undefined, jest.fn())
+          const recaptured = await result.recapture()
+          expect(recaptured).toHaveLength(12)
+          expect(pumpLineFrom(infoSpy)).toContain('meshes=20')
+        })
+
+        it('lets a total-loss throw from the ask reach the load, once', async () => {
+          // Total loss throws rather than serving an empty model
+          // (conway#672). The accessor must not swallow it — an empty scene
+          // reported as a successful load is the failure mode that costs a
+          // user their file — and the memo must not re-drive a full drain to
+          // fail a second time for the second degraded build.
+          mockIsFeatureEnabled.mockImplementation((name) => name === 'demandGeometry')
+          const ifcAPI = withWindowedSyncRefusal(makeWindowedDemandAPI(20))
+          ifcAPI.StreamAllMeshesAsync = jest.fn(() => Promise.reject(new Error(
+            'StreamAllMeshesAsync: this model was opened with STREAMING_CONSUMER, ' +
+            'so conway kept no reference to the meshes the pump delivered')))
+          const result = await parseIfcWithConway(
+            windowedFile(), ifcAPI, undefined, undefined, jest.fn())
+          await expect(result.recapture()).rejects.toThrow(/STREAMING_CONSUMER/)
+          await expect(result.recapture()).rejects.toThrow(/STREAMING_CONSUMER/)
+          expect(ifcAPI.StreamAllMeshesAsync).toHaveBeenCalledTimes(1)
+        })
+      })
+
       it('recapture is the identity on the classic non-deferred path', async () => {
         mockIsFeatureEnabled.mockImplementation(() => false)
         const ifcAPI = makeDemandAPI(10)
@@ -619,7 +850,7 @@ describe('viewer/ifc/conwayDirectIfcLoader', () => {
           cb({expressID: 11, geometries: {size: () => 1}})
         })
         const result = await parseIfcWithConway(new ArrayBuffer(4), ifcAPI)
-        expect(result.recapture()).toBe(result.captured)
+        expect(await result.recapture()).toBe(result.captured)
         expect(ifcAPI.StreamAllMeshes).toHaveBeenCalledTimes(1)
       })
     })


### PR DESCRIPTION
Part of bldrs-ai/conway#660 (and so of bldrs-ai/conway#635). **Share half only** — the pin bump that activates it and the PSB before/after that issue's A/B comment sets up are both still owed, so this carries no closing keyword.

## What this establishes

Share#1800 dropped the pumped FlatMesh spine — Share's own third pointer over the ~475 MB PlacedGeometry graph — on **buffered** deferred opens only. Its replacement for retention is re-extraction at the moment of failure (`recapture()`), and that re-extraction was `StreamAllMeshes`, which on a deferred model drains through the **synchronous** `ExtractGeometryBatch` and refuses a windowed source outright (*"ExtractGeometryBatch is synchronous and cannot page a windowed source"*). GitHub/OPFS `File` loads take the windowed open by default, so **the large models the epic is aimed at were exactly the ones still retaining** — measured on PSB (860.7 MB) as ~zero bytes reclaimed with two of three spines dropped (conway#660's A/B comment: +2,198.0 MB inert vs +2,205.0 MB active).

conway#672 added `StreamAllMeshesAsync(modelID, callback)`, which pages the window through `ExtractGeometryBatchAsync` and then runs the *same* post-drain serve the sync entry point runs. This consumes it, feature-detected:

| engine pin | buffered deferred open | windowed deferred open | `recapture()` drives |
|---|---|---|---|
| **without** `StreamAllMeshesAsync` (incl. the current pin `1.1578.666-g39d59784`) | drops (`retained=no`) | **retains** (`retained=yes`) | `StreamAllMeshes` |
| **with** it | drops | **drops** (`retained=no`) | `StreamAllMeshes` buffered, `StreamAllMeshesAsync` windowed |

**The current pin does not export it**, verified by grep over `node_modules/@bldrs-ai/conway` (zero hits; the sync `StreamAllMeshes` is there in both proxies). So the new regime is **dormant on this branch** and activates on the next routine bump — the land-then-activate pattern of #1801. Every old-pin behaviour is pinned unchanged by tests that run against a stub *without* the async ask, and revert **B** below (force the detect true) is what shows those pins are load-bearing rather than decorative.

## This is not purely additive on the new pin — one deliberate behaviour change, twice

Dormancy means nothing changes *today*. It does not mean the bump changes nothing, and two windowed cases behave differently once the ask is there. Both are intended.

**1. A fully-evicted windowed model now fails the degraded build loudly instead of rendering whatever survived.** Old windowed path: `captured` was retained, so a degraded build got the pump's own array back and rendered it — including placements whose natives a `GEOMETRY_BUDGET_MB` eviction had already freed, which `flatMeshToBufferGeometry` skips for zero vertex/index size. Partial or empty, silently, counted only as a `skippedPlacedGeometries` bump. New windowed path: the ask re-walks the geometry store, and conway#672's contract is *"the same stream the pump delivered, or an exact account of what is missing"* — partial loss serves the survivors with a warning naming the exact unresolved count, and **total loss throws**. So `parse` ends the load (null + `onError` + `ifcLastError`, the documented contract; OOM alone re-throws) rather than presenting an empty scene as a successful load. That is conway's "never a silent empty model" arriving in Share. It only bites when a degraded build is *already* running — the incremental assembly failed — on a model big enough for the budget to have evicted everything the re-walk needs, so it converts a bad-and-silent outcome into a bad-and-visible one. Pinned by `fails the load loudly when the whole-model ask rejects` and, at the loader level, by test 8 below.

**2. A properties-only windowed IFC loads instead of failing** — the sentinel change, below.

## The recapture seam: a Promise on every path

`recapture()` used to return the array synchronously. On a windowed source the re-extraction pages bytes off a `File`/OPFS store, so it *cannot* be synchronous, and the accessor now returns a `Promise` on **every** path — retained, buffered-sync, windowed-async.

A union return ("array on the old pin, Promise on the new one") would have worked by accident, because `await` normalises either. It was rejected: a missing `await` would then be invisible on the pin the developer is running and a silent wrong-type feed on the other — the builders iterate placements, so a Promise reaches them as an empty model, not an error. Uniform means a dropped `await` fails everywhere, immediately.

All four call sites, each verified to be in an async flow:

| call site | `ShareIfcLoader.js` | change |
|---|---|---|
| batchedMesh degraded build | `buildBatchedConwayModel(recapture(), …)` | `await recapture()` |
| merged degraded build | `buildConwayIfcModel(recapture(), …)` | `await recapture()` |
| `ifcItemsMapParity` diagnostic | `runIfcItemsMapParityCheck(…, recapture())` | `await recapture()` |
| instancing analysis | `logInstancedModelStats(…, recapture, …)` | the thunk stays a thunk (the gate must still be able to turn the whole-model read away); the function became `async` and awaits it inside its own try, and the caller awaits it so the load log's line order stays deterministic |

Only the second of those propagates a rejection: the first sits inside the batchedMesh branch's own try/catch, correctly — that branch's contract is "never break a load" — so a rejection there falls through to the merged build, which asks again, gets the **memoised** rejection, and carries it out. End state identical to the old synchronous form, with one drain instead of two.

The memo holds the **promise**, not the resolved array. Two readers that ask before the first ask resolves therefore still drive the engine once — an overlap only the async path can reach. conway#672 serialises overlapping asks internally too, but that *queues* a second full drain plus scene walk; this avoids asking.

## The sentinel decision (conway#661's Share-side symptom): taken

`pumpedMeshes === 0` does **not** imply conway fell back internally to a classic open — a genuinely deferred model with nothing to extract (properties-only IFC, or one whose every product failed geometry) exits the pump loop the same way. On a windowed source the sentinel's one-shot sync `StreamAllMeshes` then takes conway's deferred branch and throws the load away. #1800 pinned that as a pre-existing defect it neither introduced nor fixed.

With the async ask present the same sentinel **can** serve, so it does: one feature-detected branch, no new machinery, and it covers both sub-cases (the genuinely deferred model through the async drain; an internally-fallen-back classic one through the sync path conway delegates to internally — "safe on a resident source and on a non-deferred model", conway#672). A properties-only windowed IFC therefore loads on a pin with the ask instead of failing. Contained, so taken. **On a pin without it the throw is unchanged and still pinned** (`surfaces the engine refusal when a DEFERRED windowed model pumps nothing`), and the comment there now says which regime is which rather than describing the defect as unconditional.

Buffered opens keep the sync call on both regimes, deliberately: the async ask is wired **only** where the sync one cannot serve, so a pin bump cannot silently re-route the path that already worked onto a second implementation of the same answer. Revert **C** is that claim's discriminator.

## Observability

The permanent boundary line gained two tokens, so a production trace says which regime it measured without anyone reading a version string — which is what the PSB before/after will be read off:

```
[conwayDirect] demand pump: batches=3 meshes=150 onMeshBatch=yes onPreviewMesh=no windowed=yes asyncAsk=no retained=yes
```

`asyncAsk` is the **engine's capability**, not the entry point this load drives — nothing has been asked yet at that point, and on a buffered open `asyncAsk=yes` still drives the sync ask. The entry point actually driven is named by `recaptured N mesh(es) via StreamAllMeshes|StreamAllMeshesAsync`, which only a degraded build emits. (Review P3-3: the token was first called `wholeModelAsk=async|sync`, which read as a claim about the ask that ran.)

## What this only hopes

- **The bytes.** No memory number is claimed here. This makes the drop *reachable* on windowed opens; whether it pays out is the PSB before/after conway#660 owes, and that measurement cannot even run until the pin carries the ask.
- **That the ask serves what the pump served.** conway#672 measured it placement-for-placement on a windowed drained model (16/16, identity + full transform + colour + `occurrencePath`), and Share's side of that is a stub, not the engine. Jest mocks the engine here by construction.
- **That the new path has run in a browser.** It has not, and cannot until the bump — see the CI note below.

## Falsifiability

Each revert applied to the working tree, the suites re-run, then restored. All 63 tests in the two loader suites pass with none applied.

| revert | what it removes | result |
|---|---|---|
| **A** | the feature detect never fires (`hasAsyncWholeModelAsk = false`) — the pre-#660 world | **6 failed / 56 passed** |
| **B** | the feature detect always fires (`= true`) — no dormancy on the current pin | **2 failed / 60 passed** |
| **C** | the windowed condition on entry-point choice (`recaptureViaAsyncAsk = hasAsyncWholeModelAsk`) | **1 failed / 61 passed** |
| **D** | the retention decision as #1800 left it (`onMeshBatch === undefined \|\| windowedSource`) | **5 failed / 57 passed** |
| **E** | promise memoisation (memoise the resolved array instead) | **2 failed / 60 passed** |
| **F** | the sentinel's async branch (always the sync entry point) | **1 failed / 61 passed** |
| **G** | one `await` at a call site (`buildConwayIfcModel(recapture(), …)`) | **4 failed / 58 passed** |
| **H** | the merged degraded build's unguarded-ness (wrap it in a try/catch) | **1 failed / 6 passed** |

(A–G measured at 62 tests, before the P3 pass added the rejection test; H after.)

- **A** fails exactly the six new-regime tests and nothing else — the old-pin suite is untouched by the new path, which is the shape dormancy has to have.
- **B** is the byte-identity pin, and the important one: it fails `retains the stream on a WINDOWED open with no async ask, where re-extraction throws` and `surfaces the engine refusal when a DEFERRED windowed model pumps nothing`. Those two are today's behaviour on today's pin; if the detect were wrong in the "always on" direction, this branch would change what ships now.
- **C** fails only `keeps the SYNC ask on a buffered open even when the async one exists`.
- **D** fails the five windowed-drop tests but not the sentinel one — the sentinel branch is a separate decision, which is why F exists.
- **E** fails `memoises the async ask across the two consecutive degraded builds` (two engine drives for one model) and `lets a total-loss throw from the ask reach the load, once` (the failed drain re-driven).
- **F** fails only `recovers an empty pump on a DEFERRED windowed model through the async ask`.
- **G** fails all four degraded-build tests in `ShareIfcLoader.degraded.test.js`, which is only possible because that file's `recapture` stub was made **async** in this PR. With the old sync stub a dropped `await` passes — the stub was the thing making the seam untestable. (Verified independently by the reviewer.)
- **H** fails only `fails the load loudly when the whole-model ask rejects`, which is the point: that test's claim is specifically that the SECOND await is unguarded, since the first one's rejection is swallowed by design.

## Tests

`conwayDirectIfcLoader.test.js` — a new nested describe, `windowed retention with the async whole-model ask (conway#660)`, 8 tests. Its stubs attach a real async `StreamAllMeshesAsync` and leave the sync `StreamAllMeshes` **throwing the engine's actual refusal message**, so routing to the wrong entry point fails loudly rather than passing by accident.

1. drops the stream on a WINDOWED open once the engine can serve it back (`retained=no`, `asyncAsk=yes`, and the ask is not paid unless asked)
2. serves a degraded build through the async ask, never the sync refusal (bound to the windowed handle, not the buffered fallback's)
3. memoises the async ask across the two consecutive degraded builds — including the concurrent-overlap case
4. keeps the SYNC ask on a buffered open even when the async one exists (and pins `asyncAsk=yes` beside it, so the token's engine-level meaning is asserted rather than assumed)
5. still retains a windowed stream when nothing else takes delivery (no `onMeshBatch` ⇒ `captured` IS the delivery, regardless of the engine)
6. recovers an empty pump on a DEFERRED windowed model through the async ask (the sentinel decision; its old-pin twin still pins the throw)
7. serves the budget subset the ask answers with, without inventing a throw (conway#672's 3-of-16-under-a-2-KiB-budget semantics)
8. lets a total-loss throw from the ask reach the load, once

`ShareIfcLoader.degraded.test.js` — `fails the load loudly when the whole-model ask rejects` (review P3-2): the loader-level half of test 8. `recapture` rejects, `batchedMesh` off so the unguarded await runs, and the assertions are `parse` → null, `onError` called with the error, `ifcLastError` stashed, `addIfcModel` never called. Its stub also went async (see revert G).

Existing tests: the six `recapture()` reads became `await recapture()`; the windowed-retention and sentinel tests gained `asyncAsk` / `windowed` assertions and comments naming which regime they are. `CadView.test.jsx`'s recapture double went async too (review P3-1) — the last synchronous one repo-wide. Its comment records the measured limit of that change: it does **not** turn that file into a dropped-`await` detector, because its `buildConwayIfcModel` double ignores its argument entirely.

## Numbers

- **Baseline, measured on the untouched tree at `b02aab6`:** `yarn lint` clean; `yarn test` **259 suites / 2662 tests** (2657 passed, 5 skipped), 98 s.
- **This head:** `yarn lint` clean; `yarn test` **259 suites / 2671 tests** (2666 passed, 5 skipped) — **+9** (8 new-regime + 1 rejection pin). The husky pre-commit gate ran the same set on both commits.
- **Pre-flip validation** (the three things the draft gate does not cover), run on `ecbfb97`: `yarn build-prod` ✅; `yarn test-ci` ✅ with coverage thresholds enforced (statements 71.08%, branches 65.84%, functions 72.85%, lines 70.39%); `yarn test-flows src/loader/conwayDirect.spec.ts src/Containers/indexStepLogo.spec.ts src/viewer/loadTiming.spec.ts --workers=1` ✅ **13 passed**. `package.json`'s version stamp was restored by hand afterwards (#1747). The P3 commit is test-only plus one log token, and re-ran the full jest gate.
- **Those Playwright runs exercise the CURRENT pin**, i.e. the *dormant* regime — real windowed loads (GitHub → OPFS) taking the retaining path exactly as they do on main. They are evidence that this change did not disturb what ships today; they are **not** evidence the new path works in a browser. Nothing can be until the pin bump, and that is the first thing to check after it.

## Review focus

- **The feature-detect seam** — `hasAsyncWholeModelAsk` / `recaptureViaAsyncAsk` in `parseIfcWithConway`. Is the split right that the async ask is used *only* on windowed sources, leaving buffered opens byte-identical on both pins?
- **The async recapture at each call site.** Four sites, one made async to reach its thunk. Is there a fifth reader of `recapture()` anywhere, and is awaiting `logInstancedModelStats` (rather than firing it) the right call for log ordering?
- **The sentinel decision** — taking conway#661's fix in the same branch that drops retention. Contained enough, or should it have been a separate PR against #661?
- **Old-pin byte-identity.** Revert B is the argument; is it argued at the right level, or does something observable still change on `1.1578.666-g39d59784`?
- **The behaviour change on the new pin** (the section above): trading a silent partial/empty render for a loud failure inside an already-degraded build.