### PR TITLE
Bump @bldrs-ai/conway to 1.1583.660 — activate the windowed retention drop (conway#660)

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@babel/plugin-syntax-import-assertions": "7.18.6",
     "@babel/preset-env": "7.18.10",
     "@babel/preset-react": "7.18.6",
-    "@bldrs-ai/conway": "1.1582.673-g12d12550",
+    "@bldrs-ai/conway": "1.1583.660-g93378e5f",
     "@bldrs-ai/ifclib": "5.3.3",
     "@emotion/react": "11.10.0",
     "@emotion/styled": "11.10.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2473,10 +2473,10 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@bldrs-ai/conway@1.1582.673-g12d12550":
-  version "1.1582.673-g12d12550"
-  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.1582.673-g12d12550.tgz#8ad51a66183dcdc2d9e4e83956d17ef3210389cb"
-  integrity sha512-+l2ebAXArtBCYh1Vz14FBW2K4up3PhR+JTsw3Sv1J40cNknj9/ZUOor99BbFjC3urRwJaU3ZcCf61J84BSpCsg==
+"@bldrs-ai/conway@1.1583.660-g93378e5f":
+  version "1.1583.660-g93378e5f"
+  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.1583.660-g93378e5f.tgz#8ddbaaeb0faf7e881ecc02e4f95261cded53dc62"
+  integrity sha512-05UmI28JEwwYdy319KWKZLFGJcI/8BJi5ARILuXAMBZmH7QMA6XHuUVnGM625XW7wSRC/TqEQ3eE04XcYWjliA==
   dependencies:
     gl-matrix "3.4.3"
     seedrandom "3.0.5"


### PR DESCRIPTION
## What this releases

Bumps `@bldrs-ai/conway` `1.1582.673-g12d12550` → `1.1583.660-g93378e5f`, releasing conway#672 (`StreamAllMeshesAsync`) onto the published proxies. On the prior pin, `StreamAllMeshesAsync` did not exist, so Share#1803's feature-detect (`typeof ifcAPI.StreamAllMeshesAsync === 'function'`) always evaluated false and the windowed-drop code path was dormant.

## What this activates

Share#1803 (merged as ef96278) is the code; this pin bump is what turns it on. On windowed deferred opens (GitHub / OPFS File loads — the default path for large models), Share now drops its retained FlatMesh spine (`captured`) and recovers late whole-model reads through the async ask instead. Per Share#1803's PR body, three behavior changes activate:

1. Windowed opens print `retained=no asyncAsk=yes` on the `[conwayDirect] demand pump:` boundary line and no longer retain the pumped stream.
2. A fully-evicted windowed model now fails the degraded build loudly (parse → `null` + `onError`) instead of silently rendering a partial/empty scene.
3. A properties-only windowed IFC now loads via the async ask instead of throwing "cannot page a windowed source" (conway#661's Share-side symptom).

## Why 1.1583 and not the newer 1.1584

`1.1584.674-g470b4923` is available on npm and is newer, but it also carries conway-geom normals-in-GLB — a memory + visuals change unrelated to this epic. Pinning past it here would confound the epic's PSB before/after A/B measurement (conway#660), which needs the delta isolated to #672 alone. The prior pin, `1.1582.673-g12d12550` (Share#1802), is an ancestor of `93378e5f` on conway's main history (`470b4923 → 93378e5f(#672) → 12d12550(#673) → 1997609f(#669) → 7451b94c(#671) → 7e5a9cf8 → 39d59784`), so this bump strictly adds #672 and nothing past it.

## Evidence — real browser run on this branch

Windowed GitHub-fixture load (`/share/v/gh/bldrs-ai/test-models/main/ifc/misc/box.ifc?feature=conwayDirectIfc`), console output captured via a throwaway Playwright probe against the built bundle:

```
[conwayDirect] demand pump: batches=1 meshes=1 onMeshBatch=yes onPreviewMesh=yes windowed=yes asyncAsk=yes retained=no
[conwayDirect] parsed modelID=0 — vertices=24 triangles=12 instances=1 parents=1 materials=1 skippedFlatMeshes=0 skippedPlaced=0 skippedCoincident=0
Total: 1.158s, 65.591178 → 92.022879 MB heap | vertices=24 triangles=12 units=m
```

`retained=no` + `asyncAsk=yes` confirms the drop is live; the model still parses correctly (vertices=24 triangles=12 matches the known-good fixture geometry).

## Validation (local, since draft PRs skip gated CI)

- `yarn build-prod`: succeeded.
- `yarn test-ci` (coverage thresholds enforced): 259 suites / 2671 tests — 2666 passed, 5 skipped. Matches main baseline exactly.
- `yarn test-flows-build` + Playwright against a local server: `src/loader/conwayDirect.spec.ts src/Containers/indexStepLogo.spec.ts src/viewer/loadTiming.spec.ts` — 13/13 passed. The flows run's own load-report output additionally confirms `Conway v1.1583.660-g93378e5f` is the engine actually loaded at runtime.
- `git commit` ran the husky pre-commit gate (eslint + typecheck + full jest) — clean.
- Diff is scoped to `package.json` + `yarn.lock` only. Confirmed `StreamAllMeshesAsync` is exported from both compiled proxies (`ifc_api_proxy_ifc.js`, `ifc_api_proxy_ap214.js`) in the installed package.

Part of bldrs-ai/conway#660 (and bldrs-ai/conway#635).

---
_Generated by [Claude Code](https://claude.ai/code/session_01ScPZ6RarXvYmSdz6BUXF78)_