### PR TITLE
Sentry triage T0+T5: alert fingerprinting, diagnostics severity + model tags, pset guard, filename-parse handling

### DIFF
--- a/src/Components/Properties/itemProperties.jsx
+++ b/src/Components/Properties/itemProperties.jsx
@@ -244,6 +244,14 @@ export async function unpackHelper(model, eltArr, serial, ifcToRowCb) {
         const refId = stoi(p.value)
         if (model.getItemProperties) {
           const ifcElt = await model.getItemProperties(refId)
+          // A reference the model can't resolve yields undefined, and the
+          // row callbacks all dereference `.Name.value` — that TypeError
+          // took down the whole Properties panel rather than costing one
+          // row (SHARE-1P3). Skip the entry and keep building the table.
+          if (ifcElt === undefined || ifcElt === null) {
+            debug().warn(`unpackHelper: unresolved property reference #${refId}`)
+            continue
+          }
           ifcToRowCb(ifcElt, rows)
         } else {
           debug().warn('model has no getProperties method: ', model)
@@ -276,6 +284,13 @@ export async function hasProperties(model, hasPropertiesArr, serial) {
     throw new Error('hasPropertiesArr should be array')
   }
   return await unpackHelper(model, hasPropertiesArr, serial, (dObj, rows) => {
+    // A pset entry that resolved to something without a Name is not a row we
+    // can label — and reading through the missing Name is what crashed the
+    // panel (SHARE-1P3). Drop this one property, not the whole table.
+    if (dObj?.Name?.value === undefined) {
+      debug().warn('hasProperties: skipping property with no Name: ', dObj)
+      return
+    }
     const name = decodeIFCString(dObj.Name.value)
     const value = (dObj.NominalValue === undefined || dObj.NominalValue === null) ?
       '<error>' :

--- a/src/Components/Properties/itemProperties.jsx
+++ b/src/Components/Properties/itemProperties.jsx
@@ -206,6 +206,14 @@ async function prettyProps(model, propName, propValue, isPset, serial = 0) {
  */
 export async function quantities(model, quantitiesObj, serial) {
   return await unpackHelper(model, quantitiesObj, serial, (ifcElt, rows) => {
+    // Same shape, same guard as hasProperties below: a resolved quantity with
+    // no Name is a row we can't label, and reading through the missing Name
+    // is what crashed the panel (SHARE-1P3). Drop the one quantity, not the
+    // whole table.
+    if (ifcElt?.Name?.value === undefined) {
+      debug().warn('quantities: skipping quantity with no Name: ', ifcElt)
+      return
+    }
     const name = decodeIFCString(ifcElt.Name.value)
     let val = 'value'
     for (const key in ifcElt) {

--- a/src/Components/Properties/itemProperties.test.jsx
+++ b/src/Components/Properties/itemProperties.test.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import {render, screen} from '@testing-library/react'
 import {MockModel} from '../../utils/IfcMock.test'
-import {hasProperties} from './itemProperties'
+import {hasProperties, quantities} from './itemProperties'
 
 
 const REF_TYPE = 5
@@ -70,5 +70,54 @@ describe('hasProperties', () => {
     const model = new MockModel({})
     await expect(hasProperties(model, [{type: 1, value: 'not a ref'}], 0))
       .rejects.toThrow('Array contains non-reference type')
+  })
+})
+
+
+/**
+ * `quantities` is unpackHelper's other consumer and dereferences `.Name.value`
+ * exactly as `hasProperties` did, so it carries the same SHARE-1P3 crash
+ * shape and needs the same guard.
+ */
+describe('quantities', () => {
+  it('renders every quantity of a well-formed set', async () => {
+    const model = new MockModel({
+      1: {Name: {value: 'GrossArea'}, AreaValue: {value: '84.2'}},
+      2: {Name: {value: 'Height'}, LengthValue: {value: '3.1'}},
+    })
+    renderRow(await quantities(model, [
+      {type: REF_TYPE, value: 1},
+      {type: REF_TYPE, value: 2},
+    ], 0))
+
+    expect(screen.getByText('GrossArea')).toBeInTheDocument()
+    expect(screen.getByText('84.2')).toBeInTheDocument()
+    expect(screen.getByText('Height')).toBeInTheDocument()
+  })
+
+  it('skips a quantity that carries no Name and keeps the rest', async () => {
+    const model = new MockModel({
+      1: {AreaValue: {value: 'orphan'}},
+      2: {Name: {value: 'GrossArea'}, AreaValue: {value: '84.2'}},
+    })
+    renderRow(await quantities(model, [
+      {type: REF_TYPE, value: 1},
+      {type: REF_TYPE, value: 2},
+    ], 0))
+
+    expect(screen.getByText('GrossArea')).toBeInTheDocument()
+    expect(screen.queryByText('orphan')).not.toBeInTheDocument()
+  })
+
+  it('skips a reference the model cannot resolve and keeps the rest', async () => {
+    const model = new MockModel({
+      1: {Name: {value: 'GrossArea'}, AreaValue: {value: '84.2'}},
+    })
+    renderRow(await quantities(model, [
+      {type: REF_TYPE, value: 9},
+      {type: REF_TYPE, value: 1},
+    ], 0))
+
+    expect(screen.getByText('GrossArea')).toBeInTheDocument()
   })
 })

--- a/src/Components/Properties/itemProperties.test.jsx
+++ b/src/Components/Properties/itemProperties.test.jsx
@@ -1,0 +1,74 @@
+import React from 'react'
+import {render, screen} from '@testing-library/react'
+import {MockModel} from '../../utils/IfcMock.test'
+import {hasProperties} from './itemProperties'
+
+
+const REF_TYPE = 5
+
+
+/**
+ * `hasProperties` returns the `<tr>` wrapping the property table, so it needs
+ * a table around it to be valid DOM.
+ *
+ * @param {object} row The element hasProperties resolved to
+ */
+function renderRow(row) {
+  render(<table><tbody>{row}</tbody></table>)
+}
+
+
+/**
+ * Regression cover for SHARE-1P3: one unresolvable reference inside a
+ * property set threw a TypeError out of `dObj.Name.value` and took the whole
+ * Properties panel down, rather than costing the one row it could not build.
+ */
+describe('hasProperties', () => {
+  it('renders every property of a well-formed pset', async () => {
+    const model = new MockModel({
+      1: {Name: {value: 'Fire Rating'}, NominalValue: {value: 'F60'}},
+      2: {Name: {value: 'Load Bearing'}, NominalValue: {value: 'True'}},
+    })
+    renderRow(await hasProperties(model, [
+      {type: REF_TYPE, value: 1},
+      {type: REF_TYPE, value: 2},
+    ], 0))
+
+    expect(screen.getByText('Fire Rating')).toBeInTheDocument()
+    expect(screen.getByText('Load Bearing')).toBeInTheDocument()
+  })
+
+  it('skips a reference the model cannot resolve and keeps the rest', async () => {
+    // Id 9 is absent from the model, so getItemProperties yields undefined.
+    const model = new MockModel({
+      1: {Name: {value: 'Fire Rating'}, NominalValue: {value: 'F60'}},
+    })
+    renderRow(await hasProperties(model, [
+      {type: REF_TYPE, value: 9},
+      {type: REF_TYPE, value: 1},
+    ], 0))
+
+    expect(screen.getByText('Fire Rating')).toBeInTheDocument()
+    expect(screen.getByText('F60')).toBeInTheDocument()
+  })
+
+  it('skips a resolved property that carries no Name and keeps the rest', async () => {
+    const model = new MockModel({
+      1: {NominalValue: {value: 'orphan'}},
+      2: {Name: {value: 'Fire Rating'}, NominalValue: {value: 'F60'}},
+    })
+    renderRow(await hasProperties(model, [
+      {type: REF_TYPE, value: 1},
+      {type: REF_TYPE, value: 2},
+    ], 0))
+
+    expect(screen.getByText('Fire Rating')).toBeInTheDocument()
+    expect(screen.queryByText('orphan')).not.toBeInTheDocument()
+  })
+
+  it('still rejects a non-reference array, which is a different bug', async () => {
+    const model = new MockModel({})
+    await expect(hasProperties(model, [{type: 1, value: 'not a ref'}], 0))
+      .rejects.toThrow('Array contains non-reference type')
+  })
+})

--- a/src/Share.jsx
+++ b/src/Share.jsx
@@ -57,7 +57,13 @@ export default function Share({installPrefix, appPrefix, pathPrefix}) {
    * path, so no other useEffect is triggered.
    */
   useEffect(() => {
-    /** A demux to help forward to the index file, load a new model or do nothing. */
+    /**
+     * A demux to help forward to the index file, load a new model or do nothing.
+     *
+     * @return {boolean} False when the route was unusable and has already been
+     *   handled (alert + fallback), so the rest of the effect must stop rather
+     *   than configure a repository out of the params that just failed to parse.
+     */
     const onChangeUrlParams = (() => {
       debug().log('pathPrefix: ', pathPrefix)
       let mp
@@ -78,11 +84,11 @@ export default function Share({installPrefix, appPrefix, pathPrefix}) {
         debug().warn('Share#onChangeUrlParams: unsupported model path: ', e)
         setAlert(UNSUPPORTED_FILE_ALERT)
         navToDefault(navigate, appPrefix)
-        return
+        return false
       }
       if (mp === null) {
         navToDefault(navigate, appPrefix)
-        return
+        return true
       }
       if (modelPath === null ||
           (modelPath.filepath && modelPath.filepath !== mp.filepath) ||
@@ -91,8 +97,16 @@ export default function Share({installPrefix, appPrefix, pathPrefix}) {
         setModelPath(mp)
         debug().log('Share#onChangeUrlParams: new model path: ', mp)
       }
+      return true
     })
-    onChangeUrlParams()
+    // An unusable route (mp === null) still falls through to the repository
+    // block below — that is pre-existing behaviour for an empty path, which
+    // still carries usable :org/:repo. A *failed parse* does not: its params
+    // are the ones that just threw, so configuring a repository from them
+    // would flash setRepository(badOrg, badRepo) on the way to the fallback.
+    if (!onChangeUrlParams()) {
+      return
+    }
 
     // TODO(pablo): currently expect these to both be defined.
     const {org, repo} = routeParams

--- a/src/Share.jsx
+++ b/src/Share.jsx
@@ -10,7 +10,8 @@ import useStore from './store/useStore'
 import debug from './utils/debug'
 import {pageTitleForModel} from './utils/modelDisplayName'
 import {navToDefault} from './utils/navigate'
-import {handleRoute} from './routes/routes'
+import {FilenameParseError} from './Filetype'
+import {UNSUPPORTED_FILE_ALERT, handleRoute} from './routes/routes'
 
 
 /**
@@ -33,6 +34,7 @@ export default function Share({installPrefix, appPrefix, pathPrefix}) {
   const setIsShareEnabled = useStore((state) => state.setIsShareEnabled)
   const setIsNotesEnabled = useStore((state) => state.setIsNotesEnabled)
   const setRepository = useStore((state) => state.setRepository)
+  const setAlert = useStore((state) => state.setAlert)
   const widgetApiRef = useRef(null)
 
   // Hydrate persisted Connections & Sources from localStorage
@@ -58,7 +60,26 @@ export default function Share({installPrefix, appPrefix, pathPrefix}) {
     /** A demux to help forward to the index file, load a new model or do nothing. */
     const onChangeUrlParams = (() => {
       debug().log('pathPrefix: ', pathPrefix)
-      const mp = handleRoute(pathPrefix, routeParams)
+      let mp
+      try {
+        mp = handleRoute(pathPrefix, routeParams)
+      } catch (e) {
+        // Route parsing throws FilenameParseError for any path that doesn't
+        // name a file Share can open — an unrecognized extension
+        // ('Jetenginestep.st'), or a bare directory path. Thrown from inside
+        // this effect it reached the ErrorBoundary and took the whole app
+        // down for what is really a bad link (SHARE-1H4). Say so and fall
+        // back to the home model, which is what an unusable route already
+        // did. The raw message names the internal extension regex, so it is
+        // deliberately not what the user is shown.
+        if (!(e instanceof FilenameParseError)) {
+          throw e
+        }
+        debug().warn('Share#onChangeUrlParams: unsupported model path: ', e)
+        setAlert(UNSUPPORTED_FILE_ALERT)
+        navToDefault(navigate, appPrefix)
+        return
+      }
       if (mp === null) {
         navToDefault(navigate, appPrefix)
         return
@@ -105,7 +126,7 @@ export default function Share({installPrefix, appPrefix, pathPrefix}) {
       setIsNotesEnabled(false)
     }
   }, [appPrefix, installPrefix, modelPath, model, navigate, pathPrefix,
-    setIsVersionsEnabled, setIsShareEnabled, setIsNotesEnabled,
+    setAlert, setIsVersionsEnabled, setIsShareEnabled, setIsNotesEnabled,
     setModelPath, setRepository, routeParams])
 
   useEffect(() => {

--- a/src/Share.test.jsx
+++ b/src/Share.test.jsx
@@ -1,7 +1,10 @@
 import React from 'react'
-import {render} from '@testing-library/react'
+import {render, screen} from '@testing-library/react'
+import {MemoryRouter, Route, Routes} from 'react-router-dom'
 import {MockComponent} from './__mocks__/MockComponent'
 import MockRoutes from './BaseRoutesMock.test'
+import useStore from './store/useStore'
+import {UNSUPPORTED_FILE_ALERT} from './routes/routes'
 // Slice 5d.4: Share renders the app, which loads ShareViewer (→
 // IfcContext / ShareIfc). ShareViewer no longer self-imports the fork to
 // trigger the Jest harness, so load it explicitly before `./Share` so
@@ -26,4 +29,59 @@ test('Share renders without crashing', () => {
     </MockComponent>)
   // Just verify the component renders (container exists)
   expect(container).toBeTruthy()
+})
+
+
+/**
+ * Regression cover for SHARE-1H4. Route parsing throws FilenameParseError
+ * for a path that names no supported model file, and Share calls it from
+ * inside an effect — so the throw reached the ErrorBoundary and the app went
+ * down for what is really just a bad link. Both shapes below came from real
+ * GitHub URLs in that issue.
+ */
+describe('Share with an unsupported model path', () => {
+  /**
+   * @param {string} filepath The splat under /share/v/gh/:org/:repo/:branch
+   */
+  function renderGithubRoute(filepath) {
+    render(
+      <MockComponent>
+        <MemoryRouter initialEntries={[`/share/v/gh/bldrs-ai/test-repo/main/${filepath}`]}>
+          <Routes>
+            <Route
+              path='/share/v/gh/:org/:repo/:branch/*'
+              element={
+                <Share
+                  installPrefix=''
+                  appPrefix='/share'
+                  pathPrefix='/share/v/gh'
+                />}
+            />
+            {/* navToDefault's destination. Declared so react-router doesn't
+                warn about an unmatched location on the fallback redirect;
+                nothing needs to render there. */}
+            <Route path='/share/v/p/*' element={<div data-testid='home-model'/>}/>
+          </Routes>
+        </MemoryRouter>
+      </MockComponent>)
+  }
+
+  // Reset before rather than after each case: nothing is mounted yet at this
+  // point, so the store write can't re-render a live subscriber outside
+  // act() (PLAYBOOK.md §"Keep the test console clean").
+  beforeEach(() => {
+    useStore.setState({alert: null})
+  })
+
+  it('alerts rather than crashing on an unrecognized extension', () => {
+    renderGithubRoute('Jetenginestep.st')
+    expect(useStore.getState().alert).toBe(UNSUPPORTED_FILE_ALERT)
+    // ...and falls back to the home model, as an unusable route already did.
+    expect(screen.getByTestId('home-model')).toBeInTheDocument()
+  })
+
+  it('alerts rather than crashing on a bare directory path', () => {
+    renderGithubRoute('models/parts')
+    expect(useStore.getState().alert).toBe(UNSUPPORTED_FILE_ALERT)
+  })
 })

--- a/src/Share.test.jsx
+++ b/src/Share.test.jsx
@@ -70,7 +70,7 @@ describe('Share with an unsupported model path', () => {
   // point, so the store write can't re-render a live subscriber outside
   // act() (PLAYBOOK.md §"Keep the test console clean").
   beforeEach(() => {
-    useStore.setState({alert: null})
+    useStore.setState({alert: null, repository: null})
   })
 
   it('alerts rather than crashing on an unrecognized extension', () => {
@@ -83,5 +83,16 @@ describe('Share with an unsupported model path', () => {
   it('alerts rather than crashing on a bare directory path', () => {
     renderGithubRoute('models/parts')
     expect(useStore.getState().alert).toBe(UNSUPPORTED_FILE_ALERT)
+  })
+
+  /**
+   * The effect must stop on the handled-error path, not fall through to the
+   * repository block — those are the very params that just failed to parse,
+   * so configuring a repository from them flashes a bogus org/repo on the way
+   * to the fallback.
+   */
+  it('does not configure a repository from the params that failed to parse', () => {
+    renderGithubRoute('Jetenginestep.st')
+    expect(useStore.getState().repository).toBe(null)
   })
 })

--- a/src/loader/loadProgress.js
+++ b/src/loader/loadProgress.js
@@ -339,16 +339,22 @@ class LoadProgressReporter {
   }
 
   /**
-   * The `authoring_tool` tag value: the authoring system, or the preprocessor
-   * when that is all any header named — the same preference order
-   * formatModelLine uses for the model line's tool segment — with path-like
-   * tokens removed (see withoutPathTokens).
+   * The `authoring_tool` tag value: the authoring system matched against the
+   * known-exporter allowlist, falling back to the preprocessor when the
+   * authoring system named nothing recognizable — the same preference order
+   * formatModelLine uses for the model line's tool segment, applied to
+   * whichever header string the allowlist can actually place.
    *
-   * @return {string|undefined} undefined when no header named a tool, or when
-   *   sanitizing left nothing
+   * The fallback is only safe because of the allowlist: an unmatched
+   * preprocessor string yields no tag at all, so reaching for it can add a
+   * family but never leak one header's free text in place of another's.
+   *
+   * @return {string|undefined} undefined when neither header named a family
+   *   the allowlist knows
    */
   authoringTool() {
-    return withoutPathTokens(this.originatingSystem ?? this.preprocessorVersion)
+    return knownAuthoringTool(this.originatingSystem) ??
+      knownAuthoringTool(this.preprocessorVersion)
   }
 
   /**
@@ -553,7 +559,9 @@ class LoadProgressReporter {
     // Nothing identifying belongs here: tool, schema, extension and a
     // rounded size only. No path, no filename, no URL — content_id above is
     // where a model's identity already lives, and it is the field the
-    // scrubber is aimed at.
+    // scrubber is aimed at. The tool is the one field built from
+    // exporter-written free text, so it goes through an allowlist rather
+    // than a filter — see knownAuthoringTool.
     const authoringTool = this.authoringTool()
     if (authoringTool !== undefined) {
       tags.authoring_tool = authoringTool.slice(0, MAX_TAG_CHARS)
@@ -789,27 +797,88 @@ function extensionOf(basename) {
 
 
 /**
- * Drop whitespace-separated tokens containing a path separator, for the
- * `authoring_tool` tag.
+ * Exporter families the `authoring_tool` tag is allowed to name, most
+ * specific first — an AutoCAD Civil 3D header must land on Civil 3D, and a
+ * Bonsai one on Bonsai rather than plain Blender.
  *
- * That tag exists precisely to bypass Sentry's server-side scrubber, so it
- * has to police its own content. A STEP/IFC FILE_NAME header's
- * originating_system is exporter-written free text and sometimes carries the
- * exporter's install or output path — which on Windows means an OS username
- * ('C:\\Users\\jsmith\\...'). The tool name itself never contains a slash, so
- * dropping those tokens keeps the useful half and takes the identifying half
- * out of the event entirely.
+ * Seeded from the families seen in triage. Adding one is the intended way to
+ * extend the tag; nothing else widens it.
+ */
+const AUTHORING_TOOL_FAMILIES = [
+  {name: 'Autodesk Revit', pattern: /revit/i},
+  {name: 'Autodesk Civil 3D', pattern: /civil\s*3d/i},
+  {name: 'Autodesk Navisworks', pattern: /navisworks/i},
+  {name: 'Autodesk Inventor', pattern: /inventor/i},
+  {name: 'Autodesk Fusion', pattern: /fusion/i},
+  {name: 'Autodesk AutoCAD', pattern: /autocad/i},
+  {name: 'Graphisoft ArchiCAD', pattern: /archicad|graphisoft/i},
+  {name: 'Tekla Structures', pattern: /tekla/i},
+  {name: 'Trimble Nova', pattern: /trimble\s*nova/i},
+  {name: 'Trimble SketchUp', pattern: /sketchup/i},
+  {name: 'Dassault SOLIDWORKS', pattern: /solidworks/i},
+  {name: 'Dassault CATIA', pattern: /catia/i},
+  {name: 'PTC Creo', pattern: /creo|pro\/engineer/i},
+  {name: 'Siemens NX', pattern: /siemens\s*nx|unigraphics|\bnx\b/i},
+  {name: 'KiCad', pattern: /kicad/i},
+  {name: 'IfcOpenShell', pattern: /ifcopenshell/i},
+  {name: 'Bonsai/BlenderBIM', pattern: /blenderbim|bonsai/i},
+  {name: 'Blender', pattern: /blender/i},
+  {name: 'DigiPara Liftdesigner', pattern: /liftdesigner|digipara/i},
+  {name: 'FreeCAD', pattern: /freecad/i},
+  {name: 'Rhino', pattern: /rhino/i},
+  {name: 'Nemetschek Allplan', pattern: /allplan/i},
+  {name: 'Vectorworks', pattern: /vectorworks/i},
+  {name: 'Bentley MicroStation', pattern: /microstation|bentley/i},
+]
+
+
+/**
+ * Place a raw header string in a known exporter family, for the
+ * `authoring_tool` tag: the family's canonical name, plus the version token
+ * that immediately follows the matched name when that token is purely
+ * numeric.
+ *
+ * **Allowlist, not sanitization.** This tag exists precisely to survive
+ * Sentry's server-side scrubber, so it cannot be built by removing the bad
+ * parts of exporter-written free text — there is no bounded set of bad parts.
+ * A STEP/IFC FILE_NAME header's originating_system is whatever the exporter
+ * chose to write, and in the wild that has included install paths (an OS
+ * username), machine names and contact addresses, none of which a
+ * separator-based filter catches ('Revit exported by jane@example.com' has no
+ * path separator in it at all). So nothing reaches the tag unless the
+ * allowlist recognizes it, and what reaches it is this module's own canonical
+ * string rather than any span of the input.
+ *
+ * The version is the one exception, and it is bounded to digits and dots for
+ * the same reason: 'Autodesk Revit 2024 (ENU)' tags as 'Autodesk Revit 2024',
+ * while 'Revit exported by jane@example.com' finds no numeric token after the
+ * name and tags as plain 'Autodesk Revit'.
+ *
+ * Unmatched input yields no tag at all. The raw string is not lost — it stays
+ * in the report body on the event's context, which is the field the scrubber
+ * is entitled to rewrite. Bounding the tag to a known set also bounds its
+ * cardinality, which is what makes it worth grouping by.
  *
  * @param {string} [value] a header string, or undefined when none was given
- * @return {string|undefined} undefined when there was no value, or when every
- *   token was path-like
+ * @return {string|undefined} canonical family name (with numeric version when
+ *   the header supplied one), or undefined when nothing matched
  */
-function withoutPathTokens(value) {
+function knownAuthoringTool(value) {
   if (typeof value !== 'string') {
     return undefined
   }
-  const kept = value.split(/\s+/).filter((token) => token !== '' && !/[/\\]/.test(token))
-  return kept.length === 0 ? undefined : kept.join(' ')
+  for (const family of AUTHORING_TOOL_FAMILIES) {
+    const match = family.pattern.exec(value)
+    if (match === null) {
+      continue
+    }
+    // Only the token directly after the matched name, and only when it is
+    // digits and dots — anything else is arbitrary text and stays out.
+    const [nextToken] = value.slice(match.index + match[0].length).trim().split(/\s+/)
+    const version = /^\d+(?:\.\d+)*$/.test(nextToken ?? '') ? ` ${nextToken}` : ''
+    return `${family.name}${version}`
+  }
+  return undefined
 }
 
 

--- a/src/loader/loadProgress.js
+++ b/src/loader/loadProgress.js
@@ -2,6 +2,7 @@ import {addBreadcrumb, captureMessage, setContext, setTag} from '@sentry/react'
 import {SENTRY_CID_TAG, getOpenCidForSentry} from '../privacy/analytics'
 import useStore from '../store/useStore'
 import debug from '../utils/debug'
+import {normalizeMessageDigits} from '../utils/messageGrouping'
 // Named import so esbuild can prune the rest of the JSON (same trick as
 // index/sentry.js) — we only need `version` for the report preamble.
 import {version as shareVersion} from '../../package.json'
@@ -139,6 +140,16 @@ class LoadProgressReporter {
     // "Parsing model geometry: -1.6s" negative-duration line).
     this.engineElapsedBase = null
     this.ended = false
+    // Model-header fields the Sentry diagnostics tags are built from, kept
+    // structured as they arrive (recordModelInfo) rather than re-parsed out
+    // of the formatted model line. See captureDiagnostics for why they need
+    // to be tags rather than context.
+    this.schema = undefined
+    this.authoringTool = undefined
+    // Geometry the load actually produced, when the loader reports it
+    // (reportGeometryStats) — the load-outcome signal classifyLoadOutcome
+    // reads. Undefined means "not reported", which is not the same as zero.
+    this.geometryStats = undefined
     // Distinct console warning/error text → occurrence count, captured via
     // the console tee below and appended after the Total line (issue #301
     // preview feedback #4). Includes conway's engine warnings/errors, which
@@ -298,11 +309,40 @@ class LoadProgressReporter {
   /**
    * Remember machine-readable values that also appear in the model line.
    *
+   * Called more than once per load on the engine formats — Loader stamps a
+   * filename-derived line before the parse, and conway's ON_MODEL_INFO
+   * replaces it once the STEP header parses — so each field is only
+   * overwritten by a later non-empty value, letting the engine's richer
+   * `IFC4` win over the extension-derived `IFC` without a blank header
+   * erasing what we already had.
+   *
    * @param {object} info model metadata
    */
   recordModelInfo(info) {
     if (Number.isFinite(info?.byteLength)) {
       this.fileSize = info.byteLength
+    }
+    if (typeof info?.schema === 'string' && info.schema !== '') {
+      this.schema = info.schema
+    }
+    // Same preference order formatModelLine uses for the model line's tool
+    // segment: the authoring system, or the preprocessor when that's all the
+    // header names.
+    const tool = [info?.originatingSystem, info?.preprocessorVersion]
+      .find((candidate) => typeof candidate === 'string' && candidate !== '')
+    if (tool !== undefined) {
+      this.authoringTool = tool
+    }
+  }
+
+  /**
+   * Record what the loader built, for classifyLoadOutcome.
+   *
+   * @param {object} stats {vertexCount, triangleCount}; either may be absent
+   */
+  recordGeometryStats(stats) {
+    if (stats) {
+      this.geometryStats = {...this.geometryStats, ...stats}
     }
   }
 
@@ -468,6 +508,12 @@ class LoadProgressReporter {
   captureDiagnostics({errorCount, warningCount, contentId, contentType}) {
     const summary = this.diagnosticsSummary()
     const tags = {}
+    // Severity is the load's outcome, not its noise level (ops#27 T0): a
+    // model the user is looking at is a regular bug however many warnings it
+    // took to get there, and only a load that produced nothing to look at is
+    // a major one. This is why errorCount no longer decides the level.
+    const loadOutcome = classifyLoadOutcome(this.geometryStats)
+    tags.load_outcome = loadOutcome
     // Also set on the global scope at init by index/ga.js. Re-read here
     // because this reads later: a first-ever visitor's id only resolves
     // once gtag/js loads, which can land after bootstrap but before this
@@ -482,8 +528,32 @@ class LoadProgressReporter {
     if (contentType) {
       tags.content_type = String(contentType).slice(0, MAX_TAG_CHARS)
     }
+    // Which model this was, as tags rather than as report text. Sentry's
+    // server-side scrubber rewrites some event bodies to "[Filtered]", and
+    // when it does, the authoring tool and schema — the first two questions
+    // asked of any load diagnostic — go with it. Tags survive that, so the
+    // few fields worth searching on get their own.
+    //
+    // Nothing identifying belongs here: tool, schema, extension and a
+    // rounded size only. No path, no filename, no URL — content_id above is
+    // where a model's identity already lives, and it is the field the
+    // scrubber is aimed at.
+    if (this.authoringTool !== undefined) {
+      tags.authoring_tool = this.authoringTool.slice(0, MAX_TAG_CHARS)
+    }
+    if (this.schema !== undefined) {
+      tags.model_schema = this.schema.slice(0, MAX_TAG_CHARS)
+    }
+    const format = extensionOf(this.fallbackName) ??
+      (contentType ? String(contentType).toLowerCase().slice(0, MAX_TAG_CHARS) : undefined)
+    if (format !== undefined) {
+      tags.model_format = format
+    }
+    if (Number.isFinite(this.fileSize)) {
+      tags.model_size_mb = Math.round(this.fileSize / BYTES_PER_MB)
+    }
     captureMessage(diagnosticsTitle(summary.topText), {
-      level: errorCount > 0 ? 'error' : 'warning',
+      level: loadOutcome === 'unusable' ? 'error' : 'warning',
       tags,
       contexts: {
         loadDiagnostics: {
@@ -629,29 +699,69 @@ function ellipsize(text) {
  * and titles the event — it has no exception to fingerprint, so the
  * message text *is* the grouping key.
  *
- * Numbers collapse to `#` because engine diagnostics are per-entity
- * ("Error processing representation #1234"): the raw text would open a
- * fresh Sentry issue for every entity of every model, which is the
- * per-line flood captureLoadDiagnostics exists to avoid. Normalized,
- * each family of warning gets one issue. An entity marker the message
- * already spelled `#` is swallowed by the same pass rather than
- * doubling up into `##`.
- *
- * The pass is deliberately indiscriminate: it also collapses digits
- * inside identifiers, so "IFC4" titles as "IFC#" and "Revit 2024" as
- * "Revit #". That costs nothing for grouping — the schema and authoring
- * tool are already on the event's `load` context and the report — and
- * keeping them would reopen the per-value split this exists to close.
+ * Numbers collapse to `#` (normalizeMessageDigits, shared with the alert
+ * fingerprint) because engine diagnostics are per-entity ("Error processing
+ * representation #1234"): the raw text would open a fresh Sentry issue for
+ * every entity of every model, which is the per-line flood
+ * captureLoadDiagnostics exists to avoid. Normalized, each family of warning
+ * gets one issue.
  *
  * @param {string} topText most frequent diagnostic, '' when the console
  *   tee captured nothing (the counts can come from the engine instead)
  * @return {string}
  */
 function diagnosticsTitle(topText) {
-  const normalized = ellipsize(topText.replace(/#?\d+/g, '#')).trim()
+  const normalized = ellipsize(normalizeMessageDigits(topText)).trim()
   return normalized === '' ?
     'Load completed with diagnostics' :
     `Load diagnostics: ${normalized}`
+}
+
+
+/**
+ * How bad this load was for the person who asked for it (ops#27 T0), which
+ * is what the diagnostics event's severity reports:
+ *
+ * - `displayed` — geometry reached the scene, so the model is on screen.
+ *   A regular bug, however noisy the load was.
+ * - `unusable` — the load ran to completion and built nothing. Whatever the
+ *   diagnostics say, the user is looking at an empty viewer. Major.
+ *
+ * Ambiguity resolves to `displayed`, deliberately. Most formats report no
+ * geometry counts at all (only the conway engine path calls
+ * reportGeometryStats), and treating "didn't say" as "produced nothing"
+ * would raise every warning in the project to major — the inverse of what
+ * this split is for.
+ *
+ * @param {object} [geometry] {vertexCount, triangleCount} as reported by the
+ *   loader; undefined when the loader reported nothing
+ * @return {string} 'displayed' | 'unusable'
+ */
+export function classifyLoadOutcome(geometry) {
+  const counted = [geometry?.vertexCount, geometry?.triangleCount].filter(Number.isFinite)
+  if (counted.length === 0) {
+    return 'displayed'
+  }
+  return counted.some((count) => count > 0) ? 'displayed' : 'unusable'
+}
+
+
+/**
+ * Lowercase extension of a bare filename, for the `model_format` tag.
+ *
+ * Takes the extension and nothing else: these tags exist because the report
+ * body can be scrubbed away, so they have to stay unimpeachably free of
+ * anything that identifies a file or a user. The length/charset bound also
+ * keeps a dotted name with no real extension ("Model.v2 final") from
+ * tagging junk.
+ *
+ * @param {string} [basename] a filename with no path (the reporter's
+ *   fallbackName)
+ * @return {string|undefined}
+ */
+function extensionOf(basename) {
+  const match = /\.([a-z0-9]{1,8})$/i.exec(basename ?? '')
+  return match ? match[1].toLowerCase() : undefined
 }
 
 
@@ -691,6 +801,24 @@ export function reportModelInfo(info) {
   if (activeReporter && !activeReporter.ended) {
     activeReporter.recordModelInfo(info)
     activeReporter.addReportLine(activeReporter.log.setModelInfo(info))
+  }
+}
+
+
+/**
+ * Report what the loader actually built, as the structured twin of the
+ * `vertices=… triangles=…` segment setLoadSummary puts on the Total line.
+ * Structured because it is a decision input, not display text: it is the
+ * only signal that separates a noisy load whose model still rendered from
+ * one that finished with an empty scene (classifyLoadOutcome).
+ *
+ * Safe no-op with no active load.
+ *
+ * @param {object} stats {vertexCount, triangleCount}
+ */
+export function reportGeometryStats(stats) {
+  if (activeReporter && !activeReporter.ended) {
+    activeReporter.recordGeometryStats(stats)
   }
 }
 

--- a/src/loader/loadProgress.js
+++ b/src/loader/loadProgress.js
@@ -145,7 +145,8 @@ class LoadProgressReporter {
     // of the formatted model line. See captureDiagnostics for why they need
     // to be tags rather than context.
     this.schema = undefined
-    this.authoringTool = undefined
+    this.originatingSystem = undefined
+    this.preprocessorVersion = undefined
     // Geometry the load actually produced, when the loader reports it
     // (reportGeometryStats) — the load-outcome signal classifyLoadOutcome
     // reads. Undefined means "not reported", which is not the same as zero.
@@ -325,14 +326,29 @@ class LoadProgressReporter {
     if (typeof info?.schema === 'string' && info.schema !== '') {
       this.schema = info.schema
     }
-    // Same preference order formatModelLine uses for the model line's tool
-    // segment: the authoring system, or the preprocessor when that's all the
-    // header names.
-    const tool = [info?.originatingSystem, info?.preprocessorVersion]
-      .find((candidate) => typeof candidate === 'string' && candidate !== '')
-    if (tool !== undefined) {
-      this.authoringTool = tool
+    // Latched per field rather than as one resolved "tool" value, so a later
+    // header naming only a preprocessor can't downgrade an originatingSystem
+    // an earlier one already gave us. The preference between them is applied
+    // once, at tag time (authoringTool).
+    if (typeof info?.originatingSystem === 'string' && info.originatingSystem !== '') {
+      this.originatingSystem = info.originatingSystem
     }
+    if (typeof info?.preprocessorVersion === 'string' && info.preprocessorVersion !== '') {
+      this.preprocessorVersion = info.preprocessorVersion
+    }
+  }
+
+  /**
+   * The `authoring_tool` tag value: the authoring system, or the preprocessor
+   * when that is all any header named — the same preference order
+   * formatModelLine uses for the model line's tool segment — with path-like
+   * tokens removed (see withoutPathTokens).
+   *
+   * @return {string|undefined} undefined when no header named a tool, or when
+   *   sanitizing left nothing
+   */
+  authoringTool() {
+    return withoutPathTokens(this.originatingSystem ?? this.preprocessorVersion)
   }
 
   /**
@@ -538,14 +554,21 @@ class LoadProgressReporter {
     // rounded size only. No path, no filename, no URL — content_id above is
     // where a model's identity already lives, and it is the field the
     // scrubber is aimed at.
-    if (this.authoringTool !== undefined) {
-      tags.authoring_tool = this.authoringTool.slice(0, MAX_TAG_CHARS)
+    const authoringTool = this.authoringTool()
+    if (authoringTool !== undefined) {
+      tags.authoring_tool = authoringTool.slice(0, MAX_TAG_CHARS)
     }
     if (this.schema !== undefined) {
       tags.model_schema = this.schema.slice(0, MAX_TAG_CHARS)
     }
+    // CadView populates content_type as `loadedModel.type || 'undefined'`, so
+    // the literal string is what an unknown type looks like by the time it
+    // reaches here — tag nothing rather than tag that.
+    const declaredType = contentType === undefined || contentType === null ?
+      '' : String(contentType).toLowerCase()
     const format = extensionOf(this.fallbackName) ??
-      (contentType ? String(contentType).toLowerCase().slice(0, MAX_TAG_CHARS) : undefined)
+      (declaredType !== '' && declaredType !== 'undefined' ?
+        declaredType.slice(0, MAX_TAG_CHARS) : undefined)
     if (format !== undefined) {
       tags.model_format = format
     }
@@ -762,6 +785,31 @@ export function classifyLoadOutcome(geometry) {
 function extensionOf(basename) {
   const match = /\.([a-z0-9]{1,8})$/i.exec(basename ?? '')
   return match ? match[1].toLowerCase() : undefined
+}
+
+
+/**
+ * Drop whitespace-separated tokens containing a path separator, for the
+ * `authoring_tool` tag.
+ *
+ * That tag exists precisely to bypass Sentry's server-side scrubber, so it
+ * has to police its own content. A STEP/IFC FILE_NAME header's
+ * originating_system is exporter-written free text and sometimes carries the
+ * exporter's install or output path — which on Windows means an OS username
+ * ('C:\\Users\\jsmith\\...'). The tool name itself never contains a slash, so
+ * dropping those tokens keeps the useful half and takes the identifying half
+ * out of the event entirely.
+ *
+ * @param {string} [value] a header string, or undefined when none was given
+ * @return {string|undefined} undefined when there was no value, or when every
+ *   token was path-like
+ */
+function withoutPathTokens(value) {
+  if (typeof value !== 'string') {
+    return undefined
+  }
+  const kept = value.split(/\s+/).filter((token) => token !== '' && !/[/\\]/.test(token))
+  return kept.length === 0 ? undefined : kept.join(' ')
 }
 
 

--- a/src/loader/loadProgress.js
+++ b/src/loader/loadProgress.js
@@ -803,13 +803,25 @@ function extensionOf(basename) {
  *
  * Seeded from the families seen in triage. Adding one is the intended way to
  * extend the tag; nothing else widens it.
+ *
+ * A false match leaks nothing — the tag carries this table's own canonical
+ * name, never a span of the header — but it does mislabel the load, so the
+ * short and dictionary-word names carry their own context. Four needed it:
+ * `fusion` is a word boundary away from confusion/diffusion/profusion, while
+ * `rhino`, `inventor` and `nx` are whole words in ordinary text ('White Rhino
+ * Tower', 'Inventor: John Smith', 'NX-200'), so those three match only beside
+ * a vendor name or an immediately following numeric version. That still
+ * admits the bare headers seen in the wild ('Rhino 8', 'NX 12.0.2.9') because
+ * a version does follow them. Check any new short name against real prose
+ * with the regex engine before adding it — `\b` alone is not enough for a
+ * name that is also an English word.
  */
 const AUTHORING_TOOL_FAMILIES = [
   {name: 'Autodesk Revit', pattern: /revit/i},
   {name: 'Autodesk Civil 3D', pattern: /civil\s*3d/i},
   {name: 'Autodesk Navisworks', pattern: /navisworks/i},
-  {name: 'Autodesk Inventor', pattern: /inventor/i},
-  {name: 'Autodesk Fusion', pattern: /fusion/i},
+  {name: 'Autodesk Inventor', pattern: /\bautodesk\s+inventor\b|\binventor(?=\s+\d)/i},
+  {name: 'Autodesk Fusion', pattern: /\bfusion\b/i},
   {name: 'Autodesk AutoCAD', pattern: /autocad/i},
   {name: 'Graphisoft ArchiCAD', pattern: /archicad|graphisoft/i},
   {name: 'Tekla Structures', pattern: /tekla/i},
@@ -818,14 +830,14 @@ const AUTHORING_TOOL_FAMILIES = [
   {name: 'Dassault SOLIDWORKS', pattern: /solidworks/i},
   {name: 'Dassault CATIA', pattern: /catia/i},
   {name: 'PTC Creo', pattern: /creo|pro\/engineer/i},
-  {name: 'Siemens NX', pattern: /siemens\s*nx|unigraphics|\bnx\b/i},
+  {name: 'Siemens NX', pattern: /\bsiemens\s+nx\b|\bunigraphics\b|\bnx(?=\s+\d)/i},
   {name: 'KiCad', pattern: /kicad/i},
   {name: 'IfcOpenShell', pattern: /ifcopenshell/i},
   {name: 'Bonsai/BlenderBIM', pattern: /blenderbim|bonsai/i},
   {name: 'Blender', pattern: /blender/i},
   {name: 'DigiPara Liftdesigner', pattern: /liftdesigner|digipara/i},
   {name: 'FreeCAD', pattern: /freecad/i},
-  {name: 'Rhino', pattern: /rhino/i},
+  {name: 'Rhino', pattern: /\brhinoceros\b|\bmcneel\b|\brhino(?=\s+\d)/i},
   {name: 'Nemetschek Allplan', pattern: /allplan/i},
   {name: 'Vectorworks', pattern: /vectorworks/i},
   {name: 'Bentley MicroStation', pattern: /microstation|bentley/i},

--- a/src/loader/loadProgress.test.js
+++ b/src/loader/loadProgress.test.js
@@ -14,12 +14,14 @@ import {
   attachLoadFailureContext,
   beginLoadProgress,
   captureLoadDiagnostics,
+  classifyLoadOutcome,
   endLoadProgress,
   getCompletedLoadStats,
   isModelInfoProgress,
   isStructuredProgress,
   reportEngineVersion,
   reportFramingExclusion,
+  reportGeometryStats,
   reportLoadProgress,
   reportModelInfo,
   reportSourceInfo,
@@ -57,6 +59,27 @@ describe('loadProgress', () => {
       expect(isStructuredProgress({loaded: 1024})).toBe(false)
       expect(isModelInfoProgress({modelInfo: {fileName: 'a.ifc'}})).toBe(true)
       expect(isModelInfoProgress({phase: 'geometry', completed: 1})).toBe(false)
+    })
+  })
+
+  describe('classifyLoadOutcome', () => {
+    it('is displayed whenever anything was built', () => {
+      expect(classifyLoadOutcome({vertexCount: 8, triangleCount: 4})).toBe('displayed')
+      // One count present and non-zero is enough — a point cloud has no
+      // triangles and is still on screen.
+      expect(classifyLoadOutcome({vertexCount: 8})).toBe('displayed')
+      expect(classifyLoadOutcome({vertexCount: 8, triangleCount: 0})).toBe('displayed')
+    })
+
+    it('is unusable only when every reported count is zero', () => {
+      expect(classifyLoadOutcome({vertexCount: 0, triangleCount: 0})).toBe('unusable')
+      expect(classifyLoadOutcome({triangleCount: 0})).toBe('unusable')
+    })
+
+    it('defaults to displayed when the loader reported nothing usable', () => {
+      expect(classifyLoadOutcome(undefined)).toBe('displayed')
+      expect(classifyLoadOutcome({})).toBe('displayed')
+      expect(classifyLoadOutcome({vertexCount: undefined, triangleCount: null})).toBe('displayed')
     })
   })
 
@@ -447,15 +470,135 @@ describe('loadProgress', () => {
         warnSpy.mockRestore()
       })
 
-      it('raises the level to error when the load reported errors', () => {
+      /*
+       * Severity is the load's outcome, not its noise level (ops#27 T0).
+       * These three cases are the whole policy: geometry reached the scene
+       * → regular however loud the errors were; nothing was built → major;
+       * the loader said nothing about geometry → regular, because most
+       * formats never report counts and calling those major would raise
+       * the entire project to major.
+       */
+      it('keeps regular severity when errors came with a model that displays', () => {
         const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
         beginLoadProgress({fileInfo: 'index.stp'})
         console.error('CDT Exception (hemisphere: 0)')
+        reportGeometryStats({vertexCount: 120_000, triangleCount: 40_000})
+        endLoadProgress()
+        captureLoadDiagnostics({errorCount: 1})
+
+        expect(diagnosticsCall()[1].level).toBe('warning')
+        expect(diagnosticsCall()[1].tags.load_outcome).toBe('displayed')
+        errorSpy.mockRestore()
+      })
+
+      it('raises severity to error when the load built no geometry at all', () => {
+        const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+        beginLoadProgress({fileInfo: 'index.stp'})
+        console.error('CDT Exception (hemisphere: 0)')
+        reportGeometryStats({vertexCount: 0, triangleCount: 0})
         endLoadProgress()
         captureLoadDiagnostics({errorCount: 1})
 
         expect(diagnosticsCall()[1].level).toBe('error')
+        expect(diagnosticsCall()[1].tags.load_outcome).toBe('unusable')
         errorSpy.mockRestore()
+      })
+
+      it('defaults to regular severity when no loader reported geometry', () => {
+        const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+        beginLoadProgress({fileInfo: 'ISS_stationary.glb'})
+        console.error('missing texture')
+        endLoadProgress()
+        captureLoadDiagnostics({errorCount: 1})
+
+        expect(diagnosticsCall()[1].level).toBe('warning')
+        expect(diagnosticsCall()[1].tags.load_outcome).toBe('displayed')
+        errorSpy.mockRestore()
+      })
+
+      /*
+       * The tags exist because Sentry's server-side scrubber can rewrite the
+       * report body to "[Filtered]", taking the authoring tool and schema —
+       * the first two questions asked of any load diagnostic — with it.
+       */
+      it('tags the authoring tool, schema, format and rounded size', () => {
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+        const sizeBytes = 14_365_000
+        const sizeMb = 14
+        beginLoadProgress({fileInfo: 'https://example.test/models/Tower.ifc'})
+        reportModelInfo({
+          fileName: 'Tower.ifc',
+          schema: 'IFC4',
+          byteLength: sizeBytes,
+          originatingSystem: 'Autodesk Revit 2024 (ENU)',
+        })
+        console.warn('No basis found for brep!')
+        endLoadProgress()
+        captureLoadDiagnostics({warningCount: 1, contentType: 'ifc'})
+
+        const {tags} = diagnosticsCall()[1]
+        expect(tags.authoring_tool).toBe('Autodesk Revit 2024 (ENU)')
+        expect(tags.model_schema).toBe('IFC4')
+        expect(tags.model_format).toBe('ifc')
+        expect(tags.model_size_mb).toBe(sizeMb)
+        // Nothing that names the file or where it came from.
+        expect(Object.values(tags).join(' ')).not.toContain('example.test')
+        expect(Object.values(tags).join(' ')).not.toContain('Tower')
+        warnSpy.mockRestore()
+      })
+
+      it('prefers the parsed header over the extension-derived schema', () => {
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+        beginLoadProgress({fileInfo: 'Arty_Z7_PCB.stp'})
+        // What Loader stamps from the filename before the parse...
+        reportModelInfo({fileName: 'Arty_Z7_PCB.stp', schema: 'STP', byteLength: 1_000_000})
+        // ...then what conway's ON_MODEL_INFO reports once the header parses.
+        reportLoadProgress({modelInfo: {
+          fileName: 'Arty_Z7_PCB.stp',
+          schema: 'AP242',
+          preprocessorVersion: 'KiCad 8.0',
+        }})
+        console.warn('No basis found for brep!')
+        endLoadProgress()
+        captureLoadDiagnostics({warningCount: 1})
+
+        const {tags} = diagnosticsCall()[1]
+        expect(tags.model_schema).toBe('AP242')
+        // The header named no authoring system, so the preprocessor stands in
+        // — the same preference order the model line uses.
+        expect(tags.authoring_tool).toBe('KiCad 8.0')
+        expect(tags.model_format).toBe('stp')
+        warnSpy.mockRestore()
+      })
+
+      it('truncates tag values at Sentry limit and omits what the header never said', () => {
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+        const overlongChars = 300
+        const maxTagChars = 200
+        beginLoadProgress({fileInfo: 'noext'})
+        reportModelInfo({fileName: 'noext', originatingSystem: 'T'.repeat(overlongChars)})
+        console.warn('No basis found for brep!')
+        endLoadProgress()
+        captureLoadDiagnostics({warningCount: 1})
+
+        const {tags} = diagnosticsCall()[1]
+        expect(tags.authoring_tool).toHaveLength(maxTagChars)
+        expect(tags).not.toHaveProperty('model_schema')
+        expect(tags).not.toHaveProperty('model_size_mb')
+        // No extension to read, and no contentType passed to fall back on.
+        expect(tags).not.toHaveProperty('model_format')
+        warnSpy.mockRestore()
+      })
+
+      it('falls back to the content type when the name carries no extension', () => {
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+        beginLoadProgress({fileInfo: 'gdrive:1sWR7x4BZ'})
+        console.warn('No basis found for brep!')
+        endLoadProgress()
+        captureLoadDiagnostics({warningCount: 1, contentType: 'IFC'})
+
+        expect(diagnosticsCall()[1].tags.model_format).toBe('ifc')
+        warnSpy.mockRestore()
       })
 
       it('stays silent when the load reported no errors or warnings', () => {

--- a/src/loader/loadProgress.test.js
+++ b/src/loader/loadProgress.test.js
@@ -601,6 +601,71 @@ describe('loadProgress', () => {
         warnSpy.mockRestore()
       })
 
+      /*
+       * The tag exists to bypass Sentry's scrubber, so it has to police its
+       * own content: an exporter-written originating_system sometimes carries
+       * the exporter's install path, which on Windows names a user.
+       */
+      it('strips path-like tokens from the authoring tool', () => {
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+        beginLoadProgress({fileInfo: 'Tower.ifc'})
+        reportModelInfo({
+          fileName: 'Tower.ifc',
+          originatingSystem: 'Revit Exporter C:\\Users\\jsmith\\rvt2ifc.exe',
+        })
+        console.warn('No basis found for brep!')
+        endLoadProgress()
+        captureLoadDiagnostics({warningCount: 1})
+
+        const {tags} = diagnosticsCall()[1]
+        expect(tags.authoring_tool).toBe('Revit Exporter')
+        expect(tags.authoring_tool).not.toContain('jsmith')
+        warnSpy.mockRestore()
+      })
+
+      it('omits the authoring tool entirely when it is nothing but a path', () => {
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+        beginLoadProgress({fileInfo: 'Tower.ifc'})
+        reportModelInfo({fileName: 'Tower.ifc', originatingSystem: '/home/jsmith/exporters/ifc'})
+        console.warn('No basis found for brep!')
+        endLoadProgress()
+        captureLoadDiagnostics({warningCount: 1})
+
+        expect(diagnosticsCall()[1].tags).not.toHaveProperty('authoring_tool')
+        warnSpy.mockRestore()
+      })
+
+      /*
+       * The two header fields are latched separately, so a later header that
+       * names only a preprocessor cannot downgrade an authoring system an
+       * earlier one already supplied.
+       */
+      it('keeps the richer authoring system when a later header names only a preprocessor', () => {
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+        beginLoadProgress({fileInfo: 'Tower.ifc'})
+        reportModelInfo({fileName: 'Tower.ifc', originatingSystem: 'Autodesk Revit 2024 (ENU)'})
+        reportLoadProgress({modelInfo: {fileName: 'Tower.ifc', preprocessorVersion: 'IFC4 exporter'}})
+        console.warn('No basis found for brep!')
+        endLoadProgress()
+        captureLoadDiagnostics({warningCount: 1})
+
+        expect(diagnosticsCall()[1].tags.authoring_tool).toBe('Autodesk Revit 2024 (ENU)')
+        warnSpy.mockRestore()
+      })
+
+      // CadView sends content_type as `loadedModel.type || 'undefined'`, so
+      // the literal string is what an unknown type looks like here.
+      it('omits model_format rather than tagging the literal "undefined"', () => {
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+        beginLoadProgress({fileInfo: 'gdrive:1sWR7x4BZ'})
+        console.warn('No basis found for brep!')
+        endLoadProgress()
+        captureLoadDiagnostics({warningCount: 1, contentType: 'undefined'})
+
+        expect(diagnosticsCall()[1].tags).not.toHaveProperty('model_format')
+        warnSpy.mockRestore()
+      })
+
       it('stays silent when the load reported no errors or warnings', () => {
         beginLoadProgress({fileInfo: 'index.ifc'})
         reportLoadProgress({phase: 'geometry', completed: 1, total: 1, elapsedMs: 5})

--- a/src/loader/loadProgress.test.js
+++ b/src/loader/loadProgress.test.js
@@ -537,7 +537,7 @@ describe('loadProgress', () => {
         captureLoadDiagnostics({warningCount: 1, contentType: 'ifc'})
 
         const {tags} = diagnosticsCall()[1]
-        expect(tags.authoring_tool).toBe('Autodesk Revit 2024 (ENU)')
+        expect(tags.authoring_tool).toBe('Autodesk Revit 2024')
         expect(tags.model_schema).toBe('IFC4')
         expect(tags.model_format).toBe('ifc')
         expect(tags.model_size_mb).toBe(sizeMb)
@@ -571,19 +571,22 @@ describe('loadProgress', () => {
         warnSpy.mockRestore()
       })
 
+      // Schema is the header string that still reaches a tag verbatim; the
+      // tool no longer can (knownAuthoringTool emits this module's own short
+      // canonical name), so truncation is asserted where it stays reachable.
       it('truncates tag values at Sentry limit and omits what the header never said', () => {
         const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
         const overlongChars = 300
         const maxTagChars = 200
         beginLoadProgress({fileInfo: 'noext'})
-        reportModelInfo({fileName: 'noext', originatingSystem: 'T'.repeat(overlongChars)})
+        reportModelInfo({fileName: 'noext', schema: 'S'.repeat(overlongChars)})
         console.warn('No basis found for brep!')
         endLoadProgress()
         captureLoadDiagnostics({warningCount: 1})
 
         const {tags} = diagnosticsCall()[1]
-        expect(tags.authoring_tool).toHaveLength(maxTagChars)
-        expect(tags).not.toHaveProperty('model_schema')
+        expect(tags.model_schema).toHaveLength(maxTagChars)
+        expect(tags).not.toHaveProperty('authoring_tool')
         expect(tags).not.toHaveProperty('model_size_mb')
         // No extension to read, and no contentType passed to fall back on.
         expect(tags).not.toHaveProperty('model_format')
@@ -602,37 +605,90 @@ describe('loadProgress', () => {
       })
 
       /*
-       * The tag exists to bypass Sentry's scrubber, so it has to police its
-       * own content: an exporter-written originating_system sometimes carries
-       * the exporter's install path, which on Windows names a user.
+       * The tag exists to bypass Sentry's scrubber, so it cannot be built by
+       * removing the bad parts of exporter-written free text — there is no
+       * bounded set of bad parts. Only an allowlisted family reaches it, as
+       * this module's own canonical string.
        */
-      it('strips path-like tokens from the authoring tool', () => {
-        const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
-        beginLoadProgress({fileInfo: 'Tower.ifc'})
-        reportModelInfo({
-          fileName: 'Tower.ifc',
-          originatingSystem: 'Revit Exporter C:\\Users\\jsmith\\rvt2ifc.exe',
+      describe('authoring_tool allowlist', () => {
+        /**
+         * @param {object} info the model-header fields under test
+         * @return {object} the tags of the resulting diagnostics event
+         */
+        function tagsForHeader(info) {
+          // diagnosticsCall() reads the first matching capture, so cases that
+          // exercise several headers have to start from a clean mock.
+          captureMessage.mockClear()
+          const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+          beginLoadProgress({fileInfo: 'Tower.ifc'})
+          reportModelInfo({fileName: 'Tower.ifc', ...info})
+          console.warn('No basis found for brep!')
+          endLoadProgress()
+          captureLoadDiagnostics({warningCount: 1})
+          warnSpy.mockRestore()
+          return diagnosticsCall()[1].tags
+        }
+
+        it('names a known family canonically, with its numeric version', () => {
+          expect(tagsForHeader({originatingSystem: 'Autodesk Revit 2024 (ENU)'}).authoring_tool)
+            .toBe('Autodesk Revit 2024')
         })
-        console.warn('No basis found for brep!')
-        endLoadProgress()
-        captureLoadDiagnostics({warningCount: 1})
 
-        const {tags} = diagnosticsCall()[1]
-        expect(tags.authoring_tool).toBe('Revit Exporter')
-        expect(tags.authoring_tool).not.toContain('jsmith')
-        warnSpy.mockRestore()
-      })
+        it('canonicalizes a family however the header spelled it', () => {
+          expect(tagsForHeader({originatingSystem: 'ARCHICAD-64'}).authoring_tool)
+            .toBe('Graphisoft ArchiCAD')
+        })
 
-      it('omits the authoring tool entirely when it is nothing but a path', () => {
-        const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
-        beginLoadProgress({fileInfo: 'Tower.ifc'})
-        reportModelInfo({fileName: 'Tower.ifc', originatingSystem: '/home/jsmith/exporters/ifc'})
-        console.warn('No basis found for brep!')
-        endLoadProgress()
-        captureLoadDiagnostics({warningCount: 1})
+        // The exact shape Codex raised on PR #1815: identifying free text with
+        // no path separator anywhere in it.
+        it('never lets free text through, even when it names a family', () => {
+          const {authoring_tool: tool} = tagsForHeader({
+            originatingSystem: 'Revit exported by jane@example.com',
+          })
+          expect(tool).toBe('Autodesk Revit')
+          expect(tool).not.toContain('jane')
+          expect(tool).not.toContain('@')
+        })
 
-        expect(diagnosticsCall()[1].tags).not.toHaveProperty('authoring_tool')
-        warnSpy.mockRestore()
+        it('omits the tag entirely for a header that names no known family', () => {
+          // A real Revit preprocessor_version — it names the exporter build,
+          // not the application, so the allowlist places nothing.
+          expect(tagsForHeader({
+            originatingSystem: '20190108_1515(x64) - Exporter 19.3.0.0 - Alternative Benutzeroberflache',
+          })).not.toHaveProperty('authoring_tool')
+          expect(tagsForHeader({originatingSystem: '/home/jsmith/exporters/ifc'}))
+            .not.toHaveProperty('authoring_tool')
+        })
+
+        it('takes a version token only when it is purely numeric', () => {
+          expect(tagsForHeader({originatingSystem: 'KiCad 8.0'}).authoring_tool).toBe('KiCad 8.0')
+          // 'Structures' follows the matched name, so there is no version to
+          // take — the canonical family name stands alone rather than
+          // carrying a word out of the header.
+          expect(tagsForHeader({originatingSystem: 'Tekla Structures 21.0'}).authoring_tool)
+            .toBe('Tekla Structures')
+        })
+
+        // The table is ordered most-specific-first, which is the only thing
+        // keeping these two off the more generic family that also matches.
+        it('prefers the more specific family when a header names both', () => {
+          expect(tagsForHeader({originatingSystem: 'Autodesk AutoCAD Civil 3D 2023'}).authoring_tool)
+            .toBe('Autodesk Civil 3D 2023')
+          expect(tagsForHeader({originatingSystem: 'Bonsai 0.8 (Blender)'}).authoring_tool)
+            .toBe('Bonsai/BlenderBIM 0.8')
+        })
+
+        /*
+         * Safe only because of the allowlist: an unmatched preprocessor
+         * yields no tag at all, so reaching for it can add a family but never
+         * substitute one header's free text for another's.
+         */
+        it('falls back to the preprocessor when the authoring system matches nothing', () => {
+          expect(tagsForHeader({
+            originatingSystem: '20190108_1515(x64) - Exporter 19.3.0.0',
+            preprocessorVersion: 'Autodesk Revit 2022 (ENU)',
+          }).authoring_tool).toBe('Autodesk Revit 2022')
+        })
       })
 
       /*
@@ -644,12 +700,12 @@ describe('loadProgress', () => {
         const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
         beginLoadProgress({fileInfo: 'Tower.ifc'})
         reportModelInfo({fileName: 'Tower.ifc', originatingSystem: 'Autodesk Revit 2024 (ENU)'})
-        reportLoadProgress({modelInfo: {fileName: 'Tower.ifc', preprocessorVersion: 'IFC4 exporter'}})
+        reportLoadProgress({modelInfo: {fileName: 'Tower.ifc', preprocessorVersion: 'KiCad 8.0'}})
         console.warn('No basis found for brep!')
         endLoadProgress()
         captureLoadDiagnostics({warningCount: 1})
 
-        expect(diagnosticsCall()[1].tags.authoring_tool).toBe('Autodesk Revit 2024 (ENU)')
+        expect(diagnosticsCall()[1].tags.authoring_tool).toBe('Autodesk Revit 2024')
         warnSpy.mockRestore()
       })
 

--- a/src/loader/loadProgress.test.js
+++ b/src/loader/loadProgress.test.js
@@ -669,6 +669,38 @@ describe('loadProgress', () => {
             .toBe('Tekla Structures')
         })
 
+        /*
+         * Round-3 review: four family names are short enough, or ordinary
+         * enough as English, to match prose an exporter happened to write.
+         * Nothing leaks either way — the tag carries the table's canonical
+         * name, never a span of the header — but a mislabelled tool is a
+         * mislabelled tool. These are the reviewer's exact examples.
+         */
+        it.each([
+          ['a word that merely contains a family name', 'confusion in the model geometry'],
+          ['diffusion', 'There was diffusion between the profusion of parts'],
+          ['Rhino as an ordinary noun', 'White Rhino Tower model'],
+          ['Inventor as a role', 'Inventor: John Smith, authored 2019'],
+          ['NX as a part code', 'Complex NX-200 model code'],
+          ['NX as a project name', 'Project NX designation'],
+        ])('does not mistake %s for a family', (_label, originatingSystem) => {
+          expect(tagsForHeader({originatingSystem})).not.toHaveProperty('authoring_tool')
+        })
+
+        // The same four, spelled the way a real header spells them. The bare
+        // 'Rhino 8' / 'NX 12.0.2.9' forms are admitted by the version that
+        // follows the name, which is exactly what the prose above lacks.
+        it.each([
+          ['Autodesk Fusion 360', 'Autodesk Fusion 360'],
+          ['Rhino 8', 'Rhino 8'],
+          ['Rhinoceros 7.4', 'Rhino 7.4'],
+          ['Autodesk Inventor 2024', 'Autodesk Inventor 2024'],
+          ['Siemens NX 2306', 'Siemens NX 2306'],
+          ['NX 12.0.2.9', 'Siemens NX 12.0.2.9'],
+        ])('still places the real header %s', (originatingSystem, expected) => {
+          expect(tagsForHeader({originatingSystem}).authoring_tool).toBe(expected)
+        })
+
         // The table is ordered most-specific-first, which is the only thing
         // keeping these two off the more generic family that also matches.
         it('prefers the more specific family when a header names both', () => {

--- a/src/routes/routes.ts
+++ b/src/routes/routes.ts
@@ -5,6 +5,18 @@ import processGoogleUrl, {GoogleResult, processGoogleFileId} from './google'
 
 
 /**
+ * What the user is told when a route names no file Share can open — an
+ * unrecognized extension, or a path with no filename at all. Lives here
+ * rather than at the catch in Share.jsx because this module owns the rule
+ * being violated (`splitAroundExtension`'s FilenameParseError), and its
+ * own message names the internal extension regex.
+ */
+export const UNSUPPORTED_FILE_ALERT =
+  'This link does not point to a model file Share can open. ' +
+  'Check the file path, and that its type is one of the supported model formats.'
+
+
+/**
  * Converts routes to route results with extracted attributes.
  *
  * e.g.:
@@ -24,6 +36,9 @@ import processGoogleUrl, {GoogleResult, processGoogleFileId} from './google'
  * @param pathPrefix e.g. /share/v/p or /share/v/new or /share/v/gh or /share/v/u
  * @param routeParams e.g. from ReactRouter useParams
  * @return RouteResult or null
+ * @throws FilenameParseError when the path names no supported model file.
+ *   Callers must handle it — see Share.jsx, which turns it into
+ *   UNSUPPORTED_FILE_ALERT rather than letting it reach the ErrorBoundary.
  */
 export function handleRoute(pathPrefix: string, routeParams: RouteParams): RouteResult | null {
   debug().log('Share#handleRoute: is a remote GitHub file:', pathPrefix, routeParams)

--- a/src/utils/alertTracking.js
+++ b/src/utils/alertTracking.js
@@ -30,7 +30,7 @@ export function trackAlert(message, error = null) {
     // family instead, normalized (see normalizeMessageDigits) so a
     // per-upload byte size can't split one family into an issue per file.
     Sentry.captureException(stackError, {
-      fingerprint: ['alert', normalizeMessageDigits(String(message))],
+      fingerprint: ['alert', alertFingerprintKey(String(message))],
     })
   }
 
@@ -38,4 +38,33 @@ export function trackAlert(message, error = null) {
   gtagEvent('alert', {
     message: message,
   })
+}
+
+
+/**
+ * The grouping key for a synthesized alert: the shared digit collapse, plus
+ * an alert-only collapse of whatever a message put in parentheses.
+ *
+ * Digits alone are not enough here. `dragAndDrop`'s unknown-upload alert is
+ * `File upload of unknown type: type(${file.type}) size(${file.size})`, and
+ * `file.type` is a browser-supplied MIME string — `application/octet-stream`,
+ * `model/gltf-binary`, `''` — so collapsing only the size still mints a fresh
+ * Sentry issue per MIME, which is the same explosion SHARE-1EA is about.
+ *
+ * The parenthesized collapse stays local to the alert fingerprint and is
+ * deliberately NOT folded into normalizeMessageDigits: engine diagnostics
+ * title themselves through that same helper, and there a parenthesized tail
+ * ("(revolution unwrap)", "(hemisphere: #)") is the part that names the
+ * failure — collapsing it would merge unrelated engine bugs.
+ *
+ * It is safe for the alert population because parentheses appear in exactly
+ * two of the messages that reach this branch (the unknown-upload alert, and
+ * the stale-cache alert's "(Profile menu → Clear Local Cache)"), and both
+ * stay distinct on the surrounding text alone.
+ *
+ * @param {string} message
+ * @return {string}
+ */
+function alertFingerprintKey(message) {
+  return normalizeMessageDigits(message).replace(/\([^)]*\)/g, '(#)')
 }

--- a/src/utils/alertTracking.js
+++ b/src/utils/alertTracking.js
@@ -1,5 +1,6 @@
 import * as Sentry from '@sentry/react'
 import {gtagEvent} from '../privacy/analytics'
+import {normalizeMessageDigits} from './messageGrouping'
 
 
 /**
@@ -13,11 +14,24 @@ import {gtagEvent} from '../privacy/analytics'
 export function trackAlert(message, error = null) {
   // Track in Sentry with full stack trace if available
   if (error) {
+    // No fingerprint here on purpose: a real error carries the stack of
+    // wherever it was actually thrown, which discriminates better than its
+    // message text does. Only the synthesized branch below needs help.
     Sentry.captureException(error)
   } else {
     // Create a new error with the current stack trace
     const stackError = new Error(message)
-    Sentry.captureException(stackError)
+    // Every alert without an error object is synthesized on the line above,
+    // so all of them share one stack and Sentry's default stack-based
+    // grouping folded the whole family into a single issue — SHARE-1EA held
+    // "File upload of unknown type", "Failed to parse model" and "Could not
+    // read full model structure" together, so none of them could be counted
+    // or triaged separately. The explicit fingerprint groups by message
+    // family instead, normalized (see normalizeMessageDigits) so a
+    // per-upload byte size can't split one family into an issue per file.
+    Sentry.captureException(stackError, {
+      fingerprint: ['alert', normalizeMessageDigits(String(message))],
+    })
   }
 
   // Track in Google Analytics (just the message)

--- a/src/utils/alertTracking.test.js
+++ b/src/utils/alertTracking.test.js
@@ -26,13 +26,36 @@ describe('trackAlert', () => {
     expect(secondContext.fingerprint).toEqual(['alert', 'Could not read full model structure.'])
   })
 
-  it('groups one alert family across its per-upload numbers', () => {
-    trackAlert('File upload of unknown type: type() size(180384)')
-    trackAlert('File upload of unknown type: type() size(12345)')
+  /**
+   * `file.type` is a browser-supplied MIME string, so collapsing only the
+   * size still minted one Sentry issue per MIME — the same explosion
+   * SHARE-1EA is about, one level down.
+   */
+  it('groups one alert family across its per-upload MIME types and sizes', () => {
+    trackAlert('File upload of unknown type: type(application/octet-stream) size(180384)')
+    trackAlert('File upload of unknown type: type(model/gltf-binary) size(12345)')
+    trackAlert('File upload of unknown type: type() size(7)')
 
     const fingerprints = Sentry.captureException.mock.calls.map(([, ctx]) => ctx.fingerprint)
-    expect(fingerprints[0]).toEqual(['alert', 'File upload of unknown type: type() size(#)'])
-    expect(fingerprints[0]).toEqual(fingerprints[1])
+    expect(fingerprints[0]).toEqual(['alert', 'File upload of unknown type: type(#) size(#)'])
+    expect(fingerprints[1]).toEqual(fingerprints[0])
+    expect(fingerprints[2]).toEqual(fingerprints[0])
+  })
+
+  /**
+   * The parenthesized collapse must not over-merge. These are the only two
+   * messages reaching this branch that contain parentheses at all, plus a
+   * paren-free neighbour — all three have to stay separate issues.
+   */
+  it('keeps genuinely distinct alert families distinct', () => {
+    trackAlert('File upload of unknown type: type(application/octet-stream) size(180384)')
+    trackAlert('This model was cached in an older format that this version of Share ' +
+      'no longer reads, so element properties are unavailable. ' +
+      'Clear the local cache (Profile menu → Clear Local Cache) and reload the model to rebuild it.')
+    trackAlert('File upload initiated but found no data')
+
+    const keys = Sentry.captureException.mock.calls.map(([, ctx]) => ctx.fingerprint[1])
+    expect(new Set(keys).size).toBe(keys.length)
   })
 
   it('still captures the message as the exception, with its stack', () => {

--- a/src/utils/alertTracking.test.js
+++ b/src/utils/alertTracking.test.js
@@ -1,0 +1,63 @@
+import * as Sentry from '@sentry/react'
+import {gtagEvent} from '../privacy/analytics'
+import {trackAlert} from './alertTracking'
+
+
+jest.mock('@sentry/react', () => ({captureException: jest.fn()}))
+jest.mock('../privacy/analytics', () => ({gtagEvent: jest.fn()}))
+
+
+describe('trackAlert', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  /**
+   * Every string alert synthesizes its Error on one line of alertTracking, so
+   * Sentry's stack-based grouping had no way to tell them apart and filed
+   * them all under one issue (SHARE-1EA).
+   */
+  it('fingerprints a string alert by its message, not by the shared stack', () => {
+    trackAlert('Failed to parse model')
+    trackAlert('Could not read full model structure.')
+
+    const [firstContext, secondContext] = Sentry.captureException.mock.calls.map(([, ctx]) => ctx)
+    expect(firstContext.fingerprint).toEqual(['alert', 'Failed to parse model'])
+    expect(secondContext.fingerprint).toEqual(['alert', 'Could not read full model structure.'])
+  })
+
+  it('groups one alert family across its per-upload numbers', () => {
+    trackAlert('File upload of unknown type: type() size(180384)')
+    trackAlert('File upload of unknown type: type() size(12345)')
+
+    const fingerprints = Sentry.captureException.mock.calls.map(([, ctx]) => ctx.fingerprint)
+    expect(fingerprints[0]).toEqual(['alert', 'File upload of unknown type: type() size(#)'])
+    expect(fingerprints[0]).toEqual(fingerprints[1])
+  })
+
+  it('still captures the message as the exception, with its stack', () => {
+    trackAlert('Failed to parse model')
+    const [error] = Sentry.captureException.mock.calls[0]
+    expect(error).toBeInstanceOf(Error)
+    expect(error.message).toBe('Failed to parse model')
+    expect(error.stack).toEqual(expect.stringContaining('Error: Failed to parse model'))
+  })
+
+  /**
+   * A real error carries the stack of wherever it was actually thrown, which
+   * discriminates better than its text — so it keeps Sentry's default
+   * grouping and gets no fingerprint override.
+   */
+  it('leaves a real error to Sentry default grouping', () => {
+    const error = new Error('Load failed: out of memory')
+    trackAlert(error.message, error)
+    expect(Sentry.captureException).toHaveBeenCalledWith(error)
+  })
+
+  it('reports the raw message to analytics, un-normalized', () => {
+    trackAlert('File upload of unknown type: type() size(180384)')
+    expect(gtagEvent).toHaveBeenCalledWith('alert', {
+      message: 'File upload of unknown type: type() size(180384)',
+    })
+  })
+})

--- a/src/utils/messageGrouping.js
+++ b/src/utils/messageGrouping.js
@@ -1,0 +1,34 @@
+/**
+ * Normalization for the grouping keys Share computes itself, rather than
+ * letting Sentry derive them.
+ *
+ * Two call sites share this, for the same reason: `loadProgress`'s
+ * `diagnosticsTitle` (a `captureMessage`'s text *is* its grouping key) and
+ * `alertTracking#trackAlert` (an explicit fingerprint). Keeping the rule in
+ * one place is what keeps an alert and the load diagnostics that describe the
+ * same underlying condition from grouping by two different rules.
+ */
+
+
+/**
+ * Collapse each run of digits — and an entity marker the text already spelled
+ * `#` — to a single `#`.
+ *
+ * Both call sites carry per-instance numbers inside otherwise fixed text:
+ * engine diagnostics are per-entity ("Error processing representation #1234")
+ * and the unknown-upload alert carries the file's byte size ("File upload of
+ * unknown type: type() size(180384)"). Left raw, each distinct value opens its
+ * own Sentry issue and the family is invisible.
+ *
+ * The pass is deliberately indiscriminate: it also collapses digits inside
+ * identifiers, so "IFC4" normalizes to "IFC#" and "Revit 2024" to "Revit #".
+ * That costs nothing for grouping — schema and authoring tool ride on the
+ * event's own tags and context — and exempting them would reopen the
+ * per-value split this exists to close.
+ *
+ * @param {string} text
+ * @return {string}
+ */
+export function normalizeMessageDigits(text) {
+  return text.replace(/#?\d+/g, '#')
+}

--- a/src/utils/messageGrouping.test.js
+++ b/src/utils/messageGrouping.test.js
@@ -1,0 +1,27 @@
+import {normalizeMessageDigits} from './messageGrouping'
+
+
+describe('normalizeMessageDigits', () => {
+  it('collapses per-entity ids, whether or not the text spelled the #', () => {
+    expect(normalizeMessageDigits('Error processing representation #1204'))
+      .toBe('Error processing representation #')
+    expect(normalizeMessageDigits('CDT Exception (hemisphere: 0)'))
+      .toBe('CDT Exception (hemisphere: #)')
+  })
+
+  it('collapses every number in the message, not just the first', () => {
+    expect(normalizeMessageDigits('File upload of unknown type: type(3) size(180384)'))
+      .toBe('File upload of unknown type: type(#) size(#)')
+  })
+
+  // Documented as a cost of the pass being indiscriminate: the schema and
+  // authoring tool ride on the event's tags, so losing their digits from the
+  // grouping key buys the collapse without losing information.
+  it('collapses digits inside identifiers too', () => {
+    expect(normalizeMessageDigits('IFC4 model from Revit 2024')).toBe('IFC# model from Revit #')
+  })
+
+  it('leaves digit-free text alone', () => {
+    expect(normalizeMessageDigits('Failed to parse model')).toBe('Failed to parse model')
+  })
+})

--- a/src/viewer/ifc/ShareIfcLoader.js
+++ b/src/viewer/ifc/ShareIfcLoader.js
@@ -30,6 +30,7 @@ import {isOutOfMemoryError, markIfOutOfMemory} from '../../utils/oom'
 import {hasParams} from '../../utils/location'
 import {HASH_PREFIX_CAMERA} from '../../Components/Camera/hashState'
 import {isFeatureEnabled} from '../../FeatureFlags'
+import {reportGeometryStats} from '../../loader/loadProgress'
 import {runIfcItemsMapParityCheck} from './ifcItemsMapParity'
 import ProgressiveLoadSession from '../ProgressiveLoadSession'
 import ShareIfcManager from './ShareIfcManager'
@@ -560,6 +561,14 @@ export default class ShareIfcLoader {
         if (buildStats) {
           parts.push(`vertices=${buildStats.vertexCount ?? buildStats.totalVerts ?? '?'}`)
           parts.push(`triangles=${buildStats.triangleCount ?? buildStats.totalTriangles ?? '?'}`)
+          // Same two numbers, structured, for the Sentry diagnostics event's
+          // severity: a build that emitted nothing is a model the user
+          // cannot see, whatever the warning counts say (ops#27 T0 —
+          // loadProgress#classifyLoadOutcome).
+          reportGeometryStats({
+            vertexCount: buildStats.vertexCount ?? buildStats.totalVerts,
+            triangleCount: buildStats.triangleCount ?? buildStats.totalTriangles,
+          })
         }
         if (typeof ifcAPI.GetLinearScalingFactor === 'function') {
           // eslint-disable-next-line new-cap


### PR DESCRIPTION
Output of the 2026-08-31 Sentry triage session. Two signal-quality improvements (T0) and two bug fixes (T5).

Tracking: bldrs-ai/ops#26, bldrs-ai/ops#27 (T0), bldrs-ai/ops#32 (T5).
Fixes #1811. Fixes #1812. Sentry issues: SHARE-1EA, SHARE-1P3, SHARE-1H4.

## 1. Fingerprint `trackAlert` per message (SHARE-1EA)

`src/utils/alertTracking.js` — every alert without an error object synthesized its `Error` on one line, so all of them shared a stack and Sentry's default stack-based grouping folded the whole family into a single issue. "File upload of unknown type", "Failed to parse model" and "Could not read full model structure" were one issue, so none of them could be counted or triaged separately.

An explicit fingerprint now groups by message family via `alertFingerprintKey()`: digits collapse to `#` (so `size(180384)` and `size(12345)` stay one issue) and parenthesized segment contents collapse to `(#)` (so `type(application/octet-stream)` and `type(model/gltf-binary)` stay one issue rather than one per MIME string). The digit rule is extracted to a shared `src/utils/messageGrouping.js` and reused by `loadProgress#diagnosticsTitle`; the paren collapse is deliberately alert-only, because diagnostics titles like `(revolution unwrap)` are what name the engine failure.

An error object passed to `trackAlert` deliberately keeps Sentry's default grouping: it carries the stack of wherever it was really thrown, which discriminates better than its message text.

## 2. Severity split for load diagnostics (ops#27 T0)

`src/loader/loadProgress.js#captureDiagnostics` — the event's level was `errorCount > 0 ? 'error' : 'warning'`, i.e. how noisy the load was. It is now the load's *outcome*:

- geometry reached the scene → `warning` (regular bug), however loud the load was
- the load finished and built nothing → `error` (major), whatever the counts say

A `load_outcome` tag (`displayed` | `unusable`) carries the same classification for filtering. The signal is structured, not re-parsed from report text: `reportGeometryStats()` is a new seam on the reporter, fed by `ShareIfcLoader` from the build's vertex/triangle counts. Ambiguity resolves to regular per the T0 policy; only the conway engine path reports counts, so non-conway formats classify `displayed`. Note `captureLoadDiagnostics` only runs on the successful-open branch, so `unusable` means "succeeded but built nothing" — hard load failures already reach Sentry via `captureException`.

## 3. PII-safe model identification tags (ops#27 T0)

Sentry's server-side scrubber rewrites some event bodies to `[Filtered]`, and when it does the authoring tool and schema — the first two questions asked of any load diagnostic — go with it. Four short tags now survive that: `authoring_tool`, `model_schema` (e.g. `IFC4`, `AP242`), `model_format`, `model_size_mb`.

The `authoring_tool` tag is **allowlist-derived** (a Codex review finding, hardened over two rounds): `knownAuthoringTool()` matches the raw `originatingSystem`/`preprocessorVersion` header against a 24-family `AUTHORING_TOOL_FAMILIES` table and emits only the canonical family name plus an adjacent purely-numeric version token. No span of the raw header string can reach the tag — free-form text (names, emails, paths) is structurally excluded, and an unmatched header omits the tag; the raw string stays in the report body where the scrubber governs it. Short names that are also English words (Rhino, Inventor, NX) require vendor context or a following numeric version, so prose like "Inventor: John Smith" or a part code "NX-200" can't mislabel the tag. `model_schema` prefers conway's parsed value over the extension-derived one; values are truncated at Sentry's 200-char tag limit; absent fields omit their tag.

## 4a. Guard the pset property table (SHARE-1P3)

`src/Components/Properties/itemProperties.jsx` — a `HasProperties` reference the model could not resolve yielded `undefined`, and `dObj.Name.value` threw a `TypeError` that took the whole Properties panel down over one bad row. Now skipped — in `unpackHelper` (unresolvable reference), `hasProperties` and `quantities` (resolved element with no `Name`; the `quantities` sibling had the identical crash shape) — and the rest of the table still builds.

## 4b. Handle `FilenameParseError` from route parsing (SHARE-1H4)

`src/Share.jsx` + `src/routes/routes.ts` — a GitHub route with an unrecognized extension (`Jetenginestep.st`) or a bare directory path threw `FilenameParseError` out of `handleRoute`, inside a `useEffect`, so it reached the React ErrorBoundary and crashed the app over what is really a bad link.

Share now catches it, sets a user-facing `UNSUPPORTED_FILE_ALERT`, falls back to the home model, and early-returns so the rest of the effect never configures a repository from the params that failed to parse. Non-`FilenameParseError` throws are re-raised unchanged. This case also becomes a countable, fingerprinted Sentry alert (change 1) instead of an unhandled ErrorBoundary crash.

**`.st` is deliberately NOT added to `supportedTypes`** — that product decision is still open.

## Review

Sub-agent review (codex-substitute per agent-workflow.md §Review, then codex itself on the ready-flip): round 1 request-changes (6 findings — notably the `quantities()` crash sibling and MIME-cardinality gap in the fingerprint, both fixed in 072d5b5), round 2 approve, Codex P1 on scrubber-bypassing free-form tags (fixed via the allowlist in b9fa89c, thread resolved), round 3 approve with one data-quality nit (word-boundary false positives, fixed in 70ea9a5 with the reviewer's exact prose examples as negative tests).

## Tests

New/extended suites: `messageGrouping.test.js`, `alertTracking.test.js` (incl. MIME-variability grouping), `itemProperties.test.jsx` (psets + quantities), `loadProgress.test.js` (outcome classification, severity, tag extraction, allowlist incl. the jane@example.com negative case and prose false-positive negatives), `Share.test.jsx` (fallback + no-repo-config-from-bad-params). Every assertion break-checked per STYLE.md. Full suite: 262 suites, 2719 passed / 5 skipped. Pre-ready gates run locally: `yarn build-prod`, `yarn test-ci` (coverage 66–73% vs 50–67% thresholds), targeted Playwright specs 32 passed / 0 failed. `package.json` version stamp restored.