### PR TITLE
Fix #1806: preserve part colors when isolating

### DIFF
--- a/design/new/viewer-replacement.md
+++ b/design/new/viewer-replacement.md
@@ -329,11 +329,22 @@ Visual quality follows model shape:
   child's single material → per-PlacedGeometry colors render
   correctly. Outline + translucent x-ray fill both work.
 - **Cache-miss Conway-direct** (first load only — single Mesh with
-  array material + `geometry.groups[]`). The subset inherits the
-  array material without groups, so three renders all subset
-  triangles with `material[0]`. Small visual regression in isolation
-  mode on first load, corrects on reload (cache hit). Acceptable
-  for an admittedly rare workflow.
+  array material + `geometry.groups[]`). The subset keeps the array
+  material and rebuilds matching `groups[]` over the triangles it
+  kept, so per-PlacedGeometry colors render correctly here too.
+  Until Share#1806 this path added a single whole-buffer group
+  pointing at `material[0]`, which drew every isolated element in
+  bin 0's color — grey whenever bin 0 is the DEFAULT_COLOR bin, the
+  "parts lose color when isolated" report. Both subset builders now
+  map each kept triangle back to the source group it came from and
+  emit coalesced destination groups
+  (`src/viewer/three/subsetMaterialGroups.js`, shared by
+  `elementSubsets.buildSubsetMesh` and `IfcInstanceMap`'s
+  `buildSubsetMesh`). The whole-buffer group survives only as a
+  fallback for sources carrying no `groups[]` at all, or for an
+  array `material` override whose length can't hold the source's bin
+  indices — visible-but-monochrome still beats the renderer skipping
+  the mesh.
 
 Pickability:
 
@@ -376,10 +387,10 @@ the per-vertex `expressID` attribute across child Meshes.
   Mesh per IFC product (per `FlatMesh.expressID`) — would make
   hide trivially `mesh.visible = false`, drop the entire
   subset-construction surface for the simple case, and remove
-  the multi-material monochrome regression in `buildSubsetMesh`'s
-  `Array(N>1)` fallback. The cost is N draw calls instead of M
-  binned ones; on Snowdon (~6k products) that's noticeable but
-  recoverable with InstancedMesh batching for the
+  the `groups[]`-rebuild pass that `buildSubsetMesh`
+  now runs in its `Array(N>1)` branch (Share#1806). The cost is
+  N draw calls instead of M binned ones; on Snowdon (~6k products)
+  that's noticeable but recoverable with InstancedMesh batching for the
   `IfcMappedItem`-heavy portion and per-product Mesh for the
   rest. See §3b.iv — now an active effort.
 

--- a/src/viewer/ifc/IfcInstanceMap.js
+++ b/src/viewer/ifc/IfcInstanceMap.js
@@ -3,6 +3,7 @@ import {
   BufferGeometry,
   Mesh,
 } from 'three'
+import {assert} from '../../utils/assert'
 import {occurrencePathKey} from '../../utils/occurrencePaths'
 import {makeTriangleMaterialIndexer, resolveSubsetMaterial} from '../three/subsetMaterialGroups'
 
@@ -390,6 +391,16 @@ function buildSubsetMesh(sourceGeometry, ids, lookupTriangles, opts) {
       triangles[n++] = list[i]
     }
   }
+  // `total` was sized from a first pass over the same `ids` / `lookupTriangles`
+  // pair, so a second pass that yields fewer triangles leaves the tail of
+  // `triangles` at its zero fill — and triangle 0 is a real triangle, so the
+  // subset would silently render stray geometry from wherever the source
+  // happens to start. Fails loudly instead. Cheap: once per subset, not per
+  // triangle. Today's callers are consistent across the two passes; this
+  // guards a future one that isn't — a single-pass iterable (a generator) for
+  // `ids`, or a `lookupTriangles` whose list depends on call order.
+  assert(n === total,
+    `IfcInstanceMap.buildSubsetMesh: counted ${total} triangles, copied ${n}`)
   triangles.sort()
   const ArrayCtor = srcIndexArr.constructor
   const dstIndexArr = new ArrayCtor(total * 3)

--- a/src/viewer/ifc/IfcInstanceMap.js
+++ b/src/viewer/ifc/IfcInstanceMap.js
@@ -391,14 +391,20 @@ function buildSubsetMesh(sourceGeometry, ids, lookupTriangles, opts) {
       triangles[n++] = list[i]
     }
   }
-  // `total` was sized from a first pass over the same `ids` / `lookupTriangles`
-  // pair, so a second pass that yields fewer triangles leaves the tail of
-  // `triangles` at its zero fill — and triangle 0 is a real triangle, so the
-  // subset would silently render stray geometry from wherever the source
-  // happens to start. Fails loudly instead. Cheap: once per subset, not per
-  // triangle. Today's callers are consistent across the two passes; this
-  // guards a future one that isn't — a single-pass iterable (a generator) for
-  // `ids`, or a `lookupTriangles` whose list depends on call order.
+  // A programmer-error invariant, NOT model validation: `total` was sized from
+  // a first pass over the same `ids` / `lookupTriangles` pair, so the two
+  // passes can only disagree if a caller made them non-deterministic — a
+  // single-pass iterable (a generator) for `ids`, or a `lookupTriangles` whose
+  // list depends on call order. No model, however malformed, reaches here:
+  // both inputs are already-materialised structures the caller built before
+  // the first pass. So `assert` is meant to throw in production too — it is
+  // unreachable for any well-formed caller, and the alternative is silent
+  // corruption. A short second pass leaves the tail of `triangles` at its zero
+  // fill, and triangle 0 is a real triangle, so the subset would render stray
+  // geometry from wherever the source happens to start; a long one drops the
+  // overflow, since out-of-range typed-array writes are silently ignored.
+  // Don't soften this to a warn-and-continue. Cheap: once per subset, not per
+  // triangle.
   assert(n === total,
     `IfcInstanceMap.buildSubsetMesh: counted ${total} triangles, copied ${n}`)
   triangles.sort()

--- a/src/viewer/ifc/IfcInstanceMap.js
+++ b/src/viewer/ifc/IfcInstanceMap.js
@@ -4,6 +4,7 @@ import {
   Mesh,
 } from 'three'
 import {occurrencePathKey} from '../../utils/occurrencePaths'
+import {makeTriangleMaterialIndexer, resolveSubsetMaterial} from '../three/subsetMaterialGroups'
 
 
 /**
@@ -370,20 +371,41 @@ function buildSubsetMesh(sourceGeometry, ids, lookupTriangles, opts) {
   if (total === 0) {
     return null
   }
-  const ArrayCtor = srcIndexArr.constructor
-  const dstIndexArr = new ArrayCtor(total * 3)
-  let w = 0
+  // Gather the kept triangles first, then sort ascending before
+  // copying. Ordering is not a rendering requirement in itself, but it
+  // is what keeps the per-material `groups[]` below coalesced: the
+  // source emits triangles in color-bin order (see
+  // flatMeshToBufferGeometry.js), so ascending source order means one
+  // destination run per bin. Copying in id order instead would emit a
+  // run per instance — thousands of one-instance groups on a model
+  // whose parents interleave bins.
+  const triangles = new Uint32Array(total)
+  let n = 0
   for (const id of ids) {
     const list = lookupTriangles(id)
     if (!list) {
       continue
     }
     for (let i = 0; i < list.length; i++) {
-      const t = list[i]
-      const base = t * 3
-      dstIndexArr[w++] = srcIndexArr[base]
-      dstIndexArr[w++] = srcIndexArr[base + 1]
-      dstIndexArr[w++] = srcIndexArr[base + 2]
+      triangles[n++] = list[i]
+    }
+  }
+  triangles.sort()
+  const ArrayCtor = srcIndexArr.constructor
+  const dstIndexArr = new ArrayCtor(total * 3)
+  // Per-kept-triangle source material index, in destination order —
+  // see resolveSubsetMaterial below. Null for a single-material source.
+  const materialIndexOf = makeTriangleMaterialIndexer(sourceGeometry)
+  const dstMaterialIndices = materialIndexOf ? new Int32Array(total) : null
+  let w = 0
+  for (let i = 0; i < n; i++) {
+    const t = triangles[i]
+    const base = t * 3
+    dstIndexArr[w++] = srcIndexArr[base]
+    dstIndexArr[w++] = srcIndexArr[base + 1]
+    dstIndexArr[w++] = srcIndexArr[base + 2]
+    if (dstMaterialIndices) {
+      dstMaterialIndices[i] = materialIndexOf(t)
     }
   }
   const dstGeom = new BufferGeometry()
@@ -391,34 +413,20 @@ function buildSubsetMesh(sourceGeometry, ids, lookupTriangles, opts) {
     dstGeom.setAttribute(name, sourceGeometry.attributes[name])
   }
   dstGeom.setIndex(new BufferAttribute(dstIndexArr, 1))
-  let subsetMaterial = opts.material ?? opts.defaultMaterial ?? null
   // Three.js's WebGLRenderer `projectObject` (three.module.js around
   // line 17842 in r184) iterates `geometry.groups` when the material
   // is an array — and pushes NOTHING to the render list if `groups`
   // is empty. So a subset with `material: Array(N)` + no groups gets
   // silently skipped. Conway-direct's assembler always emits `material`
   // as an array (one entry per PlacedGeometry.color bin); even a
-  // single-color model gets `Array(1)`. Two options here, both keep
-  // the subset rendering:
-  //  - If the array has a single material, unwrap to scalar — the
-  //    renderer takes the `else if (material.visible)` branch and
-  //    pushes once. This is the cache-hit Conway-direct path for
-  //    monochrome models (the index.ifc test case that surfaced the
-  //    bug).
-  //  - If the array has multiple materials, add a single `group`
-  //    spanning the full index buffer, pointing at `material[0]`.
-  //    Subset renders monochrome (lose per-color fidelity for the
-  //    visible elements) but at least it's *visible*. The proper fix
-  //    is to walk the source's `geometry.groups` and emit a sub-group
-  //    per material the subset's triangles span; that's a separate
-  //    pass and tracked as a TODO in §3b.iii.
-  if (Array.isArray(subsetMaterial)) {
-    if (subsetMaterial.length === 1) {
-      subsetMaterial = subsetMaterial[0]
-    } else if (subsetMaterial.length > 1) {
-      dstGeom.addGroup(0, dstIndexArr.length, 0)
-    }
-  }
+  // single-color model gets `Array(1)`. resolveSubsetMaterial handles
+  // both shapes: unwrap Array(1) to a scalar so the renderer takes its
+  // `else if (material.visible)` branch, and for Array(N>1) emit one
+  // destination group per coalesced run of same-bin triangles so the
+  // subset keeps its per-color materials rather than collapsing to
+  // `material[0]` (Share#1806). See ../three/subsetMaterialGroups.js.
+  const subsetMaterial = resolveSubsetMaterial(
+    dstGeom, opts.material ?? opts.defaultMaterial ?? null, dstMaterialIndices)
   const mesh = new Mesh(dstGeom, subsetMaterial)
   if (opts.raycastInvisible !== false) {
     mesh.raycast = () => {/* see IfcItemsMap.createSubsetMesh */}

--- a/src/viewer/ifc/IfcInstanceMap.test.js
+++ b/src/viewer/ifc/IfcInstanceMap.test.js
@@ -33,6 +33,25 @@ function makeSixTriangleGeometry() {
 }
 
 
+/**
+ * Six-triangle geometry split into two color bins, the shape
+ * `flatMeshToBufferGeometry` produces: triangles emitted in bin order,
+ * one `geometry.groups[]` entry per bin, positionally paired with one
+ * entry in the mesh's `material` array.
+ *
+ *   bin 0 (material[0]) → tris 0-2 (index range 0-8)
+ *   bin 1 (material[1]) → tris 3-5 (index range 9-17)
+ *
+ * @return {BufferGeometry}
+ */
+function makeTwoBinGeometry() {
+  const geom = makeSixTriangleGeometry()
+  geom.addGroup(0, 9, 0)
+  geom.addGroup(9, 9, 1)
+  return geom
+}
+
+
 describe('viewer/ifc/IfcInstanceMap', () => {
   describe('instanceMapFromOrderedPlacedRanges', () => {
     it('builds positionally from a per-PlacedGeometry range stream', () => {
@@ -276,13 +295,14 @@ describe('viewer/ifc/IfcInstanceMap', () => {
       expect(Array.isArray(subset.material)).toBe(false)
     })
 
-    it('adds a group spanning the index buffer when material is multi-element Array', () => {
-      // Multi-material case (e.g., Snowdon with N color bins). Keep
-      // the array material reference so call-sites that rely on it
-      // (highlighting fallbacks, downstream subset construction)
-      // still see Array(N), but add a group so the renderer iterates
-      // at least once and pushes the subset onto the render list.
-      // Per-material per-triangle correctness is a TODO §3b.iii.
+    it('adds a group spanning the index buffer when the source has no groups', () => {
+      // Multi-element material array over a source geometry that
+      // carries no `groups[]` — there is nothing to attribute the
+      // triangles to, so fall back to one whole-buffer group. Keeps
+      // the array material reference (call-sites that rely on it —
+      // highlighting fallbacks, downstream subset construction — still
+      // see Array(N)) and keeps the renderer from skipping the mesh.
+      // The per-bin walk is covered by the tests below.
       const geom = makeSixTriangleGeometry()
       const map = instanceMapFromOrderedPlacedRanges([
         {parentExpressId: 100, triangleCount: 1},
@@ -297,6 +317,84 @@ describe('viewer/ifc/IfcInstanceMap', () => {
       expect(groups[0].start).toBe(0)
       expect(groups[0].count).toBe(subset.geometry.getIndex().count)
       expect(groups[0].materialIndex).toBe(0)
+    })
+
+    it('preserves a per-color-bin group walk across a multi-bin subset', () => {
+      // Share#1806: the whole-buffer `addGroup(0, len, 0)` stop-gap drew
+      // every subset triangle with material[0] — monochrome, and grey
+      // whenever bin 0 is the DEFAULT_COLOR bin. The subset must carry
+      // one group per source bin it spans, indexing the same material
+      // array the source geometry's groups were binned into.
+      const geom = makeTwoBinGeometry()
+      const map = instanceMapFromOrderedPlacedRanges([
+        {parentExpressId: 100, triangleCount: 3}, // inst 0 → bin 0
+        {parentExpressId: 200, triangleCount: 3}, // inst 1 → bin 1
+      ], {geometry: geom})
+      const materials = [new MeshBasicMaterial(), new MeshBasicMaterial()]
+      const subset = map.createSubsetMeshByInstance([0, 1],
+        {defaultMaterial: materials})
+      expect(subset.material).toBe(materials)
+      expect(subset.geometry.groups).toEqual([
+        {start: 0, count: 9, materialIndex: 0},
+        {start: 9, count: 9, materialIndex: 1},
+      ])
+    })
+
+    it('renders a single-bin subset with that bin\'s material, not material[0]', () => {
+      const geom = makeTwoBinGeometry()
+      const map = instanceMapFromOrderedPlacedRanges([
+        {parentExpressId: 100, triangleCount: 3},
+        {parentExpressId: 200, triangleCount: 3},
+      ], {geometry: geom})
+      const materials = [new MeshBasicMaterial(), new MeshBasicMaterial()]
+      const subset = map.createSubsetMeshByInstance([1],
+        {defaultMaterial: materials})
+      expect(subset.geometry.groups).toEqual([
+        {start: 0, count: 9, materialIndex: 1},
+      ])
+    })
+
+    it('sorts out-of-order instance ids so groups stay coalesced', () => {
+      // Instance ids arrive in whatever order the caller collected them
+      // (createSubsetMeshByParent walks a Map). Copying in that order
+      // would emit a group per instance; the builder sorts by source
+      // triangle first so runs collapse to one group per bin.
+      const geom = makeTwoBinGeometry()
+      const map = instanceMapFromOrderedPlacedRanges([
+        {parentExpressId: 100, triangleCount: 1}, // inst 0 → bin 0, tri 0
+        {parentExpressId: 200, triangleCount: 3}, // inst 1 → tris 1-3
+        {parentExpressId: 300, triangleCount: 1}, // inst 2 → bin 1, tri 4
+      ], {geometry: geom})
+      const materials = [new MeshBasicMaterial(), new MeshBasicMaterial()]
+      const subset = map.createSubsetMeshByInstance([2, 0, 1],
+        {defaultMaterial: materials})
+      // Tris 0-2 are bin 0, tris 3-4 are bin 1 — two groups regardless
+      // of the id order they were requested in.
+      expect(subset.geometry.groups).toEqual([
+        {start: 0, count: 9, materialIndex: 0},
+        {start: 9, count: 6, materialIndex: 1},
+      ])
+    })
+
+    it('falls back to a whole-buffer group when the material array cannot hold the bin indices', () => {
+      // An array `material` override that is not the source's own bin
+      // array: the group material indices only mean something against
+      // the array they were binned into, so an out-of-range index means
+      // "these indices are not for this array". Visible-but-monochrome
+      // beats the renderer skipping the mesh entirely.
+      const geom = makeSixTriangleGeometry()
+      geom.addGroup(0, 6, 0)
+      geom.addGroup(6, 6, 1)
+      geom.addGroup(12, 6, 2)
+      const map = instanceMapFromOrderedPlacedRanges([
+        {parentExpressId: 100, triangleCount: 6},
+      ], {geometry: geom})
+      const shortArray = [new MeshBasicMaterial(), new MeshBasicMaterial()]
+      const subset = map.createSubsetMeshByInstance([0],
+        {defaultMaterial: shortArray})
+      expect(subset.geometry.groups).toEqual([
+        {start: 0, count: 18, materialIndex: 0},
+      ])
     })
   })
 

--- a/src/viewer/ifc/IfcInstanceMap.test.js
+++ b/src/viewer/ifc/IfcInstanceMap.test.js
@@ -261,6 +261,40 @@ describe('viewer/ifc/IfcInstanceMap', () => {
       expect(map.createSubsetMeshByInstance([])).toBeNull()
     })
 
+    it('throws rather than drawing a zero-filled tail when the two passes disagree', () => {
+      const geom = makeSixTriangleGeometry()
+      const map = instanceMapFromOrderedPlacedRanges([
+        {parentExpressId: 100, triangleCount: 2},
+        {parentExpressId: 200, triangleCount: 2},
+      ], {geometry: geom})
+      // `buildSubsetMesh` sizes its triangle array from a first pass over
+      // `ids` and fills it from a second. A single-pass iterable is the
+      // cheapest way to make the two disagree: the generator is exhausted by
+      // the sizing pass, so the fill pass writes nothing and every slot keeps
+      // its zero fill — which is triangle 0, real geometry, silently drawn in
+      // place of the requested instance. Today's callers all pass arrays or
+      // Sets; this pins the guard for the one that doesn't.
+      const singlePassIds = (function* gen() {
+        yield 0
+        yield 1
+      })()
+      expect(() => map.createSubsetMeshByInstance(singlePassIds))
+        .toThrow(/counted 4 triangles, copied 0/)
+    })
+
+    it('accepts an id list that is consistent across both passes', () => {
+      // The guard's negative control: the same ids as an array must not throw
+      // — otherwise the test above would pass against a builder that rejects
+      // everything.
+      const geom = makeSixTriangleGeometry()
+      const map = instanceMapFromOrderedPlacedRanges([
+        {parentExpressId: 100, triangleCount: 2},
+        {parentExpressId: 200, triangleCount: 2},
+      ], {geometry: geom})
+      const subset = map.createSubsetMeshByInstance([0, 1])
+      expect(subset.geometry.getIndex().count).toBe(12)
+    })
+
     it('honours a material override; defaults raycast-invisible', () => {
       const geom = makeSixTriangleGeometry()
       const map = instanceMapFromOrderedPlacedRanges([

--- a/src/viewer/three/CustomPostProcessor.js
+++ b/src/viewer/three/CustomPostProcessor.js
@@ -10,6 +10,7 @@ import {
 } from 'postprocessing'
 import {WebGLRenderer, Scene, Camera, UnsignedShortType} from 'three'
 import {isFeatureEnabled} from '../../FeatureFlags'
+import {patchOutlineForBatchedMeshes} from './outlineBatching'
 
 
 // SSAO defaults (§6e). Screen-space ambient occlusion darkens crevices /
@@ -213,6 +214,10 @@ export default class CustomPostProcessor {
    */
   createOutlineEffect(effectOpts) {
     const outlineEffect = new OutlineEffect(this._scene, this._camera, effectOpts)
+    // Every outline effect gets the batching patch, not just the isolator's:
+    // any selection that can contain a `THREE.BatchedMesh` hits the same
+    // uncompilable mask shader. See outlineBatching.js for the failure mode.
+    patchOutlineForBatchedMeshes(outlineEffect)
     const selectionOutlinePass = new EffectPass(this._camera, outlineEffect)
     this._composer.addPass(selectionOutlinePass)
     return outlineEffect

--- a/src/viewer/three/IfcIsolator.js
+++ b/src/viewer/three/IfcIsolator.js
@@ -1,5 +1,6 @@
 import {ShareViewer} from '../ShareViewer'
 import {unsortedArraysAreEqual, arrayRemove} from '../../utils/arrays'
+import {clearBatchedSelection} from '../ifc/batchedHighlight'
 import {eachBatch, isBatchedModel} from '../ifc/batchedModel'
 import {MeshLambertMaterial, DoubleSide, Mesh} from 'three'
 import useStore from '../../store/useStore'
@@ -701,6 +702,15 @@ export default class IfcIsolator {
       // `BotChat` calls this method directly without entering isolation mode
       // (no `tempIsolationModeOn` / `isolatedIds`) — reading the fields would
       // make a bot-driven isolate a no-op.
+      // Drop the selection paint before masking. Isolate normally targets the
+      // *selection*, so the isolated instances are exactly the ones
+      // `applyBatchedSelection` painted cyan — leaving that on would show the
+      // user a cyan part rather than the part's own colour, which is the whole
+      // of Share#1806. Logical selection is untouched (store-side
+      // `selectedElements` / `selectedInstanceIds`), and `resetTempIsolation`
+      // repaints from it via `_rebuildSelectionVisualFromStore`, so a click
+      // made while isolated still highlights normally.
+      this._clearSelectionVisualOnly()
       this._applyBatchedVisibility({isolatedIds: includedIds})
       // No subset Mesh exists to outline. Point the effect at the batch meshes
       // themselves: only the isolated instances are visible on them now, so the
@@ -791,15 +801,18 @@ export default class IfcIsolator {
 
 
   /**
-   * Clear the Conway-direct selection visual (cyan outline + fill
-   * subsets + OutlineEffect selection set) WITHOUT touching the
-   * store-side `selectedElements` / `selectedInstanceIds` or the
-   * viewer's `_selectedExpressIds` cache.
+   * Clear the selection visual (cyan outline + fill subsets +
+   * OutlineEffect selection set on the subset paths; the in-place
+   * `setColorAt` selection paint on the batched path) WITHOUT
+   * touching the store-side `selectedElements` /
+   * `selectedInstanceIds` or the viewer's `_selectedExpressIds`
+   * cache.
    *
-   * Used by hide-paths that preserve selection state for H-toggle
-   * semantics but still want the cyan to disappear so the hide reads
-   * cleanly. The counterpart `_rebuildSelectionVisualFromStore`
-   * resyncs the visual from the (preserved) store state on unhide.
+   * Used by hide- and isolate-paths that preserve selection state for
+   * H- / I-toggle semantics but still want the cyan to disappear so
+   * the operation reads cleanly. The counterpart
+   * `_rebuildSelectionVisualFromStore` resyncs the visual from the
+   * (preserved) store state on unhide / un-isolate.
    *
    * @private
    */
@@ -809,6 +822,14 @@ export default class IfcIsolator {
     }
     if (typeof this.viewer._clearConwaySelectionSubsets === 'function') {
       this.viewer._clearConwaySelectionSubsets()
+    }
+    // Batched path: there is no subset to remove — the selection was painted
+    // onto the live instances (`applyBatchedSelection` → `setColorAt`), so the
+    // only way to take it off is to repaint them from `instanceColors`. Without
+    // this the two calls above are no-ops here and the cyan survives (Share#1806:
+    // an isolated part stayed selection-cyan instead of showing its own colour).
+    if (this._isBatchedModel()) {
+      clearBatchedSelection(this.ifcModel)
     }
   }
 

--- a/src/viewer/three/IfcIsolator.js
+++ b/src/viewer/three/IfcIsolator.js
@@ -1,5 +1,6 @@
 import {ShareViewer} from '../ShareViewer'
 import {unsortedArraysAreEqual, arrayRemove} from '../../utils/arrays'
+import {eachBatch, isBatchedModel} from '../ifc/batchedModel'
 import {MeshLambertMaterial, DoubleSide, Mesh} from 'three'
 import useStore from '../../store/useStore'
 import {BlendFunction} from 'postprocessing'
@@ -18,6 +19,20 @@ import ThreeContext from './ThreeContext'
  * `_removeSubsetFromScene` / `_subsetMeshes` helpers normalise both
  * shapes so the public methods don't branch. See
  * design/new/viewer-replacement.md §3b.iii.
+ *
+ * **Batched path is different: no subset is built at all.** When the model
+ * is a `THREE.BatchedMesh` (or a Group of them — the opaque/transparent
+ * split), hide and isolate run *in place* by flipping per-instance
+ * visibility with `BatchedMesh.setVisibleAt` (`_applyBatchedVisibility`).
+ * Re-baking a subset Mesh there was Share#1806: the baked Mesh gets the
+ * batch's shared colourless `makeSurfaceMaterial` and cannot read the
+ * batch's per-instance colour texture, so every isolated part rendered
+ * light grey. Masking visibility keeps the real geometry, materials,
+ * per-instance colours (`setColorAt` / `instanceColors` / the auto-colour
+ * palette) and picking intact by construction, and the model never leaves
+ * the scene or `pickableModels`. `batchedSubset.js` is still used on this
+ * path for the reveal-hidden ghost overlay (which *wants* a flat cyan
+ * material), and by the other backends for everything.
  */
 export default class IfcIsolator {
   subsetCustomId = 'Bldrs::Share::Isolator'
@@ -335,8 +350,14 @@ export default class IfcIsolator {
    * @param {boolean} removeModel Whether to remove the model
    */
   initHideOperationsSubset(includedIds, removeModel = true) {
+    const batched = this._isBatchedModel()
     if (removeModel) {
-      this._removeSubsetFromScene(this.ifcModel)
+      // The batched path masks visibility on the model itself, so it must stay
+      // in the scene (and in `pickableModels`) — detaching it would leave an
+      // empty viewport.
+      if (!batched) {
+        this._removeSubsetFromScene(this.ifcModel)
+      }
       this.viewer.selector?.clearSelection()
       this.viewer.selector?.clearPreselection()
     }
@@ -352,6 +373,15 @@ export default class IfcIsolator {
     // the pool here so the subset is what the user actually sees.
     if (typeof this.viewer._clearPreselectionForAllModels === 'function') {
       this.viewer._clearPreselectionForAllModels()
+    }
+    if (batched) {
+      // `includedIds` is redundant here: every caller passes
+      // `visualElementsIds − hiddenIds`, and the per-occurrence subtraction is
+      // `_hiddenInstanceIdSet()` — both of which `_applyBatchedVisibility`
+      // re-derives from the same state, along with the isolation filter that
+      // a `createSubset` call could not express.
+      this._applyBatchedVisibility()
+      return
     }
     this.unhiddenSubset = this.ifcModel.createSubset({
       modelID: 0,
@@ -385,6 +415,177 @@ export default class IfcIsolator {
       }
     }
     return set
+  }
+
+
+  /**
+   * True when the loaded model renders through the `THREE.BatchedMesh` path
+   * (`buildBatchedConwayModel` / `instancedGlbToBatchedModel`) — i.e. hide and
+   * isolate mask per-instance visibility in place instead of re-baking a
+   * subset Mesh. Discriminated by the `instanceParents` pick table, the same
+   * signal `batchedHighlight` uses.
+   *
+   * @return {boolean}
+   * @private
+   */
+  _isBatchedModel() {
+    return isBatchedModel(this.ifcModel)
+  }
+
+
+  /**
+   * Put the source model back on screen after hide / isolate ended.
+   *
+   * On the subset paths that means re-attaching the model the hide/isolate
+   * detached. On the batched path the model never left the scene — re-adding
+   * it would push a duplicate onto `pickableModels` — so this instead
+   * re-derives the visibility mask, which drops it entirely once nothing is
+   * hidden or isolated. Callers must clear `hiddenIds` / `hiddenOccurrences` /
+   * `isolatedIds` first.
+   *
+   * @private
+   */
+  _restoreModelToScene() {
+    if (this._isBatchedModel()) {
+      this._applyBatchedVisibility()
+      return
+    }
+    this._addSubsetToScene(this.ifcModel)
+  }
+
+
+  /**
+   * Re-derive and apply per-instance visibility for every batch of a batched
+   * model. A batchId is visible iff it passes **both** filters:
+   *
+   *   - isolation — not isolating, or its parent product is in `isolatedIds`;
+   *   - hide — its parent isn't in `hiddenIds` and its occurrence id isn't in
+   *     `_hiddenInstanceIdSet()` (the STEP per-occurrence hides).
+   *
+   * With nothing hidden and nothing isolated the mask is released and the
+   * batch returns to whatever visibility its other owner (residency) had set.
+   *
+   * Ownership handshake with `ResidencyController`. Residency
+   * (`src/viewer/residency/ResidencyController.js`) also drives `setVisibleAt`
+   * — it evicts instances for the residency slider / LOD, and it tracks its own
+   * `instance.visible` belief. Two owners of one bit needs an arbiter, so while
+   * a mask is installed the isolator wraps the batch's `setVisibleAt`
+   * (`_ensureBatchedMask`): residency's writes land in the mask's `base` array
+   * (its *intent*, preserved) and reach the GPU only when the isolator's
+   * `allow` bit also permits it. Isolation therefore wins for parts it hides,
+   * residency wins for parts it evicts, and `_releaseBatchedMask` replays
+   * `base` on the way out — so un-isolating restores exactly what residency
+   * had set, not a blanket "everything visible".
+   *
+   * @param {object} [opts]
+   * @param {Array<number>} [opts.isolatedIds] isolate this set instead of the
+   *   isolator's own `isolatedIds` / `tempIsolationModeOn` state — for the
+   *   direct `initTemporaryIsolationSubset` callers that never enter isolation
+   *   mode (BotChat).
+   * @private
+   */
+  _applyBatchedVisibility(opts = {}) {
+    const hiddenParents = new Set(this.hiddenIds)
+    const hiddenInstances = this._hiddenInstanceIdSet()
+    const explicitIsolation = Array.isArray(opts.isolatedIds)
+    const isolating = explicitIsolation || this.tempIsolationModeOn
+    const isolatedParents = isolating ?
+      new Set(explicitIsolation ? opts.isolatedIds : this.isolatedIds) : null
+    const masking = isolating || hiddenParents.size > 0 || hiddenInstances.size > 0
+    eachBatch(this.ifcModel, (mesh) => {
+      if (!mesh.instanceParents || typeof mesh.setVisibleAt !== 'function') {
+        return
+      }
+      if (!masking) {
+        this._releaseBatchedMask(mesh)
+        return
+      }
+      const mask = this._ensureBatchedMask(mesh)
+      const parents = mesh.instanceParents
+      const occurrenceIds = mesh.instanceOccurrenceIds
+      for (let batchId = 0; batchId < parents.length; batchId++) {
+        const parent = parents[batchId]
+        const allowed =
+          (!isolating || isolatedParents.has(parent)) &&
+          !hiddenParents.has(parent) &&
+          !(occurrenceIds && hiddenInstances.has(occurrenceIds[batchId]))
+        mask.allow[batchId] = allowed ? 1 : 0
+        // Bypass the wrapper: this is the isolator's own write, and it must not
+        // be mistaken for residency intent (which would overwrite `base`).
+        mask.nativeSetVisibleAt.call(mesh, batchId, allowed && mask.base[batchId] === 1)
+      }
+      // three's own `setVisibleAt` sets this; poke it too since we went around
+      // it, so `BatchedMesh.onBeforeRender` rebuilds its multi-draw ranges and
+      // the change repaints on the next frame (cf. shadingMode.js).
+      mesh._visibilityChanged = true
+    })
+  }
+
+
+  /**
+   * Install (or fetch) this batch's isolation mask: a snapshot of the
+   * pre-isolation per-instance visibility (`base`), the isolator's per-instance
+   * verdict (`allow`), and a `setVisibleAt` wrapper that keeps the two owners
+   * from clobbering each other. See `_applyBatchedVisibility` for the handshake.
+   *
+   * State lives under `mesh.userData` (repo convention, cf.
+   * `userData.batchedHighlight`) so it survives an isolator re-creation over
+   * the same model.
+   *
+   * @param {object} mesh a decorated BatchedMesh
+   * @return {object} `{base, allow, nativeSetVisibleAt, hadOwnSetVisibleAt}`
+   * @private
+   */
+  _ensureBatchedMask(mesh) {
+    const existing = mesh.userData.isolationMask
+    if (existing) {
+      return existing
+    }
+    const count = mesh.instanceParents.length
+    const base = new Uint8Array(count)
+    for (let batchId = 0; batchId < count; batchId++) {
+      base[batchId] = mesh.getVisibleAt(batchId) ? 1 : 0
+    }
+    const nativeSetVisibleAt = mesh.setVisibleAt
+    const mask = {
+      base,
+      allow: new Uint8Array(count).fill(1),
+      nativeSetVisibleAt,
+      // Normally the prototype method; remembered so release restores the mesh
+      // to the exact shape it had rather than leaving a stray own property.
+      hadOwnSetVisibleAt: Object.prototype.hasOwnProperty.call(mesh, 'setVisibleAt'),
+    }
+    mesh.userData.isolationMask = mask
+    mesh.setVisibleAt = function maskedSetVisibleAt(batchId, visible) {
+      mask.base[batchId] = visible ? 1 : 0
+      return nativeSetVisibleAt.call(this, batchId, visible && mask.allow[batchId] === 1)
+    }
+    return mask
+  }
+
+
+  /**
+   * Remove this batch's isolation mask and replay the snapshotted visibility,
+   * handing the bit back to residency exactly as it left it.
+   *
+   * @param {object} mesh a decorated BatchedMesh
+   * @private
+   */
+  _releaseBatchedMask(mesh) {
+    const mask = mesh.userData?.isolationMask
+    if (!mask) {
+      return
+    }
+    delete mesh.userData.isolationMask
+    if (mask.hadOwnSetVisibleAt) {
+      mesh.setVisibleAt = mask.nativeSetVisibleAt
+    } else {
+      delete mesh.setVisibleAt
+    }
+    for (let batchId = 0; batchId < mask.base.length; batchId++) {
+      mask.nativeSetVisibleAt.call(mesh, batchId, mask.base[batchId] === 1)
+    }
+    mesh._visibilityChanged = true
   }
 
 
@@ -483,13 +684,31 @@ export default class IfcIsolator {
    * @param {Array} includedIds element ids included in the subset
    */
   initTemporaryIsolationSubset(includedIds) {
-    this._removeSubsetFromScene(this.ifcModel)
+    const batched = this._isBatchedModel()
+    if (!batched) {
+      this._removeSubsetFromScene(this.ifcModel)
+    }
     // Same hover-pool cleanup reasoning as in `initHideOperationsSubset`.
     // For isolate this matters less visually (the pool's last-hovered
     // element typically IS the isolated one, so it's redundant rather
     // than wrong), but keeping the two paths symmetric avoids drift.
     if (typeof this.viewer._clearPreselectionForAllModels === 'function') {
       this.viewer._clearPreselectionForAllModels()
+    }
+    if (batched) {
+      // Isolate in place (Share#1806) — see the class doc. `includedIds` is
+      // passed explicitly rather than read off `isolatedIds`, because
+      // `BotChat` calls this method directly without entering isolation mode
+      // (no `tempIsolationModeOn` / `isolatedIds`) — reading the fields would
+      // make a bot-driven isolate a no-op.
+      this._applyBatchedVisibility({isolatedIds: includedIds})
+      // No subset Mesh exists to outline. Point the effect at the batch meshes
+      // themselves: only the isolated instances are visible on them now, so the
+      // outline pass's mask traces exactly the isolated geometry.
+      const batches = []
+      eachBatch(this.ifcModel, (mesh) => batches.push(mesh))
+      this.isolationOutlineEffect.setSelection(batches)
+      return
     }
     this.isolationSubset = this.ifcModel.createSubset({
       modelID: 0,
@@ -716,9 +935,12 @@ export default class IfcIsolator {
     }
     this._removeSubsetFromScene(this.unhiddenSubset)
     this.unhiddenSubset = null
-    this._addSubsetToScene(this.ifcModel)
+    // Clear the hidden state BEFORE restoring: `_restoreModelToScene` re-derives
+    // the batched visibility mask from it, so restoring first would re-apply the
+    // hides it is meant to drop. Order is irrelevant on the subset paths.
     this.hiddenIds = []
     this.hiddenOccurrences.clear()
+    this._restoreModelToScene()
     useStore.setState({hiddenElements: {}})
     // Rebuild the cyan selection visual from the preserved store
     // state. `hideSelectedElements` cleared the visual but kept the
@@ -869,7 +1091,7 @@ export default class IfcIsolator {
       const toBeShown = this.visualElementsIds.filter((el) => !this.hiddenIds.includes( el ))
       this.initHideOperationsSubset(toBeShown, false)
     } else {
-      this._addSubsetToScene(this.ifcModel)
+      this._restoreModelToScene()
     }
     this.isolationOutlineEffect.setSelection([])
     // Rebuild the cyan selection visual. Covers the hide-then-
@@ -880,6 +1102,17 @@ export default class IfcIsolator {
     // was never cleared, `_setConwaySelectionFromModel` inside
     // setSelection clears + rebuilds at the same position).
     this._rebuildSelectionVisualFromStore()
+  }
+
+  /**
+   * Release every batched visibility mask this isolator installed, handing the
+   * `setVisibleAt` bit back to residency. Called by `ShareViewer#dispose` (via
+   * optional chaining) when the viewer or its model goes away, so a model that
+   * is unloaded while isolated doesn't keep a wrapped `setVisibleAt` — and a
+   * model kept across the teardown comes back with residency's visibility.
+   */
+  dispose() {
+    eachBatch(this.ifcModel, (mesh) => this._releaseBatchedMask(mesh))
   }
 
   /**

--- a/src/viewer/three/IfcIsolator.spec.ts
+++ b/src/viewer/three/IfcIsolator.spec.ts
@@ -1,7 +1,8 @@
 /* eslint-disable no-magic-numbers */
 import {Page, expect, test} from '@playwright/test'
+import {setupVirtualPathIntercept, waitForModelReady} from '../../tests/e2e/models'
+import {describeMobileAndDesktop} from '../../tests/e2e/formFactor'
 import {homepageSetup, setIsReturningUser} from '../../tests/e2e/utils'
-import {waitForModelReady} from '../../tests/e2e/models'
 
 
 const {beforeEach, describe} = test
@@ -234,5 +235,157 @@ describe('viewer/three/IfcIsolator: isolate/hide combinations (Conway-direct)', 
 
     const state = await readIsolatorState(page)
     expect(state.revealedSubsetMeshes.length).toBe(0)
+  })
+})
+
+
+// ---------------------------------------------------------------------------
+// Batched render path (Share#1806): "Parts lose color when isolated".
+//
+// The suite above covers the merged Conway-direct path, where isolation swaps
+// the model for a re-baked subset Mesh. On the default STEP path the model is
+// a `THREE.BatchedMesh` whose per-part colour lives in the batch's per-instance
+// colour texture — a re-baked subset can't read that texture and inherited the
+// batch's shared colourless material, so every isolated part rendered light
+// grey. Isolation there now masks per-instance visibility in place
+// (`setVisibleAt`), which is what these tests assert against the real scene:
+// the batch is still the object being drawn, the instance colour table is
+// untouched, and only the isolated product's instances remain visible.
+// ---------------------------------------------------------------------------
+
+// The model from the issue report. Its own presentation data colours 2 of its
+// 5 parts, which is precisely the case that turned grey.
+const AS1_PATH = '/share/v/gh/bldrs-ai/test-models/main/step/nist/as1-oc-214.stp'
+// STEP parse + BREP tessellation is heavier than the IFC smoke models
+// (matching colorMode.spec.ts / displayPermalink.spec.ts).
+const STEP_TEST_TIMEOUT_MS = 90_000
+
+
+interface BatchedSnapshot {
+  /** Per-instance visibility, batchId order, across every batch. */
+  visible: boolean[]
+  /** Per-instance source colour (`instanceColors`), same order. */
+  colors: number[][]
+  /** Is the loaded model itself still a child of the scene? */
+  modelInScene: boolean
+  /** Isolation subset meshes — must stay 0 on the batched path. */
+  isolationSubsetCount: number
+  tempIsolationModeOn: boolean
+}
+
+
+/**
+ * Snapshot the live batched model: what the renderer draws (per-instance
+ * visibility + the colour table it draws from) plus the isolator's slots.
+ *
+ * @param page playwright page
+ * @return snapshot of the batched scene state
+ */
+function readBatchedSnapshot(page: Page): Promise<BatchedSnapshot> {
+  return page.evaluate(() => {
+    /* eslint-disable @typescript-eslint/no-explicit-any */
+    const w = window as any
+    const state = w.store?.getState?.()
+    const model = state?.model
+    const iso = state?.viewer?.isolator
+    if (!model || !iso) {
+      throw new Error('readBatchedSnapshot: no model/isolator on window — is the page in test mode?')
+    }
+    const meshes: any[] = []
+    if (model.isBatchedMesh) {
+      meshes.push(model)
+    }
+    (model.children ?? []).forEach((child: any) => {
+      if (child?.isBatchedMesh) {
+        meshes.push(child)
+      }
+    })
+    const visible: boolean[] = []
+    const colors: number[][] = []
+    for (const mesh of meshes) {
+      const count = mesh.instanceParents?.length ?? 0
+      for (let index = 0; index < count; index++) {
+        visible.push(mesh.getVisibleAt(index))
+        const c = mesh.instanceColors?.[index]
+        colors.push(c ? [c.x, c.y, c.z, c.w] : [])
+      }
+    }
+    const subset = iso.isolationSubset
+    return {
+      visible,
+      colors,
+      modelInScene: iso.context.getScene().children.includes(model),
+      isolationSubsetCount: subset ? (Array.isArray(subset) ? subset.length : 1) : 0,
+      tempIsolationModeOn: iso.tempIsolationModeOn,
+    }
+    /* eslint-enable @typescript-eslint/no-explicit-any */
+  })
+}
+
+
+/**
+ * @param page playwright page
+ * @return number of selected elements in the store
+ */
+function selectedCount(page: Page): Promise<number> {
+  return page.evaluate(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const w = window as any
+    return (w.store?.getState?.().selectedElements ?? []).length
+  })
+}
+
+
+describeMobileAndDesktop('viewer/three/IfcIsolator: isolate on the batched STEP path', () => {
+  test('isolates in place, keeping the coloured batch on screen (#1806)', async ({page}) => {
+    test.setTimeout(STEP_TEST_TIMEOUT_MS)
+    page.on('pageerror', (err) => console.warn(`[pageerror] ${err.message}`))
+    await homepageSetup(page)
+    await setIsReturningUser(page.context())
+
+    const {navigateAndWaitForModel} = await setupVirtualPathIntercept(page, AS1_PATH, '')
+    await navigateAndWaitForModel()
+    await waitForModelReady(page)
+
+    const before = await readBatchedSnapshot(page)
+    expect(before.visible.length).toBeGreaterThan(1)
+    expect(before.visible.every((v) => v)).toBe(true)
+
+    // Pick a part in the scene: the model is fit-to-frame and centred, so a
+    // centre double-click lands on geometry (same premise as
+    // SynchronizedView.spec.ts's scene-pick test).
+    await page.locator('canvas').first().dblclick()
+    await expect.poll(() => selectedCount(page)).toBeGreaterThan(0)
+
+    // Focus the canvas so `shortcutKeys.js`'s window handler doesn't
+    // early-return, then isolate.
+    await page.locator('canvas').first().focus()
+    await page.keyboard.press('KeyI')
+
+    await expect
+      .poll(async () => (await readBatchedSnapshot(page)).visible.filter((v) => v).length)
+      .toBeLessThan(before.visible.length)
+    const isolated = await readBatchedSnapshot(page)
+    expect(isolated.tempIsolationModeOn).toBe(true)
+    // Something is still on screen — an isolate that hides everything would
+    // also satisfy the "fewer visible" poll above.
+    expect(isolated.visible.filter((v) => v).length).toBeGreaterThan(0)
+    // The load-bearing claim: what the scene draws is still the batch, with no
+    // re-baked subset standing in for it. That is what keeps the per-instance
+    // colours below on screen — detached, they'd still be in the table but the
+    // grey subset would be what renders.
+    expect(isolated.modelInScene).toBe(true)
+    expect(isolated.isolationSubsetCount).toBe(0)
+    expect(isolated.colors).toEqual(before.colors)
+
+    // Un-isolate: everything comes back, still with its own colours.
+    await page.keyboard.press('KeyI')
+    await expect
+      .poll(async () => (await readBatchedSnapshot(page)).visible.every((v) => v))
+      .toBe(true)
+    const restored = await readBatchedSnapshot(page)
+    expect(restored.tempIsolationModeOn).toBe(false)
+    expect(restored.modelInScene).toBe(true)
+    expect(restored.colors).toEqual(before.colors)
   })
 })

--- a/src/viewer/three/IfcIsolator.spec.ts
+++ b/src/viewer/three/IfcIsolator.spec.ts
@@ -136,15 +136,47 @@ describe('viewer/three/IfcIsolator: isolate/hide combinations (Conway-direct)', 
 
     const after = await readIsolatorState(page)
     expect(after.tempIsolationModeOn).toBe(true)
-    expect(after.ifcModelInScene).toBe(false)
-    expect(after.ifcModelInPickable).toBe(false)
-    // Isolation subsets in scene + pickable — the H-bug regression
-    // gate. Pre-fix, these would be detached subtree children of
-    // the removed Group and `inScene` would be false.
-    expect(after.isolationSubsetMeshes.length).toBeGreaterThan(0)
-    for (const m of after.isolationSubsetMeshes) {
-      expect(m.inScene).toBe(true)
-      expect(m.inPickable).toBe(true)
+
+    // Which architecture isolate uses is a property of the loaded model, not
+    // of this test: a batched model (BatchedMesh + `instanceParents`) masks
+    // per-instance visibility in place (Share#1806), anything else detaches
+    // the model and re-bakes a subset Mesh. Assert whichever one is live —
+    // both claims are equally strong, they just describe different mechanisms.
+    const batch = await readBatchedSnapshot(page)
+    if (batch.isBatched) {
+      // In-place masking: the model itself is what's still being drawn and
+      // picked against, and no subset Mesh was baked to stand in for it.
+      expect(after.ifcModelInScene).toBe(true)
+      expect(after.ifcModelInPickable).toBe(true)
+      expect(after.isolationSubsetMeshes.length).toBe(0)
+      // The mask has to be doing the actual isolating: a non-empty *strict*
+      // subset of instances visible (an isolate that hid nothing, or hid
+      // everything, fails here), and every one of them owned by the isolated
+      // product.
+      const visibleIds = batch.visible.flatMap((v, i) => (v ? [i] : []))
+      expect(visibleIds.length).toBeGreaterThan(0)
+      expect(visibleIds.length).toBeLessThan(batch.visible.length)
+      const isolatedParents = new Set(batch.isolatedIds)
+      expect(isolatedParents.size).toBeGreaterThan(0)
+      const strays = visibleIds.filter((i) => !isolatedParents.has(batch.parents[i]))
+      expect(strays).toEqual([])
+      // Round trip: leaving isolation releases the mask, so every instance the
+      // model started with is drawable again.
+      await page.keyboard.press('KeyI')
+      await expect
+        .poll(async () => (await readBatchedSnapshot(page)).visible.filter((v) => v).length)
+        .toBe(batch.visible.length)
+    } else {
+      expect(after.ifcModelInScene).toBe(false)
+      expect(after.ifcModelInPickable).toBe(false)
+      // Isolation subsets in scene + pickable — the H-bug regression
+      // gate. Pre-fix, these would be detached subtree children of
+      // the removed Group and `inScene` would be false.
+      expect(after.isolationSubsetMeshes.length).toBeGreaterThan(0)
+      for (const m of after.isolationSubsetMeshes) {
+        expect(m.inScene).toBe(true)
+        expect(m.inPickable).toBe(true)
+      }
     }
   })
 
@@ -179,11 +211,34 @@ describe('viewer/three/IfcIsolator: isolate/hide combinations (Conway-direct)', 
     const state = await readIsolatorState(page)
     expect(state.tempIsolationModeOn).toBe(false)
     expect(state.hiddenIdsCount).toBeGreaterThan(0)
-    expect(state.ifcModelInScene).toBe(false)
-    expect(state.unhiddenSubsetMeshes.length).toBeGreaterThan(0)
-    for (const m of state.unhiddenSubsetMeshes) {
-      expect(m.inScene).toBe(true)
-      expect(m.inPickable).toBe(true)
+
+    // Same two architectures as the isolate test above — hide masks in place
+    // on a batched model, and re-bakes an "everything except the hidden ids"
+    // subset otherwise.
+    const batch = await readBatchedSnapshot(page)
+    if (batch.isBatched) {
+      expect(state.ifcModelInScene).toBe(true)
+      expect(state.ifcModelInPickable).toBe(true)
+      expect(state.unhiddenSubsetMeshes.length).toBe(0)
+      // Hide is isolate's inverse, and the mask must show it: the hidden
+      // product's instances all go dark, and the rest of the model — a
+      // non-empty remainder — keeps drawing.
+      const hiddenParents = new Set(batch.hiddenIds)
+      expect(hiddenParents.size).toBeGreaterThan(0)
+      const hiddenInstances = batch.parents.flatMap((p, i) => (hiddenParents.has(p) ? [i] : []))
+      expect(hiddenInstances.length).toBeGreaterThan(0)
+      const stillVisible = hiddenInstances.filter((i) => batch.visible[i])
+      expect(stillVisible).toEqual([])
+      const visibleCount = batch.visible.filter((v) => v).length
+      expect(visibleCount).toBeGreaterThan(0)
+      expect(visibleCount).toBe(batch.visible.length - hiddenInstances.length)
+    } else {
+      expect(state.ifcModelInScene).toBe(false)
+      expect(state.unhiddenSubsetMeshes.length).toBeGreaterThan(0)
+      for (const m of state.unhiddenSubsetMeshes) {
+        expect(m.inScene).toBe(true)
+        expect(m.inPickable).toBe(true)
+      }
     }
   })
 
@@ -262,8 +317,12 @@ const STEP_TEST_TIMEOUT_MS = 90_000
 
 
 interface BatchedSnapshot {
+  /** Did we find any decorated `BatchedMesh` at all — i.e. is this the batched path? */
+  isBatched: boolean
   /** Per-instance visibility, batchId order, across every batch. */
   visible: boolean[]
+  /** Per-instance owning product expressID (`instanceParents`), same order. */
+  parents: number[]
   /** Per-instance source colour (`instanceColors`), same order. */
   colors: number[][]
   /** Is the loaded model itself still a child of the scene? */
@@ -271,12 +330,22 @@ interface BatchedSnapshot {
   /** Isolation subset meshes — must stay 0 on the batched path. */
   isolationSubsetCount: number
   tempIsolationModeOn: boolean
+  /** The isolator's current isolate / hide sets, for cross-checking the mask. */
+  isolatedIds: number[]
+  hiddenIds: number[]
 }
 
 
 /**
  * Snapshot the live batched model: what the renderer draws (per-instance
- * visibility + the colour table it draws from) plus the isolator's slots.
+ * visibility, the parent product of each instance, and the colour table it
+ * draws from) plus the isolator's slots and its isolate / hide sets.
+ *
+ * `isBatched` is false when the loaded model carries no decorated
+ * `BatchedMesh` — the first describe block above uses that to pick which
+ * architecture its assertions should demand (masked in place vs. re-baked
+ * subset), since which one a given model gets is a property of the load, not
+ * of the test.
  *
  * @param page playwright page
  * @return snapshot of the batched scene state
@@ -291,32 +360,43 @@ function readBatchedSnapshot(page: Page): Promise<BatchedSnapshot> {
     if (!model || !iso) {
       throw new Error('readBatchedSnapshot: no model/isolator on window — is the page in test mode?')
     }
+    // Same "mesh-or-Group" walk as `eachBatch` (src/viewer/ifc/batchedModel.js),
+    // which is what the isolator itself uses to decide the path — the batches
+    // can sit anywhere under the model root, not just as direct children.
     const meshes: any[] = []
-    if (model.isBatchedMesh) {
-      meshes.push(model)
-    }
-    (model.children ?? []).forEach((child: any) => {
-      if (child?.isBatchedMesh) {
-        meshes.push(child)
+    const visit = (obj: any) => {
+      if (!obj) {
+        return
       }
-    })
+      if (obj.isBatchedMesh && obj.instanceParents) {
+        meshes.push(obj)
+      }
+      (obj.children ?? []).forEach(visit)
+    }
+    visit(model)
     const visible: boolean[] = []
+    const parents: number[] = []
     const colors: number[][] = []
     for (const mesh of meshes) {
       const count = mesh.instanceParents?.length ?? 0
       for (let index = 0; index < count; index++) {
         visible.push(mesh.getVisibleAt(index))
+        parents.push(mesh.instanceParents[index])
         const c = mesh.instanceColors?.[index]
         colors.push(c ? [c.x, c.y, c.z, c.w] : [])
       }
     }
     const subset = iso.isolationSubset
     return {
+      isBatched: meshes.length > 0,
       visible,
+      parents,
       colors,
       modelInScene: iso.context.getScene().children.includes(model),
       isolationSubsetCount: subset ? (Array.isArray(subset) ? subset.length : 1) : 0,
       tempIsolationModeOn: iso.tempIsolationModeOn,
+      isolatedIds: [...(iso.isolatedIds ?? [])],
+      hiddenIds: [...(iso.hiddenIds ?? [])],
     }
     /* eslint-enable @typescript-eslint/no-explicit-any */
   })

--- a/src/viewer/three/IfcIsolator.spec.ts
+++ b/src/viewer/three/IfcIsolator.spec.ts
@@ -420,6 +420,21 @@ describeMobileAndDesktop('viewer/three/IfcIsolator: isolate on the batched STEP 
   test('isolates in place, keeping the coloured batch on screen (#1806)', async ({page}) => {
     test.setTimeout(STEP_TEST_TIMEOUT_MS)
     page.on('pageerror', (err) => console.warn(`[pageerror] ${err.message}`))
+    // Isolation points the OutlineEffect at the `BatchedMesh`es themselves.
+    // three compiles the effect's mask material (postprocessing's
+    // DepthComparisonMaterial) with USE_BATCHING for a BatchedMesh, and that
+    // shader ships without the batching chunks, so without the patch in
+    // `outlineBatching.js` the mask program fails to link: one
+    // `'batchingMatrix' : undeclared identifier` and then `useProgram:
+    // program not valid` every frame — 89 of these were logged in the run
+    // that established this, against 0 with the patch — while the isolation
+    // outline silently renders nothing at all.
+    const outlineShaderErrors: string[] = []
+    page.on('console', (msg) => {
+      if (/Shader Error|batchingMatrix|useProgram: program not valid/.test(msg.text())) {
+        outlineShaderErrors.push(msg.text())
+      }
+    })
     await homepageSetup(page)
     await setIsReturningUser(page.context())
 
@@ -457,6 +472,7 @@ describeMobileAndDesktop('viewer/three/IfcIsolator: isolate on the batched STEP 
     expect(isolated.modelInScene).toBe(true)
     expect(isolated.isolationSubsetCount).toBe(0)
     expect(isolated.colors).toEqual(before.colors)
+    expect(outlineShaderErrors).toEqual([])
 
     // Un-isolate: everything comes back, still with its own colours.
     await page.keyboard.press('KeyI')

--- a/src/viewer/three/IfcIsolator.spec.ts
+++ b/src/viewer/three/IfcIsolator.spec.ts
@@ -325,6 +325,13 @@ interface BatchedSnapshot {
   parents: number[]
   /** Per-instance source colour (`instanceColors`), same order. */
   colors: number[][]
+  /**
+   * Per-instance colour as it is CURRENTLY in the batch's colour texture —
+   * what the GPU draws. Distinct from `colors`: that is a JS side-array of
+   * originals which `setColorAt` never writes, so it is identical whether or
+   * not a selection / highlight is painted. Only this one can see the paint.
+   */
+  live: number[][]
   /** Is the loaded model itself still a child of the scene? */
   modelInScene: boolean
   /** Isolation subset meshes — must stay 0 on the batched path. */
@@ -377,6 +384,27 @@ function readBatchedSnapshot(page: Page): Promise<BatchedSnapshot> {
     const visible: boolean[] = []
     const parents: number[] = []
     const colors: number[][] = []
+    const live: number[][] = []
+    // `getColorAt` writes into any target exposing three's `Color` reader
+    // surface — duck-typed here so the spec needs no THREE import in page
+    // scope. `fromArray` is the branch taken once a colour texture exists;
+    // `setRGB` is three's white default for a batch that has none.
+    const target = {
+      r: 1, g: 1, b: 1,
+      setRGB(r: number, g: number, b: number) {
+        this.r = r
+        this.g = g
+        this.b = b
+        return this
+      },
+      fromArray(arr: ArrayLike<number>, offset: number) {
+        this.r = arr[offset]
+        this.g = arr[offset + 1]
+        this.b = arr[offset + 2]
+        return this
+      },
+    }
+    const ROUND = 1000
     for (const mesh of meshes) {
       const count = mesh.instanceParents?.length ?? 0
       for (let index = 0; index < count; index++) {
@@ -384,6 +412,8 @@ function readBatchedSnapshot(page: Page): Promise<BatchedSnapshot> {
         parents.push(mesh.instanceParents[index])
         const c = mesh.instanceColors?.[index]
         colors.push(c ? [c.x, c.y, c.z, c.w] : [])
+        mesh.getColorAt(index, target)
+        live.push([target.r, target.g, target.b].map((v) => Math.round(v * ROUND) / ROUND))
       }
     }
     const subset = iso.isolationSubset
@@ -392,6 +422,7 @@ function readBatchedSnapshot(page: Page): Promise<BatchedSnapshot> {
       visible,
       parents,
       colors,
+      live,
       modelInScene: iso.context.getScene().children.includes(model),
       isolationSubsetCount: subset ? (Array.isArray(subset) ? subset.length : 1) : 0,
       tempIsolationModeOn: iso.tempIsolationModeOn,
@@ -413,6 +444,23 @@ function selectedCount(page: Page): Promise<number> {
     const w = window as any
     return (w.store?.getState?.().selectedElements ?? []).length
   })
+}
+
+
+/**
+ * Which instances are currently painted something other than their own colour
+ * — i.e. wearing the selection / preselection highlight. Compares the live
+ * colour texture against a baseline snapshot taken before anything was
+ * selected, so it needs no hardcoded cyan (the selection material's colour is
+ * theme-driven).
+ *
+ * @param snapshot the snapshot to inspect
+ * @param baseline a snapshot taken with nothing selected
+ * @return batchIds whose live colour has moved off the baseline
+ */
+function paintedInstances(snapshot: BatchedSnapshot, baseline: BatchedSnapshot): number[] {
+  return snapshot.live.flatMap((rgb, index) =>
+    (JSON.stringify(rgb) === JSON.stringify(baseline.live[index]) ? [] : [index]))
 }
 
 
@@ -451,6 +499,14 @@ describeMobileAndDesktop('viewer/three/IfcIsolator: isolate on the batched STEP 
     // SynchronizedView.spec.ts's scene-pick test).
     await page.locator('canvas').first().dblclick()
     await expect.poll(() => selectedCount(page)).toBeGreaterThan(0)
+    // Selection on this path is painted onto the live instances
+    // (`applyBatchedSelection` -> `setColorAt`), so wait for the paint to
+    // actually land before snapshotting it.
+    await expect
+      .poll(async () => paintedInstances(await readBatchedSnapshot(page), before).length)
+      .toBeGreaterThan(0)
+    const selected = await readBatchedSnapshot(page)
+    const painted = paintedInstances(selected, before)
 
     // Focus the canvas so `shortcutKeys.js`'s window handler doesn't
     // early-return, then isolate.
@@ -471,17 +527,52 @@ describeMobileAndDesktop('viewer/three/IfcIsolator: isolate on the batched STEP 
     // grey subset would be what renders.
     expect(isolated.modelInScene).toBe(true)
     expect(isolated.isolationSubsetCount).toBe(0)
-    expect(isolated.colors).toEqual(before.colors)
+    // The #1806 claim itself, read off the colour texture the GPU samples:
+    // every instance still drawn shows the colour it had before anything was
+    // selected. Isolate targets the selection, so the isolated instances are
+    // exactly the ones selection had painted cyan (`painted`, non-empty by the
+    // poll above) — leaving that paint on is what made an isolated part read
+    // as cyan rather than as itself.
+    //
+    // Note this cannot be asserted on `colors` (`mesh.instanceColors`): that
+    // is a JS side-array of ORIGINALS which `setColorAt` never writes, so it
+    // is byte-identical with the paint on, with it off, and on the pre-fix
+    // build that shipped the bug.
+    for (const index of painted) {
+      expect(isolated.live[index]).toEqual(before.live[index])
+    }
+    const visiblePainted = painted.filter((index) => isolated.visible[index])
+    expect(visiblePainted.length).toBeGreaterThan(0)
     expect(outlineShaderErrors).toEqual([])
 
-    // Un-isolate: everything comes back, still with its own colours.
+    // Un-isolate: everything comes back, and so does the selection paint —
+    // on exactly the instances that wore it before the isolate.
     await page.keyboard.press('KeyI')
     await expect
       .poll(async () => (await readBatchedSnapshot(page)).visible.every((v) => v))
       .toBe(true)
+    await expect
+      .poll(async () => paintedInstances(await readBatchedSnapshot(page), before))
+      .toEqual(painted)
     const restored = await readBatchedSnapshot(page)
     expect(restored.tempIsolationModeOn).toBe(false)
     expect(restored.modelInScene).toBe(true)
-    expect(restored.colors).toEqual(before.colors)
+    for (const index of painted) {
+      expect(restored.live[index]).toEqual(selected.live[index])
+    }
+
+    // Selecting WHILE isolated must still paint: the clear is a one-shot at
+    // isolate time, not a suppression of selection feedback.
+    await page.keyboard.press('KeyI')
+    await expect
+      .poll(async () => (await readBatchedSnapshot(page)).tempIsolationModeOn)
+      .toBe(true)
+    await page.locator('canvas').first().dblclick()
+    await expect
+      .poll(async () => {
+        const snapshot = await readBatchedSnapshot(page)
+        return paintedInstances(snapshot, before).filter((index) => snapshot.visible[index]).length
+      })
+      .toBeGreaterThan(0)
   })
 })

--- a/src/viewer/three/IfcIsolator.test.js
+++ b/src/viewer/three/IfcIsolator.test.js
@@ -15,6 +15,7 @@
 import {
   BufferAttribute,
   BufferGeometry,
+  Color,
   Group,
   Mesh,
   MeshBasicMaterial,
@@ -854,6 +855,297 @@ describe('viewer/three/IfcIsolator', () => {
       iso._rebuildSelectionVisualFromStore()
       expect(iso.viewer.setSelection).toHaveBeenCalledWith(0, [100], false)
       expect(iso.viewer.setInstanceSelection).not.toHaveBeenCalled()
+    })
+  })
+
+
+  // ----------------------------------------------------------------
+  // Batched render path (Share#1806). The default Conway-direct model is
+  // a `THREE.BatchedMesh`: hide / isolate mask per-instance visibility in
+  // place instead of re-baking a subset Mesh, because a baked Mesh gets
+  // the batch's shared colourless material and cannot read the batch's
+  // per-instance colour texture (the reported "isolated parts turn light
+  // grey"). These tests assert the visibility *and* the colours, so they
+  // go red against the subset behaviour.
+  // ----------------------------------------------------------------
+  describe('batched path — in-place isolation via setVisibleAt', () => {
+    let flatMeshToBatchedModel
+    let attachBatchedSubsets
+    let ResidencyController
+    beforeAll(() => {
+      flatMeshToBatchedModel = require('../ifc/flatMeshToBatchedModel').flatMeshToBatchedModel
+      attachBatchedSubsets = require('../ifc/batchedSubset').attachBatchedSubsets
+      ResidencyController = require('../residency/ResidencyController').ResidencyController
+    })
+
+    /** Identity 4x4, three.js column-major flat form. */
+    const IDENTITY_MAT = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]
+    const RED = {x: 1, y: 0, z: 0, w: 1}
+    const GREEN = {x: 0, y: 1, z: 0, w: 1}
+    const BLUE = {x: 0, y: 0, z: 1, w: 1}
+
+    /**
+     * @param {number} x translation in X (keeps placements distinct so the
+     *   builder's coincident-placement dedupe doesn't collapse them)
+     * @return {Array<number>} column-major translation matrix
+     */
+    function translateX(x) {
+      const m = [...IDENTITY_MAT]
+      m[12] = x
+      return m
+    }
+
+    /** @return {object} mock Conway IfcAPI serving one unit triangle at id 999. */
+    function unitTriApi() {
+      const verts = new Float32Array([
+        0, 0, 0, 0, 0, 1,
+        1, 0, 0, 0, 0, 1,
+        0, 1, 0, 0, 0, 1,
+      ])
+      const indices = new Uint32Array([0, 1, 2])
+      return {
+        GetGeometry: (_modelID, id) => (id === 999 ? {
+          GetVertexData: () => id,
+          GetIndexData: () => id,
+          GetVertexDataSize: () => verts.length,
+          GetIndexDataSize: () => indices.length,
+        } : null),
+        GetVertexArray: () => verts,
+        GetIndexArray: () => indices,
+      }
+    }
+
+    /**
+     * One decorated opaque BatchedMesh with four instances in emission order
+     * (which is also their occurrence id):
+     *
+     *   0: product 100, RED    1: product 100, RED
+     *   2: product 200, GREEN  3: product 300, BLUE
+     *
+     * Product 100 is placed twice so the per-occurrence hide has a reused
+     * part to narrow onto. `attachBatchedSubsets` is attached exactly as
+     * production does — so the pre-fix subset path would actually run here
+     * and these tests fail on behaviour, not on a missing method.
+     *
+     * @return {object} a THREE.BatchedMesh carrying the pick tables
+     */
+    function makeBatchedModel() {
+      const geom = (color) => [{geometryExpressID: 999, flatTransformation: IDENTITY_MAT, color}]
+      const at = (x, color) => [{geometryExpressID: 999, flatTransformation: translateX(x), color}]
+      const flatMeshes = [
+        {expressID: 100, geometries: geom(RED)},
+        {expressID: 100, geometries: at(10, RED)},
+        {expressID: 200, geometries: at(20, GREEN)},
+        {expressID: 300, geometries: at(30, BLUE)},
+      ]
+      const {batches} = flatMeshToBatchedModel(flatMeshes, unitTriApi(), 0)
+      expect(batches.length).toBe(1) // all opaque → one batch
+      const batch = batches[0]
+      const mesh = batch.mesh
+      mesh.instanceParents = batch.instanceParents
+      mesh.instanceOccurrenceIds = batch.instanceOccurrenceIds
+      mesh.instanceGeometry = batch.instanceGeometry
+      mesh.instanceColors = batch.instanceColors
+      attachBatchedSubsets(mesh, null, {})
+      return mesh
+    }
+
+    /**
+     * @return {{scene: Group, pickable: Array, iso: IfcIsolator, mesh: object}}
+     */
+    function setupBatchedIsolator() {
+      const scene = new Group()
+      const pickable = []
+      const iso = makeIsolator({scene, pickable})
+      const mesh = makeBatchedModel()
+      scene.add(mesh)
+      pickable.push(mesh)
+      iso.ifcModel = mesh
+      iso.visualElementsIds = [100, 200, 300]
+      iso.spatialStructure = {}
+      return {scene, pickable, iso, mesh}
+    }
+
+    /**
+     * @param {object} mesh BatchedMesh
+     * @return {Array<boolean>} per-instance visibility, batchId order
+     */
+    function visibility(mesh) {
+      const out = []
+      for (let batchId = 0; batchId < mesh.instanceParents.length; batchId++) {
+        out.push(mesh.getVisibleAt(batchId))
+      }
+      return out
+    }
+
+    /**
+     * @param {object} mesh BatchedMesh
+     * @param {number} batchId
+     * @return {Color} the instance colour currently in the batch's colour texture
+     */
+    function colorAt(mesh, batchId) {
+      return mesh.getColorAt(batchId, new Color())
+    }
+
+    it('isolates in place: only the isolated product stays visible, model stays in scene', () => {
+      const {scene, pickable, iso, mesh} = setupBatchedIsolator()
+      iso.viewer.getSelectedIds = jest.fn(() => [100])
+
+      iso.isolateSelectedElements()
+
+      // Pre-fix this detached the model and added a baked subset Mesh.
+      expect(scene.children).toContain(mesh)
+      expect(pickable).toEqual([mesh])
+      expect(iso.isolationSubset).toBeNull()
+      expect(visibility(mesh)).toEqual([true, true, false, false])
+    })
+
+    it('renders the isolated part from the coloured batch, not a grey subset (#1806)', () => {
+      const {scene, iso, mesh} = setupBatchedIsolator()
+      iso.viewer.getSelectedIds = jest.fn(() => [100])
+
+      iso.isolateSelectedElements()
+
+      // What is on screen IS the batch — nothing else was added to the scene.
+      // (Pre-fix a re-baked subset Mesh took its place, wearing the batch's
+      // shared colourless material: the reported light grey. Asserting the
+      // colour alone would still pass then, since the detached batch keeps its
+      // colour texture — so the rendered-object assertion carries the claim.)
+      expect(scene.children).toEqual([mesh])
+      expect(mesh.getVisibleAt(0)).toBe(true)
+      // The surviving instances still carry their own colour — the whole point
+      // of masking rather than re-baking onto the batch's shared material.
+      const isolated = colorAt(mesh, 0)
+      expect(isolated.r).toBeCloseTo(1)
+      expect(isolated.g).toBeCloseTo(0)
+      expect(isolated.b).toBeCloseTo(0)
+      // Masked-out instances keep theirs too, so un-isolating needs no repaint.
+      const masked = colorAt(mesh, 2)
+      expect(masked.g).toBeCloseTo(1)
+      const stillMasked = colorAt(mesh, 3)
+      expect(stillMasked.b).toBeCloseTo(1)
+    })
+
+    it('un-isolate restores full visibility and drops the mask (round trip)', () => {
+      const {scene, pickable, iso, mesh} = setupBatchedIsolator()
+      iso.viewer.getSelectedIds = jest.fn(() => [100])
+
+      iso.isolateSelectedElements()
+      // Midpoint: the isolate actually took effect (without this the round-trip
+      // assertion below would pass against a no-op isolate).
+      expect(visibility(mesh)).toEqual([true, true, false, false])
+
+      iso.resetTempIsolation()
+
+      expect(visibility(mesh)).toEqual([true, true, true, true])
+      expect(mesh.userData.isolationMask).toBeUndefined()
+      // No duplicate model in the scene / pick registry from the restore.
+      expect(scene.children.filter((c) => c === mesh).length).toBe(1)
+      expect(pickable).toEqual([mesh])
+      expect(colorAt(mesh, 2).g).toBeCloseTo(1)
+    })
+
+    it('composes isolation with a product-type hide (both filters must pass)', () => {
+      const {iso, mesh} = setupBatchedIsolator()
+      // Hide 300 first, the way hideElementsById would.
+      iso.hiddenIds = [300]
+      iso.initHideOperationsSubset(iso.visualElementsIds.filter((e) => e !== 300))
+      expect(visibility(mesh)).toEqual([true, true, true, false])
+
+      // Isolate 100 + 300: 300 is isolated but still hidden, so it stays masked.
+      iso.viewer.getSelectedIds = jest.fn(() => [100, 300])
+      iso.isolateSelectedElements()
+      expect(visibility(mesh)).toEqual([true, true, false, false])
+
+      // Un-isolating returns to the hide-only state, not to everything-visible.
+      iso.resetTempIsolation()
+      expect(visibility(mesh)).toEqual([true, true, true, false])
+    })
+
+    it('hides a single occurrence of a reused part, leaving its sibling visible', () => {
+      const {iso, mesh} = setupBatchedIsolator()
+      // Occurrence id 1 is product 100's second placement (node 6 = its NAUO id).
+      iso.hideOccurrence(6, [1])
+      expect(visibility(mesh)).toEqual([true, false, true, true])
+
+      iso.unHideOccurrence(6)
+      expect(visibility(mesh)).toEqual([true, true, true, true])
+      expect(mesh.userData.isolationMask).toBeUndefined()
+    })
+
+    it('unHideAllElements clears a product hide in place', () => {
+      const {scene, pickable, iso, mesh} = setupBatchedIsolator()
+      iso.hiddenIds = [200]
+      iso.initHideOperationsSubset(iso.visualElementsIds.filter((e) => e !== 200))
+      expect(visibility(mesh)).toEqual([true, true, false, true])
+
+      iso.unHideAllElements()
+      expect(visibility(mesh)).toEqual([true, true, true, true])
+      expect(scene.children.filter((c) => c === mesh).length).toBe(1)
+      expect(pickable).toEqual([mesh])
+    })
+
+    it('isolates the ids passed straight to initTemporaryIsolationSubset (BotChat)', () => {
+      // BotChat calls this method directly, without entering isolation mode —
+      // so the batched filter has to read `includedIds`, not `isolatedIds`.
+      const {iso, mesh} = setupBatchedIsolator()
+      iso.initTemporaryIsolationSubset([200])
+      expect(iso.tempIsolationModeOn).toBe(false)
+      expect(visibility(mesh)).toEqual([false, false, true, false])
+    })
+
+    it('dispose releases the mask so the model is left as residency had it', () => {
+      const {iso, mesh} = setupBatchedIsolator()
+      mesh.setVisibleAt(3, false) // a residency eviction
+      iso.viewer.getSelectedIds = jest.fn(() => [100])
+      iso.isolateSelectedElements()
+
+      iso.dispose()
+
+      expect(mesh.userData.isolationMask).toBeUndefined()
+      expect(visibility(mesh)).toEqual([true, true, true, false])
+    })
+
+    it('preserves residency\'s eviction across an isolate / un-isolate round trip', () => {
+      // Residency (ResidencyController) owns the same setVisibleAt bit. Its
+      // intent must survive isolation rather than being blanket-restored —
+      // hence the mask's `base` snapshot + setVisibleAt interception.
+      const {iso, mesh} = setupBatchedIsolator()
+      const residency = new ResidencyController(mesh)
+      expect(residency.instanceCount).toBe(4)
+      // Evict everything, then bring half back: instance 0 (nearest the camera
+      // proxy) is not what matters — only that SOME instances are evicted.
+      residency.setTarget(0)
+      expect(visibility(mesh)).toEqual([false, false, false, false])
+
+      iso.viewer.getSelectedIds = jest.fn(() => [100])
+      iso.isolateSelectedElements()
+      // Isolation can't resurrect what residency evicted.
+      expect(visibility(mesh)).toEqual([false, false, false, false])
+
+      // Residency re-admits everything WHILE isolated: isolation still wins for
+      // the parts it masks, but the intent is recorded.
+      residency.setTarget(1)
+      expect(visibility(mesh)).toEqual([true, true, false, false])
+
+      iso.resetTempIsolation()
+      expect(visibility(mesh)).toEqual([true, true, true, true])
+    })
+
+    it('restores residency\'s exact visibility on un-isolate, not everything-visible', () => {
+      const {iso, mesh} = setupBatchedIsolator()
+      // Simulate an eviction of instance 3 — setVisibleAt is residency's only
+      // write surface, so this is exactly what the controller does.
+      mesh.setVisibleAt(3, false)
+
+      iso.viewer.getSelectedIds = jest.fn(() => [100])
+      iso.isolateSelectedElements()
+      expect(visibility(mesh)).toEqual([true, true, false, false])
+
+      iso.resetTempIsolation()
+      // Instance 3 stays evicted: the mask replayed residency's snapshot.
+      expect(visibility(mesh)).toEqual([true, true, true, false])
+      expect(mesh.userData.isolationMask).toBeUndefined()
     })
   })
 

--- a/src/viewer/three/IfcIsolator.test.js
+++ b/src/viewer/three/IfcIsolator.test.js
@@ -1000,6 +1000,26 @@ describe('viewer/three/IfcIsolator', () => {
       expect(visibility(mesh)).toEqual([true, true, false, false])
     })
 
+    it('outlines the batch meshes themselves — there is no subset to point at', () => {
+      const {iso, mesh} = setupBatchedIsolator()
+      iso.viewer.getSelectedIds = jest.fn(() => [100])
+
+      iso.isolateSelectedElements()
+
+      // Pinning the argument matters because of what it costs: an OutlineEffect
+      // whose selection holds a `THREE.BatchedMesh` compiles its mask pass
+      // (postprocessing's DepthComparisonMaterial) with three's USE_BATCHING
+      // define, and that shader ships without the batching chunks —
+      // `'batchingMatrix' : undeclared identifier`, no outline at all, and a
+      // per-frame `useProgram: program not valid`. `outlineBatching.js` patches
+      // the material so this selection is drawable; if the batches ever stop
+      // being what is selected here, that patch is dead weight, and if this
+      // starts selecting batches somewhere the patch doesn't reach, the outline
+      // silently disappears again.
+      expect(iso.isolationOutlineEffect.setSelection).toHaveBeenCalledWith([mesh])
+      expect(iso.isolationSubset).toBeNull()
+    })
+
     it('renders the isolated part from the coloured batch, not a grey subset (#1806)', () => {
       const {scene, iso, mesh} = setupBatchedIsolator()
       iso.viewer.getSelectedIds = jest.fn(() => [100])

--- a/src/viewer/three/IfcIsolator.test.js
+++ b/src/viewer/three/IfcIsolator.test.js
@@ -872,10 +872,14 @@ describe('viewer/three/IfcIsolator', () => {
     let flatMeshToBatchedModel
     let attachBatchedSubsets
     let ResidencyController
+    let applyBatchedSelection
+    let applyBatchedInstanceSelection
     beforeAll(() => {
       flatMeshToBatchedModel = require('../ifc/flatMeshToBatchedModel').flatMeshToBatchedModel
       attachBatchedSubsets = require('../ifc/batchedSubset').attachBatchedSubsets
       ResidencyController = require('../residency/ResidencyController').ResidencyController
+      applyBatchedSelection = require('../ifc/batchedHighlight').applyBatchedSelection
+      applyBatchedInstanceSelection = require('../ifc/batchedHighlight').applyBatchedInstanceSelection
     })
 
     /** Identity 4x4, three.js column-major flat form. */
@@ -1166,6 +1170,185 @@ describe('viewer/three/IfcIsolator', () => {
       // Instance 3 stays evicted: the mask replayed residency's snapshot.
       expect(visibility(mesh)).toEqual([true, true, true, false])
       expect(mesh.userData.isolationMask).toBeUndefined()
+    })
+
+
+    // ------------------------------------------------------------------
+    // Selection paint vs. isolation (Share#1806). On this path the selection
+    // highlight is not an overlay Mesh but cyan written onto the live
+    // instances (`applyBatchedSelection` → `setColorAt`). Every user-reachable
+    // isolate goes through `isolateSelectedElements`, which isolates *the
+    // selection* — so the isolated part is exactly the part wearing cyan, and
+    // without an explicit clear "isolating a part preserves its colour" fails
+    // on its own default flow. `_clearSelectionVisualOnly` is the seam: it was
+    // a no-op for batched models (it only knew the highlighter + Conway
+    // subsets), so hide was blind to this too.
+    // ------------------------------------------------------------------
+
+    /** Cyan `batchedHighlight` paints selection with (its DEFAULT_HIGHLIGHT). */
+    const SELECTION_CYAN = {r: 0, g: 0.8, b: 1}
+
+    /**
+     * Assert one instance's live colour in the batch's colour texture — what
+     * the GPU actually draws, as opposed to `instanceColors`, the JS side-array
+     * of ORIGINAL colours that `setColorAt` never writes (so comparing that
+     * across an isolate can't fail: it is byte-identical either way).
+     *
+     * @param {object} mesh BatchedMesh
+     * @param {number} batchId
+     * @param {object} rgb expected `{r,g,b}` 0..1
+     */
+    function expectColorAt(mesh, batchId, rgb) {
+      const c = colorAt(mesh, batchId)
+      expect([c.r, c.g, c.b].map((v) => Math.round(v * 100) / 100))
+        .toEqual([rgb.r, rgb.g, rgb.b].map((v) => Math.round(v * 100) / 100))
+    }
+
+    /**
+     * Point the mock viewer's selection entry points at the real batched
+     * highlight, as `ShareViewer#setSelection` / `#setInstanceSelection` do on
+     * this path. The restore assertions need it: un-isolate rebuilds the visual
+     * by calling back through the viewer, so a bare `jest.fn()` would record
+     * the call and repaint nothing.
+     *
+     * @param {IfcIsolator} iso
+     * @param {object} mesh BatchedMesh
+     */
+    function wireBatchedSelection(iso, mesh) {
+      iso.viewer.setSelection = jest.fn(
+        (_modelID, ids) => applyBatchedSelection(mesh, ids, SELECTION_CYAN))
+      iso.viewer.setInstanceSelection = jest.fn(
+        (_modelID, ids) => applyBatchedInstanceSelection(mesh, ids, SELECTION_CYAN))
+    }
+
+    /**
+     * Seed the mocked store for one test and restore the module-singleton
+     * mock afterwards (it is shared across this file's suites).
+     *
+     * @param {object} state extra store fields to serve
+     * @param {Function} body the test body
+     */
+    function withStoreState(state, body) {
+      const useStore = require('../../store/useStore').default
+      const orig = useStore.getState.getMockImplementation()
+      useStore.getState.mockImplementation(() => ({elementTypesMap: [], ...state}))
+      try {
+        body()
+      } finally {
+        useStore.getState.mockImplementation(orig)
+      }
+    }
+
+    it('isolate clears the selection paint, so the isolated part shows its own colour (#1806)', () => {
+      const {iso, mesh} = setupBatchedIsolator()
+      // Select product 100 the way ShareViewer does on this path.
+      applyBatchedSelection(mesh, [100], SELECTION_CYAN)
+      // Midpoint — the paint really is on both of 100's occurrences, so the
+      // assertions after the isolate have something to go red against.
+      expectColorAt(mesh, 0, SELECTION_CYAN)
+      expectColorAt(mesh, 1, SELECTION_CYAN)
+
+      iso.viewer.getSelectedIds = jest.fn(() => [100])
+      iso.isolateSelectedElements()
+
+      // Both occurrences of the reused product are back to their own red.
+      expectColorAt(mesh, 0, {r: 1, g: 0, b: 0})
+      expectColorAt(mesh, 1, {r: 1, g: 0, b: 0})
+      // The isolate itself still happened (a clear that also broke isolation
+      // would otherwise satisfy the colour assertions).
+      expect(visibility(mesh)).toEqual([true, true, false, false])
+    })
+
+    it('isolate drops only the paint — the logical selection is untouched', () => {
+      const useStore = require('../../store/useStore').default
+      useStore.setState.mockClear()
+      const {iso, mesh} = setupBatchedIsolator()
+      applyBatchedSelection(mesh, [100], SELECTION_CYAN)
+      iso.viewer.getSelectedIds = jest.fn(() => [100])
+      // The viewer's own selection cache — read by later picks and by the
+      // permalink — must survive the clear as well.
+      iso.viewer._selectedExpressIds = [100]
+
+      iso.isolateSelectedElements()
+
+      const setStateCalls = useStore.setState.mock.calls.map((c) => c[0])
+      // Isolation state was published (so the scan below isn't over nothing).
+      expect(setStateCalls.some((c) => c && 'isTempIsolationModeOn' in c)).toBe(true)
+      // …and nothing wrote the store-side selection. CadView's
+      // `[selectedElements, selectedInstanceIds]` effect therefore doesn't
+      // re-run and can't repaint over the clear.
+      const selectionWrite = setStateCalls.find(
+        (c) => c && ('selectedElements' in c || 'selectedInstanceIds' in c))
+      expect(selectionWrite).toBeUndefined()
+      expect(iso.viewer._selectedExpressIds).toEqual([100])
+    })
+
+    it('un-isolate repaints the selection cyan from the preserved store state', () => {
+      withStoreState({selectedElements: ['100'], selectedInstanceIds: []}, () => {
+        const {iso, mesh} = setupBatchedIsolator()
+        wireBatchedSelection(iso, mesh)
+        applyBatchedSelection(mesh, [100], SELECTION_CYAN)
+        iso.viewer.getSelectedIds = jest.fn(() => [100])
+
+        iso.isolateSelectedElements()
+        expectColorAt(mesh, 0, {r: 1, g: 0, b: 0}) // midpoint: cleared
+
+        iso.resetTempIsolation()
+
+        // Every occurrence of the selected product is cyan again.
+        expectColorAt(mesh, 0, SELECTION_CYAN)
+        expectColorAt(mesh, 1, SELECTION_CYAN)
+        // Unselected parts were never touched by any of it.
+        expectColorAt(mesh, 2, {r: 0, g: 1, b: 0})
+      })
+    })
+
+    it('un-isolate restores a per-occurrence selection to that occurrence only', () => {
+      // `selectedInstanceIds` narrowing (`applyBatchedInstanceSelection`) is a
+      // second repaint on top of the parent-level one; the rebuild has to run
+      // both or a per-occurrence pick comes back highlighting all six
+      // occurrences of the part.
+      withStoreState({selectedElements: ['100'], selectedInstanceIds: [1]}, () => {
+        const {iso, mesh} = setupBatchedIsolator()
+        wireBatchedSelection(iso, mesh)
+        applyBatchedSelection(mesh, [100], SELECTION_CYAN)
+        applyBatchedInstanceSelection(mesh, [1], SELECTION_CYAN)
+        iso.viewer.getSelectedIds = jest.fn(() => [100])
+
+        iso.isolateSelectedElements()
+        expectColorAt(mesh, 1, {r: 1, g: 0, b: 0}) // midpoint: cleared
+
+        iso.resetTempIsolation()
+
+        expectColorAt(mesh, 1, SELECTION_CYAN)
+        expectColorAt(mesh, 0, {r: 1, g: 0, b: 0}) // sibling occurrence stays red
+      })
+    })
+
+    it('a selection made while isolated still paints cyan', () => {
+      // The clear is one-shot at isolate time, not a suppression: clicking a
+      // part while isolated must still give the normal selection feedback.
+      const {iso, mesh} = setupBatchedIsolator()
+      iso.viewer.getSelectedIds = jest.fn(() => [100])
+      iso.isolateSelectedElements()
+      expectColorAt(mesh, 0, {r: 1, g: 0, b: 0})
+
+      applyBatchedSelection(mesh, [100], SELECTION_CYAN)
+
+      expectColorAt(mesh, 0, SELECTION_CYAN)
+    })
+
+    it('hide clears the selection paint too (same seam)', () => {
+      const {iso, mesh} = setupBatchedIsolator()
+      applyBatchedSelection(mesh, [200], SELECTION_CYAN)
+      expectColorAt(mesh, 2, SELECTION_CYAN)
+
+      iso.viewer.getSelectedIds = jest.fn(() => [200])
+      iso.hideSelectedElements()
+
+      // Green again — and masked out, so the hide itself ran.
+      expectColorAt(mesh, 2, {r: 0, g: 1, b: 0})
+      expect(mesh.getVisibleAt(2)).toBe(false)
     })
   })
 

--- a/src/viewer/three/elementSubsets.js
+++ b/src/viewer/three/elementSubsets.js
@@ -3,6 +3,7 @@ import {
   BufferGeometry,
   Mesh,
 } from 'three'
+import {makeTriangleMaterialIndexer, resolveSubsetMaterial} from './subsetMaterialGroups'
 
 
 /**
@@ -112,7 +113,15 @@ export function buildSubsetMesh(sourceMesh, idSet, opts = {}) {
   // → `createSubset` from shared arrays).
   const ArrayCtor = srcIndexArr.constructor
   const dstIndexArr = new ArrayCtor(matchCount * 3)
+  // Per-kept-triangle source material index, in destination order —
+  // what lets resolveSubsetMaterial rebuild `groups[]` so a subset
+  // spanning several color bins keeps all of their materials instead
+  // of collapsing to `material[0]` (Share#1806). Null when the source
+  // is single-material (no groups to preserve).
+  const materialIndexOf = makeTriangleMaterialIndexer(srcGeom)
+  const dstMaterialIndices = materialIndexOf ? new Int32Array(matchCount) : null
   let w = 0
+  let dstTri = 0
   for (let t = 0; t < triCount; t++) {
     const base = t * 3
     const a = srcIndexArr[base]
@@ -128,6 +137,13 @@ export function buildSubsetMesh(sourceMesh, idSet, opts = {}) {
     dstIndexArr[w++] = a
     dstIndexArr[w++] = b
     dstIndexArr[w++] = c
+    if (dstMaterialIndices) {
+      // This walk is in ascending source-triangle order, so the
+      // indexer's cursor never rewinds and destination runs stay
+      // coalesced one-per-bin.
+      dstMaterialIndices[dstTri] = materialIndexOf(t)
+    }
+    dstTri++
   }
   const dstGeom = new BufferGeometry()
   // Share vertex attributes — same underlying typed arrays. No copy.
@@ -135,21 +151,17 @@ export function buildSubsetMesh(sourceMesh, idSet, opts = {}) {
     dstGeom.setAttribute(name, srcGeom.attributes[name])
   }
   dstGeom.setIndex(new BufferAttribute(dstIndexArr, 1))
-  let subsetMaterial = material ?? sourceMesh.material
   // Three.js's `WebGLRenderer.projectObject` (r184 three.module.js
   // around line 17842) skips Meshes when `material` is an array but
   // `geometry.groups.length === 0` — the group-walk in the renderer
   // pushes nothing to the render list. Conway-direct models always
   // carry `material: Array(N)` (one per color bin), so a subset with
-  // shared array material + no groups is invisible. Same shape, same
-  // fix here as in IfcInstanceMap#buildSubsetMesh.
-  if (Array.isArray(subsetMaterial)) {
-    if (subsetMaterial.length === 1) {
-      subsetMaterial = subsetMaterial[0]
-    } else if (subsetMaterial.length > 1) {
-      dstGeom.addGroup(0, dstIndexArr.length, 0)
-    }
-  }
+  // shared array material + no groups is invisible. resolveSubsetMaterial
+  // unwraps Array(1) and rebuilds per-bin groups for Array(N>1); see
+  // ./subsetMaterialGroups.js. Same shape, same call in
+  // IfcInstanceMap#buildSubsetMesh.
+  const subsetMaterial = resolveSubsetMaterial(
+    dstGeom, material ?? sourceMesh.material, dstMaterialIndices)
   const subsetMesh = new Mesh(dstGeom, subsetMaterial)
   // Local transform mirrors source's local transform. World
   // transform alignment is the caller's responsibility (parent the
@@ -407,12 +419,9 @@ export function buildInstanceMapSubsetMesh(sourceMesh, parentIdSet, opts = {}) {
   // Conway-direct models each child Mesh is single-material (one
   // material per PlacedGeometry.color bin — GLTFExporter split by
   // material group on write). For cache-miss the source carries an
-  // array material + `geometry.groups[]`; three.js renders our subset
-  // with `material[0]` because subset geometries are built without
-  // groups[]. Visually approximate but functional — the "isolation
-  // shows monochrome on cache-miss" small regression is documented
-  // in §3b.iii. Cache-hit (the steady-state) renders with correct
-  // per-PlacedGeometry colors.
+  // array material + `geometry.groups[]`, and the subset builder now
+  // rebuilds matching groups over the kept triangles (Share#1806), so
+  // both shapes render with correct per-PlacedGeometry colors.
   const subset = sourceMesh.instanceMap.createSubsetMeshByParent(parentIdSet, {
     material: opts.material,
     defaultMaterial: sourceMesh.material,

--- a/src/viewer/three/elementSubsets.test.js
+++ b/src/viewer/three/elementSubsets.test.js
@@ -59,6 +59,40 @@ function makeTwoElementMesh() {
 }
 
 
+/**
+ * Two-color-bin source, the shape `flatMeshToBufferGeometry` produces:
+ * triangles emitted in bin order, one `geometry.groups[]` entry per bin,
+ * positionally paired with one entry in the mesh's `material` array.
+ *
+ *   tri 0 → element 10 ┐ bin 0 (material[0])
+ *   tri 1 → element 11 ┘
+ *   tri 2 → element 20 ┐ bin 1 (material[1])
+ *   tri 3 → element 21 ┘
+ *
+ * @return {Mesh}
+ */
+function makeTwoBinMesh() {
+  const geom = new BufferGeometry()
+  const vertsPerTri = 3
+  const triCount = 4
+  geom.setAttribute(
+    'position',
+    new BufferAttribute(new Float32Array(triCount * vertsPerTri * 3), 3),
+  )
+  geom.setAttribute('expressID', new BufferAttribute(
+    new Int32Array([10, 10, 10, 11, 11, 11, 20, 20, 20, 21, 21, 21]), 1,
+  ))
+  geom.setIndex(new BufferAttribute(
+    new Uint32Array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]), 1,
+  ))
+  // Bin 0 = tris 0-1 (indices 0-5), bin 1 = tris 2-3 (indices 6-11).
+  geom.addGroup(0, 6, 0)
+  geom.addGroup(6, 6, 1)
+  const materials = [new MeshBasicMaterial(), new MeshBasicMaterial()]
+  return new Mesh(geom, materials)
+}
+
+
 describe('viewer/three/elementSubsets', () => {
   describe('buildSubsetMesh', () => {
     it('keeps only triangles whose vertices all match the id set', () => {
@@ -161,6 +195,53 @@ describe('viewer/three/elementSubsets', () => {
       const override = new MeshBasicMaterial()
       const customSubset = buildSubsetMesh(src, new Set([10]), {material: override})
       expect(customSubset.material).toBe(override)
+    })
+
+    it('preserves every color bin\'s material when the subset spans bins', () => {
+      // Share#1806: the old code collapsed a multi-material subset to a
+      // single group pointing at material[0], so an isolated element
+      // rendered monochrome — grey whenever bin 0 is the DEFAULT_COLOR
+      // bin. The subset must carry one group per bin it spans.
+      const src = makeTwoBinMesh()
+      const subset = buildSubsetMesh(src, new Set([10, 11, 20, 21]))
+      expect(subset.material).toBe(src.material)
+      expect(subset.geometry.groups).toEqual([
+        {start: 0, count: 6, materialIndex: 0},
+        {start: 6, count: 6, materialIndex: 1},
+      ])
+    })
+
+    it('renders a single-bin subset with that bin\'s material, not material[0]', () => {
+      // The regression that made isolated parts grey: a subset entirely
+      // inside bin 1 was drawn with material[0].
+      const src = makeTwoBinMesh()
+      const subset = buildSubsetMesh(src, new Set([20, 21]))
+      expect(subset.material).toBe(src.material)
+      expect(subset.geometry.groups).toEqual([
+        {start: 0, count: 6, materialIndex: 1},
+      ])
+    })
+
+    it('coalesces adjacent same-bin triangles into one group', () => {
+      // Two triangles from bin 0 plus one from bin 1 → two groups, not
+      // three. Emitting a group per triangle would be correct but would
+      // cost a draw call per triangle on real models.
+      const src = makeTwoBinMesh()
+      const subset = buildSubsetMesh(src, new Set([10, 11, 21]))
+      expect(subset.geometry.groups).toEqual([
+        {start: 0, count: 6, materialIndex: 0},
+        {start: 6, count: 3, materialIndex: 1},
+      ])
+    })
+
+    it('an explicit single-material override still wins over the bin walk', () => {
+      const src = makeTwoBinMesh()
+      const override = new MeshBasicMaterial()
+      const subset = buildSubsetMesh(src, new Set([10, 20]), {material: override})
+      expect(subset.material).toBe(override)
+      // A scalar material needs no groups — the renderer takes its
+      // `material.visible` branch.
+      expect(subset.geometry.groups).toEqual([])
     })
 
     it('supports a custom attribute name for non-IFC formats', () => {
@@ -443,6 +524,37 @@ describe('viewer/three/elementSubsets', () => {
       // No override → falls back to source.
       const subset2 = buildInstanceMapSubsetMesh(src, new Set([100]))
       expect(subset2.material).toBe(src.material)
+    })
+
+    it('preserves per-color-bin materials across the instance-map path', () => {
+      // Cache-miss Conway-direct shape: one Mesh, array material, one
+      // geometry group per color bin. Parent 100's two instances span
+      // tris 0-3, which straddles the bin boundary at tri 3 — the subset
+      // must come out with both bins' materials (Share#1806).
+      const src = makeInstanceMappedMesh()
+      // Bin 0 = tris 0-2 (indices 0-8), bin 1 = tris 3-5 (indices 9-17).
+      src.geometry.addGroup(0, 9, 0)
+      src.geometry.addGroup(9, 9, 1)
+      const materials = [new MeshBasicMaterial(), new MeshBasicMaterial()]
+      src.material = materials
+      const subset = buildInstanceMapSubsetMesh(src, new Set([100]))
+      expect(subset.material).toBe(materials)
+      expect(subset.geometry.groups).toEqual([
+        {start: 0, count: 9, materialIndex: 0},
+        {start: 9, count: 3, materialIndex: 1},
+      ])
+    })
+
+    it('a subset inside one bin uses that bin\'s material, not material[0]', () => {
+      const src = makeInstanceMappedMesh()
+      src.geometry.addGroup(0, 9, 0)
+      src.geometry.addGroup(9, 9, 1)
+      src.material = [new MeshBasicMaterial(), new MeshBasicMaterial()]
+      // Parent 200 is instance 2 → tris 4-5, wholly inside bin 1.
+      const subset = buildInstanceMapSubsetMesh(src, new Set([200]))
+      expect(subset.geometry.groups).toEqual([
+        {start: 0, count: 6, materialIndex: 1},
+      ])
     })
 
     it('the subset is raycast-active (not invisible)', () => {

--- a/src/viewer/three/outlineBatching.js
+++ b/src/viewer/three/outlineBatching.js
@@ -73,11 +73,19 @@ export function injectBatchingChunks(vertexShader) {
  * Patch an OutlineEffect's mask-pass material so a BatchedMesh in its
  * selection outlines instead of failing to compile. See the module comment.
  *
- * Reassigning `maskPass.overrideMaterial` is load-bearing, not redundant:
- * postprocessing's `OverrideMaterialManager` clones the material into six
- * side/flat-shading variants at construction time, so mutating the original
- * in place would leave every clone — the ones actually bound at draw time —
- * on the unpatched source. The setter calls `setMaterial`, which re-clones.
+ * Mutating `material.vertexShader` in place is what actually fixes the draw:
+ * `OverrideMaterialManager.render` (postprocessing 6.39.1) assigns
+ * `scene.overrideMaterial = this.material` — this same object — in its
+ * default path. Its other path, the one that binds the six cached
+ * side/flat-shading clones instead, runs only when the module-level static
+ * `OverrideMaterialManager.workaroundEnabled` is true; it defaults to false
+ * and nothing in postprocessing or in Share sets it.
+ *
+ * The `maskPass.overrideMaterial` reassignment is kept anyway, as cheap
+ * defense-in-depth: the setter routes to `setMaterial`, which re-clones the
+ * variants off the now-patched source, so the clones can't be stale if
+ * anything ever flips `workaroundEnabled` on. It costs six clones once, at
+ * patch time.
  *
  * @param {object} outlineEffect a postprocessing `OutlineEffect`
  * @return {boolean} whether the material was patched

--- a/src/viewer/three/outlineBatching.js
+++ b/src/viewer/three/outlineBatching.js
@@ -1,0 +1,98 @@
+/**
+ * outlineBatching — teach `postprocessing`'s OutlineEffect mask pass how to
+ * draw a `THREE.BatchedMesh`.
+ *
+ * Why this exists: `OutlineEffect` builds its mask pass as
+ * `new RenderPass(scene, camera, new DepthComparisonMaterial(...))`
+ * (postprocessing 6.39.1, `postprocessing.js` ~line 8834) — unconditionally,
+ * whatever `xRay` is set to; `xRay` only toggles a define in the *outline*
+ * fragment shader, so turning it off does not avoid this material. That
+ * material's vertex shader (`src/materials/glsl/depth-comparison.vert`)
+ * includes only the morphtarget / skinning / clipping-plane chunks. three.js
+ * still compiles it with `USE_BATCHING` whenever the object being drawn is a
+ * BatchedMesh (`WebGLPrograms`: `IS_BATCHEDMESH` drives the define, keyed off
+ * the object, not the material), and its `project_vertex` chunk then reads
+ * `batchingMatrix`, which nothing declared:
+ *
+ *   THREE.WebGLProgram: Shader Error 0 - VALIDATE_STATUS false
+ *   Material Name: DepthComparisonMaterial (ShaderMaterial)
+ *   ERROR: 0:204: 'batchingMatrix' : undeclared identifier
+ *
+ * The program then fails to link, the mask never renders, and the isolation
+ * outline silently disappears while WebGL logs `useProgram: program not
+ * valid` every frame. This surfaced when Share#1806 moved batched-path
+ * isolation in place (`BatchedMesh.setVisibleAt`) and pointed the outline at
+ * the batches themselves instead of at a re-baked plain `Mesh`.
+ *
+ * The fix is the two chunks three's own materials carry, injected in three's
+ * own order (`batching_pars_vertex` alongside the other `_pars` includes,
+ * `batching_vertex` before `begin_vertex` so `batchingMatrix` is in scope by
+ * the time `project_vertex` multiplies by it — cf. `meshbasic_vert.glsl.js`).
+ * The uniforms it needs (`batchingTexture`, `batchingIdTexture`) are bound by
+ * `WebGLRenderer.setProgram` for any material drawn on a BatchedMesh, and the
+ * `GL_ANGLE_multi_draw` extension line is emitted for the same reason, so
+ * nothing else has to be wired up.
+ *
+ * Drop this module when postprocessing ships the batching chunks in
+ * `depth-comparison.vert` upstream — at that point `injectBatchingChunks`
+ * finds the include already present and no-ops, so removal is safe to do
+ * lazily.
+ */
+const BATCHING_PARS_INCLUDE = '#include <batching_pars_vertex>'
+const BATCHING_INCLUDE = '#include <batching_vertex>'
+const PARS_ANCHOR = '#include <common>'
+const MAIN_ANCHOR = '#include <begin_vertex>'
+
+
+/**
+ * Add the batching chunks to a GLSL vertex shader source that lacks them.
+ *
+ * Exported for testing and for `patchOutlineForBatchedMeshes` below; a source
+ * that already includes the pars chunk (a fixed upstream, or a second patch
+ * pass) is returned untouched, which is what makes the patch idempotent.
+ *
+ * @param {string} vertexShader GLSL source
+ * @return {?string} the patched source, or null when it could not be
+ *   patched — already batching-aware, or missing an anchor the injection
+ *   needs (an upstream rewrite we should not guess at).
+ */
+export function injectBatchingChunks(vertexShader) {
+  if (typeof vertexShader !== 'string' ||
+      vertexShader.includes(BATCHING_PARS_INCLUDE) ||
+      !vertexShader.includes(PARS_ANCHOR) ||
+      !vertexShader.includes(MAIN_ANCHOR)) {
+    return null
+  }
+  return vertexShader
+    .replace(PARS_ANCHOR, `${PARS_ANCHOR}\n${BATCHING_PARS_INCLUDE}`)
+    .replace(MAIN_ANCHOR, `${BATCHING_INCLUDE}\n${MAIN_ANCHOR}`)
+}
+
+
+/**
+ * Patch an OutlineEffect's mask-pass material so a BatchedMesh in its
+ * selection outlines instead of failing to compile. See the module comment.
+ *
+ * Reassigning `maskPass.overrideMaterial` is load-bearing, not redundant:
+ * postprocessing's `OverrideMaterialManager` clones the material into six
+ * side/flat-shading variants at construction time, so mutating the original
+ * in place would leave every clone — the ones actually bound at draw time —
+ * on the unpatched source. The setter calls `setMaterial`, which re-clones.
+ *
+ * @param {object} outlineEffect a postprocessing `OutlineEffect`
+ * @return {boolean} whether the material was patched
+ */
+export function patchOutlineForBatchedMeshes(outlineEffect) {
+  const material = outlineEffect?.maskPass?.overrideMaterial
+  if (!material) {
+    return false
+  }
+  const patched = injectBatchingChunks(material.vertexShader)
+  if (patched === null) {
+    return false
+  }
+  material.vertexShader = patched
+  material.needsUpdate = true
+  outlineEffect.maskPass.overrideMaterial = material
+  return true
+}

--- a/src/viewer/three/outlineBatching.test.js
+++ b/src/viewer/three/outlineBatching.test.js
@@ -1,0 +1,103 @@
+import {OutlineEffect} from 'postprocessing'
+import {PerspectiveCamera, Scene} from 'three'
+import {injectBatchingChunks, patchOutlineForBatchedMeshes} from './outlineBatching'
+
+
+describe('viewer/three/outlineBatching', () => {
+  describe('injectBatchingChunks', () => {
+    // A stand-in with the anchors the real depth-comparison.vert has.
+    const SHADER = [
+      '#include <common>',
+      '#include <skinning_pars_vertex>',
+      'void main(){',
+      '#include <begin_vertex>',
+      '#include <project_vertex>',
+      '}',
+    ].join('\n')
+
+    it('declares batchingMatrix before project_vertex reads it', () => {
+      const patched = injectBatchingChunks(SHADER)
+      const pars = patched.indexOf('#include <batching_pars_vertex>')
+      const vertex = patched.indexOf('#include <batching_vertex>')
+      const begin = patched.indexOf('#include <begin_vertex>')
+      const project = patched.indexOf('#include <project_vertex>')
+      expect(pars).toBeGreaterThan(-1)
+      // The ordering IS the fix: `batching_vertex` declares `batchingMatrix`,
+      // `project_vertex` multiplies by it, and the pars chunk defines the
+      // helpers `batching_vertex` calls. Getting them in the wrong order is
+      // the same compile failure with a different line number.
+      expect(pars).toBeLessThan(vertex)
+      expect(vertex).toBeLessThan(begin)
+      expect(begin).toBeLessThan(project)
+    })
+
+    it('leaves an already-batching-aware shader alone', () => {
+      // Upstream may ship the chunk; patching twice must not double-declare.
+      const patched = injectBatchingChunks(SHADER)
+      expect(injectBatchingChunks(patched)).toBeNull()
+    })
+
+    it('declines a shader missing an anchor rather than guessing', () => {
+      expect(injectBatchingChunks('void main(){}')).toBeNull()
+      expect(injectBatchingChunks('#include <common>\nvoid main(){}')).toBeNull()
+      expect(injectBatchingChunks(undefined)).toBeNull()
+    })
+  })
+
+
+  describe('patchOutlineForBatchedMeshes', () => {
+    /** @return {OutlineEffect} a real effect, as CustomPostProcessor builds one */
+    function makeEffect() {
+      return new OutlineEffect(new Scene(), new PerspectiveCamera(), {xRay: true})
+    }
+
+    it('patches the real DepthComparisonMaterial, which ships without batching', () => {
+      const effect = makeEffect()
+      // Pin the upstream premise: when postprocessing adds the chunks itself
+      // this assertion fails and the whole module can be deleted.
+      expect(effect.maskPass.overrideMaterial.vertexShader)
+        .not.toContain('batching')
+      expect(patchOutlineForBatchedMeshes(effect)).toBe(true)
+      expect(effect.maskPass.overrideMaterial.vertexShader)
+        .toContain('#include <batching_vertex>')
+    })
+
+    it('rebuilds the override-material clones, which are what get drawn', () => {
+      // OverrideMaterialManager clones the material into side / flat-shading
+      // variants up front and binds a clone — never the original — at draw
+      // time. Mutating only the original would leave the shader error exactly
+      // where it was, with a patched material to point at as proof it worked.
+      const effect = makeEffect()
+      patchOutlineForBatchedMeshes(effect)
+      const manager = effect.maskPass.overrideMaterialManager
+      const variants = [
+        ...manager.materials,
+        ...manager.materialsBackSide,
+        ...manager.materialsDoubleSide,
+        ...manager.materialsFlatShaded,
+      ]
+      expect(variants.length).toBeGreaterThan(0)
+      for (const variant of variants) {
+        expect(variant.vertexShader).toContain('#include <batching_vertex>')
+      }
+    })
+
+    it('keeps the depth-buffer uniform wired through the re-clone', () => {
+      // The manager nulls render-target uniforms while cloning and restores
+      // them afterwards; a re-clone that lost `depthBuffer` would compile
+      // fine and mask against nothing.
+      const effect = makeEffect()
+      patchOutlineForBatchedMeshes(effect)
+      const material = effect.maskPass.overrideMaterialManager.materials[0]
+      expect(material.uniforms.depthBuffer.value).toBe(effect.depthPass.texture)
+    })
+
+    it('is idempotent and safe on an effect with no mask pass', () => {
+      const effect = makeEffect()
+      expect(patchOutlineForBatchedMeshes(effect)).toBe(true)
+      expect(patchOutlineForBatchedMeshes(effect)).toBe(false)
+      expect(patchOutlineForBatchedMeshes({})).toBe(false)
+      expect(patchOutlineForBatchedMeshes(null)).toBe(false)
+    })
+  })
+})

--- a/src/viewer/three/outlineBatching.test.js
+++ b/src/viewer/three/outlineBatching.test.js
@@ -1,4 +1,4 @@
-import {OutlineEffect} from 'postprocessing'
+import {OutlineEffect, OverrideMaterialManager} from 'postprocessing'
 import {PerspectiveCamera, Scene} from 'three'
 import {injectBatchingChunks, patchOutlineForBatchedMeshes} from './outlineBatching'
 
@@ -62,11 +62,25 @@ describe('viewer/three/outlineBatching', () => {
         .toContain('#include <batching_vertex>')
     })
 
-    it('rebuilds the override-material clones, which are what get drawn', () => {
-      // OverrideMaterialManager clones the material into side / flat-shading
-      // variants up front and binds a clone — never the original — at draw
-      // time. Mutating only the original would leave the shader error exactly
-      // where it was, with a patched material to point at as proof it worked.
+    it('leaves the patched original as what the default path binds', () => {
+      // The premise the module comment rests on: `OverrideMaterialManager
+      // .render` assigns `this.material` — the very object patched in place —
+      // and only reaches for its clones when the static workaround flag is
+      // on, which postprocessing ships off. If an upgrade flips that default,
+      // the clones become load-bearing and this assertion says so.
+      expect(OverrideMaterialManager.workaroundEnabled).toBe(false)
+      const effect = makeEffect()
+      patchOutlineForBatchedMeshes(effect)
+      expect(effect.maskPass.overrideMaterialManager.material.vertexShader)
+        .toContain('#include <batching_vertex>')
+    })
+
+    it('rebuilds the clones the workaroundEnabled path would bind', () => {
+      // These clones are dormant in this codebase — `render()` binds
+      // `this.material` unless the static `OverrideMaterialManager
+      // .workaroundEnabled` is on, and nothing turns it on. Pinning them
+      // patched is what makes the reassignment in the module defensible as
+      // defense-in-depth rather than cargo cult.
       const effect = makeEffect()
       patchOutlineForBatchedMeshes(effect)
       const manager = effect.maskPass.overrideMaterialManager

--- a/src/viewer/three/subsetMaterialGroups.js
+++ b/src/viewer/three/subsetMaterialGroups.js
@@ -46,8 +46,13 @@ const INDICES_PER_TRIANGLE = 3
  * `group.start` / `group.count` are in *index-buffer* units, so a group
  * covers triangles `[start / 3, (start + count) / 3)`. The returned
  * function keeps a cursor and is O(1) amortised for monotonically
- * non-decreasing queries (the copy-loop access pattern); it stays
- * correct — just slower — for out-of-order ones by rewinding.
+ * non-decreasing queries (the copy-loop access pattern), gaps between
+ * groups included; a backward query costs one step per range it walks
+ * back over, so out-of-order callers stay correct, just slower.
+ *
+ * Source groups are neither required to be sorted nor to be disjoint.
+ * Where two groups overlap, the one with the lower `start` wins — the
+ * cursor stops at the first range whose `endTri` is past `t`.
  *
  * @param {object} srcGeom source BufferGeometry
  * @return {?function(number): number} triangle index → material index,
@@ -73,8 +78,15 @@ export function makeTriangleMaterialIndexer(srcGeom) {
     .sort((a, b) => a.startTri - b.startTri)
   let cursor = 0
   return (t) => {
-    if (cursor >= ranges.length || t < ranges[cursor].startTri) {
-      cursor = 0
+    // Rewind one range at a time rather than resetting to 0. A reset would
+    // also fire for *forward* queries that land in a gap between groups
+    // (`t` past `ranges[cursor - 1].endTri` but before `ranges[cursor]`
+    // starts), making every triangle in the gap re-walk the whole prefix —
+    // O(ranges) per triangle on the copy loop's hot path. Stepping back only
+    // while the query is genuinely behind the previous range's end keeps the
+    // amortised O(1) the doc comment above claims, for gaps included.
+    while (cursor > 0 && t < ranges[cursor - 1].endTri) {
+      cursor--
     }
     while (cursor < ranges.length && t >= ranges[cursor].endTri) {
       cursor++

--- a/src/viewer/three/subsetMaterialGroups.js
+++ b/src/viewer/three/subsetMaterialGroups.js
@@ -1,0 +1,166 @@
+/**
+ * subsetMaterialGroups — preserve per-material `geometry.groups` when
+ * filtering a multi-material source geometry down to a subset.
+ *
+ * The Conway-direct assembler (`src/viewer/ifc/flatMeshToBufferGeometry.js`)
+ * merges a model into a single BufferGeometry whose triangles are emitted
+ * in *color-bin order*: one `geometry.groups[]` entry per bin, paired
+ * positionally with one entry in the mesh's `material` array. A subset
+ * built from that geometry inherits the array material, so unless it
+ * carries its own `groups[]` three.js has nothing to render against —
+ * `WebGLRenderer.projectObject` walks `geometry.groups` when the material
+ * is an array and pushes NOTHING when that array is empty (r184
+ * three.module.js ~line 17842). That is the render-skip bug behind
+ * "isolated elements disappear".
+ *
+ * The historical stop-gap was `addGroup(0, wholeIndexBuffer, 0)`: visible,
+ * but every triangle drawn with `material[0]` — i.e. monochrome, and grey
+ * whenever bin 0 is the DEFAULT_COLOR bin (Share#1806). This module does
+ * the real thing: map each kept triangle back to the source group it came
+ * from, then emit coalesced destination groups so each run of triangles
+ * renders with its own bin's material.
+ *
+ * Both subset builders (`elementSubsets.buildSubsetMesh` and
+ * `IfcInstanceMap`'s `buildSubsetMesh`) copy triangles in **ascending
+ * source-triangle order**, which is what keeps the destination group count
+ * at one-per-material-bin instead of one-per-triangle. Callers that gather
+ * triangles out of order (the instance-map path walks per-instance lists)
+ * must sort before copying — see `createSubsetMeshByInstance`.
+ */
+
+
+/**
+ * Sentinel returned by the indexer for a triangle that no source group
+ * covers (a gap between groups, or a triangle past the last group).
+ * Callers treat it as "can't attribute this run" and fall back.
+ */
+export const UNKNOWN_MATERIAL_INDEX = -1
+
+
+const INDICES_PER_TRIANGLE = 3
+
+
+/**
+ * Build a source-triangle → material-index lookup from `srcGeom.groups`.
+ *
+ * `group.start` / `group.count` are in *index-buffer* units, so a group
+ * covers triangles `[start / 3, (start + count) / 3)`. The returned
+ * function keeps a cursor and is O(1) amortised for monotonically
+ * non-decreasing queries (the copy-loop access pattern); it stays
+ * correct — just slower — for out-of-order ones by rewinding.
+ *
+ * @param {object} srcGeom source BufferGeometry
+ * @return {?function(number): number} triangle index → material index,
+ *   or `UNKNOWN_MATERIAL_INDEX`. Null when the geometry carries no
+ *   groups at all (single-material source — nothing to preserve).
+ */
+export function makeTriangleMaterialIndexer(srcGeom) {
+  const groups = srcGeom && srcGeom.groups
+  if (!groups || groups.length === 0) {
+    return null
+  }
+  // Copy before sorting: `geometry.groups` is the live array three.js
+  // renders from, and the assembler's emission order is load-bearing
+  // elsewhere. Sorting is defensive — the assembler already emits in
+  // ascending order — but a GLB round-trip or a hand-built geometry
+  // need not.
+  const ranges = groups
+    .map((g) => ({
+      startTri: g.start / INDICES_PER_TRIANGLE,
+      endTri: (g.start + g.count) / INDICES_PER_TRIANGLE,
+      materialIndex: g.materialIndex ?? 0,
+    }))
+    .sort((a, b) => a.startTri - b.startTri)
+  let cursor = 0
+  return (t) => {
+    if (cursor >= ranges.length || t < ranges[cursor].startTri) {
+      cursor = 0
+    }
+    while (cursor < ranges.length && t >= ranges[cursor].endTri) {
+      cursor++
+    }
+    if (cursor >= ranges.length || t < ranges[cursor].startTri) {
+      return UNKNOWN_MATERIAL_INDEX
+    }
+    return ranges[cursor].materialIndex
+  }
+}
+
+
+/**
+ * Settle a subset mesh's material and, when it stays an array, give the
+ * destination geometry the `groups[]` three.js needs to draw it.
+ *
+ * Behaviour by material shape:
+ *  - not an array → returned unchanged (an explicit single-material
+ *    override, the common highlight case). No groups needed.
+ *  - `Array(1)` → unwrapped to the scalar, so the renderer takes its
+ *    `material.visible` branch rather than the group walk. This is the
+ *    monochrome-model cache-hit path.
+ *  - `Array(N > 1)` → kept as an array, with one destination group per
+ *    coalesced run of same-material triangles. Falls back to a single
+ *    whole-buffer group pointing at `material[0]` when the per-triangle
+ *    material indices are unavailable or don't fit this array (see
+ *    below) — visible-but-monochrome beats invisible.
+ *
+ * The fallback also covers the case where an array `opts.material`
+ * override is not the source mesh's own material array: the indices
+ * come from the source geometry's groups and only mean anything against
+ * the array they were binned into, so an out-of-range index is treated
+ * as "these indices aren't for this array".
+ *
+ * @param {object} dstGeom destination BufferGeometry (already indexed)
+ * @param {object|Array<object>} material subset material candidate
+ * @param {?(Array<number>|Int32Array)} triangleMaterialIndices one entry
+ *   per destination triangle, in destination order
+ * @return {object|Array<object>} material to assign to the subset Mesh
+ */
+export function resolveSubsetMaterial(dstGeom, material, triangleMaterialIndices) {
+  if (!Array.isArray(material)) {
+    return material
+  }
+  if (material.length === 1) {
+    return material[0]
+  }
+  if (material.length === 0) {
+    return material
+  }
+  const dstIndex = dstGeom.getIndex()
+  const dstIndexCount = dstIndex ? dstIndex.count : 0
+  const dstTriangleCount = dstIndexCount / INDICES_PER_TRIANGLE
+  const usable =
+    triangleMaterialIndices !== null &&
+    triangleMaterialIndices !== undefined &&
+    triangleMaterialIndices.length === dstTriangleCount &&
+    dstTriangleCount > 0
+  if (usable) {
+    let runStart = 0
+    let runMaterial = triangleMaterialIndices[0]
+    let ok = true
+    // One extra iteration past the end flushes the final run.
+    for (let t = 0; t <= dstTriangleCount; t++) {
+      const current = t < dstTriangleCount ? triangleMaterialIndices[t] : UNKNOWN_MATERIAL_INDEX
+      if (t < dstTriangleCount && (current < 0 || current >= material.length)) {
+        ok = false
+        break
+      }
+      if (t === dstTriangleCount || current !== runMaterial) {
+        dstGeom.addGroup(
+          runStart * INDICES_PER_TRIANGLE,
+          (t - runStart) * INDICES_PER_TRIANGLE,
+          runMaterial,
+        )
+        runStart = t
+        runMaterial = current
+      }
+    }
+    if (ok) {
+      return material
+    }
+    // Partial groups may have been emitted before the bad index was
+    // seen; drop them so the whole-buffer fallback is the only group.
+    dstGeom.clearGroups()
+  }
+  dstGeom.addGroup(0, dstIndexCount, 0)
+  return material
+}

--- a/src/viewer/three/subsetMaterialGroups.js
+++ b/src/viewer/three/subsetMaterialGroups.js
@@ -48,11 +48,19 @@ const INDICES_PER_TRIANGLE = 3
  * function keeps a cursor and is O(1) amortised for monotonically
  * non-decreasing queries (the copy-loop access pattern), gaps between
  * groups included; a backward query costs one step per range it walks
- * back over, so out-of-order callers stay correct, just slower.
+ * back over, so out-of-order callers stay correct, just slower — that
+ * holds for every query order, not only the copy loop's.
  *
  * Source groups are neither required to be sorted nor to be disjoint.
- * Where two groups overlap, the one with the lower `start` wins — the
- * cursor stops at the first range whose `endTri` is past `t`.
+ * They are normalised at construction time — sorted by start, then each
+ * range clipped to begin no earlier than the highest end seen so far,
+ * dropping any range that clipping empties. So where ranges overlap the
+ * one with the lower start wins (ties broken by array order), and the
+ * ranges the cursor walks are disjoint and ascending, which is what
+ * makes the one-step rewind below correct rather than merely usually
+ * correct: with overlaps left in place, a rewind that cleared a narrow
+ * inner range would stop there instead of walking back to the wider
+ * range that still covers `t`.
  *
  * @param {object} srcGeom source BufferGeometry
  * @return {?function(number): number} triangle index → material index,
@@ -66,16 +74,33 @@ export function makeTriangleMaterialIndexer(srcGeom) {
   }
   // Copy before sorting: `geometry.groups` is the live array three.js
   // renders from, and the assembler's emission order is load-bearing
-  // elsewhere. Sorting is defensive — the assembler already emits in
-  // ascending order — but a GLB round-trip or a hand-built geometry
-  // need not.
-  const ranges = groups
+  // elsewhere. Sorting and the clipping below are defensive — the
+  // assembler already emits ascending, disjoint groups — but a GLB
+  // round-trip or a hand-built geometry need not.
+  const sorted = groups
     .map((g) => ({
       startTri: g.start / INDICES_PER_TRIANGLE,
       endTri: (g.start + g.count) / INDICES_PER_TRIANGLE,
       materialIndex: g.materialIndex ?? 0,
     }))
     .sort((a, b) => a.startTri - b.startTri)
+  // Clip to disjoint, mutating the copies `map` just made. `coveredTo` is
+  // the highest end reached so far rather than the previous range's end, so
+  // a narrow range nested inside a wider earlier one is dropped outright
+  // instead of resuming after it. O(n), once per subset build, over at most
+  // a few dozen colour bins.
+  const ranges = []
+  let coveredTo = -Infinity
+  for (const range of sorted) {
+    if (coveredTo >= range.endTri) {
+      continue
+    }
+    if (coveredTo > range.startTri) {
+      range.startTri = coveredTo
+    }
+    ranges.push(range)
+    coveredTo = range.endTri
+  }
   let cursor = 0
   return (t) => {
     // Rewind one range at a time rather than resetting to 0. A reset would
@@ -84,7 +109,10 @@ export function makeTriangleMaterialIndexer(srcGeom) {
     // starts), making every triangle in the gap re-walk the whole prefix —
     // O(ranges) per triangle on the copy loop's hot path. Stepping back only
     // while the query is genuinely behind the previous range's end keeps the
-    // amortised O(1) the doc comment above claims, for gaps included.
+    // amortised O(1) the doc comment above claims, for gaps included. The
+    // ranges are disjoint and ascending after normalisation, so stopping at
+    // the first range whose end is at or before `t` cannot skip past a range
+    // that still covers it.
     while (cursor > 0 && t < ranges[cursor - 1].endTri) {
       cursor--
     }

--- a/src/viewer/three/subsetMaterialGroups.test.js
+++ b/src/viewer/three/subsetMaterialGroups.test.js
@@ -115,8 +115,43 @@ describe('viewer/three/subsetMaterialGroups', () => {
       const indexer = makeTriangleMaterialIndexer(
         geomWithGroups([[0, 6, 1], [3, 9, 2]]))
       expect([0, 5].map(indexer)).toEqual([1, 1])
-      // Past the first group's end the second one takes over.
+      // Past the first group's end the clipped remainder of the second takes
+      // over — the overlap [3, 6) belongs to the lower-start group.
       expect([6, 8].map(indexer)).toEqual([2, 2])
+    })
+
+    it('drops a group wholly covered by an earlier, wider one', () => {
+      // Normalisation clips against the highest end seen so far, not the
+      // previous range's end, so a nested group vanishes instead of
+      // reappearing as a hole punched in its container.
+      const indexer = makeTriangleMaterialIndexer(
+        geomWithGroups([[0, 20, 0], [5, 6, 1], [10, 15, 2]]))
+      expect([0, 5, 12, 19].map(indexer)).toEqual([0, 0, 0, 0])
+      expect(indexer(20)).toBe(UNKNOWN_MATERIAL_INDEX)
+    })
+
+    it('resolves an overlapped triangle after a backward query', () => {
+      // Regression: with the overlaps left in the range list, the one-step
+      // rewind stopped as soon as it cleared the narrow inner range [5, 6)
+      // and never walked back to [0, 20), which still covers triangle 7 —
+      // so a query behind the cursor returned the gap sentinel for a
+      // triangle that is plainly inside a group.
+      const indexer = makeTriangleMaterialIndexer(
+        geomWithGroups([[0, 20, 0], [5, 6, 1], [10, 15, 2]]))
+      // Drive the cursor past everything first.
+      expect(indexer(25)).toBe(UNKNOWN_MATERIAL_INDEX)
+      expect(indexer(7)).toBe(0)
+      // And the rewound cursor still answers forward queries.
+      expect(indexer(19)).toBe(0)
+    })
+
+    it('breaks a start tie by array order', () => {
+      // Equal starts have no "lower start" to prefer; the sort is stable, so
+      // the group that came first in `groups` keeps the overlap.
+      const indexer = makeTriangleMaterialIndexer(
+        geomWithGroups([[0, 4, 8], [0, 6, 9]]))
+      expect([0, 3].map(indexer)).toEqual([8, 8])
+      expect([4, 5].map(indexer)).toEqual([9, 9])
     })
 
     it('handles start / count that are not whole triangles', () => {
@@ -139,11 +174,14 @@ describe('viewer/three/subsetMaterialGroups', () => {
 
 
       /**
-       * Wrap the source `groups` so that every indexed read of the internal
-       * `ranges` array the indexer builds from it is counted. The indexer does
-       * `groups.map(...).sort(...)` once and then indexes the result on every
-       * query, so proxying what `map` returns counts exactly the per-query
-       * walk — which is what the "O(1) amortised" claim is about.
+       * Wrap the source `groups` so that every read of a range boundary the
+       * indexer's cursor walk performs is counted. The indexer builds its
+       * internal range objects with one `groups.map(...)` and then reads
+       * `startTri` / `endTri` off them on every query, so proxying the mapped
+       * objects counts exactly the per-query walk — which is what the
+       * "O(1) amortised" claim is about. (Counting index reads of the array
+       * instead would miss it: normalisation copies the surviving ranges into
+       * an array of its own.)
        *
        * @return {{srcGeom: object, reads: {count: number}}}
        */
@@ -160,14 +198,14 @@ describe('viewer/three/subsetMaterialGroups', () => {
         const srcGeom = {
           groups: {
             length: groups.length,
-            map: (fn) => new Proxy(groups.map(fn), {
+            map: (fn) => groups.map(fn).map((range) => new Proxy(range, {
               get(target, prop, receiver) {
-                if (typeof prop === 'string' && /^\d+$/.test(prop)) {
+                if (prop === 'startTri' || prop === 'endTri') {
                   reads.count++
                 }
                 return Reflect.get(target, prop, receiver)
               },
-            }),
+            })),
           },
         }
         return {srcGeom, reads}

--- a/src/viewer/three/subsetMaterialGroups.test.js
+++ b/src/viewer/three/subsetMaterialGroups.test.js
@@ -1,0 +1,304 @@
+/* eslint-disable no-magic-numbers */
+import {BufferAttribute, BufferGeometry} from 'three'
+import {
+  UNKNOWN_MATERIAL_INDEX,
+  makeTriangleMaterialIndexer,
+  resolveSubsetMaterial,
+} from './subsetMaterialGroups'
+
+
+// Direct coverage for the module both subset builders delegate their
+// per-material `groups[]` reconstruction to. Reaching it only through
+// `elementSubsets` / `IfcInstanceMap` exercises exactly one shape of input —
+// strictly ascending, gap-free, already-sorted triangle runs — which leaves
+// the gap sentinel, the unsorted / overlapping source groups, the fallbacks
+// and the cursor's rewind path untested. Those are what this file drives.
+describe('viewer/three/subsetMaterialGroups', () => {
+  const TRI = 3
+
+
+  /**
+   * @param {Array<Array<number>>} triples `[startTri, endTri, materialIndex?]`
+   *   per group, expressed in triangles; converted to the index-buffer units
+   *   `geometry.groups` actually carries.
+   * @return {object} a stand-in for a source BufferGeometry
+   */
+  function geomWithGroups(triples) {
+    return {
+      groups: triples.map(([startTri, endTri, materialIndex]) => {
+        const group = {start: startTri * TRI, count: (endTri - startTri) * TRI}
+        if (materialIndex !== undefined) {
+          group.materialIndex = materialIndex
+        }
+        return group
+      }),
+    }
+  }
+
+
+  /**
+   * An indexed destination geometry with `triangleCount` triangles and no
+   * groups. The index values are irrelevant here — `resolveSubsetMaterial`
+   * only reads `getIndex().count`.
+   *
+   * @param {number} triangleCount
+   * @return {BufferGeometry}
+   */
+  function dstGeomWithTriangles(triangleCount) {
+    const geom = new BufferGeometry()
+    const indices = new Uint32Array(triangleCount * TRI)
+    for (let i = 0; i < indices.length; i++) {
+      indices[i] = i
+    }
+    geom.setIndex(new BufferAttribute(indices, 1))
+    return geom
+  }
+
+
+  /**
+   * `[start, count, materialIndex]` per emitted group, in emission order.
+   *
+   * @param {BufferGeometry} geom
+   * @return {Array<Array<number>>}
+   */
+  function groupTuples(geom) {
+    return geom.groups.map((g) => [g.start, g.count, g.materialIndex])
+  }
+
+
+  describe('makeTriangleMaterialIndexer', () => {
+    it('returns null for a source with no groups at all', () => {
+      // The single-material source — nothing to preserve, and the callers
+      // branch on null to skip building a per-triangle index array.
+      expect(makeTriangleMaterialIndexer({groups: []})).toBeNull()
+      expect(makeTriangleMaterialIndexer({})).toBeNull()
+      expect(makeTriangleMaterialIndexer(null)).toBeNull()
+    })
+
+    it('maps each triangle to its covering group', () => {
+      const indexer = makeTriangleMaterialIndexer(
+        geomWithGroups([[0, 2, 7], [2, 5, 3]]))
+      expect([0, 1, 2, 3, 4].map(indexer)).toEqual([7, 7, 3, 3, 3])
+    })
+
+    it('returns the sentinel inside a gap between groups and past the last', () => {
+      // No caller produces this today — both builders walk gap-free sources —
+      // so without this test the UNKNOWN_MATERIAL_INDEX path never runs.
+      const indexer = makeTriangleMaterialIndexer(
+        geomWithGroups([[0, 2, 1], [5, 7, 4]]))
+      expect([2, 3, 4].map(indexer)).toEqual(
+        [UNKNOWN_MATERIAL_INDEX, UNKNOWN_MATERIAL_INDEX, UNKNOWN_MATERIAL_INDEX])
+      expect(indexer(5)).toBe(4)
+      expect(indexer(7)).toBe(UNKNOWN_MATERIAL_INDEX)
+      expect(indexer(99)).toBe(UNKNOWN_MATERIAL_INDEX)
+    })
+
+    it('sorts unsorted source groups without mutating the live array', () => {
+      // `geometry.groups` is the array three.js renders from, so the sort has
+      // to happen on a copy — a reordered live array would repaint the source
+      // model with the wrong materials.
+      const geom = geomWithGroups([[4, 6, 2], [0, 4, 9]])
+      const before = geom.groups.map((g) => g.start)
+      const indexer = makeTriangleMaterialIndexer(geom)
+      expect([0, 3, 4, 5].map(indexer)).toEqual([9, 9, 2, 2])
+      expect(geom.groups.map((g) => g.start)).toEqual(before)
+    })
+
+    it('treats a group with no materialIndex as bin 0', () => {
+      // three.js defaults `materialIndex` to 0; a GLB round-trip can drop it.
+      const indexer = makeTriangleMaterialIndexer(geomWithGroups([[0, 2]]))
+      expect(indexer(0)).toBe(0)
+      expect(indexer(1)).toBe(0)
+    })
+
+    it('gives an overlapped triangle to the group with the lower start', () => {
+      const indexer = makeTriangleMaterialIndexer(
+        geomWithGroups([[0, 6, 1], [3, 9, 2]]))
+      expect([0, 5].map(indexer)).toEqual([1, 1])
+      // Past the first group's end the second one takes over.
+      expect([6, 8].map(indexer)).toEqual([2, 2])
+    })
+
+    it('handles start / count that are not whole triangles', () => {
+      // A malformed source shouldn't throw; the fractional boundaries just
+      // land where the arithmetic puts them, and the caller's fallback deals
+      // with whatever comes back.
+      const indexer = makeTriangleMaterialIndexer({
+        groups: [{start: 1, count: 4, materialIndex: 5}],
+      })
+      // Covers triangles [1/3, 5/3): triangle 0 starts before it, triangle 1
+      // falls inside, triangle 2 is past the end.
+      expect(indexer(0)).toBe(UNKNOWN_MATERIAL_INDEX)
+      expect(indexer(1)).toBe(5)
+      expect(indexer(2)).toBe(UNKNOWN_MATERIAL_INDEX)
+    })
+
+    describe('cursor', () => {
+      const PREFIX_GROUPS = 20
+      const GAP_END = 120
+
+
+      /**
+       * Wrap the source `groups` so that every indexed read of the internal
+       * `ranges` array the indexer builds from it is counted. The indexer does
+       * `groups.map(...).sort(...)` once and then indexes the result on every
+       * query, so proxying what `map` returns counts exactly the per-query
+       * walk — which is what the "O(1) amortised" claim is about.
+       *
+       * @return {{srcGeom: object, reads: {count: number}}}
+       */
+      function countingSource() {
+        // 20 single-triangle groups covering [0, 20), then a long gap, then
+        // one more group at [120, 130).
+        const triples = []
+        for (let i = 0; i < PREFIX_GROUPS; i++) {
+          triples.push([i, i + 1, i])
+        }
+        triples.push([GAP_END, GAP_END + 10, 99])
+        const {groups} = geomWithGroups(triples)
+        const reads = {count: 0}
+        const srcGeom = {
+          groups: {
+            length: groups.length,
+            map: (fn) => new Proxy(groups.map(fn), {
+              get(target, prop, receiver) {
+                if (typeof prop === 'string' && /^\d+$/.test(prop)) {
+                  reads.count++
+                }
+                return Reflect.get(target, prop, receiver)
+              },
+            }),
+          },
+        }
+        return {srcGeom, reads}
+      }
+
+      it('does not rescan from the start for forward queries inside a gap', () => {
+        const {srcGeom, reads} = countingSource()
+        const indexer = makeTriangleMaterialIndexer(srcGeom)
+        // Walk up to the gap first so the cursor is parked past the prefix.
+        for (let t = 0; t < PREFIX_GROUPS; t++) {
+          expect(indexer(t)).toBe(t)
+        }
+        reads.count = 0
+        const gapQueries = GAP_END - PREFIX_GROUPS
+        for (let t = PREFIX_GROUPS; t < GAP_END; t++) {
+          expect(indexer(t)).toBe(UNKNOWN_MATERIAL_INDEX)
+        }
+        // Each gap query touches a small, constant number of ranges (3 with
+        // the current guards). The pre-fix code reset the cursor to 0 on every
+        // one of them and re-walked all 20 prefix ranges: 2281 reads measured,
+        // against 301 here. The bound sits between the two.
+        expect(reads.count).toBeLessThan(gapQueries * 4)
+        // And it must have done *some* work — a bound satisfied by an indexer
+        // that never reads its ranges would prove nothing.
+        expect(reads.count).toBeGreaterThan(0)
+      })
+
+      it('still resolves correctly after a genuinely backward query', () => {
+        const {srcGeom} = countingSource()
+        const indexer = makeTriangleMaterialIndexer(srcGeom)
+        expect(indexer(GAP_END + 5)).toBe(99)
+        // Backward, across the whole gap and most of the prefix.
+        expect(indexer(3)).toBe(3)
+        expect(indexer(0)).toBe(0)
+        // Forward again from the rewound cursor.
+        expect(indexer(19)).toBe(19)
+        expect(indexer(50)).toBe(UNKNOWN_MATERIAL_INDEX)
+      })
+    })
+  })
+
+
+  describe('resolveSubsetMaterial', () => {
+    const matA = {name: 'a'}
+    const matB = {name: 'b'}
+    const matC = {name: 'c'}
+
+    it('returns a non-array material untouched and adds no groups', () => {
+      const geom = dstGeomWithTriangles(2)
+      expect(resolveSubsetMaterial(geom, matA, null)).toBe(matA)
+      expect(geom.groups).toEqual([])
+    })
+
+    it('unwraps a single-entry array to the scalar', () => {
+      // The renderer's group walk is skipped entirely for a scalar material,
+      // which is the monochrome-model path.
+      const geom = dstGeomWithTriangles(2)
+      expect(resolveSubsetMaterial(geom, [matA], null)).toBe(matA)
+      expect(geom.groups).toEqual([])
+    })
+
+    it('returns an empty array unchanged without touching the geometry', () => {
+      const geom = dstGeomWithTriangles(2)
+      const material = []
+      expect(resolveSubsetMaterial(geom, material, null)).toBe(material)
+      expect(geom.groups).toEqual([])
+    })
+
+    it('coalesces runs of same-bin triangles into one group each', () => {
+      const geom = dstGeomWithTriangles(5)
+      const material = [matA, matB, matC]
+      expect(resolveSubsetMaterial(geom, material, [0, 0, 2, 2, 1])).toBe(material)
+      expect(groupTuples(geom)).toEqual([
+        [0, 6, 0],
+        [6, 6, 2],
+        [12, 3, 1],
+      ])
+    })
+
+    it('flushes the final run at the t === dstTriangleCount boundary', () => {
+      // The loop runs one iteration past the last triangle purely to emit the
+      // trailing group; a uniform index array is the case where that final
+      // flush is the *only* thing that emits anything.
+      const geom = dstGeomWithTriangles(4)
+      expect(resolveSubsetMaterial(geom, [matA, matB], [1, 1, 1, 1])).toEqual([matA, matB])
+      expect(groupTuples(geom)).toEqual([[0, 12, 1]])
+    })
+
+    it('falls back to one whole-buffer group when indices are missing', () => {
+      const geom = dstGeomWithTriangles(3)
+      const material = [matA, matB]
+      expect(resolveSubsetMaterial(geom, material, null)).toBe(material)
+      expect(groupTuples(geom)).toEqual([[0, 9, 0]])
+    })
+
+    it('falls back when the index array length disagrees with the geometry', () => {
+      const geom = dstGeomWithTriangles(3)
+      resolveSubsetMaterial(geom, [matA, matB], [0, 1])
+      expect(groupTuples(geom)).toEqual([[0, 9, 0]])
+    })
+
+    it('falls back for a zero-triangle destination', () => {
+      const geom = dstGeomWithTriangles(0)
+      resolveSubsetMaterial(geom, [matA, matB], [])
+      expect(groupTuples(geom)).toEqual([[0, 0, 0]])
+    })
+
+    it('falls back for a destination with no index buffer', () => {
+      const geom = new BufferGeometry()
+      resolveSubsetMaterial(geom, [matA, matB], null)
+      expect(groupTuples(geom)).toEqual([[0, 0, 0]])
+    })
+
+    it('drops partial groups and falls back on an out-of-range index', () => {
+      // An array `material` override that isn't the source's own bin array:
+      // the indices mean nothing against it, and a group pointing past the
+      // array's end renders nothing at all.
+      const geom = dstGeomWithTriangles(4)
+      const clearGroups = jest.spyOn(geom, 'clearGroups')
+      resolveSubsetMaterial(geom, [matA, matB], [0, 0, 5, 1])
+      // Triangles 0-1 had already been emitted as a group before index 5 was
+      // seen; only the whole-buffer fallback may survive.
+      expect(clearGroups).toHaveBeenCalled()
+      expect(groupTuples(geom)).toEqual([[0, 12, 0]])
+    })
+
+    it('falls back when a triangle carries the gap sentinel', () => {
+      // UNKNOWN_MATERIAL_INDEX is negative, so it fails the same range check.
+      const geom = dstGeomWithTriangles(3)
+      resolveSubsetMaterial(geom, [matA, matB], [0, UNKNOWN_MATERIAL_INDEX, 1])
+      expect(groupTuples(geom)).toEqual([[0, 9, 0]])
+    })
+  })
+})


### PR DESCRIPTION
Fixes #1806 — isolating a part ("i" or the Isolate button) made it render light grey instead of keeping its color.

## Root cause

Two independent bugs produced the same symptom, one per subset backend.

**Batched path** (the default, and what the issue's STEP repro hits). Isolation detached the model and re-baked a plain `Mesh` from the batch's geometry, handing it the batch's shared, colorless `makeSurfaceMaterial`. All per-part color on a `BatchedMesh` lives in the per-instance color texture (`setColorAt`), `instanceColors`, and the auto-color palette — none of which a plain `Mesh` can read. So the isolated subset rendered untinted white, washed to grey by lighting. STEP is the worst case: colorless STEP is colored *entirely* by `applyProductPalette`.

**Merged Conway-direct and per-vertex GLB paths.** Subset geometry was rebuilt without `groups[]`, so an array material was collapsed to a single whole-buffer group pointing at `material[0]` — monochrome, and grey whenever bin 0 was the `DEFAULT_COLOR` bin. This was the `addGroup(0, len, 0)` stop-gap previously TODO'd to `viewer-replacement.md` §3b.iii.

## Changes

**Batched isolate and hide now run in place.** Instead of rebuilding geometry, `IfcIsolator` masks per-instance visibility with `BatchedMesh.setVisibleAt`. Colors, materials, the auto-color palette and picking all stay correct by construction, and the model never leaves the scene or `pickableModels`. A batchId is visible iff it passes both the isolation filter and the hide filter, derived in one place (`_applyBatchedVisibility`), so the two compose rather than fighting.

Because `ResidencyController` also owns `setVisibleAt`, the isolator wraps the method while a mask is installed: residency's writes land in the mask's `base` array (its intent, preserved) and reach the GPU only when the isolator's verdict also permits. Releasing the mask replays that intent, so un-isolating restores exactly what residency had set rather than blanket-showing everything.

**Isolate clears the selection paint.** On the batched path, selection is painted onto the live instances with `setColorAt` rather than drawn as an overlay — so keeping the batch on screen also kept the cyan, and the isolated part showed selection color instead of its own. (The old grey subset was masking this.) `_clearSelectionVisualOnly` already existed for "drop the visual, keep the selection", but both its calls were no-ops on the batched path, leaving the seam blind for hide too; it now repaints from `instanceColors`. Logical selection is untouched — store state, Properties panel, NavTree, permalink — and `resetTempIsolation` repaints from it, so un-isolate restores the cyan and clicking while isolated still highlights.

**New `src/viewer/three/subsetMaterialGroups.js`** maps each kept triangle back to its source group and emits coalesced per-material destination groups, so a subset keeps every color bin it spans. Both non-batched builders now use it. `IfcInstanceMap`'s builder additionally sorts kept triangle ids ascending, which is what keeps those runs coalesced one-per-bin instead of one-per-instance. Source groups are normalized disjoint at construction, so "lower start wins" holds by construction and the indexer's cursor is correct for any query order. The whole-buffer group survives only as a genuine fallback.

**New `src/viewer/three/outlineBatching.js`.** Pointing the outline effect at the batch meshes exposed a latent incompatibility: `postprocessing`'s `OutlineEffect` builds its mask pass from `DepthComparisonMaterial` unconditionally, and that material's vertex shader carries no batching chunks. three.js still compiles it with `USE_BATCHING` when the drawn object is a `BatchedMesh`, so it failed to link on `'batchingMatrix' : undeclared identifier` — the mask never rendered, isolation lost its outline entirely, and WebGL logged a program error every frame. (`xRay` is not implicated; it only toggles a define in the outline *fragment* shader.) The fix injects three's own `batching_pars_vertex` / `batching_vertex` chunks in three's order, applied in `createOutlineEffect` so every outline benefits, and it no-ops once postprocessing ships the chunks upstream.

## Testing

- Jest: batched isolate/hide composition, per-occurrence hide, the un-isolate round trip, residency eviction and exact restore, selection-paint clear and restore; per-bin group walks on both non-batched builders; direct coverage of the material-group indexer (gaps, overlap, nesting, adjacency, fallbacks) and of the shader patch. All new assertions verified red by mutation.
- Playwright: a `describeMobileAndDesktop` suite loading the issue's repro model (`as1-oc-214.stp`), reading live per-instance color back with `getColorAt()` across the isolate round trip and asserting no outline shader error.
- Two **pre-existing** specs hard-coded the old detach-and-rebake architecture (`ifcModelInScene === false`). They are now path-aware, and the batched branch is a stronger claim, not a weaker one.
- One assertion in this PR's own new E2E was **vacuous** and is fixed: it compared `mesh.instanceColors`, a side array `setColorAt` never writes, so it was byte-identical on `main` too and would have passed while the bug shipped. It now reads live color and is proven red against a build with only the fix removed.
- Every commit passed the pre-commit gate. `yarn test-ci` passes with coverage thresholds met; `yarn build-prod` clean; full `test-flows` green.
- Verified in a real browser against the repro model: with a part selected, isolating now shows its source color `[0.8, 1, 0]` where it previously showed cyan `[0, 0.871, 1]` (and grey on `main`), with the same visibility and `isolatedIds`; un-isolate restores the palette and the selection highlight; the isolation outline renders with zero shader errors.

## Reviewer notes

- **Hide moved onto the same branch as isolate.** It had the identical grey bug, and the two must compose through one filter — so the blast radius is slightly wider than "isolate only".
- **`batchedSubset.js` is not dead** — on the batched path it still builds the reveal-hidden ghost overlay, which genuinely wants a flat cyan material.
- **Pre-existing, not addressed here:** the isolation outline is cyan blended with `BlendFunction.SCREEN`, so it is effectively invisible on the light theme. Worth its own issue.