### PR TITLE
Bump @bldrs-ai/conway to 1.1592.684 — colours for shading-only styles and mapped-item material bindings

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@babel/plugin-syntax-import-assertions": "7.18.6",
     "@babel/preset-env": "7.18.10",
     "@babel/preset-react": "7.18.6",
-    "@bldrs-ai/conway": "1.1585.676-g80859a4d",
+    "@bldrs-ai/conway": "1.1592.684-g9c1cd597",
     "@bldrs-ai/ifclib": "5.3.3",
     "@emotion/react": "11.10.0",
     "@emotion/styled": "11.10.0",

--- a/src/loader/glbCacheKey.js
+++ b/src/loader/glbCacheKey.js
@@ -20,6 +20,21 @@
  * it (`BLDRS_GLB_BATCHED_SCHEMA_VERSION` below) — deliberately, since that
  * is the slot most users actually read. Nothing extra to do here; the note
  * exists so the coupling is visible from where the bump gets written.
+ * 0.18.0 — retires artifacts baked with pre-1.1592 engine colours
+ *         (conway#684, issue test-models-private#61): legacyColor — the
+ *         field the streaming path bakes into per-instance source colours
+ *         — was never populated for models styled only with
+ *         IfcSurfaceStyleShading, so every placement arrived as the
+ *         0.8-grey default and got auto-coloured; material-association
+ *         styles on mapped items were dropped entirely. Colours are baked
+ *         into the artifact (per-instance source colours in
+ *         `BLDRS_instance_tables` on the batched slot, per-material bins
+ *         on the merged slot) and nothing in the cache key identifies the
+ *         engine, so without this bump a returning user's cache hit keeps
+ *         serving the all-grey model indefinitely while cache-miss users
+ *         see the authored palette. Same failure shape and remedy as
+ *         0.17.0/0.16.0/0.15.0; found by review on the bump PR
+ *         (Share#1817).
  * 0.17.0 — retires artifacts baked by pre-1.1585 engines, releasing the
  *         #641-epic geometry + shading train (conway#666/#668/#674/#676:
  *         wrong-sheet inverse-solve recovery, ribbon-sweep chain side,
@@ -174,7 +189,7 @@
  * 0.2.0 — generalised cache key from GitHub-only (owner/repo/branch) to a
  *         per-source-kind 3-level namespace (ns1/ns2/ns3).
  */
-export const BLDRS_GLB_SCHEMA_VERSION = '0.17.0'
+export const BLDRS_GLB_SCHEMA_VERSION = '0.18.0'
 
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -2473,10 +2473,10 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@bldrs-ai/conway@1.1585.676-g80859a4d":
-  version "1.1585.676-g80859a4d"
-  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.1585.676-g80859a4d.tgz#8eb0bac476b7e7467e4fae7a6b6240bd8893cda4"
-  integrity sha512-p1MiWQyMk4+lbpq6V/z9T4Cb7nElqlnLBGfsJbb+WPmqhscE2ILBv2eIhU2IKocdKJQM8i0ZXIm2HwT50rgkRw==
+"@bldrs-ai/conway@1.1592.684-g9c1cd597":
+  version "1.1592.684-g9c1cd597"
+  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.1592.684-g9c1cd597.tgz#63bff1883bb2c7dc8f15044f283ac571abf38505"
+  integrity sha512-ScoHPRpGfV3ORCDg//nP02GIWhcHWnT5wvtjhSJB1TwVIz+5texdYubQ47K3JqofizEpYpOyJHsw2HpGkMXKbg==
   dependencies:
     gl-matrix "3.4.3"
     seedrandom "3.0.5"


### PR DESCRIPTION
Picks up [bldrs-ai/conway#684](https://github.com/bldrs-ai/conway/pull/684), fixing the all-grey / auto-coloured load of the Renga convenience store ([bldrs-ai/test-models-private#61](https://github.com/bldrs-ai/test-models-private/issues/61)).

What the conway release carries:
- `legacyColor` — the field Share's streaming path (`PlacedGeometry.color`) reads — is now populated for models styled only with `IfcSurfaceStyleShading`; previously only `IfcSurfaceStyleRendering` set it, so shading-only models arrived all default-grey and Share's auto-colour heuristic fired.
- Styles reached via `IfcRelAssociatesMaterial → IfcMaterialDefinitionRepresentation` now bind to mapped/instanced geometry, per-product (shared mapped bodies can't leak one product's material onto another's instances), with explicit item styles taking precedence per IFC.

Also bumps `BLDRS_GLB_SCHEMA_VERSION` to `0.18.0` (from codex review): colours are baked into cached GLB artifacts and the cache key doesn't identify the engine, so without the bump a returning user's cache hit would keep serving the pre-fix all-grey model indefinitely. Same pairing as the 0.17.0/0.16.0/0.15.0 entries.

Verified against this exact published build from Share's `node_modules`: `StreamAllMeshes` on the issue model now delivers the authored 15-colour palette (steel rebar grey, concrete, brick, galvanised steel, red/orange markers, whites) instead of one default grey × 5,351 placements. Local: commit gate (eslint+typecheck+jest) green on both commits, `yarn build-prod` green against the new package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HSPoDZwutgTofFsHaZ5jpA