### PR TITLE
STEP: select one body of a no-NAUO multibody model (BLSN_007)

### DIFF
--- a/design/new/step-occurrence-selection.md
+++ b/design/new/step-occurrence-selection.md
@@ -89,7 +89,7 @@ contract change and not a bug fix:
   and has no tree node. This is the Arty_Z7 "trailing non-NAUO segment"
   extension described above, which therefore largely disappears for solids —
   but `trimToTreeOccurrencePath`'s prefix fallback stays, because suppressed
-  anonymous dumps and pre-0.18.0 cache artifacts still produce paths the tree
+  anonymous dumps and pre-0.19.0 cache artifacts still produce paths the tree
   doesn't have.
 - The ephemeral solid layer is **on by default** and uncapped for named sets.
   Suppression is all-or-nothing: a partially emitted layer would leave the
@@ -127,12 +127,16 @@ hands over a key that the existing machinery could already carry):
   already has a tree node. The pair keeps a body's URL canonical; the extra
   segment stays required for pieces that genuinely share their owner's path
   (an anonymous piece, and a pre-#628 solid).
-- **GLB schema bumped `0.17.0 → 0.18.0`.** Path composition is baked into the
+- **GLB schema bumped `0.18.0 → 0.19.0`.** Path composition is baked into the
   artifact on both sides (`BLDRS_face_ids.occurrencePaths` and the
-  `BLDRS_spatial_tree` node paths), so a 0.17.0 cache hit would keep serving
-  pre-#628 paths — bodies sharing one path again, and no body nodes in the
-  tree — to post-#628 resolution code. Cache-hit users would never see the
-  fix; same shape and same remedy as the 0.15.0/0.16.0/0.17.0 engine bumps.
+  `BLDRS_spatial_tree` node paths), so a hit on an artifact baked by a
+  pre-#628 engine would keep serving those paths — bodies sharing one path
+  again, and no body nodes in the tree — to post-#628 resolution code.
+  Cache-hit users would never see the fix; same shape and same remedy as the
+  0.15.0/0.16.0/0.17.0/0.18.0 engine bumps. Its own number rather than a
+  merge into 0.18.0: that bump shipped to main on conway 1.1592.684, which
+  predates #628, so 0.18.0 artifacts already exist holding the old path
+  shape.
 
 Everything else took the new paths unchanged, which is the point of keying on
 the path in the first place: `IfcInstanceMap`'s occurrence tables and the

--- a/design/new/step-occurrence-selection.md
+++ b/design/new/step-occurrence-selection.md
@@ -127,6 +127,23 @@ hands over a key that the existing machinery could already carry):
   already has a tree node. The pair keeps a body's URL canonical; the extra
   segment stays required for pieces that genuinely share their owner's path
   (an anonymous piece, and a pre-#628 solid).
+- **Hover is a separate path from the click funnel**, and had the same bug
+  one layer down. `Containers/viewer.js`'s mousemove (throttled to 30fps)
+  calls `ShareViewer#highlightIfcItem`, whose batched-render branch resolved
+  the hit to its *parent product* (`getPickedItemId` →
+  `instanceParents[batchId]`) and recoloured every instance under it — one
+  product for the whole of BLSN_007, so hovering anything turned the entire
+  hull cyan while the click highlight beneath it was already correct. It now
+  resolves the hovered instance's global occurrence id straight off the hit's
+  `batchId` and paints through `applyBatchedInstancePreselection`, the hover
+  twin of the selection narrowing. Two things this costs nothing: the lookup
+  is a typed-array index plus a memoised `Map` (no traversal per mouse-move),
+  and the repaint only runs when the hovered *instance* changes — which is
+  also why the per-frame dedup key had to stop being the product id, since
+  every body of a no-NAUO product shares one. The merged/cache-hit render
+  path was already per-instance (`_setConwayPreselectionFromHit` builds its
+  subset from the hovered triangle's instance), and models with no occurrence
+  table still hover at product level, which is the right granularity there.
 - **GLB schema bumped `0.18.0 → 0.19.0`.** Path composition is baked into the
   artifact on both sides (`BLDRS_face_ids.occurrencePaths` and the
   `BLDRS_spatial_tree` node paths), so a hit on an artifact baked by a

--- a/design/new/step-occurrence-selection.md
+++ b/design/new/step-occurrence-selection.md
@@ -103,9 +103,15 @@ hands over a key that the existing machinery could already carry):
 - `findNodeByOccurrencePath` no longer *skips* ephemeral solid nodes; it
   prefers a product node and falls back to a solid one. That fallback is what
   makes a body reachable at all — with its own segment on the path, a pick's
-  trimmed path lands ON the solid node. The product preference is what keeps a
-  pre-#628 cache artifact working, where solids share their part's path and a
-  path-only lookup must not name one body.
+  trimmed path lands ON the solid node. The product preference covers the
+  pre-#628 shape, where solids share their part's path and a path-only lookup
+  must not name one body. Nothing shipped feeds that shape to this code today
+  — the engine no longer emits it, and an artifact written by one that did is
+  never opened, because the schema version is part of the artifact *filename*
+  (`glbArtifactPath`), so a stale artifact reads as a miss rather than as old
+  data. Treat the preference as defence against engine/schema lockstep drift
+  (the extension readers run on every GLB load, not only on cache lookups),
+  not as a live compatibility path.
 - `resolvePickedOccurrenceNode` (extracted from `canvasDoubleClickHandler`'s
   funnel, so it can be tested) promotes the selection to the solid node when
   the path names one. Without it a BLSN pick still degraded to the
@@ -114,8 +120,13 @@ hands over a key that the existing machinery could already carry):
 - `occurrenceElementPathIds` / `resolveElementPathOccurrence` are the
   permalink pair. The solid's express id is appended below the occurrence path
   **only when the path doesn't already end with it**; appending
-  unconditionally would mint `/1020254/367733/367733`, which reads back as an
-  anonymous piece *under* the body and resolves to nothing.
+  unconditionally would mint `/1020254/367733/367733`. That doubled URL is
+  degraded rather than dead — the resolver reads the repeat through the
+  conway#387 anonymous-piece branch, so the selection still lands on the body,
+  at the cost of registering a transient "piece" row for something that
+  already has a tree node. The pair keeps a body's URL canonical; the extra
+  segment stays required for pieces that genuinely share their owner's path
+  (an anonymous piece, and a pre-#628 solid).
 - **GLB schema bumped `0.17.0 → 0.18.0`.** Path composition is baked into the
   artifact on both sides (`BLDRS_face_ids.occurrencePaths` and the
   `BLDRS_spatial_tree` node paths), so a 0.17.0 cache hit would keep serving

--- a/design/new/step-occurrence-selection.md
+++ b/design/new/step-occurrence-selection.md
@@ -66,6 +66,78 @@ upstream in Conway's `makeThunk` occurrence stamping; the Share-side fixes above
 keep working either way since a NAUO-only geometry path is just the zero-
 extension case.
 
+### Identity below the product (conway#628)
+
+`BLSN_007.stp` (test-models-private#98) is the case the occurrence path alone
+could not express: a 281 MB Rhino 7 / ST-DEVELOPER hull export that is **one
+product, zero NAUOs, zero CDSRs and 2,268 individually named bodies**. Every
+body shares the one product's (empty) occurrence path *and* its
+`product_definition_shape`, so both join keys collapse — Share showed a
+one-node tree in which every click selected the whole boat.
+
+Conway's fix changes what an occurrence path is **made of**, so read it as a
+contract change and not a bug fix:
+
+- An individually addressable body **ends its occurrence path with its own
+  express id**, on the `PlacedGeometry` and on the spatial-tree node alike.
+  So a body's path is `[...nauoChain, bodyExpressID]` (the NEMA motor:
+  `[14107, 14045]`), a no-NAUO body's is just `[bodyExpressID]`, and a
+  single-solid part keeps a NAUO-only path (`[14108]` — the product node *is*
+  the body, so there is nothing to disambiguate).
+- **A plain `shape_representation_relationship` id is no longer a segment.**
+  It binds a part to its own detail representation; it is not an occurrence
+  and has no tree node. This is the Arty_Z7 "trailing non-NAUO segment"
+  extension described above, which therefore largely disappears for solids —
+  but `trimToTreeOccurrencePath`'s prefix fallback stays, because suppressed
+  anonymous dumps and pre-0.18.0 cache artifacts still produce paths the tree
+  doesn't have.
+- The ephemeral solid layer is **on by default** and uncapped for named sets.
+  Suppression is all-or-nothing: a partially emitted layer would leave the
+  dropped bodies stamped with paths that resolve to no node. The >32-unnamed
+  anonymous-dump gate still applies, and there the geometry stamps no body
+  segment either, so paths collapse to the product node coherently.
+
+**What that changed in Share** (the consumer side is small — the engine now
+hands over a key that the existing machinery could already carry):
+
+- `findNodeByOccurrencePath` no longer *skips* ephemeral solid nodes; it
+  prefers a product node and falls back to a solid one. That fallback is what
+  makes a body reachable at all — with its own segment on the path, a pick's
+  trimmed path lands ON the solid node. The product preference is what keeps a
+  pre-#628 cache artifact working, where solids share their part's path and a
+  path-only lookup must not name one body.
+- `resolvePickedOccurrenceNode` (extracted from `canvasDoubleClickHandler`'s
+  funnel, so it can be tested) promotes the selection to the solid node when
+  the path names one. Without it a BLSN pick still degraded to the
+  `product_definition_shape` — the tree resolved, the *selection* didn't, and
+  Properties showed 'Document' for every body.
+- `occurrenceElementPathIds` / `resolveElementPathOccurrence` are the
+  permalink pair. The solid's express id is appended below the occurrence path
+  **only when the path doesn't already end with it**; appending
+  unconditionally would mint `/1020254/367733/367733`, which reads back as an
+  anonymous piece *under* the body and resolves to nothing.
+- **GLB schema bumped `0.17.0 → 0.18.0`.** Path composition is baked into the
+  artifact on both sides (`BLDRS_face_ids.occurrencePaths` and the
+  `BLDRS_spatial_tree` node paths), so a 0.17.0 cache hit would keep serving
+  pre-#628 paths — bodies sharing one path again, and no body nodes in the
+  tree — to post-#628 resolution code. Cache-hit users would never see the
+  fix; same shape and same remedy as the 0.15.0/0.16.0/0.17.0 engine bumps.
+
+Everything else took the new paths unchanged, which is the point of keying on
+the path in the first place: `IfcInstanceMap`'s occurrence tables and the
+batched builder's path tables carry them verbatim,
+`getInstanceIdsForOccurrencePath` resolves a body's exact key (its
+`geometryExpressId` filter is now redundant for a body but still needed for
+anonymous pieces and pre-#628 solids), the NavTree renders the solid nodes as
+ordinary rows and matches `isSelected`/scroll on (path, solid id), and the
+per-occurrence hide keys on the body's own express id either way.
+
+**Scale.** A 2,268-body product is a 2,269-node tree and a 2,269-row flatten;
+`VariableSizeList` renders only the visible window, and `getVisibleNodes` is
+one map + one push per node, so the panel does not hang. It is still a single
+flat sibling list with no grouping or search-within-node affordance — the
+usability limit, not a performance one.
+
 ### The id-space mismatch (why scalar `expressID` can't join the two sides)
 
 The two surfaces speak **different express-id spaces** for STEP:
@@ -216,19 +288,29 @@ order; BVH permutes only the index buffer, not the numbering).
    (the store is keyed by node id); child-leaf eyes still read "shown." Toggling
    the assembly eye is the way to reveal them again. Making descendant eyes
    follow would need per-node hidden-state derived from the occurrence prefix.
-4. **Root-level parts.** A placement directly under the product root has an empty
-   occurrence path (no NAUO), which `getOccurrencePathByInstance` normalizes to
-   `null` — an empty path can't disambiguate anything. So a scene pick of a
-   *root-level* part can't reconcile to its NavTree node (the pick reports the
-   PDS id, which never equals the node's id), and it silently degrades to
-   type-level. Harmless when the file has one root assembly (the common case);
-   only bites files with several distinct parts placed directly at the root. A
-   real fix needs a PDS→product-definition→node reverse map, out of scope here.
+4. **Root-level parts** — mostly closed by conway#628, see §"Identity below
+   the product". A *body* placed directly under the product root now carries
+   `[bodyExpressID]`, so the no-NAUO multibody file (BLSN_007) reconciles
+   exactly. What remains is the sliver the body segment can't reach: a
+   root-level product whose single solid makes it its own body, where the path
+   is legitimately empty and `getOccurrencePathByInstance` still normalizes it
+   to `null`. Harmless with one root assembly (the common case); a file with
+   several distinct single-solid products at the root still degrades to
+   type-level there, and a real fix still needs a PDS→product-definition→node
+   reverse map.
 5. **`?feature=batchedMesh`.** The BatchedMesh render path builds no
    `IfcInstanceMap`, so per-occurrence (and all per-instance) selection no-ops
    under that flag — a documented gap in `buildBatchedConwayModel`, not a
    regression (NAUO≠PDS meant a STEP node click highlighted nothing there
    before this work either).
+6. **No eye on a body row.** `IfcIsolator.canBeHidden` answers from
+   `visualElementsIds` (per-vertex expressIDs, i.e. the PDS) and the
+   parent→children map, so a `type:'solid'` leaf is in neither and
+   `NavTreeNode` renders no hide icon for it. The hide itself works — `H` on a
+   selected body takes `hideSelectedElements`' occurrence branch and removes
+   just that body — so this is a missing affordance, not a broken one. It
+   predates conway#628 (the NEMA motor's bodies had it too) but is far more
+   visible on a model whose rows are *all* bodies.
 
 Each step degrades gracefully to today's type-level behavior when no occurrence
 path is present (IFC, single-occurrence parts). NavTree **shift-click** on an

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@babel/plugin-syntax-import-assertions": "7.18.6",
     "@babel/preset-env": "7.18.10",
     "@babel/preset-react": "7.18.6",
-    "@bldrs-ai/conway": "1.1585.676-g80859a4d",
+    "@bldrs-ai/conway": "1.1593.683-g9ff7aa12",
     "@bldrs-ai/ifclib": "5.3.3",
     "@emotion/react": "11.10.0",
     "@emotion/styled": "11.10.0",

--- a/src/Components/NavTree/NavTreePanel.jsx
+++ b/src/Components/NavTree/NavTreePanel.jsx
@@ -120,10 +120,11 @@ export default function NavTreePanel({
     // STEP: a scene pick reports the geometry's owner id
     // (product_definition_shape), which never equals a tree node's id (its NAUO
     // express id) — the shared occurrence path is the only reliable join, so
-    // prefer it. A multibody part's ephemeral solid rows share the part's
-    // path, so within the path match the solid id decides: a solid selection
+    // prefer it. Within a path match the solid id decides: a solid selection
     // scrolls to its own row, a part selection to the (non-ephemeral) part
-    // row. Falls back to expressID for IFC and when no occurrence is set.
+    // row. That tie-break is what a pre-conway#628 solid row needs (it shares
+    // its part's path) and what a transient anonymous-piece row still needs
+    // today. Falls back to expressID for IFC and when no occurrence is set.
     if (selectedOccurrencePathKey !== null) {
       index = visibleNodes.findIndex(
         ({node}) => Array.isArray(node.occurrencePath) &&
@@ -324,17 +325,19 @@ function getVisibleNodes(treeData, expandedNodeIds, isNavTree, model, transientT
       mapped.occurrencePath = node.occurrencePath
     }
     // Preserve the ephemeral-solid marker (a multibody part's named body).
-    // Solid rows share the parent part's occurrence path, so `isSelected`,
-    // the scroll effect, and the click funnel all need this to tell "the
-    // part" from "one body inside it". Absent for products and IFC.
+    // `isSelected`, the scroll effect, and the click funnel need it to tell
+    // "the part" from "one body inside it" — decisive for a pre-conway#628
+    // solid row and a transient piece row, which carry their part's own path.
+    // Absent for products and IFC.
     if (node.ephemeral === true) {
       mapped.ephemeral = true
     }
     // Anonymous-geometry affordances (conway#387). Both are session-only
     // and reconstructed on the fly — nothing here persists to the cache.
-    // Ephemeral solid rows share their parent part's occurrence path, so
-    // without the `ephemeral` guard every solid of a multibody part would
-    // re-inject the same transient rows the part already carries.
+    // The `ephemeral` guard keeps the injection at the part: a transient row
+    // carries its part's path, so without it every such row (and every
+    // pre-conway#628 solid row, which also shares that path) would re-inject
+    // the same rows the part already carries.
     if (Array.isArray(node.occurrencePath) && node.occurrencePath.length > 0 &&
         node.ephemeral !== true) {
       const pathKey = occurrencePathKey(node.occurrencePath)
@@ -465,10 +468,11 @@ const RenderRow = ({index, style, data}) => {
   // only the clicked/picked node, not every reuse. Falls back to expressID for
   // IFC and when no occurrence is selected (selectedOccurrencePathKey is null).
   if (selectedOccurrencePathKey !== null && Array.isArray(node.occurrencePath)) {
-    // A multibody part's ephemeral solid rows share the part's occurrence
-    // path, so the path match alone would light up the part AND all its
-    // bodies at once. The solid id splits them: a solid selection highlights
-    // only its own row; a part selection only the (non-ephemeral) part row.
+    // Rows that share their part's occurrence path — a pre-conway#628 solid
+    // row, a transient anonymous-piece row — would otherwise light up
+    // together with the part on a path match alone. The solid id splits them:
+    // a solid selection highlights only its own row; a part selection only
+    // the (non-ephemeral) part row.
     const pathMatches = occurrencePathKey(node.occurrencePath) === selectedOccurrencePathKey
     isSelected = pathMatches && (selectedSolidExpressId !== null ?
       (node.ephemeral === true && node.expressID === selectedSolidExpressId) :

--- a/src/Components/NavTree/NavTreePanel.test.jsx
+++ b/src/Components/NavTree/NavTreePanel.test.jsx
@@ -125,6 +125,13 @@ describe('NavTreePanel/getVisibleNodes — transient anonymous-geometry rows (co
   const PART_NAUO = 14107
   const FACE_ID = 4462
   const SOLID_ID = 250
+  // The conway#628 no-NAUO multibody shape (BLSN_007): one product, bodies
+  // whose occurrence path is their own express id, at the real fixture's width.
+  const PRODUCT_ID = 1020254
+  const BODY_A_ID = 367733
+  const BODY_B_ID = 367891
+  const FIRST_BODY_ID = 400000
+  const BLSN_BODY_COUNT = 2268
 
   /**
    * A STEP part node with an occurrence path, in the shape the spatial
@@ -210,6 +217,48 @@ describe('NavTreePanel/getVisibleNodes — transient anonymous-geometry rows (co
     const solidRows = visible.map(({node: n}) => n)
       .filter((n) => n.ephemeral === true && n.transient !== true)
     expect(solidRows.every((n) => n.hasChildren === false)).toBe(true)
+  })
+
+  it('renders conway#628 body nodes as ordinary rows, each on its own path', () => {
+    // The no-NAUO multibody shape (BLSN_007, test-models-private#98): the
+    // bodies arrive as real tree children whose occurrence path ends with
+    // their own express id. They must render with their file names and keep
+    // those distinct paths — that path is what the row highlight, the scroll
+    // and the per-body hide all key on. The transient-row injection is gated
+    // on `!ephemeral`, so a body must not sprout synthetic children either.
+    const bodies = [BODY_A_ID, BODY_B_ID].map((id, index) => ({
+      ...node(id, `brep_${index + 1}`),
+      type: 'solid',
+      occurrencePath: [id],
+      ephemeral: true,
+    }))
+    const root = {...node(PRODUCT_ID, 'Document', bodies), occurrencePath: []}
+    const transient = {[BODY_A_ID]: [{expressID: FACE_ID, label: 'Face #4462'}]}
+    const visible = getVisibleNodes(root, [`${PRODUCT_ID}`], true, model, transient)
+    expect(visible.map(({node: n}) => n.label)).toEqual(['Document', 'brep_1', 'brep_2'])
+    const rows = visible.map(({node: n}) => n)
+    expect(rows[1].occurrencePath).toEqual([BODY_A_ID])
+    expect(rows[2].occurrencePath).toEqual([BODY_B_ID])
+    expect(rows[1].ephemeral).toBe(true)
+    expect(rows[1].hasChildren).toBe(false)
+    expect(rows.some((n) => n.transient === true)).toBe(false)
+  })
+
+  it('flattens a 2,268-body product without special-casing (virtualized rows)', () => {
+    // BLSN_007's real width. getVisibleNodes builds the whole flat list; only
+    // `VariableSizeList` decides what renders, so the cost here is one map +
+    // one push per node. This pins that nothing walks the sibling set
+    // quadratically — the transient/"more" injection runs per node and reads
+    // `transientTreeNodes` by path key, not by scanning siblings.
+    const bodies = []
+    for (let i = 0; i < BLSN_BODY_COUNT; i++) {
+      const id = FIRST_BODY_ID + i
+      bodies.push({...node(id, `brep_${i}`), type: 'solid', occurrencePath: [id], ephemeral: true})
+    }
+    const root = {...node(PRODUCT_ID, 'Document', bodies), occurrencePath: []}
+    const visible = getVisibleNodes(root, [`${PRODUCT_ID}`], true, model, {})
+    expect(visible.length).toBe(BLSN_BODY_COUNT + 1)
+    expect(visible[visible.length - 1].node.label).toBe(`brep_${BLSN_BODY_COUNT - 1}`)
   })
 
   it('leaves IFC nodes (no occurrence path) untouched', () => {

--- a/src/Components/NavTree/navTreeBodySelection.spec.ts
+++ b/src/Components/NavTree/navTreeBodySelection.spec.ts
@@ -1,0 +1,178 @@
+import {Page, expect, test} from '@playwright/test'
+import {setupVirtualPathIntercept, waitForModelReady} from '../../tests/e2e/models'
+import {describeMobileAndDesktop} from '../../tests/e2e/formFactor'
+import {homepageSetup, setIsReturningUser} from '../../tests/e2e/utils'
+
+
+/**
+ * Per-BODY selection in a STEP model that has no assembly structure at all —
+ * the shape `BLSN_007.stp` (test-models-private#98) turned out to be: ONE
+ * product, zero `NEXT_ASSEMBLY_USAGE_OCCURRENCE`, and every body named
+ * individually inside one child representation. Share showed it as a
+ * single-node tree in which every click selected the whole boat.
+ *
+ * conway#628 gives such a body its own identity: its occurrence path ends
+ * with its own express id, on the spatial-tree node and on the geometry
+ * instance alike, so the path alone is the selection key. Share's side of
+ * that is `resolvePickedOccurrenceNode` / `resolveElementPathOccurrence`
+ * (`utils/occurrencePaths.js`) — see
+ * design/new/step-occurrence-selection.md §"Identity below the product".
+ *
+ * The fixture is conway's `data/ap214-inverted-srr-multibody.step`, the same
+ * shape reduced to three named bodies behind three inverted relationship
+ * edges. Two consequences for what this spec can assert:
+ *
+ *   - Its `CLOSED_SHELL`s are empty, so the model tessellates to nothing.
+ *     The tree, the row highlight and the permalink are all driven by
+ *     `getSpatialStructure` and are fully exercised; the scene-side
+ *     `setInstanceSelection` narrowing has no geometry to draw and is
+ *     pinned by unit tests instead (`ShareViewer.test.js`
+ *     "resolves one body of a no-NAUO multibody model", `IfcIsolator.test.js`
+ *     "hides one body of a no-NAUO multibody product").
+ *   - A scene double-click likewise has nothing to hit, so the pick →
+ *     NavTree/Properties direction is unit-tested
+ *     (`occurrencePaths.test.js` "selects the picked body of a no-NAUO
+ *     multibody model") rather than driven through the canvas here.
+ *
+ * Node identity is read through the `data-node-label` / `data-is-selected`
+ * hooks on `NavTreeNode`, as in the sibling `navTreeOccurrenceSelection` /
+ * `navTreePermalink` specs.
+ */
+const MODEL_PATH =
+  '/share/v/gh/bldrs-ai/test-models/main/step/ap214-inverted-srr-multibody.step'
+const TEST_TIMEOUT_MS = 90_000
+
+
+/**
+ * The spatial tree's body rows, as the engine handed them over. Read through
+ * the store (`window.store` under the playwright build, `window.useStore`
+ * otherwise — see `store/useStore.js` and `BaseRoutes.jsx`) because the DOM
+ * shows only the label: the occurrence path is the thing under test.
+ *
+ * @param page playwright page
+ * @return one entry per child of the product root
+ */
+async function readBodyPaths(
+  page: Page,
+): Promise<Array<{expressID: number, occurrencePath: number[]}>> {
+  return await page.evaluate(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const w = window as any
+    const root = (w.store ?? w.useStore)?.getState?.().rootElement
+    if (!root) {
+      throw new Error('readBodyPaths: no rootElement on the store — did the model load?')
+    }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return (root.children ?? []).map((child: any) => ({
+      expressID: child.expressID,
+      occurrencePath: child.occurrencePath,
+    }))
+  })
+}
+
+
+/**
+ * The occurrence-keyed half of the current selection.
+ *
+ * @param page playwright page
+ * @return selected element ids, occurrence path and solid express id
+ */
+async function readSelection(
+  page: Page,
+): Promise<{selectedElements: string[], occurrencePath: number[], solidExpressId: number|null}> {
+  return await page.evaluate(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const w = window as any
+    const state = (w.store ?? w.useStore)?.getState?.()
+    return {
+      selectedElements: state?.selectedElements ?? [],
+      // Normalised to an array so a null path (the pre-conway#628 fall-through
+      // to scalar-id selection) fails the length assertion rather than the
+      // evaluate itself.
+      occurrencePath: state?.selectedOccurrencePath ?? [],
+      solidExpressId: state?.selectedSolidExpressId ?? null,
+    }
+  })
+}
+
+describeMobileAndDesktop('NavTree STEP per-body selection', () => {
+  test('each named body is its own tree row and its own selection', async ({page}) => {
+    test.setTimeout(TEST_TIMEOUT_MS)
+    page.on('pageerror', (err) => console.warn(`[pageerror] ${err.message}`))
+
+    await homepageSetup(page)
+    await setIsReturningUser(page.context())
+
+    const {navigateAndWaitForModel} = await setupVirtualPathIntercept(page, MODEL_PATH, '')
+    await navigateAndWaitForModel()
+    await waitForModelReady(page)
+
+    await page.getByTestId('control-button-navigation').click()
+    const navTreePanel = page.getByTestId('NavTreePanel')
+    await expect(navTreePanel).toBeVisible()
+
+    const node = (label: string) => navTreePanel.locator(`[data-node-label="${label}"]`)
+
+    // The product root, and — expanded — one row per named body. Pre-#628 the
+    // solid layer was opt-in, so this tree was the root alone.
+    await expect(node('Document')).toBeVisible()
+    await node('Document').getByTestId('NavTreeNodeToggle').click()
+    await expect(node('brep_0')).toBeVisible()
+    await expect(node('brep_1')).toBeVisible()
+    await expect(node('Hauptkoerper')).toBeVisible()
+
+    // Every body node's occurrence path is its own express id — the conway#628
+    // contract Share's whole per-body join rests on. Read from the live tree
+    // rather than inferred from the UI, because it is what distinguishes this
+    // engine from the one before it: pre-#628 all three bodies carried the
+    // product's (empty) path and were indistinguishable.
+    const bodyPaths = await readBodyPaths(page)
+    expect(bodyPaths).toHaveLength(3)
+    for (const {expressID, occurrencePath} of bodyPaths) {
+      expect(occurrencePath).toEqual([expressID])
+    }
+
+    // Selecting one body highlights that row and no other. All three bodies
+    // belong to the same product_definition_shape, so a selection keyed on the
+    // scalar expressID — or on a shared occurrence path — lights up all of
+    // them; only the per-body path tells them apart.
+    await node('brep_1').getByTestId('NavTreeNodeLabel').click()
+    await expect(node('brep_1')).toHaveAttribute('data-is-selected', 'true')
+    await expect(page.locator('[data-is-selected="true"]')).toHaveCount(1)
+
+    // …and the selection that reached the store IS the body: its own express
+    // id as the selected element, the same id as the occurrence path's only
+    // segment and as the selected solid. Pre-#628 this click fell through to
+    // the scalar-id branch with a null occurrence path, which is exactly the
+    // state a scene pick could not reconcile against.
+    const selection = await readSelection(page)
+    expect(selection.occurrencePath).toHaveLength(1)
+    expect(selection.solidExpressId).toBe(selection.occurrencePath[0])
+    expect(selection.selectedElements).toEqual([`${selection.solidExpressId}`])
+
+    // The permalink addresses the body directly: [root, ...occurrencePath],
+    // where the path's last segment IS the body. The bug this guards is a
+    // repeated trailing segment (/root/body/body), which reads back as an
+    // anonymous piece under the body and resolves to nothing.
+    const selectedPath = new URL(page.url()).pathname
+    const elementPath = selectedPath.split('.step')[1]
+    expect(elementPath).toMatch(/^\/\d+\/\d+$/)
+    const [rootId, bodyId] = elementPath.slice(1).split('/')
+    expect(bodyId).not.toBe(rootId)
+
+    // Reload that permalink: the body must come back selected — the resolver
+    // reading the URL is the inverse of the writer that produced it.
+    await page.goto(selectedPath)
+    await waitForModelReady(page)
+    await page.getByTestId('control-button-navigation').click()
+    await expect(navTreePanel).toBeVisible()
+    await expect(node('brep_1')).toHaveAttribute('data-is-selected', 'true')
+    await expect(page.locator('[data-is-selected="true"]')).toHaveCount(1)
+
+    // A different body selects independently: the first row's highlight moves,
+    // it doesn't accumulate.
+    await node('Hauptkoerper').getByTestId('NavTreeNodeLabel').click()
+    await expect(node('Hauptkoerper')).toHaveAttribute('data-is-selected', 'true')
+    await expect(node('brep_1')).toHaveAttribute('data-is-selected', 'false')
+  })
+})

--- a/src/Components/NavTree/navTreeBodySelection.spec.ts
+++ b/src/Components/NavTree/navTreeBodySelection.spec.ts
@@ -32,7 +32,11 @@ import {homepageSetup, setIsReturningUser} from '../../tests/e2e/utils'
  *   - A scene double-click likewise has nothing to hit, so the pick →
  *     NavTree/Properties direction is unit-tested
  *     (`occurrencePaths.test.js` "selects the picked body of a no-NAUO
- *     multibody model") rather than driven through the canvas here.
+ *     multibody model") rather than driven through the canvas here. Same for
+ *     hover, which is a separate path (`Containers/viewer.js` mousemove →
+ *     `ShareViewer#highlightIfcItem`): with nothing under the cursor there is
+ *     no preselection to assert, so it is pinned in `ShareViewer.test.js`
+ *     ("batched hover").
  *
  * Node identity is read through the `data-node-label` / `data-is-selected`
  * hooks on `NavTreeNode`, as in the sibling `navTreeOccurrenceSelection` /

--- a/src/Components/NavTree/navTreeBodySelection.spec.ts
+++ b/src/Components/NavTree/navTreeBodySelection.spec.ts
@@ -151,9 +151,11 @@ describeMobileAndDesktop('NavTree STEP per-body selection', () => {
     expect(selection.selectedElements).toEqual([`${selection.solidExpressId}`])
 
     // The permalink addresses the body directly: [root, ...occurrencePath],
-    // where the path's last segment IS the body. The bug this guards is a
-    // repeated trailing segment (/root/body/body), which reads back as an
-    // anonymous piece under the body and resolves to nothing.
+    // where the path's last segment IS the body. What this guards is a
+    // repeated trailing segment (/root/body/body) — the selection would still
+    // resolve (through the conway#387 anonymous-piece branch) but the URL
+    // would not be the body's canonical one, and reading it registers a
+    // transient row for a piece that already has a tree node.
     const selectedPath = new URL(page.url()).pathname
     const elementPath = selectedPath.split('.step')[1]
     expect(elementPath).toMatch(/^\/\d+\/\d+$/)

--- a/src/Containers/CadView.jsx
+++ b/src/Containers/CadView.jsx
@@ -1037,10 +1037,11 @@ export default function CadView({
    * @param {number} solidExpressId Express id of the selected ephemeral solid
    *   (a multibody STEP part's named body), or null when the selection is a
    *   whole product/occurrence. Since conway#628 it is also the last segment
-   *   of `occurrencePath`; carried separately because it's what tells "the
-   *   part" from "one body inside it" — NavTree row highlight, per-solid hide
-   *   and the permalink all read it, and pre-#628 caches key a body as the
-   *   (path, solid expressID) pair with no body segment on the path.
+   *   of `occurrencePath` for a body with a tree node; carried separately
+   *   because it's what tells "the part" from "one piece inside it" wherever
+   *   the two share a path — an anonymous piece (conway#387) has no node and
+   *   no segment of its own — and because NavTree row highlight, per-solid
+   *   hide and the permalink all read it.
    * @param {Array} anchorIds The ids the user actually picked, when the
    *   caller expanded them into descendants for the scene highlight
    *   (`elementSelection` does). Null (the default) means every result is
@@ -1215,10 +1216,10 @@ export default function CadView({
         state.selectedElements.includes(`${targetId}`) ||
         viewer.getSelectedIds().includes(targetId)
       // Occurrence identity is the path — plus the solid id when the URL
-      // addresses one body of a multibody part, since a pre-conway#628 solid
-      // shares its part's path and path equality alone would treat "the part"
-      // and "one body inside it" as the same selection, skipping the
-      // re-select.
+      // addresses one piece of a multibody part. For a piece that shares its
+      // part's path (an anonymous conway#387 piece, a pre-conway#628 solid)
+      // path equality alone would treat "the part" and "one piece inside it"
+      // as the same selection and skip the re-select.
       const alreadySelected = (occurrencePath && state.selectedOccurrencePath) ?
         (occurrencePathsEqual(occurrencePath, state.selectedOccurrencePath) &&
           state.selectedSolidExpressId === solidExpressId) :

--- a/src/Containers/CadView.jsx
+++ b/src/Containers/CadView.jsx
@@ -42,10 +42,12 @@ import {navWith} from '../utils/navigate'
 import {addProperties} from '../utils/objects'
 import {labelForGeometryId} from '../utils/geometryLabels'
 import {
-  findNodeByOccurrencePath,
+  occurrenceElementPathIds,
   occurrencePathKey,
   occurrencePathKeySetForTree,
   occurrencePathsEqual,
+  resolveElementPathOccurrence,
+  resolvePickedOccurrenceNode,
   trimToTreeOccurrencePath,
 } from '../utils/occurrencePaths'
 import {isOutOfMemoryError} from '../utils/oom'
@@ -886,12 +888,12 @@ export default function CadView({
    * once from `onModel`, before that render's `rootElement` is set.
    *
    * Ephemeral solid resolution: when the tree surfaces the picked body as a
-   * `type:'solid'` child of the node at this path (Conway's multibody solid
-   * layer), select THAT node — its express id is the picked instance's
-   * `PlacedGeometry.geometryExpressID` — so the NavTree highlights the one
-   * body, not the whole part. Falls back to the part-level selection when
-   * the tree has no matching solid (single-solid parts, suppressed
-   * anonymous dumps, old caches).
+   * `type:'solid'` node — since conway#628 the trimmed path lands on it
+   * directly (a body's path ends with its own express id), before that as a
+   * child of the node at this path — select THAT node, so the NavTree
+   * highlights the one body, not the whole part. `resolvePickedOccurrenceNode`
+   * owns those cases; it falls back to the part-level selection when the tree
+   * has no matching solid (single-solid parts, suppressed anonymous dumps).
    *
    * @param {object} pick
    * @param {number} pick.parentExpressId the geometry-owner product id
@@ -911,28 +913,15 @@ export default function CadView({
     const occurrencePath = rawPath ?
       trimToTreeOccurrencePath(rawPath, occurrencePathKeySetForTree(rootEltForPick)) :
       null
-    let targetId = parentExpressId
-    let solidExpressId = null
-    if (occurrencePath) {
-      const pathNode = pickedGeometryId !== null ?
-        findNodeByOccurrencePath(rootEltForPick, occurrencePath) : null
-      const solidNode = pathNode?.children?.find?.(
-        (child) => child.ephemeral === true && child.expressID === pickedGeometryId)
-      if (solidNode) {
-        targetId = solidNode.expressID
-        solidExpressId = solidNode.expressID
-      } else if (pickedGeometryId !== null && pathNode &&
-          occurrenceInstanceIds(occurrencePath, false).length > 1) {
-        // Anonymous piece of a multi-piece part (conway#387): no tree
-        // node exists, but (path, geometry id) is a complete identity —
-        // select it as a solid and materialize a transient NavTree row
-        // so highlight/scroll/eye/permalink all work. The >1-instance
-        // guard keeps single-solid parts (as1's nut, the NEMA screws)
-        // on the part-level selection, where the part node IS the piece.
-        targetId = pickedGeometryId
-        solidExpressId = pickedGeometryId
-        materializeTransientNode(occurrencePath, pickedGeometryId)
-      }
+    const {targetId, solidExpressId, transientGeometryId} = resolvePickedOccurrenceNode({
+      rootNode: rootEltForPick,
+      occurrencePath,
+      pickedGeometryId,
+      parentExpressId,
+      instanceCountAtPath: (path) => occurrenceInstanceIds(path, false).length,
+    })
+    if (transientGeometryId !== null) {
+      materializeTransientNode(occurrencePath, transientGeometryId)
     }
     selectItemsInScene([targetId], true, instanceIds, occurrencePath, solidExpressId)
   }
@@ -1047,9 +1036,11 @@ export default function CadView({
    *   null (the default) clears it for IFC and non-occurrence sources.
    * @param {number} solidExpressId Express id of the selected ephemeral solid
    *   (a multibody STEP part's named body), or null when the selection is a
-   *   whole product/occurrence. Solid nodes share their parent's occurrence
-   *   path, so this is what tells "the part" from "one body inside it" —
-   *   NavTree row highlight, per-solid hide and the permalink all read it.
+   *   whole product/occurrence. Since conway#628 it is also the last segment
+   *   of `occurrencePath`; carried separately because it's what tells "the
+   *   part" from "one body inside it" — NavTree row highlight, per-solid hide
+   *   and the permalink all read it, and pre-#628 caches key a body as the
+   *   (path, solid expressID) pair with no body segment on the path.
    * @param {Array} anchorIds The ids the user actually picked, when the
    *   caller expanded them into descendants for the scene highlight
    *   (`elementSelection` does). Null (the default) means every result is
@@ -1105,12 +1096,11 @@ export default function CadView({
           occurrencePath && occurrencePath.length > 0 && rootElt &&
           occurrencePathKeySetForTree(rootElt)?.has(occurrencePathKey(occurrencePath)))
         // A selected solid appends its own express id below the occurrence
-        // path — solids aren't path-addressable on their own (they share the
-        // parent part's path), so the URL identity is [root, ...path, solid].
-        // `selectElementBasedOnFilepath` resolves it back symmetrically.
+        // path when the path doesn't already carry it — see
+        // `occurrenceElementPathIds`, whose inverse
+        // `selectElementBasedOnFilepath` applies on load.
         const pathIds = isTreeOccurrencePath ?
-          [rootElt.expressID, ...occurrencePath,
-            ...(solidExpressId !== null ? [solidExpressId] : [])] :
+          occurrenceElementPathIds(rootElt.expressID, occurrencePath, solidExpressId) :
           getParentPathIdsForElement(elementsById, parseInt(firstId))
         const repoFilePath = modelPath.gitpath ? modelPath.getRepoPath() : modelPath.filepath
         const enabledFeatures = searchParams.get('feature')
@@ -1177,11 +1167,11 @@ export default function CadView({
       // a reused sub-assembly (under-determined in the tree) and never equals
       // the product_definition_shape id that owns the geometry (unreachable
       // in the scene). See design/new/step-occurrence-selection.md.
-      // `findNodeByOccurrencePath` is the single tree-membership gate (a
-      // non-null node ⟺ the tree knows the path) and its node supplies
-      // `hasChildren` for the scene resolution below. Null for IFC (nodes
-      // carry no occurrence paths) and for element paths the tree doesn't
-      // know — those keep the plain scalar-id selection.
+      // `resolveElementPathOccurrence` is the single tree-membership gate (a
+      // non-null occurrence path ⟺ the tree knows these ids) and its node
+      // supplies `hasChildren` for the scene resolution below. Null for IFC
+      // (nodes carry no occurrence paths) and for element paths the tree
+      // doesn't know — those keep the plain scalar-id selection.
       //
       // The first segment must be the root id: every app-written element
       // path starts at the root (both the occurrence branch and
@@ -1192,37 +1182,16 @@ export default function CadView({
       const eltPathIds = parts.slice(1).map((part) => parseInt(part))
       const startsAtRoot =
         state.rootElement && parseInt(parts[0]) === state.rootElement.expressID
-      let node = startsAtRoot ?
-        findNodeByOccurrencePath(state.rootElement, eltPathIds) : null
-      let occurrencePath = node ? eltPathIds : null
-      // Ephemeral solid permalink: the writer appends the solid's express id
-      // below its parent part's occurrence path ([root, ...path, solid]), so
-      // when the full segment list isn't a tree path, try the prefix as the
-      // path and the trailing id as one of that node's `type:'solid'`
-      // children. Mirrors the write in selectItemsInScene.
-      let solidExpressId = null
-      if (!node && startsAtRoot && eltPathIds.length >= 2) {
-        const parentPathIds = eltPathIds.slice(0, -1)
-        const parentNode = findNodeByOccurrencePath(state.rootElement, parentPathIds)
-        const solidNode = parentNode?.children?.find?.(
-          (child) => child.ephemeral === true && child.expressID === targetId)
-        if (solidNode) {
-          node = parentNode
-          occurrencePath = parentPathIds
-          solidExpressId = targetId
-        } else if (parentNode &&
-            occurrenceInstanceIds(parentPathIds, false, targetId).length > 0) {
-          // Anonymous-geometry permalink (conway#387): the trailing id names
-          // no tree node, but the instance map holds geometry with that id
-          // under the parent path — the piece exists, it just has no in-file
-          // identity beyond its express id. Select it as a solid and
-          // materialize its transient row so the tree shows what the URL
-          // addressed.
-          node = parentNode
-          occurrencePath = parentPathIds
-          solidExpressId = targetId
-          materializeTransientNode(parentPathIds, targetId)
-        }
+      const {node, occurrencePath, solidExpressId, transientGeometryId} = startsAtRoot ?
+        resolveElementPathOccurrence({
+          rootNode: state.rootElement,
+          eltPathIds,
+          hasGeometryAtPath: (path, geometryExpressId) =>
+            occurrenceInstanceIds(path, false, geometryExpressId).length > 0,
+        }) :
+        {node: null, occurrencePath: null, solidExpressId: null, transientGeometryId: null}
+      if (transientGeometryId !== null) {
+        materializeTransientNode(occurrencePath, transientGeometryId)
       }
       // Skip re-selecting when this element is already the active
       // selection. We consult the store (selectItemsInScene updates it
@@ -1246,9 +1215,10 @@ export default function CadView({
         state.selectedElements.includes(`${targetId}`) ||
         viewer.getSelectedIds().includes(targetId)
       // Occurrence identity is the path — plus the solid id when the URL
-      // addresses one body of a multibody part: solid and parent share the
-      // path, so path equality alone would treat "the part" and "one body
-      // inside it" as the same selection and skip the re-select.
+      // addresses one body of a multibody part, since a pre-conway#628 solid
+      // shares its part's path and path equality alone would treat "the part"
+      // and "one body inside it" as the same selection, skipping the
+      // re-select.
       const alreadySelected = (occurrencePath && state.selectedOccurrencePath) ?
         (occurrencePathsEqual(occurrencePath, state.selectedOccurrencePath) &&
           state.selectedSolidExpressId === solidExpressId) :
@@ -1568,9 +1538,11 @@ export default function CadView({
                 // toggles/accumulates against the current selection (multi-select);
                 // the per-occurrence scene highlight is single-selection only, so
                 // shift keeps its legacy type-level accumulate behavior.
-                // An ephemeral solid node shares its parent part's occurrence
-                // path; its own express id (= PlacedGeometry.geometryExpressID)
-                // narrows the resolution to the one clicked body.
+                // An ephemeral solid node's own express id
+                // (= PlacedGeometry.geometryExpressID) narrows the resolution
+                // to the one clicked body — necessary for a pre-conway#628
+                // solid, which shares its part's path, and harmless for a
+                // #628 body, whose path already names it alone.
                 const solidExpressId = isEphemeralSolid ? parseInt(expressIdOrIds, 10) : null
                 const instanceIds =
                   occurrenceInstanceIds(occurrencePath, hasChildren, solidExpressId)

--- a/src/loader/glbCacheKey.js
+++ b/src/loader/glbCacheKey.js
@@ -20,6 +20,29 @@
  * it (`BLDRS_GLB_BATCHED_SCHEMA_VERSION` below) — deliberately, since that
  * is the slot most users actually read. Nothing extra to do here; the note
  * exists so the coupling is visible from where the bump gets written.
+ * 0.18.0 — retires artifacts whose STEP occurrence paths mean something
+ *         different from what the app now reads. conway#628
+ *         (test-models-private#98) changed the path's own composition, not
+ *         just its contents: an individually addressable body now ends its
+ *         occurrence path with its OWN express id, on the geometry instance
+ *         and on the spatial-tree node alike, and a plain
+ *         `shape_representation_relationship` id is no longer a segment at
+ *         all. Both tables travel baked into the artifact — `occurrencePaths`
+ *         on `BLDRS_face_ids`, and the node paths in `BLDRS_spatial_tree` —
+ *         so a 0.17.0 cache hit serves pre-#628 paths to post-#628 resolution
+ *         code: a multibody part's bodies again share one path (every body of
+ *         BLSN_007 selecting the whole boat, the bug this fixes), and NEMA's
+ *         relationship-suffixed `[14107, 6611]` still matches no tree node.
+ *         The same release also turns the ephemeral solid layer on by default
+ *         and drops its 256-per-product cap, so a cached tree simply lacks
+ *         the body nodes a fresh parse now emits. Cache-hit users would never
+ *         see any of the fix — the same "cache-hit users see it, cache-miss
+ *         users don't" shape as 0.15.0/0.16.0/0.17.0, and the same remedy.
+ *         Older 0.17.0 artifacts read as miss; next miss rewrites with the
+ *         new paths and solid nodes. IFC artifacts carry no occurrence data
+ *         and are unaffected, but the key is format-blind so they rewrite
+ *         too. See design/new/step-occurrence-selection.md §"Identity below
+ *         the product".
  * 0.17.0 — retires artifacts baked by pre-1.1585 engines, releasing the
  *         #641-epic geometry + shading train (conway#666/#668/#674/#676:
  *         wrong-sheet inverse-solve recovery, ribbon-sweep chain side,
@@ -174,7 +197,7 @@
  * 0.2.0 — generalised cache key from GitHub-only (owner/repo/branch) to a
  *         per-source-kind 3-level namespace (ns1/ns2/ns3).
  */
-export const BLDRS_GLB_SCHEMA_VERSION = '0.17.0'
+export const BLDRS_GLB_SCHEMA_VERSION = '0.18.0'
 
 
 /**

--- a/src/tests/fixtures/github/bldrs-ai/test-models/main/step/ap214-inverted-srr-multibody.step
+++ b/src/tests/fixtures/github/bldrs-ai/test-models/main/step/ap214-inverted-srr-multibody.step
@@ -1,0 +1,58 @@
+ISO-10303-21;
+HEADER;
+/* Reduction of the BLSN_007 hull export (Rhino 7 / ST-DEVELOPER, 281 MB,
+ * test-models-private#98): ONE product with no NEXT_ASSEMBLY_USAGE_OCCURRENCE
+ * and no CONTEXT_DEPENDENT_SHAPE_REPRESENTATION anywhere, all of its bodies
+ * named individually inside one child representation, and the relationships
+ * binding that child written in BOTH argument orders.
+ *
+ * #500 is the (product rep, detail rep) order every other fixture here uses.
+ * #701/#702/#703 are the same kind of relation written the other way round --
+ * the shape that made the whole model 308 walk roots and placed every body
+ * once per root, all of them sharing two occurrence paths. Three inverted
+ * edges is enough: it takes only one to make the SDR-bound representation a
+ * child, and the third proves the multiplier is the count of them. */
+FILE_DESCRIPTION ('AP214 inverted-SRR multibody / occurrence-identity test fixture','2;1');
+FILE_NAME('ap214-inverted-srr-multibody','2026-01-01T00:00:00',('test'),('bldrs'),'','','');
+FILE_SCHEMA(('AUTOMOTIVE_DESIGN { 1 0 10303 214 1 1 1 1 }'));
+ENDSEC;
+DATA;
+#1 = APPLICATION_PROTOCOL_DEFINITION('international standard','automotive_design',2010,#2);
+#2 = APPLICATION_CONTEXT('mechanical design');
+#10 = CARTESIAN_POINT('',(0.,0.,0.));
+#11 = CARTESIAN_POINT('',(1.,0.,0.));
+#20 = DIRECTION('',(0.,0.,1.));
+#21 = DIRECTION('',(1.,0.,0.));
+#30 = AXIS2_PLACEMENT_3D('',#10,#20,#21);
+#100 = ( GEOMETRIC_REPRESENTATION_CONTEXT(3) GLOBAL_UNCERTAINTY_ASSIGNED_CONTEXT((#104)) GLOBAL_UNIT_ASSIGNED_CONTEXT((#101,#102,#103)) REPRESENTATION_CONTEXT('Context','3D') );
+#101 = ( LENGTH_UNIT() NAMED_UNIT(*) SI_UNIT(.MILLI.,.METRE.) );
+#102 = ( NAMED_UNIT(*) PLANE_ANGLE_UNIT() SI_UNIT($,.RADIAN.) );
+#103 = ( NAMED_UNIT(*) SI_UNIT($,.STERADIAN.) SOLID_ANGLE_UNIT() );
+#104 = UNCERTAINTY_MEASURE_WITH_UNIT(LENGTH_MEASURE(1.E-07),#101,'','');
+#201 = PRODUCT_CONTEXT('',#2,'mechanical');
+#202 = PRODUCT_DEFINITION_CONTEXT('part definition',#2,'design');
+#210 = PRODUCT('Document','Document','',(#201));
+#211 = PRODUCT_DEFINITION_FORMATION('','',#210);
+#212 = PRODUCT_DEFINITION('design','',#211,#202);
+#300 = SHAPE_REPRESENTATION('Document',(#30),#100);
+#301 = PRODUCT_DEFINITION_SHAPE('','',#212);
+#302 = SHAPE_DEFINITION_REPRESENTATION(#301,#300);
+#400 = ADVANCED_BREP_SHAPE_REPRESENTATION('brep_rep_0',(#401,#402,#403),#100);
+#401 = MANIFOLD_SOLID_BREP('brep_0',#411);
+#402 = MANIFOLD_SOLID_BREP('brep_1',#412);
+#403 = MANIFOLD_SOLID_BREP('Hauptkoerper',#413);
+#411 = CLOSED_SHELL('',());
+#412 = CLOSED_SHELL('',());
+#413 = CLOSED_SHELL('',());
+#500 = SHAPE_REPRESENTATION_RELATIONSHIP('','',#300,#400);
+#601 = GEOMETRICALLY_BOUNDED_WIREFRAME_SHAPE_REPRESENTATION('wireframe_rep_0',(#611),#100);
+#602 = GEOMETRICALLY_BOUNDED_WIREFRAME_SHAPE_REPRESENTATION('wireframe_rep_1',(#612),#100);
+#603 = GEOMETRICALLY_BOUNDED_WIREFRAME_SHAPE_REPRESENTATION('wireframe_rep_2',(#613),#100);
+#611 = GEOMETRIC_CURVE_SET('curves_0',(#11));
+#612 = GEOMETRIC_CURVE_SET('curves_1',(#11));
+#613 = GEOMETRIC_CURVE_SET('curves_2',(#11));
+#701 = SHAPE_REPRESENTATION_RELATIONSHIP('','',#601,#300);
+#702 = SHAPE_REPRESENTATION_RELATIONSHIP('','',#602,#300);
+#703 = SHAPE_REPRESENTATION_RELATIONSHIP('','',#603,#300);
+ENDSEC;
+END-ISO-10303-21;

--- a/src/utils/occurrencePaths.js
+++ b/src/utils/occurrencePaths.js
@@ -50,10 +50,15 @@ export function occurrencePathsEqual(a, b) {
  * occurrence path — its child count decides whether the scene resolution
  * needs the descendant prefix scan (assembly) or the exact-key lookup (leaf).
  *
- * Ephemeral solid nodes are skipped: a multibody part's solids share the
- * part's occurrence path (they are not occurrences themselves — their
- * identity is (path, solid expressID)), so a path-only lookup must land on
- * the product node, never one of its bodies.
+ * A product node wins over an ephemeral solid node carrying the same path.
+ * Since conway#628 an individually addressable body ends its path with its
+ * own express id, so its path is strictly deeper than its part's and the two
+ * can't collide — but a pre-#628 cache artifact still holds solid nodes whose
+ * path IS the part's, and there the product node is the answer (their identity
+ * was the (path, solid expressID) pair, so a path-only lookup can't name one
+ * body). The ephemeral fallback is what makes a #628 body reachable: with the
+ * body's own segment on the path, this lookup lands ON the solid node and the
+ * scene pick / permalink resolve it as the selection.
  *
  * @param {object|null|undefined} rootNode spatial-structure root element
  * @param {Array<number>|null|undefined} path NAUO express ids, root→leaf
@@ -65,11 +70,14 @@ export function findNodeByOccurrencePath(rootNode, path) {
   }
   const target = occurrencePathKey(path)
   const stack = [rootNode]
+  let ephemeralMatch = null
   while (stack.length > 0) {
     const node = stack.pop()
-    if (node.ephemeral !== true &&
-        Array.isArray(node.occurrencePath) && occurrencePathKey(node.occurrencePath) === target) {
-      return node
+    if (Array.isArray(node.occurrencePath) && occurrencePathKey(node.occurrencePath) === target) {
+      if (node.ephemeral !== true) {
+        return node
+      }
+      ephemeralMatch = ephemeralMatch ?? node
     }
     if (Array.isArray(node.children)) {
       for (const child of node.children) {
@@ -79,7 +87,174 @@ export function findNodeByOccurrencePath(rootNode, path) {
       }
     }
   }
-  return null
+  return ephemeralMatch
+}
+
+
+/**
+ * Resolve a scene pick to the tree identity Share selects: which express id
+ * becomes the selection, and whether it names one body (solid) of a part
+ * rather than the part itself. Pure — the caller supplies the tree, the
+ * pick's (trimmed) occurrence path and its `PlacedGeometry.geometryExpressID`,
+ * plus a probe for how many instances sit at a path.
+ *
+ * Three shapes, in the order they're tried:
+ *
+ * 1. **The path names the body** (conway#628). An individually addressable
+ *    body ends its occurrence path with its own express id, so the trimmed
+ *    path lands directly on the `type:'solid'` node — nothing to search. This
+ *    is the whole no-NAUO multibody case (BLSN_007: one product, 2,268 named
+ *    bodies), where the part-level fallback would select the boat.
+ * 2. **The path names the part, a solid child matches the geometry id.**
+ *    Pre-#628 engines and cache artifacts key a body as the (path, solid
+ *    expressID) pair, so the body is found among the node's children.
+ * 3. **Anonymous piece of a multi-piece part** (conway#387): no tree node
+ *    exists, but (path, geometry id) is a complete identity — select it as a
+ *    solid and let the caller materialize a transient NavTree row. The
+ *    >1-instance guard keeps single-solid parts (as1's nut, the NEMA screws)
+ *    on the part-level selection, where the part node IS the piece.
+ *
+ * @param {object} args
+ * @param {object|null|undefined} args.rootNode spatial-structure root element
+ * @param {Array<number>} args.occurrencePath tree-trimmed occurrence path
+ * @param {number|null} args.pickedGeometryId the instance's own geometry
+ *   (solid) express id, null when the engine/cache carries none
+ * @param {number} args.parentExpressId the geometry-owner product id, the
+ *   fallback selection when the pick resolves to no body
+ * @param {Function} args.instanceCountAtPath `(path) => number` instances
+ *   placed exactly at a path (no descendants); only case 3 calls it
+ * @return {object} `{targetId, solidExpressId, transientGeometryId}` — a
+ *   non-null `transientGeometryId` asks the caller to materialize a transient
+ *   NavTree row for that piece
+ */
+export function resolvePickedOccurrenceNode({
+  rootNode, occurrencePath, pickedGeometryId, parentExpressId, instanceCountAtPath,
+}) {
+  const partLevel = {targetId: parentExpressId, solidExpressId: null, transientGeometryId: null}
+  if (!Array.isArray(occurrencePath) || occurrencePath.length === 0) {
+    return partLevel
+  }
+  const pathNode = findNodeByOccurrencePath(rootNode, occurrencePath)
+  if (!pathNode) {
+    return partLevel
+  }
+  if (pathNode.ephemeral === true) {
+    return {targetId: pathNode.expressID, solidExpressId: pathNode.expressID, transientGeometryId: null}
+  }
+  if (pickedGeometryId === null) {
+    return partLevel
+  }
+  const solidNode = pathNode.children?.find?.(
+    (child) => child.ephemeral === true && child.expressID === pickedGeometryId)
+  if (solidNode) {
+    return {targetId: solidNode.expressID, solidExpressId: solidNode.expressID, transientGeometryId: null}
+  }
+  if (instanceCountAtPath(occurrencePath) > 1) {
+    return {
+      targetId: pickedGeometryId,
+      solidExpressId: pickedGeometryId,
+      transientGeometryId: pickedGeometryId,
+    }
+  }
+  return partLevel
+}
+
+
+/**
+ * The element-path ids a permalink encodes for one occurrence selection —
+ * `[rootExpressID, ...occurrencePath]`, plus the solid's express id when the
+ * path doesn't already end with it.
+ *
+ * The conditional tail is the conway#628 seam: a body addressable in its own
+ * right carries its express id as the path's last segment, so appending it
+ * again would mint `/1020254/367733/367733` and the resolver would read the
+ * repeat as an anonymous piece under the body. A pre-#628 solid (which shares
+ * its part's path) still needs the extra segment — that pairing is the only
+ * thing that tells "the part" from "one body inside it" there.
+ * `resolveElementPathOccurrence` is the inverse.
+ *
+ * @param {number} rootExpressID the tree root's express id (paths omit it)
+ * @param {Array<number>} occurrencePath NAUO express ids, root→leaf
+ * @param {number|null} [solidExpressId] selected solid (body), if any
+ * @return {Array<number>} element-path ids below the model file
+ */
+export function occurrenceElementPathIds(rootExpressID, occurrencePath, solidExpressId = null) {
+  const ids = [rootExpressID, ...occurrencePath]
+  if (solidExpressId !== null && ids[ids.length - 1] !== solidExpressId) {
+    ids.push(solidExpressId)
+  }
+  return ids
+}
+
+
+/**
+ * Resolve a permalink's element-path ids (below the root) back to the
+ * occurrence selection that wrote them — the inverse of
+ * `occurrenceElementPathIds`. Pure; the caller supplies the tree and a probe
+ * for whether a geometry piece exists under a path.
+ *
+ * Returns `occurrencePath: null` when the tree doesn't know these ids at all
+ * (IFC, a hand-trimmed URL, a pre-occurrence permalink), which is the
+ * caller's signal to keep the legacy scalar-id selection.
+ *
+ * @param {object} args
+ * @param {object|null|undefined} args.rootNode spatial-structure root element
+ * @param {Array<number>} args.eltPathIds element-path ids below the root
+ * @param {Function} args.hasGeometryAtPath `(path, geometryExpressId) =>
+ *   boolean`, true when the instance map holds that piece under that path
+ * @return {object} `{node, occurrencePath, solidExpressId,
+ *   transientGeometryId}` — all null when the path resolves to nothing
+ */
+export function resolveElementPathOccurrence({rootNode, eltPathIds, hasGeometryAtPath}) {
+  const none = {node: null, occurrencePath: null, solidExpressId: null, transientGeometryId: null}
+  if (!Array.isArray(eltPathIds) || eltPathIds.length === 0) {
+    return none
+  }
+  const node = findNodeByOccurrencePath(rootNode, eltPathIds)
+  if (node) {
+    // A conway#628 body IS the path's last segment, so the node found here can
+    // be the solid itself; its express id is what narrows the scene highlight
+    // and keys the per-body hide.
+    return {
+      node,
+      occurrencePath: eltPathIds,
+      solidExpressId: node.ephemeral === true ? node.expressID : null,
+      transientGeometryId: null,
+    }
+  }
+  // Pre-#628 solid / anonymous piece: the writer appended the piece's express
+  // id below its parent part's occurrence path, so try the prefix as the path
+  // and the trailing id as a body under it.
+  const minSegmentsForSolid = 2
+  if (eltPathIds.length < minSegmentsForSolid) {
+    return none
+  }
+  const parentPathIds = eltPathIds.slice(0, -1)
+  const targetId = eltPathIds[eltPathIds.length - 1]
+  const parentNode = findNodeByOccurrencePath(rootNode, parentPathIds)
+  if (!parentNode) {
+    return none
+  }
+  const solidNode = parentNode.children?.find?.(
+    (child) => child.ephemeral === true && child.expressID === targetId)
+  if (solidNode) {
+    return {
+      node: parentNode, occurrencePath: parentPathIds,
+      solidExpressId: targetId, transientGeometryId: null,
+    }
+  }
+  if (hasGeometryAtPath(parentPathIds, targetId)) {
+    // Anonymous-geometry permalink (conway#387): the trailing id names no tree
+    // node, but the instance map holds geometry with that id under the parent
+    // path — the piece exists, it just has no in-file identity beyond its
+    // express id. The transient row makes the tree show what the URL
+    // addressed.
+    return {
+      node: parentNode, occurrencePath: parentPathIds,
+      solidExpressId: targetId, transientGeometryId: targetId,
+    }
+  }
+  return none
 }
 
 

--- a/src/utils/occurrencePaths.js
+++ b/src/utils/occurrencePaths.js
@@ -50,15 +50,21 @@ export function occurrencePathsEqual(a, b) {
  * occurrence path — its child count decides whether the scene resolution
  * needs the descendant prefix scan (assembly) or the exact-key lookup (leaf).
  *
- * A product node wins over an ephemeral solid node carrying the same path.
- * Since conway#628 an individually addressable body ends its path with its
- * own express id, so its path is strictly deeper than its part's and the two
- * can't collide — but a pre-#628 cache artifact still holds solid nodes whose
- * path IS the part's, and there the product node is the answer (their identity
- * was the (path, solid expressID) pair, so a path-only lookup can't name one
- * body). The ephemeral fallback is what makes a #628 body reachable: with the
- * body's own segment on the path, this lookup lands ON the solid node and the
- * scene pick / permalink resolve it as the selection.
+ * The ephemeral fallback is what makes a conway#628 body reachable: a body
+ * ends its path with its own express id, so this lookup lands ON the solid
+ * node and the scene pick / permalink resolve it as the selection.
+ *
+ * A product node still wins over an ephemeral solid node carrying the *same*
+ * path — the pre-#628 shape, where a body's identity was the (path, solid
+ * expressID) pair and a path-only lookup therefore couldn't name one body.
+ * No shipped producer feeds that shape to this code today: the engine no
+ * longer emits it, and a cache artifact written by one that did is
+ * unreachable because `BLDRS_GLB_SCHEMA_VERSION` is part of the artifact
+ * FILENAME (`glbCacheKey.glbArtifactPath`), so an old artifact is never
+ * opened, only missed. The preference is kept as defence against
+ * engine/schema lockstep drift — a tree from *any* GLB reaches
+ * `newGltfLoader`'s extension readers, cache lookup or not (`Loader.js`) —
+ * and it costs one branch.
  *
  * @param {object|null|undefined} rootNode spatial-structure root element
  * @param {Array<number>|null|undefined} path NAUO express ids, root→leaf
@@ -167,10 +173,14 @@ export function resolvePickedOccurrenceNode({
  *
  * The conditional tail is the conway#628 seam: a body addressable in its own
  * right carries its express id as the path's last segment, so appending it
- * again would mint `/1020254/367733/367733` and the resolver would read the
- * repeat as an anonymous piece under the body. A pre-#628 solid (which shares
- * its part's path) still needs the extra segment — that pairing is the only
- * thing that tells "the part" from "one body inside it" there.
+ * again would mint `/1020254/367733/367733`. That URL is not fatal — the
+ * inverse resolver reads the repeat through the conway#387 anonymous-piece
+ * branch and still lands the selection on the body — but it registers a
+ * transient row for a piece that already has a tree node, so keep the URL a
+ * body's canonical one. The extra segment is still required wherever a piece
+ * shares its owner's path: an anonymous piece (which has no node at all), and
+ * a pre-#628 solid, where the (path, expressID) pairing is the only thing
+ * that tells "the part" from "one body inside it".
  * `resolveElementPathOccurrence` is the inverse.
  *
  * @param {number} rootExpressID the tree root's express id (paths omit it)

--- a/src/utils/occurrencePaths.test.js
+++ b/src/utils/occurrencePaths.test.js
@@ -81,10 +81,12 @@ describe('utils/occurrencePaths', () => {
     })
 
     it('prefers the product over an ephemeral solid sharing its path (pre-conway#628)', () => {
-      // A pre-#628 engine / cache artifact keys a body as the (path, solid
-      // expressID) pair, so its solids share the part's occurrence path and a
-      // path-only lookup cannot name one body — it must return the product
-      // node, whichever order the DFS happens to pop them in.
+      // The pre-#628 shape, kept as a defensive invariant rather than a live
+      // compatibility path (no shipped producer reaches this code — see the
+      // function's docstring): a body keyed as the (path, solid expressID)
+      // pair shares the part's occurrence path, so a path-only lookup cannot
+      // name one body and must return the product node, whichever order the
+      // DFS happens to pop them in.
       const solidA = {expressID: 250, occurrencePath: [10], ephemeral: true, children: []}
       const part = {expressID: 10, occurrencePath: [10], children: [solidA]}
       const solidTree = {expressID: 1, occurrencePath: [], children: [part]}
@@ -230,8 +232,10 @@ describe('utils/occurrencePaths', () => {
 
     it('round-trips a conway#628 body without repeating its segment', () => {
       // The body's express id is already the path's last segment; appending it
-      // again would mint /1020254/367733/367733, which reads back as an
-      // anonymous piece UNDER the body and resolves to nothing.
+      // again would mint /1020254/367733/367733, which reads back through the
+      // conway#387 anonymous-piece branch — the selection still lands on the
+      // body, but a transient "piece" row gets registered for something that
+      // already has a tree node. The canonical URL has no repeat.
       const tree = makeNoNauoMultibodyTree()
       const ids = occurrenceElementPathIds(ROOT_ID, [367733], 367733)
       expect(ids).toEqual([ROOT_ID, 367733])

--- a/src/utils/occurrencePaths.test.js
+++ b/src/utils/occurrencePaths.test.js
@@ -1,11 +1,40 @@
 /* eslint-disable no-magic-numbers */
 import {
   findNodeByOccurrencePath,
+  occurrenceElementPathIds,
   occurrencePathKey,
   occurrencePathKeySetForTree,
   occurrencePathsEqual,
+  resolveElementPathOccurrence,
+  resolvePickedOccurrenceNode,
   trimToTreeOccurrencePath,
 } from './occurrencePaths'
+
+
+/**
+ * The BLSN_007 shape (test-models-private#98, conway#628) in miniature: ONE
+ * product ('Document'), zero NAUOs, and named bodies whose occurrence path is
+ * just their own express id. The geometry side stamps the same paths, so the
+ * path alone is the selection key — there is no NAUO to disambiguate with.
+ *
+ * @return {object} spatial-structure root with two solid children
+ */
+function makeNoNauoMultibodyTree() {
+  const bodyA = {
+    expressID: 367733, type: 'solid', Name: {value: 'brep_1'},
+    productDefinitionExpressID: 1020254, occurrencePath: [367733],
+    ephemeral: true, children: [],
+  }
+  const bodyB = {
+    expressID: 367891, type: 'solid', Name: {value: 'brep_2'},
+    productDefinitionExpressID: 1020254, occurrencePath: [367891],
+    ephemeral: true, children: [],
+  }
+  return {
+    expressID: 1020254, type: 'product', Name: {value: 'Document'},
+    occurrencePath: [], children: [bodyA, bodyB],
+  }
+}
 
 
 describe('utils/occurrencePaths', () => {
@@ -51,15 +80,25 @@ describe('utils/occurrencePaths', () => {
       expect(findNodeByOccurrencePath(tree, [11])).toBe(tree.children[1])
     })
 
-    it('skips ephemeral solid nodes — a path-only lookup lands on the product', () => {
-      // A multibody part's solids share the part's occurrence path (their
-      // identity is (path, solid expressID)), and getVisibleNodes renders
-      // them BEFORE deeper siblings a DFS might pop first — the lookup must
-      // always return the product node, never one of its bodies.
+    it('prefers the product over an ephemeral solid sharing its path (pre-conway#628)', () => {
+      // A pre-#628 engine / cache artifact keys a body as the (path, solid
+      // expressID) pair, so its solids share the part's occurrence path and a
+      // path-only lookup cannot name one body — it must return the product
+      // node, whichever order the DFS happens to pop them in.
       const solidA = {expressID: 250, occurrencePath: [10], ephemeral: true, children: []}
       const part = {expressID: 10, occurrencePath: [10], children: [solidA]}
       const solidTree = {expressID: 1, occurrencePath: [], children: [part]}
       expect(findNodeByOccurrencePath(solidTree, [10])).toBe(part)
+    })
+
+    it('lands ON the solid node when the path names a body (conway#628)', () => {
+      // The no-NAUO multibody shape: a body's path ends with its own express
+      // id, so it is the only node carrying that path. Returning null here
+      // (the pre-#628 ephemeral skip) is what left a BLSN_007 pick resolving
+      // to the product — every body selecting the whole boat.
+      const bodyTree = makeNoNauoMultibodyTree()
+      expect(findNodeByOccurrencePath(bodyTree, [367733])).toBe(bodyTree.children[0])
+      expect(findNodeByOccurrencePath(bodyTree, [367891])).toBe(bodyTree.children[1])
     })
 
     it('returns null for unknown paths, empty paths, and missing roots', () => {
@@ -94,9 +133,169 @@ describe('utils/occurrencePaths', () => {
       expect(occurrencePathKeySetForTree(undefined)).toBeNull()
     })
 
+    it('includes solid nodes\' body paths, so a picked body trims to itself', () => {
+      // conway#628: the geometry stamps [bodyId] and the tree carries the same
+      // key, so trimToTreeOccurrencePath must pass a body path through intact.
+      // Were solid nodes excluded from this set, the trim would walk up to the
+      // (empty, root) path and the pick would degrade to type-level.
+      const bodyTree = makeNoNauoMultibodyTree()
+      const keys = occurrencePathKeySetForTree(bodyTree)
+      expect(keys).toEqual(new Set(['367733', '367891']))
+      expect(trimToTreeOccurrencePath([367733], keys)).toEqual([367733])
+    })
+
     it('returns an empty set for an IFC-style tree with no occurrence paths', () => {
       const ifcTree = {expressID: 1, children: [{expressID: 2, children: []}]}
       expect(occurrencePathKeySetForTree(ifcTree).size).toBe(0)
+    })
+  })
+
+  describe('resolvePickedOccurrenceNode', () => {
+    // The pick reports the geometry's owner (the product_definition_shape),
+    // which is what the selection degrades to when no body resolves.
+    const PDS_ID = 1020254
+
+    /**
+     * @param {object} args see resolvePickedOccurrenceNode
+     * @return {object} resolution
+     */
+    function resolve({rootNode, occurrencePath, pickedGeometryId, instanceCount = 1}) {
+      return resolvePickedOccurrenceNode({
+        rootNode,
+        occurrencePath,
+        pickedGeometryId,
+        parentExpressId: PDS_ID,
+        instanceCountAtPath: () => instanceCount,
+      })
+    }
+
+    it('selects the picked body of a no-NAUO multibody model (conway#628)', () => {
+      // BLSN_007: the picked instance's path IS the body, so the selection is
+      // the body's own express id — that is what the Properties panel reads
+      // and what the NavTree row highlight keys on. Falling back to
+      // parentExpressId here is the reported bug (every part one selection).
+      const tree = makeNoNauoMultibodyTree()
+      expect(resolve({rootNode: tree, occurrencePath: [367733], pickedGeometryId: 367733}))
+        .toEqual({targetId: 367733, solidExpressId: 367733, transientGeometryId: null})
+      expect(resolve({rootNode: tree, occurrencePath: [367891], pickedGeometryId: 367891}))
+        .toEqual({targetId: 367891, solidExpressId: 367891, transientGeometryId: null})
+    })
+
+    it('selects a body whose path the tree knows even with no geometry id', () => {
+      // The path is the whole key since conway#628, so a pick that carries no
+      // PlacedGeometry.geometryExpressID (older cache artifact) still resolves.
+      const tree = makeNoNauoMultibodyTree()
+      expect(resolve({rootNode: tree, occurrencePath: [367891], pickedGeometryId: null}))
+        .toEqual({targetId: 367891, solidExpressId: 367891, transientGeometryId: null})
+    })
+
+    it('selects a pre-conway#628 solid child by its geometry id', () => {
+      // Solids sharing the part's path: the geometry id picks the body out of
+      // the part node's children.
+      const solid = {expressID: 250, occurrencePath: [10], ephemeral: true, children: []}
+      const part = {expressID: 10, occurrencePath: [10], children: [solid]}
+      const tree = {expressID: 1, occurrencePath: [], children: [part]}
+      expect(resolve({rootNode: tree, occurrencePath: [10], pickedGeometryId: 250}))
+        .toEqual({targetId: 250, solidExpressId: 250, transientGeometryId: null})
+    })
+
+    it('materializes an anonymous piece of a multi-piece part (conway#387)', () => {
+      const part = {expressID: 10, occurrencePath: [10], children: []}
+      const tree = {expressID: 1, occurrencePath: [], children: [part]}
+      expect(resolve({
+        rootNode: tree, occurrencePath: [10], pickedGeometryId: 6321, instanceCount: 4,
+      })).toEqual({targetId: 6321, solidExpressId: 6321, transientGeometryId: 6321})
+    })
+
+    it('stays part-level for a single-solid part, and for an unknown path', () => {
+      // One instance at the path → the part node IS the piece (as1's nut).
+      const part = {expressID: 10, occurrencePath: [10], children: []}
+      const tree = {expressID: 1, occurrencePath: [], children: [part]}
+      const partLevel = {targetId: PDS_ID, solidExpressId: null, transientGeometryId: null}
+      expect(resolve({
+        rootNode: tree, occurrencePath: [10], pickedGeometryId: 6321, instanceCount: 1,
+      })).toEqual(partLevel)
+      // No tree node for the path (IFC, engine skew) and no path at all.
+      expect(resolve({rootNode: tree, occurrencePath: [99], pickedGeometryId: 6321}))
+        .toEqual(partLevel)
+      expect(resolve({rootNode: tree, occurrencePath: null, pickedGeometryId: 6321}))
+        .toEqual(partLevel)
+    })
+  })
+
+  describe('occurrenceElementPathIds / resolveElementPathOccurrence', () => {
+    const ROOT_ID = 1020254
+    /** @return {boolean} no anonymous geometry in these trees */
+    const noGeometry = () => false
+
+    it('round-trips a conway#628 body without repeating its segment', () => {
+      // The body's express id is already the path's last segment; appending it
+      // again would mint /1020254/367733/367733, which reads back as an
+      // anonymous piece UNDER the body and resolves to nothing.
+      const tree = makeNoNauoMultibodyTree()
+      const ids = occurrenceElementPathIds(ROOT_ID, [367733], 367733)
+      expect(ids).toEqual([ROOT_ID, 367733])
+      const resolved = resolveElementPathOccurrence({
+        rootNode: tree, eltPathIds: ids.slice(1), hasGeometryAtPath: noGeometry,
+      })
+      expect(resolved.occurrencePath).toEqual([367733])
+      expect(resolved.solidExpressId).toBe(367733)
+      expect(resolved.node).toBe(tree.children[0])
+    })
+
+    it('round-trips a pre-conway#628 solid, which needs its own segment', () => {
+      const solid = {expressID: 250, occurrencePath: [10], ephemeral: true, children: []}
+      const part = {expressID: 10, occurrencePath: [10], children: [solid]}
+      const tree = {expressID: 1, occurrencePath: [], children: [part]}
+      const ids = occurrenceElementPathIds(1, [10], 250)
+      expect(ids).toEqual([1, 10, 250])
+      const resolved = resolveElementPathOccurrence({
+        rootNode: tree, eltPathIds: ids.slice(1), hasGeometryAtPath: noGeometry,
+      })
+      expect(resolved.occurrencePath).toEqual([10])
+      expect(resolved.solidExpressId).toBe(250)
+      expect(resolved.node).toBe(part)
+    })
+
+    it('round-trips a whole occurrence (no solid selected)', () => {
+      const leaf = {expressID: 20, occurrencePath: [10, 20], children: []}
+      const mid = {expressID: 10, occurrencePath: [10], children: [leaf]}
+      const tree = {expressID: 1, occurrencePath: [], children: [mid]}
+      const ids = occurrenceElementPathIds(1, [10, 20], null)
+      expect(ids).toEqual([1, 10, 20])
+      const resolved = resolveElementPathOccurrence({
+        rootNode: tree, eltPathIds: ids.slice(1), hasGeometryAtPath: noGeometry,
+      })
+      expect(resolved).toEqual({
+        node: leaf, occurrencePath: [10, 20], solidExpressId: null, transientGeometryId: null,
+      })
+    })
+
+    it('resolves an anonymous piece via the instance-map probe (conway#387)', () => {
+      const part = {expressID: 10, occurrencePath: [10], children: []}
+      const tree = {expressID: 1, occurrencePath: [], children: [part]}
+      const probe = jest.fn((path, geometryExpressId) =>
+        occurrencePathKey(path) === '10' && geometryExpressId === 6321)
+      const resolved = resolveElementPathOccurrence({
+        rootNode: tree, eltPathIds: [10, 6321], hasGeometryAtPath: probe,
+      })
+      expect(resolved).toEqual({
+        node: part, occurrencePath: [10], solidExpressId: 6321, transientGeometryId: 6321,
+      })
+      expect(probe).toHaveBeenCalledWith([10], 6321)
+    })
+
+    it('yields a null path for ids the tree does not know (IFC / trimmed URL)', () => {
+      const tree = makeNoNauoMultibodyTree()
+      expect(resolveElementPathOccurrence({
+        rootNode: tree, eltPathIds: [42], hasGeometryAtPath: noGeometry,
+      }).occurrencePath).toBeNull()
+      expect(resolveElementPathOccurrence({
+        rootNode: tree, eltPathIds: [], hasGeometryAtPath: noGeometry,
+      }).occurrencePath).toBeNull()
+      expect(resolveElementPathOccurrence({
+        rootNode: null, eltPathIds: [367733], hasGeometryAtPath: noGeometry,
+      }).occurrencePath).toBeNull()
     })
   })
 

--- a/src/viewer/ShareViewer.js
+++ b/src/viewer/ShareViewer.js
@@ -1090,10 +1090,11 @@ export class ShareViewer {
    *   needs the prefix scan).
    * @param {number|null} [opts.geometryExpressId] When set, keep only
    *   instances whose `PlacedGeometry.geometryExpressID` matches — the join
-   *   for the NavTree's ephemeral solid nodes. Load-bearing wherever a body
-   *   shares its part's occurrence path: a pre-conway#628 engine or cache
-   *   artifact, and an anonymous piece with no node of its own. Redundant
-   *   (but harmless) for a #628 body, whose path ends with this same id.
+   *   for the NavTree's ephemeral solid nodes. Load-bearing wherever a piece
+   *   shares its part's occurrence path — today that is an anonymous piece
+   *   with no node of its own (conway#387), and it was every solid of a
+   *   multibody part before conway#628. Redundant (but harmless) for a #628
+   *   body, whose path ends with this same id.
    *   Null (the default) keeps every instance at/under the path.
    * @return {number[]} synthetic instance ids (empty when none)
    */

--- a/src/viewer/ShareViewer.js
+++ b/src/viewer/ShareViewer.js
@@ -1090,10 +1090,11 @@ export class ShareViewer {
    *   needs the prefix scan).
    * @param {number|null} [opts.geometryExpressId] When set, keep only
    *   instances whose `PlacedGeometry.geometryExpressID` matches — the join
-   *   for the NavTree's ephemeral solid nodes: a multibody part's solids all
-   *   share the part's occurrence path, and the solid's own express id is
-   *   what narrows the selection to the one clicked body. Null (the default)
-   *   keeps every instance at/under the path.
+   *   for the NavTree's ephemeral solid nodes. Load-bearing wherever a body
+   *   shares its part's occurrence path: a pre-conway#628 engine or cache
+   *   artifact, and an anonymous piece with no node of its own. Redundant
+   *   (but harmless) for a #628 body, whose path ends with this same id.
+   *   Null (the default) keeps every instance at/under the path.
    * @return {number[]} synthetic instance ids (empty when none)
    */
   getInstanceIdsForOccurrencePath(

--- a/src/viewer/ShareViewer.js
+++ b/src/viewer/ShareViewer.js
@@ -38,6 +38,7 @@ import {occurrencePathKey} from '../utils/occurrencePaths'
 import {modelHasCapability} from './ShareModel'
 import {isFeatureEnabled} from '../FeatureFlags'
 import {
+  applyBatchedInstancePreselection,
   applyBatchedInstanceSelection,
   applyBatchedPreselection,
   applyBatchedSelection,
@@ -1565,16 +1566,34 @@ export class ShareViewer {
       // a click would select.
       this._setConwayPreselectionFromHit(found.object, found.faceIndex)
     } else if (modelHasCapability(model, 'batchedPicking')) {
-      // BatchedMesh render path: recolor the hovered product's instances in
-      // place (setColorAt). Coexists with — and paints over — the selection
-      // recolor; cleared on cursor-leave by `_clearPreselectionForAllModels`.
-      // Dedup on the resolved id: `highlightIfcItem` fires per animation frame
-      // while the cursor rests, and a repaint re-uploads the colours texture —
-      // skip when the hovered product hasn't changed.
-      if (id !== this._lastBatchedPreselectId) {
-        this._lastBatchedPreselectId = id
+      // BatchedMesh render path: recolor in place (setColorAt). Coexists with
+      // — and paints over — the selection recolor; cleared on cursor-leave by
+      // `_clearPreselectionForAllModels`.
+      //
+      // Prefer the hovered INSTANCE (its global occurrence id, straight off
+      // the hit's batchId — the same table the click funnel reads) over its
+      // parent product. Parent-level hover paints every instance sharing that
+      // `instanceParents` entry, which for a no-NAUO multibody STEP is the
+      // whole model: hovering one body of BLSN_007 turned the entire hull
+      // cyan (test-models-private#98). Falls back to the parent for models
+      // whose batches carry no occurrence table (IFC, older cached batched
+      // artifacts), where product-level hover is the correct granularity.
+      //
+      // Dedup: `highlightIfcItem` fires per animation frame while the cursor
+      // rests and a repaint re-uploads the colours texture, so skip when the
+      // hovered thing hasn't changed. The key must be the instance whenever
+      // we highlight per instance — every body of a no-NAUO product shares
+      // one parent id, so a parent-keyed dedup would pin the highlight to
+      // whichever body was hovered first.
+      const hovered = this._batchedHoverTarget(found)
+      if (hovered.key !== this._lastBatchedPreselectKey) {
+        this._lastBatchedPreselectKey = hovered.key
         const preMat = this.selector.getPreselectionMaterial()
-        applyBatchedPreselection(model, [id], preMat?.color)
+        if (hovered.occurrenceId !== null) {
+          applyBatchedInstancePreselection(model, [hovered.occurrenceId], preMat?.color)
+        } else {
+          applyBatchedPreselection(model, [id], preMat?.color)
+        }
       }
     } else if (modelHasCapability(model, 'ifcSubsets')) {
       // Real-IFC path: web-ifc-three's preselection.pick handles
@@ -1605,6 +1624,35 @@ export class ShareViewer {
 
 
   /**
+   * Resolve a BatchedMesh raycast hit to what the hover highlight should
+   * paint: the instance's global occurrence id when its batch carries the
+   * table, else null (parent-level hover). `key` is the dedup key for the
+   * per-frame hover throttle — namespaced by mode so the two id spaces
+   * (occurrence ids and parent express ids) can't alias each other.
+   *
+   * O(1) per mouse-move: one typed-array index, no traversal. Deliberately
+   * reads the hit's own `batchId` rather than re-deriving it, since
+   * `getPickedItemId` already proved it in range on this same hit.
+   *
+   * @param {object} found raycaster hit (`object`, `batchId`)
+   * @return {object} `{occurrenceId, key}` — occurrenceId null when unknown
+   * @private
+   */
+  _batchedHoverTarget(found) {
+    const mesh = found?.object
+    const batchId = found?.batchId
+    if (!mesh?.isBatchedMesh || batchId === undefined || batchId < 0) {
+      return {occurrenceId: null, key: undefined}
+    }
+    const occurrenceId = mesh.instanceOccurrenceIds?.[batchId]
+    if (occurrenceId === undefined) {
+      return {occurrenceId: null, key: `p:${mesh.instanceParents?.[batchId]}`}
+    }
+    return {occurrenceId, key: `o:${occurrenceId}`}
+  }
+
+
+  /**
    * Drop any per-model preselection subset when the cursor leaves
    * all geometry. Mirrors what `selector.togglePreselectionVisibility(false)`
    * does for the real-IFC path — preselection is hover-only and
@@ -1629,8 +1677,8 @@ export class ShareViewer {
     // logic stays in one place instead of being split between
     // ShareViewer (Conway) and each model's `removeSubset` (legacy).
     this._clearConwayPreselectionSubsets()
-    // Reset the batched hover-dedup so re-entering the same product repaints.
-    this._lastBatchedPreselectId = undefined
+    // Reset the batched hover-dedup so re-entering the same instance repaints.
+    this._lastBatchedPreselectKey = undefined
     const models = this.IFC?.context?.items?.ifcModels
     if (!Array.isArray(models)) {
       return

--- a/src/viewer/ShareViewer.test.js
+++ b/src/viewer/ShareViewer.test.js
@@ -30,8 +30,9 @@ jest.mock('three', () => jest.requireActual('three'))
 // before `./ShareViewer` resolves those deps. The hoisted
 // `jest.mock('three', requireActual)` above still wins for three.
 import '../../__mocks__/shareViewerTestHarness'
-import {BufferAttribute, BufferGeometry, Group, Mesh, Scene} from 'three'
+import {BufferAttribute, BufferGeometry, Color, Group, Mesh, Scene} from 'three'
 import {ShareViewer} from './ShareViewer'
+import {flatMeshToBatchedModel} from './ifc/flatMeshToBatchedModel'
 import {instanceMapFromGeometry, instanceMapFromOrderedPlacedRanges} from './ifc/IfcInstanceMap'
 import Selector from './three/Selector'
 import ThreeContext from './three/ThreeContext'
@@ -691,5 +692,129 @@ describe('viewer/ShareViewer getInstanceIdsForOccurrencePath', () => {
     // prefix scan must still yield exactly the one instance.
     expect(ShareViewer.prototype.getInstanceIdsForOccurrencePath.call(
       viewer, 0, [367891], {geometryExpressId: 367891})).toEqual([1])
+  })
+})
+
+
+describe('viewer/ShareViewer highlightIfcItem — batched hover', () => {
+  const IDENTITY_MAT = [
+    1, 0, 0, 0,
+    0, 1, 0, 0,
+    0, 0, 1, 0,
+    0, 0, 0, 1,
+  ]
+  const GREY = {x: 0.8, y: 0.8, z: 0.8, w: 1}
+  const HOVER = {r: 1, g: 0, b: 0}
+
+  /** @return {object} conway api stub with one unit-triangle shape at id 999 */
+  function unitTriApi() {
+    const vertexData = new Float32Array([
+      0, 0, 0, 0, 0, 1,
+      1, 0, 0, 0, 0, 1,
+      0, 1, 0, 0, 0, 1,
+    ])
+    const indexData = new Uint32Array([0, 1, 2])
+    return {
+      GetGeometry: (_m, id) => (id === 999 ? {
+        GetVertexData: () => id,
+        GetIndexData: () => id,
+        GetVertexDataSize: () => vertexData.length,
+        GetIndexDataSize: () => indexData.length,
+      } : null),
+      GetVertexArray: () => vertexData,
+      GetIndexArray: () => indexData,
+    }
+  }
+
+  /**
+   * A live batched model in the BLSN_007 shape (test-models-private#98): ONE
+   * product owning three separately pickable bodies. Distinct translations,
+   * since coincident placements of one geometry are deduplicated.
+   *
+   * @return {object} BatchedMesh with the pick + highlight tables wired
+   */
+  function noNauoMultibodyModel() {
+    const geometries = [0, 1, 2].map((i) => {
+      const flatTransformation = IDENTITY_MAT.slice()
+      flatTransformation[12] = i * 2
+      return {geometryExpressID: 999, flatTransformation, color: GREY}
+    })
+    const {batches} = flatMeshToBatchedModel(
+      [{expressID: 1020254, geometries}], unitTriApi(), 0)
+    const mesh = batches[0].mesh
+    mesh.instanceParents = batches[0].instanceParents
+    mesh.instanceColors = batches[0].instanceColors
+    mesh.instanceOccurrenceIds = batches[0].instanceOccurrenceIds
+    mesh.capabilities = {expressIdPicking: true, batchedPicking: true}
+    return mesh
+  }
+
+  /**
+   * @param {object} model the batched model to serve as the scene's only model
+   * @param {object|null} hit the raycast result castRayIfc should return
+   * @return {object} ShareViewer with just the surfaces highlightIfcItem reads
+   */
+  function makeHoverViewer(model, hit) {
+    const viewer = new ShareViewer()
+    viewer.context._legacy.castRayIfc = jest.fn(() => hit)
+    viewer.IFC.context = {items: {ifcModels: [model]}}
+    viewer.isolator = {canBePickedInScene: () => true}
+    viewer.selector = {
+      getPreselectionMaterial: () => ({color: HOVER}),
+      togglePreselectionVisibility: jest.fn(),
+    }
+    return viewer
+  }
+
+  /**
+   * @param {object} mesh BatchedMesh
+   * @return {Array<boolean>} per batchId, whether it carries the hover colour
+   */
+  function hoverPainted(mesh) {
+    return [0, 1, 2].map((batchId) => {
+      const c = mesh.getColorAt(batchId, new Color())
+      return c.r > 0.5 && c.g < 0.5
+    })
+  }
+
+  it('paints only the hovered body, not every body of the shared parent', async () => {
+    // The reported bug: hovering any part of BLSN_007 turned the WHOLE model
+    // cyan. Its 2,268 bodies share one product_definition_shape, and the hover
+    // branch resolved the hit to that parent id
+    // (`getPickedItemId` → `instanceParents[batchId]`) and painted every
+    // instance under it. The click funnel was already per-instance; hover is a
+    // separate path (`viewer.js` mousemove → highlightIfcItem).
+    const model = noNauoMultibodyModel()
+    // Premise: one parent for all three bodies — otherwise this proves nothing.
+    expect(new Set(model.instanceParents).size).toBe(1)
+
+    const viewer = makeHoverViewer(model, {object: model, batchId: 1, faceIndex: 0})
+    await ShareViewer.prototype.highlightIfcItem.call(viewer)
+    expect(hoverPainted(model)).toEqual([false, true, false])
+  })
+
+  it('follows the cursor between bodies of one product', async () => {
+    // The per-frame hover dedup used to key on the resolved product id. Every
+    // body here resolves to the SAME product, so an id-keyed dedup would treat
+    // moving between them as "unchanged" and strand the highlight on the first.
+    const model = noNauoMultibodyModel()
+    const hit = {object: model, batchId: 0, faceIndex: 0}
+    const viewer = makeHoverViewer(model, hit)
+    await ShareViewer.prototype.highlightIfcItem.call(viewer)
+    expect(hoverPainted(model)).toEqual([true, false, false])
+
+    hit.batchId = 2
+    await ShareViewer.prototype.highlightIfcItem.call(viewer)
+    expect(hoverPainted(model)).toEqual([false, false, true])
+  })
+
+  it('degrades to product-level hover when the batch carries no occurrence ids', async () => {
+    // IFC and older cached batched artifacts have no `instanceOccurrenceIds`;
+    // there, every instance of the hovered product IS the right granularity.
+    const model = noNauoMultibodyModel()
+    delete model.instanceOccurrenceIds
+    const viewer = makeHoverViewer(model, {object: model, batchId: 1, faceIndex: 0})
+    await ShareViewer.prototype.highlightIfcItem.call(viewer)
+    expect(hoverPainted(model)).toEqual([true, true, true])
   })
 })

--- a/src/viewer/ShareViewer.test.js
+++ b/src/viewer/ShareViewer.test.js
@@ -664,4 +664,32 @@ describe('viewer/ShareViewer getInstanceIdsForOccurrencePath', () => {
     expect(ShareViewer.prototype.getInstanceIdsForOccurrencePath.call(ifcViewer, 0, [10, 20]))
       .toEqual([])
   })
+
+  it('resolves one body of a no-NAUO multibody model to its own instance (conway#628)', () => {
+    // BLSN_007 in miniature (test-models-private#98): ONE product, no NAUOs,
+    // named bodies whose occurrence path is just their own express id. Every
+    // instance shares the product_definition_shape as parent, so the path is
+    // the only thing that tells the bodies apart — before conway#628 they all
+    // shared one path and a NavTree click highlighted the whole hull.
+    const mesh = makeOccurrenceMesh([
+      {parentExpressId: 1020254, triangleCount: 1,
+        occurrencePath: [367733], geometryExpressId: 367733},
+      {parentExpressId: 1020254, triangleCount: 1,
+        occurrencePath: [367891], geometryExpressId: 367891},
+      {parentExpressId: 1020254, triangleCount: 1,
+        occurrencePath: [368002], geometryExpressId: 368002},
+    ])
+    const viewer = makeResolverViewer(mesh)
+    const forBody = (bodyId) => ShareViewer.prototype.getInstanceIdsForOccurrencePath.call(
+      viewer, 0, [bodyId], {includeDescendants: false, geometryExpressId: bodyId})
+    // The NavTree solid-leaf click funnel: exact key + geometry-id filter.
+    expect(forBody(367733)).toEqual([0])
+    expect(forBody(367891)).toEqual([1])
+    expect(forBody(368002)).toEqual([2])
+    // The hide funnel takes the same path without the leaf fast path
+    // (includeDescendants defaults true); a body has no descendants, so the
+    // prefix scan must still yield exactly the one instance.
+    expect(ShareViewer.prototype.getInstanceIdsForOccurrencePath.call(
+      viewer, 0, [367891], {geometryExpressId: 367891})).toEqual([1])
+  })
 })

--- a/src/viewer/ifc/batchedHighlight.js
+++ b/src/viewer/ifc/batchedHighlight.js
@@ -236,6 +236,26 @@ export function applyBatchedPreselection(model, expressIds, color = DEFAULT_HIGH
 
 
 /**
+ * Narrow the transient preselection (hover) highlight to specific occurrences
+ * (global emission-order occurrence ids off `instanceOccurrenceIds`) — the
+ * hover counterpart of {@link applyBatchedInstanceSelection}.
+ *
+ * Required, not a refinement, wherever one product owns many separately
+ * pickable bodies: the parent-keyed form above paints every instance sharing
+ * the hovered instance's `instanceParents` entry, and a no-NAUO multibody
+ * STEP file has exactly one such parent for the whole model — hovering any
+ * body of BLSN_007 (test-models-private#98) turned the entire hull cyan.
+ *
+ * @param {object} model BatchedMesh or Group
+ * @param {Array<number>|Set<number>} occurrenceIds global occurrence ids
+ * @param {object} [color] `{r,g,b}` 0..1; defaults to cyan
+ */
+export function applyBatchedInstancePreselection(model, occurrenceIds, color = DEFAULT_HIGHLIGHT) {
+  setLayer(model, occurrenceIds, color, 'pre', true)
+}
+
+
+/**
  * Clear the transient preselection highlight.
  *
  * @param {object} model BatchedMesh or Group

--- a/src/viewer/ifc/batchedHighlight.test.js
+++ b/src/viewer/ifc/batchedHighlight.test.js
@@ -1,6 +1,7 @@
 /* eslint-disable no-magic-numbers */
 import {Color, Group} from 'three'
 import {
+  applyBatchedInstancePreselection,
   applyBatchedPreselection,
   applyBatchedSelection,
   clearBatchedPreselection,
@@ -89,6 +90,31 @@ function batchIdFor(mesh, expressId) {
 }
 
 
+/**
+ * The no-NAUO multibody shape (BLSN_007, test-models-private#98): ONE
+ * product owning several separately pickable bodies, each its own placement.
+ * Distinct translations because coincident placements of one geometry are
+ * deduplicated by `collectGroups`.
+ *
+ * @param {number} [bodyCount]
+ * @return {object} a THREE.BatchedMesh with parent + occurrence tables wired
+ */
+function noNauoMultibodyBatch(bodyCount = 3) {
+  const geometries = []
+  for (let i = 0; i < bodyCount; i++) {
+    const transform = IDENTITY_MAT.slice()
+    transform[12] = i * 2 // distinct placement, else deduped as coincident
+    geometries.push({geometryExpressID: 999, flatTransformation: transform, color: GREY})
+  }
+  const {batches} = flatMeshToBatchedModel([{expressID: 1020254, geometries}], unitTriApi(), 0)
+  const batch = batches[0]
+  batch.mesh.instanceParents = batch.instanceParents
+  batch.mesh.instanceColors = batch.instanceColors
+  batch.mesh.instanceOccurrenceIds = batch.instanceOccurrenceIds
+  return batch.mesh
+}
+
+
 describe('viewer/ifc/batchedHighlight', () => {
   it('recolors only the selected product, leaving others original', () => {
     const mesh = decoratedBatch()
@@ -129,6 +155,35 @@ describe('viewer/ifc/batchedHighlight', () => {
     const after = colorAt(mesh, batchIdFor(mesh, 100))
     expect(after.r).toBeCloseTo(0)
     expect(after.b).toBeCloseTo(1)
+  })
+
+  it('preselects ONE body of a no-NAUO multibody product, not the whole parent', () => {
+    // The BLSN_007 hover bug: every body of that file shares one
+    // product_definition_shape, so the parent-keyed hover below paints the
+    // entire model. The occurrence-keyed form paints only the hovered body.
+    const mesh = noNauoMultibodyBatch()
+    // Premise check — without a single shared parent this test proves nothing.
+    expect(new Set(mesh.instanceParents).size).toBe(1)
+    expect(mesh.instanceOccurrenceIds.length).toBe(3)
+    const isPreselected = (batchId) => colorAt(mesh, batchId).r > 0.5 &&
+      colorAt(mesh, batchId).g < 0.5
+
+    applyBatchedInstancePreselection(mesh, [mesh.instanceOccurrenceIds[1]], PRESELECT)
+    expect([0, 1, 2].map(isPreselected)).toEqual([false, true, false])
+
+    // Contrast, and the pre-fix behaviour: keyed by the shared parent, all
+    // three light up. This is what the user saw as "the whole model is cyan".
+    applyBatchedPreselection(mesh, [mesh.instanceParents[1]], PRESELECT)
+    expect([0, 1, 2].map(isPreselected)).toEqual([true, true, true])
+
+    // Moving the hover to another body releases the previous one — the case a
+    // parent-keyed dedup would swallow, since all three share that parent.
+    applyBatchedInstancePreselection(mesh, [mesh.instanceOccurrenceIds[2]], PRESELECT)
+    expect([0, 1, 2].map(isPreselected)).toEqual([false, false, true])
+
+    clearBatchedPreselection(mesh)
+    expect([0, 1, 2].map(isPreselected)).toEqual([false, false, false])
+    expect(colorAt(mesh, 2).r).toBeCloseTo(GREY.x)
   })
 
   it('isBatchedModel detects a BatchedMesh and a Group of them', () => {

--- a/src/viewer/three/IfcIsolator.js
+++ b/src/viewer/three/IfcIsolator.js
@@ -523,11 +523,11 @@ export default class IfcIsolator {
     const occurrencePath = useStore.getState().selectedOccurrencePath
     if (Array.isArray(occurrencePath) && occurrencePath.length > 0 &&
         typeof this.viewer.getInstanceIdsForOccurrencePath === 'function') {
-      // A selected ephemeral solid (a multibody part's named body) shares the
-      // part's occurrence path; keying the hide by the solid's own id (and
-      // filtering the instances by it) hides just that body, and keeps its
-      // hidden-state separate from the whole part's so the eyes toggle
-      // independently.
+      // Key the hide by the selected solid's own id (and filter the instances
+      // by it) so just that body disappears and its hidden-state stays
+      // separate from the whole part's — required where a body shares its
+      // part's occurrence path (pre-conway#628 solids, anonymous pieces), and
+      // the same id a #628 body's path ends with anyway.
       const solidExpressId = useStore.getState().selectedSolidExpressId
       const nodeId = solidExpressId ?? occurrencePath[occurrencePath.length - 1]
       if (this.hiddenOccurrences.has(nodeId)) {

--- a/src/viewer/three/IfcIsolator.test.js
+++ b/src/viewer/three/IfcIsolator.test.js
@@ -651,6 +651,68 @@ describe('viewer/three/IfcIsolator', () => {
       expect(useStore.setState).toHaveBeenLastCalledWith({hiddenElements: {}})
     })
 
+    it('hideSelectedElements hides one body of a no-NAUO multibody product (conway#628)', () => {
+      // BLSN_007 (test-models-private#98): one product, no NAUOs, named bodies
+      // whose occurrence path is their own express id. Every body shares the
+      // product_definition_shape (100 here), so the product-type hide below
+      // would vanish the whole hull; the H key must take the occurrence branch
+      // and remove just the selected body's instance.
+      const scene = new Group()
+      const pickable = []
+      const iso = makeIsolator({scene, pickable})
+      const child = makeChildMesh([
+        {parentExpressId: 100, triangleCount: 1,
+          occurrencePath: [367733], geometryExpressId: 367733},
+        {parentExpressId: 100, triangleCount: 1,
+          occurrencePath: [367891], geometryExpressId: 367891},
+        {parentExpressId: 100, triangleCount: 1,
+          occurrencePath: [368002], geometryExpressId: 368002},
+      ])
+      const model = new Group()
+      model.add(child)
+      attachInstanceMapSubsets(model, null)
+      scene.add(model)
+      pickable.push(model)
+      iso.ifcModel = model
+      iso.visualElementsIds = [100]
+      iso.spatialStructure = {}
+      // Resolve through the mesh's own occurrence tables, the same join
+      // ShareViewer.getInstanceIdsForOccurrencePath makes (unit-tested against
+      // this shape in ShareViewer.test.js).
+      // Plain Array, matching the real resolver's return — hideOccurrence's
+      // guard is `Array.isArray`, which a Uint32Array does not satisfy.
+      iso.viewer.getInstanceIdsForOccurrencePath = (modelID, path, {geometryExpressId} = {}) =>
+        Array.from(child.instanceMap.getInstanceIdsByOccurrencePath(path) ?? []).filter(
+          (instanceId) => geometryExpressId === undefined || geometryExpressId === null ||
+            child.instanceMap.getGeometryExpressIdByInstance(instanceId) === geometryExpressId)
+
+      const useStore = require('../../store/useStore').default
+      const origGetState = useStore.getState.getMockImplementation()
+      useStore.getState.mockReturnValue({
+        elementTypesMap: [],
+        selectedElements: [],
+        selectedInstanceIds: [],
+        selectedOccurrencePath: [367891],
+        selectedSolidExpressId: 367891,
+      })
+      try {
+        iso.hideSelectedElements()
+        // Keyed by the body's own express id so its NavTree eye toggles alone.
+        expect(iso.hiddenOccurrences.has(367891)).toBe(true)
+        expect(iso.hiddenOccurrences.get(367891)).toEqual([1])
+        // Two of the three bodies remain — hiding by the shared parent id
+        // would have left zero.
+        expect(countTriangles(iso, iso.unhiddenSubset)).toBe(2)
+
+        // Second H press unhides it: the full model comes back.
+        iso.hideSelectedElements()
+        expect(iso.hiddenOccurrences.has(367891)).toBe(false)
+        expect(scene.children).toContain(model)
+      } finally {
+        useStore.getState.mockImplementation(origGetState)
+      }
+    })
+
     it('product-type and per-occurrence hides compose without clobbering each other', () => {
       // Regression for the review cluster: the pre-existing product-type hide
       // paths replaced hiddenElements from hiddenIds only, wiping occurrence eye

--- a/yarn.lock
+++ b/yarn.lock
@@ -2473,10 +2473,10 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@bldrs-ai/conway@1.1585.676-g80859a4d":
-  version "1.1585.676-g80859a4d"
-  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.1585.676-g80859a4d.tgz#8eb0bac476b7e7467e4fae7a6b6240bd8893cda4"
-  integrity sha512-p1MiWQyMk4+lbpq6V/z9T4Cb7nElqlnLBGfsJbb+WPmqhscE2ILBv2eIhU2IKocdKJQM8i0ZXIm2HwT50rgkRw==
+"@bldrs-ai/conway@1.1593.683-g9ff7aa12":
+  version "1.1593.683-g9ff7aa12"
+  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.1593.683-g9ff7aa12.tgz#61e68d44c6bb684ee31297f1962ebd58b6ee459f"
+  integrity sha512-9n4CUnmUCfSXmBmWSvKVi1+pdXLoJVr1p0TqpdUQw7AcHPt2rsqay0ixSrLCuA0LRIuWxeX3A0jrhkd2V6UKnQ==
   dependencies:
     gl-matrix "3.4.3"
     seedrandom "3.0.5"


### PR DESCRIPTION
Fixes [bldrs-ai/test-models-private#98](https://github.com/bldrs-ai/test-models-private/issues/98): `BLSN_007.stp` (one product, zero NAUOs, 2,268 named bodies via `SHAPE_REPRESENTATION_RELATIONSHIP`s) loaded fine but hovering/selecting anywhere selected the entire model — one NavTree node, one Properties entity.

Two halves:

## Engine bump

`@bldrs-ai/conway` `1.1585.676-g80859a4d` → `1.1593.683-g9ff7aa12`, bringing in [conway#683](https://github.com/bldrs-ai/conway/pull/683): per-body occurrence paths (a body's own express id is the path's last segment), the solid tree layer on by default (a tree leaf per named body, `ephemeral: true`, `type: 'solid'`), and the inverted-SRR orientation fix that also killed a 308× duplicate geometry walk on this model (698,544 → 2,268 scene nodes, 59 s → 42 s extraction). This supersedes main's `1.1592.684-g9c1cd597` pin (that commit is an ancestor, so the conway#684 color fix and the #1816 georeferencing engine fix ride along; the branch carries main through #1815/#1816).

## Consumer fixes

Three real defects in the "resolve a path to a node" seam, verified against the new engine (everything downstream — instance tables, batched-path tables, `getInstanceIdsForOccurrencePath`, per-occurrence hide, NavTree rendering — took the new paths unchanged):

1. **`findNodeByOccurrencePath` skipped ephemeral solid nodes** (`src/utils/occurrencePaths.js`) — with per-body paths, a picked body's path resolved to *no node at all*. Now: prefer a product node, fall back to an ephemeral one (the preference is defense against engine/schema lockstep drift, not a live compat path — the schema version in the artifact filename means stale artifacts read as misses).
2. **`selectFromInstancePick` only promoted to a solid found as a *child* of the path node** (`src/Containers/CadView.jsx`) — with the body itself being the path node, every pick fell back to the shared PDS id, so Properties showed `Document` for every body. Extracted as the pure, tested `resolvePickedOccurrenceNode`.
3. **Permalink write/read asymmetry** — the writer appended `solidExpressId` unconditionally, minting `/…/367733/367733`, which reads back through the anonymous-piece branch (selection still lands on the body; the cost is a phantom transient row). Now a tested inverse pair (`occurrenceElementPathIds` / `resolveElementPathOccurrence`).

Plus a **GLB cache schema bump → 0.19.0** (`src/loader/glbCacheKey.js`): path composition is baked into both `BLDRS_face_ids.occurrencePaths` and the persisted spatial tree. 0.18.0 was already taken by main's conway#684 color bump, which shipped on a pre-#628 engine — 0.18.0 artifacts in the wild hold the old path shape, so this change takes its own number.

## Tests

- Jest (final merged tree): 264 suites / 2,799 passed, 5 skipped, coverage thresholds met; `build-prod` clean; lint (`--max-warnings 0`) and typecheck clean — all with the published engine.
- Every new unit test verified red under a mutation of the behavior it pins (details in the test files); the review's independent mutation checks reproduced this.
- New E2E `src/Components/NavTree/navTreeBodySelection.spec.ts` (desktop + mobile via `describeMobileAndDesktop`) on the new fixture `ap214-inverted-srr-multibody.step` — the BLSN shape at 3-body scale. Passes with the fixed engine, fails with the old one for the right reason (empty `occurrencePath` on every body). Fixture has empty shells, so the spec covers tree/selection/permalink state; the scene-highlight half is unit-tested. Ran 4/4 green alongside `navTreeOccurrenceSelection` + `navTreePermalink`, zero flakes.
- `design/new/step-occurrence-selection.md` updated (new §"Identity below the product"; follow-up #4 rewritten as narrowed).

## Verification note

An already-cached copy of a STEP model on a given origin re-fetches once (schema bump makes the old artifact a miss) — expected, same as the 0.9.0 precedent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mt7JNP4gwujYPEj5kaK74y