### PR TITLE
Fix silent BatchedMesh degradation past three's setGeometrySize spread limit, and pre-size the batch from the pump's product total

### DIFF
--- a/src/viewer/ifc/ShareIfcLoader.degraded.test.js
+++ b/src/viewer/ifc/ShareIfcLoader.degraded.test.js
@@ -157,7 +157,7 @@ describe('viewer/ifc/ShareIfcLoader degraded end-of-load builds (conway#638)', (
       // eslint-disable-next-line require-await
       async (buffer, api, settings, onProgress, onMeshBatch) => {
         if (onMeshBatch) {
-          onMeshBatch(PUMPED, 4)
+          onMeshBatch(PUMPED, 4, {done: PUMPED.length, total: PUMPED.length})
         }
         return {modelID: 4, captured: [], recapture}
       })
@@ -220,6 +220,7 @@ describe('viewer/ifc/ShareIfcLoader degraded end-of-load builds (conway#638)', (
     IncrementalBatchedBuilder.mockImplementation(() => ({
       root: {parent: null},
       appendBatch: jest.fn(),
+      setPumpProgress: jest.fn(),
       hasContent: () => false,
       finalize: jest.fn(),
     }))
@@ -236,6 +237,7 @@ describe('viewer/ifc/ShareIfcLoader degraded end-of-load builds (conway#638)', (
     IncrementalBatchedBuilder.mockImplementation(() => ({
       root: {parent: null},
       appendBatch: jest.fn(),
+      setPumpProgress: jest.fn(),
       hasContent: () => true,
       finalize: () => {
         throw new Error('finalize failed')
@@ -268,6 +270,7 @@ describe('viewer/ifc/ShareIfcLoader degraded end-of-load builds (conway#638)', (
     IncrementalBatchedBuilder.mockImplementation(() => ({
       root: {parent: null},
       appendBatch: jest.fn(),
+      setPumpProgress: jest.fn(),
       hasContent: () => true,
       finalize: () => ({batches: [], stats: BUILD_STATS}),
     }))
@@ -276,6 +279,28 @@ describe('viewer/ifc/ShareIfcLoader degraded end-of-load builds (conway#638)', (
     expect(recapture).not.toHaveBeenCalled()
     expect(buildConwayIfcModel).not.toHaveBeenCalled()
     expect(buildBatchedConwayModel).not.toHaveBeenCalled()
+  })
+
+  it('gives the builder the pump progress before the batch it sizes from', async () => {
+    // Share#1809: the builder reserves its BatchedMesh buffers for the
+    // WHOLE model once a batch grows past the point where three can still
+    // resize it, and the pump's product progress is the only place that
+    // whole-model size exists. Arriving after `appendBatch` would be too
+    // late — the batch that crosses the threshold is sized during the very
+    // append it accompanies.
+    const setPumpProgress = jest.fn()
+    const appendBatch = jest.fn()
+    IncrementalBatchedBuilder.mockImplementation(() => ({
+      root: {parent: null},
+      appendBatch,
+      setPumpProgress,
+      hasContent: () => true,
+      finalize: () => ({batches: [], stats: BUILD_STATS}),
+    }))
+    await parseOnce()
+    expect(setPumpProgress).toHaveBeenCalledWith(PUMPED.length, PUMPED.length)
+    expect(setPumpProgress.mock.invocationCallOrder[0])
+      .toBeLessThan(appendBatch.mock.invocationCallOrder[0])
   })
 
   it('fails the load loudly when the whole-model ask rejects', async () => {

--- a/src/viewer/ifc/ShareIfcLoader.js
+++ b/src/viewer/ifc/ShareIfcLoader.js
@@ -401,7 +401,7 @@ export default class ShareIfcLoader {
       // there is no monolithic end-of-load build and no swap. Falls
       // back to the render-only preview mesh (and the end-of-load
       // builds below) on any builder failure.
-      const onMeshBatch = !usePreview ? undefined : (batch, batchModelID) => {
+      const onMeshBatch = !usePreview ? undefined : (batch, batchModelID, progress) => {
         try {
           if (builder === null) {
             builder = new IncrementalBatchedBuilder(ifcAPI, batchModelID, {
@@ -410,6 +410,13 @@ export default class ShareIfcLoader {
             })
             scene.add(builder.root)
           }
+          // Before appendBatch: the builder sizes its BatchedMesh buffers
+          // from how far through the model the pump is, and the batch
+          // about to be appended is the one that may trigger that sizing
+          // (Share#1809). Fed unguarded — `setPumpProgress` ignores
+          // anything non-finite, which is what a pre-total first batch or
+          // an engine without the pump hands over.
+          builder.setPumpProgress(progress?.done, progress?.total)
           builder.appendBatch(batch)
         } catch (e) {
           debug(WARN).warn('incremental batch append failed; preview fallback:', e)

--- a/src/viewer/ifc/conwayDirectIfcLoader.js
+++ b/src/viewer/ifc/conwayDirectIfcLoader.js
@@ -92,7 +92,8 @@ import {instanceMapFromGeometry} from './IfcInstanceMap'
  *   the parse — a conway `Loadersettings.ON_PROGRESS` extension (#301);
  *   silently ignored by engines that predate it (real web-ifc, old pins).
  * @param {Function} [onMeshBatch] demand/tiled slice A: receives
- *   `(flatMeshes, modelID)` for each extracted batch as it lands (only
+ *   `(flatMeshes, modelID, {done, total})` — the batch, its model, and
+ *   the pump's product progress — for each extracted batch as it lands (only
  *   on the `demandGeometry` deferred path) so callers can render
  *   progressively. Passing it makes the caller the OWNER of the stream:
  *   `captured` then stays empty and degraded readers must go through
@@ -347,7 +348,15 @@ export async function parseIfcWithConway(
         pumpedMeshes += batch.length
         pumpedBatches++
         if (onMeshBatch) {
-          onMeshBatch(batch, modelID)
+          // `progress` is the same product counter `reportGeometry` above
+          // publishes, handed to the consumer because it is the only
+          // whole-model size a batch-at-a-time assembler can see: the
+          // incremental BatchedMesh builder sizes its buffers from it
+          // instead of doubling into them, which past ~125k geometries is
+          // not survivable (Share#1809). `total` is undefined until the
+          // first pump call has returned, which is also the first call
+          // that can produce a batch, so in practice it is always set here.
+          onMeshBatch(batch, modelID, {done: geometryDone, total: geometryTotal})
         }
         // `batch` itself goes out of scope on the next iteration, so on the
         // streaming path the last reference to this batch's FlatMeshes is

--- a/src/viewer/ifc/conwayDirectIfcLoader.test.js
+++ b/src/viewer/ifc/conwayDirectIfcLoader.test.js
@@ -203,6 +203,27 @@ describe('viewer/ifc/conwayDirectIfcLoader', () => {
         expect(ifcAPI.StreamAllMeshes).not.toHaveBeenCalled()
       })
 
+      it('hands each batch the pump product progress alongside it', async () => {
+        // The incremental BatchedMesh builder sizes its buffers from how
+        // far through the model the pump is (Share#1809): past ~125k
+        // geometries three's setGeometrySize can no longer resize a batch,
+        // so the builder has to reserve for the whole model while it still
+        // can, and this is the only place the whole-model size exists.
+        // Counted in extracted PRODUCTS, the same unit the geometry
+        // progress stage reports, not in delivered FlatMeshes.
+        mockIsFeatureEnabled.mockImplementation((name) => name === 'demandGeometry')
+        const ifcAPI = makeDemandAPI(150)
+        const progress = []
+        await parseIfcWithConway(
+          new ArrayBuffer(4), ifcAPI, undefined, undefined,
+          (batch, modelID, pumped) => progress.push(pumped))
+        expect(progress).toEqual([
+          {done: 64, total: 150},
+          {done: 128, total: 150},
+          {done: 150, total: 150},
+        ])
+      })
+
       it('reports a Geometry progress stage across the demand pump', async () => {
         mockIsFeatureEnabled.mockImplementation((name) => name === 'demandGeometry')
         const ifcAPI = makeDemandAPI(150)

--- a/src/viewer/ifc/flatMeshToBatchedModel.js
+++ b/src/viewer/ifc/flatMeshToBatchedModel.js
@@ -251,6 +251,39 @@ export class CoincidenceSet {
    *   of a placement already recorded (the caller should drop it)
    */
   add(parentExpressId, geometryExpressId, matrix, color) {
+    const token = this.probe(parentExpressId, geometryExpressId, matrix, color)
+    if (token === null) {
+      return false
+    }
+    this.commit(token)
+    return true
+  }
+
+
+  /**
+   * Fingerprint a placement and report whether it is new, WITHOUT
+   * recording it.
+   *
+   * Split out of `add` so a caller that has fallible work to do BETWEEN
+   * the test and the set can order it correctly without hashing twice.
+   * The incremental builder is that caller: it must reject a duplicate
+   * before touching BatchedMesh capacity (growing the instance buffers for
+   * a placement that adds nothing permanently retains the doubling, since
+   * `finalize` trims only geometry) and must not record the identity until
+   * the capacity is secured (a placement marked seen but never appended
+   * would make a later re-emission a duplicate of nothing). Both are codex
+   * findings on Share#1809; hashing is 3 passes over ~20 words per
+   * placement and a large model has half a million of them, so paying it
+   * twice to get that ordering is not an option.
+   *
+   * @param {number} parentExpressId
+   * @param {number} geometryExpressId
+   * @param {Array<number>} matrix 16-element flatTransformation
+   * @param {?{x: number, y: number, z: number, w: number}} color
+   * @return {?{primary: number, secondary: number}} a token to hand to
+   *   `commit`, or null when this placement is already recorded
+   */
+  probe(parentExpressId, geometryExpressId, matrix, color) {
     const words = coincidenceWords(parentExpressId, geometryExpressId, matrix, color)
     const primary = hashWords(words, FP_SEED_A, FP_MUL_A)
     const secondary =
@@ -258,24 +291,46 @@ export class CoincidenceSet {
       (hashWords(words, FP_SEED_C, FP_MUL_C) >>> FP_LOW_SHIFT)
     const existing = this.byPrimary_.get(primary)
     if (existing === undefined) {
+      return {primary, secondary}
+    }
+    if (typeof existing === 'number') {
+      return existing === secondary ? null : {primary, secondary}
+    }
+    return existing.includes(secondary) ? null : {primary, secondary}
+  }
+
+
+  /**
+   * Record a placement `probe` reported as new.
+   *
+   * Re-reads the bucket rather than trusting the token's view of it, so
+   * committing an identity that arrived by some other route in between is
+   * a no-op instead of a double count — the token carries the expensive
+   * part (the fingerprints), not a claim about the set's contents.
+   *
+   * @param {{primary: number, secondary: number}} token from `probe`
+   */
+  commit(token) {
+    const {primary, secondary} = token
+    const existing = this.byPrimary_.get(primary)
+    if (existing === undefined) {
       this.byPrimary_.set(primary, secondary)
       this.size++
-      return true
+      return
     }
     if (typeof existing === 'number') {
       if (existing === secondary) {
-        return false
+        return
       }
       this.byPrimary_.set(primary, [existing, secondary])
       this.size++
-      return true
+      return
     }
     if (existing.includes(secondary)) {
-      return false
+      return
     }
     existing.push(secondary)
     this.size++
-    return true
   }
 
 

--- a/src/viewer/ifc/incrementalBatchedBuilder.js
+++ b/src/viewer/ifc/incrementalBatchedBuilder.js
@@ -419,11 +419,19 @@ export class IncrementalBatchedBuilder {
     // throw — that is the whole subject of Share#1809 — and a placement
     // marked seen but never appended would make a later re-emission a
     // duplicate of something that does not exist, counted as a coincident
-    // skip instead of retried. Nothing re-emits one today (conway's pump
-    // promises "each placed instance is emitted exactly once across all
-    // calls", and the degraded end-of-load builds construct a FRESH
-    // builder from `recapture()`), so that half is an invariant kept
-    // honest rather than a live bug fixed.
+    // skip instead of retried.
+    //
+    // How reachable that is depends on which source you believe, so assume
+    // the worse one. Conway's DELTA CONTRACT (`ifc_api.d.ts`) promises
+    // "each placed instance is emitted exactly once across all calls",
+    // which would make it unreachable; but this file's own
+    // "drops an exact coincident duplicate that arrives in a later delta
+    // batch" test says the pump re-emits identical placements via
+    // rel-aggregates re-extraction, and the whole cross-batch
+    // CoincidenceSet exists because of that. If the test is right, this is
+    // a live path, not a hypothetical one. (Either way the degraded
+    // end-of-load builds are not it: they construct a FRESH builder from
+    // `recapture()` and never see this `seenPlacements`.)
     //
     // The split exists so both can hold at once without hashing twice: the
     // probe runs on the STAGED matrix elements, after every Conway-boundary
@@ -821,13 +829,39 @@ export class IncrementalBatchedBuilder {
    * `max(vertexStart + reservedVertexCount)`, which is the figure
    * setGeometrySize checks a shrink against.
    *
-   * Cost and failure mode, both deliberate. The trim is one reallocation
-   * and copy of the batch buffers, so a steady-state saving is bought with
-   * a transient peak of capacity + used at the end of the load, after the
-   * parse-time transients have been released. And on a batch past three's
-   * spread limit it throws exactly like a growth would — and, like a
-   * growth, before it has touched the mesh — so it is best-effort: those
-   * batches keep their slack rather than losing their geometry to it.
+   * The cost is deliberate: one reallocation and copy of the batch
+   * buffers, so a steady-state saving is bought with a transient peak of
+   * capacity + used at the end of the load, after the parse-time
+   * transients have been released.
+   *
+   * BEST-EFFORT, BUT ONLY WHERE THE MESH SURVIVES (codex round 3 on
+   * Share#1809). `setGeometrySize` has two failure regions and they are
+   * not equivalent:
+   *
+   *   1. The shrink checks at the top — including the `Math.max(...)`
+   *      spread that PRESIZE_FROM_GEOMETRIES exists for. These run before
+   *      anything is mutated, so a batch past the spread limit throws with
+   *      its mesh untouched. Swallow it: that batch keeps its slack rather
+   *      than losing its geometry to a size optimisation.
+   *   2. Everything after `oldGeometry.dispose()`
+   *      (`node_modules/three/src/objects/BatchedMesh.js:1350` onwards):
+   *      three disposes the old geometry, overwrites `_maxVertexCount` and
+   *      `_maxIndexCount`, replaces `this.geometry` with a fresh
+   *      `BufferGeometry`, and only THEN allocates the new typed arrays
+   *      inside `_initializeGeometry`. An allocation failure there — the
+   *      plausible one, since the trim's own peak is capacity + used on
+   *      exactly the largest models — leaves a gutted mesh: disposed
+   *      buffers, empty geometry, `_geometryInitialized` false. Swallowing
+   *      THAT reports a destroyed model as a successful load.
+   *
+   * So the catch classifies by observable effect rather than by error
+   * type: if the geometry object is the same one and its arrays are the
+   * same length, nothing was mutated and the throw was benign. Otherwise
+   * the batch is gone and the throw is re-raised, which fails `finalize`
+   * and drops ShareIfcLoader into the degraded end-of-load rebuild from
+   * `recapture()` — a complete model, re-extracted. A rare trim-OOM
+   * landing in the fallback that exists for exactly this is the honest
+   * outcome; silently returning a hollow BatchedMesh is not.
    *
    * @param {object} state batch state
    */
@@ -835,11 +869,28 @@ export class IncrementalBatchedBuilder {
     if (state.usedVertices >= state.maxVertices && state.usedIndices >= state.maxIndices) {
       return
     }
+    // Captured for the classification below, before three can replace any
+    // of it. Lengths as well as identity: `_initializeGeometry` assigns a
+    // new geometry before it allocates, so a failure part-way through can
+    // leave an object that exists but has nothing in it.
+    const geometryBefore = state.mesh.geometry
+    const positionsBefore = geometryBefore?.attributes?.position?.array?.length ?? 0
+    const indicesBefore = geometryBefore?.index?.array?.length ?? 0
     try {
       state.mesh.setGeometrySize(state.usedVertices, state.usedIndices)
       state.maxVertices = state.usedVertices
       state.maxIndices = state.usedIndices
     } catch (e) {
+      const geometryAfter = state.mesh.geometry
+      const intact = geometryAfter === geometryBefore &&
+        (geometryAfter?.attributes?.position?.array?.length ?? 0) === positionsBefore &&
+        (geometryAfter?.index?.array?.length ?? 0) === indicesBefore
+      if (!intact) {
+        debug(WARN).warn(
+          'IncrementalBatchedBuilder: batch capacity trim destroyed the mesh; ' +
+          'failing the incremental assembly so the load rebuilds completely:', e)
+        throw e
+      }
       debug(WARN).warn('IncrementalBatchedBuilder: batch capacity trim skipped:', e)
     }
   }

--- a/src/viewer/ifc/incrementalBatchedBuilder.js
+++ b/src/viewer/ifc/incrementalBatchedBuilder.js
@@ -47,6 +47,34 @@ const PRESIZE_HEADROOM = 1.15
 // Pump progress below which the projection is not trusted: dividing a
 // handful of dense products by a near-zero fraction reserves gigabytes.
 const PRESIZE_MIN_FRACTION = 0.02
+// Active-geometry count past which a batch is treated as having ONE resize
+// left, and reserves accordingly (see projectCapacity_).
+//
+// Deliberately well under the 125,279 measured above, because that number
+// is V8's argument cap on three's `Math.max(...)` spread and is therefore
+// stack-depth dependent: the same batch resized from a deeper call stack
+// fails earlier. 110,000 keeps ~12% of margin against a measurement taken
+// on one stack on one box, which is the right side to be wrong on — the
+// cost of triggering early is a slightly larger reservation, the cost of
+// triggering late is the reservation never happening at all.
+const LAST_CHANCE_GEOMETRIES = 110000
+// Headroom the last-chance reservation uses in place of PRESIZE_HEADROOM.
+//
+// The projection is linear in products, which is only conservative when
+// early products are at least as geometry-dense as late ones. A model that
+// front-loads reuse and back-loads novel or denser shapes breaks that and
+// the projection under-reserves (codex P1 on Share#1809). Below the
+// threshold a later resize corrects it; past the threshold there is no
+// later resize, so the estimate has to absorb the error instead. Read it
+// as the tolerance it is: the remaining products may be up to 50% denser
+// per product than everything seen so far.
+const LAST_CHANCE_HEADROOM = 1.5
+// Floor for the last-chance reservation as a multiple of what the batch
+// needs right now, applied when there is no usable pump progress to
+// project from. Unreachable in production — `onMeshBatch` only fires on
+// the deferred pump path, which always reports totals — so this is what
+// keeps the branch total rather than a second estimator.
+const LAST_CHANCE_GROWTH = 2
 // Console cap for per-record skip warnings (see warnBadRecord_): a model
 // with many budget-evicted geometries (conway#535) shouldn't flood the
 // console one line per id -- the load report's skipped* counts already
@@ -94,6 +122,8 @@ export class IncrementalBatchedBuilder {
    *   at which projectCapacity_ takes over from doubling. Lowering it is
    *   the only way to exercise the projection without building a batch of
    *   PRESIZE_FROM_GEOMETRIES real geometries.
+   * @param {number} [opts.lastChanceGeometries] test hook: geometry count
+   *   at which a resize is treated as the last one this batch will get.
    */
   constructor(api, modelID, opts = {}) {
     this.api = api
@@ -103,6 +133,7 @@ export class IncrementalBatchedBuilder {
     this.initialVertices = opts.initialVertices ?? INITIAL_VERTICES
     this.initialIndices = opts.initialIndices ?? INITIAL_INDICES
     this.presizeFromGeometries = opts.presizeFromGeometries ?? PRESIZE_FROM_GEOMETRIES
+    this.lastChanceGeometries = opts.lastChanceGeometries ?? LAST_CHANCE_GEOMETRIES
     this.root = new Group()
     // geometryExpressID → {geometry, vertCount, indexCount, box,
     // idByBatch: Map(batchState → geometryId)} — geometry fetched from
@@ -369,23 +400,41 @@ export class IncrementalBatchedBuilder {
       this.totals.skippedPlacedGeometries++
       return
     }
+    const isTransparent = color.w < OPAQUE_ALPHA
+    const state = this.ensureBatch_(isTransparent)
+    // Capacity BEFORE the duplicate marker, not after (codex P2 on
+    // Share#1809). `ensureCapacity_` is the one call left here that can
+    // throw — that is the whole subject of Share#1809 — and CoincidenceSet
+    // is a combined test-and-set with no remove, so marking first would
+    // record an identity for a placement that never landed. A later
+    // emission of that same placement would then be dropped as a duplicate
+    // of something that does not exist, and counted as a coincident skip
+    // rather than retried.
+    //
+    // Nothing today re-emits one: conway's pump contract is "each placed
+    // instance is emitted exactly once across all calls"
+    // (`ifc_api.d.ts`'s DELTA CONTRACT), and every degraded end-of-load
+    // build in ShareIfcLoader constructs a FRESH builder from
+    // `recapture()` rather than reusing this one's `seenPlacements`. So
+    // the ordering is an invariant kept honest, not a live bug fixed —
+    // but it costs nothing and the alternative is a guard that depends on
+    // an engine contract staying the way it is.
+    this.ensureCapacity_(state, entry)
+
     // Drop an exact coincident duplicate (same part + geometry + transform +
     // colour): it would z-fight the one already appended. See CoincidenceSet.
     //
     // The combined test-and-set runs on the STAGED matrix elements, after
     // every Conway-boundary read and the geometry fetch above, so a
     // boundary throw can never mark an identity as seen (codex P2 on
-    // Share#1798). Only the three.js tail below — writes into preallocated
-    // buffers and JS array pushes, which don't throw in practice — follows
-    // the mark; CoincidenceSet has no remove, so that residual is accepted
-    // rather than guarded with rollback machinery.
+    // Share#1798). What follows the mark is now only the three.js tail —
+    // `addGeometry` into space `ensureCapacity_` has already secured,
+    // `addInstance`, writes into preallocated buffers and JS array pushes
+    // — none of which throw once capacity is in hand.
     if (!this.seenPlacements.add(parentExpressId, geomExpressID, matrix.elements, color)) {
       this.totals.skippedCoincidentPlacements++
       return
     }
-    const isTransparent = color.w < OPAQUE_ALPHA
-    const state = this.ensureBatch_(isTransparent)
-    this.ensureCapacity_(state, entry)
 
     let geometryId = entry.idByBatch.get(state)
     if (geometryId === undefined) {
@@ -659,12 +708,22 @@ export class IncrementalBatchedBuilder {
    * growths reserves once for the rest of the load instead of doubling
    * into a call that will throw (see PRESIZE_FROM_GEOMETRIES).
    *
-   * The estimator is linear in products, which is conservative in the
-   * right direction: geometry is deduplicated by `geometryExpressID`, so
-   * products seen early contribute proportionally MORE new vertices than
-   * products seen late, and the projection therefore lands above the true
-   * total. Measured on sp-946MB.ifc: +11% at the first trigger point,
-   * +12% at the last one before three's ceiling.
+   * The estimator is linear in products. It TENDS to land above the true
+   * total, because geometry is deduplicated by `geometryExpressID` and so
+   * products seen early contribute proportionally more new vertices than
+   * products seen late — measured on sp-946MB.ifc at +11% over the true
+   * requirement at the first trigger point and +12% at the last one before
+   * three's ceiling. It is NOT a bound, and one model's overshoot does not
+   * establish one for other product orderings: a file that front-loads
+   * reuse and back-loads novel or denser shapes under-reserves here (codex
+   * P1 on Share#1809). That is survivable while resizes still work — the
+   * projection is re-run at every growth and corrects itself — which is
+   * why LAST_CHANCE_GEOMETRIES exists to widen it at the point where they
+   * stop working. Past that point the ceiling is steered around, not
+   * removed: an under-reservation still degrades, but degrades HONESTLY,
+   * because ensureCapacity_ leaves Share and three agreeing and the
+   * placements that cannot fit are counted. Removing the ceiling means not
+   * putting 125k geometries in one BatchedMesh.
    *
    * Returns null — leaving the doubling in charge — whenever the estimate
    * would be guesswork: no pump progress (every one-shot and unit-test
@@ -679,18 +738,28 @@ export class IncrementalBatchedBuilder {
    *   null when unprojectable
    */
   projectCapacity_(state, needVertices, needIndices) {
-    if (this.pumpTotal <= 0 || state.geometryCount < this.presizeFromGeometries) {
+    // Is this, in expectation, the last resize this batch will complete?
+    // Decided first: it changes the headroom below, and it stands in for
+    // the projection entirely when there is no pump progress to project
+    // from.
+    const lastChance = state.geometryCount >= this.lastChanceGeometries
+    let scale = 0
+    if (this.pumpTotal > 0 && state.geometryCount >= this.presizeFromGeometries) {
+      const total = this.pumpTotal - state.startDone
+      const fraction = total > 0 ?
+        Math.min((this.pumpDone - state.startDone) / total, 1) : 0
+      if (fraction >= PRESIZE_MIN_FRACTION) {
+        scale = (lastChance ? LAST_CHANCE_HEADROOM : PRESIZE_HEADROOM) / fraction
+      }
+    }
+    if (lastChance) {
+      scale = Math.max(scale, LAST_CHANCE_GROWTH)
+    }
+    // Below 1 means "no usable estimate" (no pump, too small a sample, too
+    // little of the model seen); the caller's doubling stays in charge.
+    if (scale <= 1) {
       return null
     }
-    const total = this.pumpTotal - state.startDone
-    if (total <= 0) {
-      return null
-    }
-    const fraction = Math.min((this.pumpDone - state.startDone) / total, 1)
-    if (fraction < PRESIZE_MIN_FRACTION) {
-      return null
-    }
-    const scale = PRESIZE_HEADROOM / fraction
     return {
       vertices: Math.ceil(needVertices * scale),
       indices: Math.ceil(needIndices * scale),

--- a/src/viewer/ifc/incrementalBatchedBuilder.js
+++ b/src/viewer/ifc/incrementalBatchedBuilder.js
@@ -400,41 +400,45 @@ export class IncrementalBatchedBuilder {
       this.totals.skippedPlacedGeometries++
       return
     }
-    const isTransparent = color.w < OPAQUE_ALPHA
-    const state = this.ensureBatch_(isTransparent)
-    // Capacity BEFORE the duplicate marker, not after (codex P2 on
-    // Share#1809). `ensureCapacity_` is the one call left here that can
-    // throw — that is the whole subject of Share#1809 — and CoincidenceSet
-    // is a combined test-and-set with no remove, so marking first would
-    // record an identity for a placement that never landed. A later
-    // emission of that same placement would then be dropped as a duplicate
-    // of something that does not exist, and counted as a coincident skip
-    // rather than retried.
-    //
-    // Nothing today re-emits one: conway's pump contract is "each placed
-    // instance is emitted exactly once across all calls"
-    // (`ifc_api.d.ts`'s DELTA CONTRACT), and every degraded end-of-load
-    // build in ShareIfcLoader constructs a FRESH builder from
-    // `recapture()` rather than reusing this one's `seenPlacements`. So
-    // the ordering is an invariant kept honest, not a live bug fixed —
-    // but it costs nothing and the alternative is a guard that depends on
-    // an engine contract staying the way it is.
-    this.ensureCapacity_(state, entry)
-
     // Drop an exact coincident duplicate (same part + geometry + transform +
     // colour): it would z-fight the one already appended. See CoincidenceSet.
     //
-    // The combined test-and-set runs on the STAGED matrix elements, after
-    // every Conway-boundary read and the geometry fetch above, so a
-    // boundary throw can never mark an identity as seen (codex P2 on
-    // Share#1798). What follows the mark is now only the three.js tail —
-    // `addGeometry` into space `ensureCapacity_` has already secured,
-    // `addInstance`, writes into preallocated buffers and JS array pushes
-    // — none of which throw once capacity is in hand.
-    if (!this.seenPlacements.add(parentExpressId, geomExpressID, matrix.elements, color)) {
+    // PROBE, CAPACITY, THEN COMMIT — the three-step is load-bearing at both
+    // ends, and both ends are codex findings on Share#1809.
+    //
+    // Probing FIRST, before `ensureBatch_`/`ensureCapacity_`, keeps a
+    // duplicate from mutating anything: a duplicate arriving at
+    // `cursor === maxInstances` would otherwise double the instance
+    // buffers to make room for an instance that is never added, and
+    // `finalize`'s trim only reclaims geometry, so that doubling is
+    // retained for the life of the model. It also keeps an allocation
+    // failure from turning a harmless duplicate into a failed placement.
+    //
+    // Committing LAST, only once capacity is secured, keeps the reverse
+    // from happening: `ensureCapacity_` is the one call left here that can
+    // throw — that is the whole subject of Share#1809 — and a placement
+    // marked seen but never appended would make a later re-emission a
+    // duplicate of something that does not exist, counted as a coincident
+    // skip instead of retried. Nothing re-emits one today (conway's pump
+    // promises "each placed instance is emitted exactly once across all
+    // calls", and the degraded end-of-load builds construct a FRESH
+    // builder from `recapture()`), so that half is an invariant kept
+    // honest rather than a live bug fixed.
+    //
+    // The split exists so both can hold at once without hashing twice: the
+    // probe runs on the STAGED matrix elements, after every Conway-boundary
+    // read and the geometry fetch above, so a boundary throw still cannot
+    // mark an identity as seen (codex P2 on Share#1798).
+    const placementToken =
+      this.seenPlacements.probe(parentExpressId, geomExpressID, matrix.elements, color)
+    if (placementToken === null) {
       this.totals.skippedCoincidentPlacements++
       return
     }
+    const isTransparent = color.w < OPAQUE_ALPHA
+    const state = this.ensureBatch_(isTransparent)
+    this.ensureCapacity_(state, entry)
+    this.seenPlacements.commit(placementToken)
 
     let geometryId = entry.idByBatch.get(state)
     if (geometryId === undefined) {
@@ -624,6 +628,11 @@ export class IncrementalBatchedBuilder {
       // is what decides whether setGeometrySize can still be called, see
       // PRESIZE_FROM_GEOMETRIES.
       geometryCount: 0,
+      // Whether the one-shot widened reservation at LAST_CHANCE_GEOMETRIES
+      // has been made (see ensureCapacity_). Without it the crossing would
+      // re-trigger on every geometry past the threshold, one full buffer
+      // copy each.
+      lastChanceReserved: false,
       // Pump progress when this batch was created. The projection measures
       // from here, not from zero: the transparent batch's first placement
       // lands a third of the way through sp-946MB, and charging it for
@@ -679,7 +688,24 @@ export class IncrementalBatchedBuilder {
     }
     const needVertices = state.usedVertices + entry.vertCount
     const needIndices = state.usedIndices + entry.indexCount
-    if (needVertices > state.maxVertices || needIndices > state.maxIndices) {
+    // Past the early return above, this geometry is NEW to the batch, so
+    // the count it is about to reach is the one that matters here.
+    const lastChance = state.geometryCount + 1 >= this.lastChanceGeometries
+    // Two things call for a resize, and the second is not obvious.
+    //
+    // Running out of room is the obvious one. The other is this geometry
+    // taking the batch across LAST_CHANCE_GEOMETRIES: resizing stops being
+    // reliable past that point, so the widened reservation has to be made
+    // HERE, on the crossing, while it still works. Waiting for the batch to
+    // run out — as this did until codex's second round on Share#1809 — hands
+    // the widening to whichever later placement happens to exhaust the
+    // reserve, and an ample 1.15 projection can postpone that well beyond
+    // the spread ceiling, at which point `setGeometrySize` throws and the
+    // widening arrives exactly one throw too late. One shot, so
+    // `lastChanceReserved` stops it becoming a resize per geometry.
+    const exhausted = needVertices > state.maxVertices || needIndices > state.maxIndices
+    const crossing = lastChance && !state.lastChanceReserved
+    if (exhausted || crossing) {
       let nextVertices = state.maxVertices
       let nextIndices = state.maxIndices
       while (nextVertices < needVertices) {
@@ -688,14 +714,24 @@ export class IncrementalBatchedBuilder {
       while (nextIndices < needIndices) {
         nextIndices *= GROWTH
       }
-      const projected = this.projectCapacity_(state, needVertices, needIndices)
+      const projected = this.projectCapacity_(state, needVertices, needIndices, lastChance)
       if (projected !== null) {
         nextVertices = Math.max(nextVertices, projected.vertices)
         nextIndices = Math.max(nextIndices, projected.indices)
       }
-      state.mesh.setGeometrySize(nextVertices, nextIndices)
-      state.maxVertices = nextVertices
-      state.maxIndices = nextIndices
+      // A crossing whose widened reservation asks for no more than the
+      // batch already holds must not pay a full buffer copy for nothing.
+      if (nextVertices > state.maxVertices || nextIndices > state.maxIndices) {
+        state.mesh.setGeometrySize(nextVertices, nextIndices)
+        state.maxVertices = nextVertices
+        state.maxIndices = nextIndices
+      }
+      // Spent whether or not it changed the size — the question "has this
+      // batch taken its last-chance reservation" is about the crossing,
+      // not about whether the crossing needed more room.
+      if (crossing) {
+        state.lastChanceReserved = true
+      }
     }
     state.usedVertices = needVertices
     state.usedIndices = needIndices
@@ -734,15 +770,15 @@ export class IncrementalBatchedBuilder {
    * @param {number} needVertices vertices this batch needs including the
    *   geometry being added
    * @param {number} needIndices indices this batch needs, likewise
+   * @param {boolean} lastChance treat this as the last resize the batch
+   *   will complete: widen the headroom, and stand in for the projection
+   *   entirely when there is no pump progress to project from. Decided by
+   *   the caller because it is the same predicate that decides whether to
+   *   resize at all on a threshold crossing.
    * @return {?{vertices: number, indices: number}} projected capacity, or
    *   null when unprojectable
    */
-  projectCapacity_(state, needVertices, needIndices) {
-    // Is this, in expectation, the last resize this batch will complete?
-    // Decided first: it changes the headroom below, and it stands in for
-    // the projection entirely when there is no pump progress to project
-    // from.
-    const lastChance = state.geometryCount >= this.lastChanceGeometries
+  projectCapacity_(state, needVertices, needIndices, lastChance) {
     let scale = 0
     if (this.pumpTotal > 0 && state.geometryCount >= this.presizeFromGeometries) {
       const total = this.pumpTotal - state.startDone

--- a/src/viewer/ifc/incrementalBatchedBuilder.js
+++ b/src/viewer/ifc/incrementalBatchedBuilder.js
@@ -22,6 +22,31 @@ const INITIAL_INSTANCES = 1024
 const INITIAL_VERTICES = 1 << 18
 const INITIAL_INDICES = 1 << 19
 const GROWTH = 2
+// Geometry count from which a batch stops doubling blindly and is sized
+// for the whole model instead (see projectCapacity_).
+//
+// three r0.184's `BatchedMesh.setGeometrySize` spreads one argument per
+// ACTIVE geometry into `Math.max( ...validRanges.map( … ) )`
+// (node_modules/three/src/objects/BatchedMesh.js:1329 and :1339), so the
+// call throws `RangeError: Maximum call stack size exceeded` once a batch
+// holds more geometries than V8's argument limit. That limit is
+// stack-depth dependent, so it is a soft ceiling rather than a constant to
+// sit on: measured at 125,279 entries on the box that root-caused this
+// (Share#1809), reached by sp-946MB.ifc at roughly a quarter of its load.
+// Past it a batch can never grow again, so the last growth that still
+// works has to be the one that covers the rest of the model. Triggering at
+// well under half the measured limit leaves room for a shallower stack and
+// still gives the projection a sample of tens of thousands of geometries.
+export const PRESIZE_FROM_GEOMETRIES = 50000
+// Over-provision the projected whole-model requirement by this much. The
+// projection is re-run at every later growth, so this only has to cover
+// the error of the LAST projection made before the ceiling above; measured
+// over-shoot on sp-946MB was already +11% at the first trigger point, so
+// this is margin on top of a conservative estimator, not the estimator.
+const PRESIZE_HEADROOM = 1.15
+// Pump progress below which the projection is not trusted: dividing a
+// handful of dense products by a near-zero fraction reserves gigabytes.
+const PRESIZE_MIN_FRACTION = 0.02
 // Console cap for per-record skip warnings (see warnBadRecord_): a model
 // with many budget-evicted geometries (conway#535) shouldn't flood the
 // console one line per id -- the load report's skipped* counts already
@@ -65,6 +90,10 @@ export class IncrementalBatchedBuilder {
    * @param {number} [opts.initialInstances] test hook: initial capacity.
    * @param {number} [opts.initialVertices] test hook: initial capacity.
    * @param {number} [opts.initialIndices] test hook: initial capacity.
+   * @param {number} [opts.presizeFromGeometries] test hook: geometry count
+   *   at which projectCapacity_ takes over from doubling. Lowering it is
+   *   the only way to exercise the projection without building a batch of
+   *   PRESIZE_FROM_GEOMETRIES real geometries.
    */
   constructor(api, modelID, opts = {}) {
     this.api = api
@@ -73,6 +102,7 @@ export class IncrementalBatchedBuilder {
     this.initialInstances = opts.initialInstances ?? INITIAL_INSTANCES
     this.initialVertices = opts.initialVertices ?? INITIAL_VERTICES
     this.initialIndices = opts.initialIndices ?? INITIAL_INDICES
+    this.presizeFromGeometries = opts.presizeFromGeometries ?? PRESIZE_FROM_GEOMETRIES
     this.root = new Group()
     // geometryExpressID → {geometry, vertCount, indexCount, box,
     // idByBatch: Map(batchState → geometryId)} — geometry fetched from
@@ -90,6 +120,12 @@ export class IncrementalBatchedBuilder {
     this.failedThisBatch = new Set()
     // Running count backing warnBadRecord_'s console cap.
     this.badRecordWarnings = 0
+    // Demand-pump product progress, the only whole-model quantity a
+    // streaming builder can see (setPumpProgress). Zeroes mean "no pump
+    // told us" — every one-shot and unit-test caller — and disable the
+    // capacity projection, leaving the 2x doubling in charge.
+    this.pumpDone = 0
+    this.pumpTotal = 0
     // Placement identities already appended, across all batches — drops
     // exact duplicate placements that would z-fight (see CoincidenceSet).
     // Load-time only: `finalize` releases it (conway#636).
@@ -122,6 +158,32 @@ export class IncrementalBatchedBuilder {
   /** @return {boolean} True once any instance has been appended. */
   hasContent() {
     return this.totals.placements > 0
+  }
+
+
+  /**
+   * Record how far the demand pump has got through the model's products,
+   * in the pump's own units (`geometryDone` / `geometryTotal` from
+   * `conwayDirectIfcLoader`'s loop — products extracted, not FlatMeshes
+   * delivered, which is a smaller number because not every product yields
+   * geometry). This is the only signal that lets a builder assembling one
+   * batch at a time size the batch for the WHOLE model instead of
+   * doubling into it; see projectCapacity_ for what it is used for and
+   * Share#1809 for why doubling into it is not survivable at scale.
+   *
+   * Called per batch rather than passed to the constructor because the
+   * total is not known until the first `ExtractGeometryBatch` returns —
+   * which is the same call that produces the first batch.
+   *
+   * @param {number} done products the pump has extracted so far
+   * @param {number} total products the pump reported in the model
+   */
+  setPumpProgress(done, total) {
+    if (!Number.isFinite(done) || !Number.isFinite(total) || total <= 0) {
+      return
+    }
+    this.pumpDone = done
+    this.pumpTotal = total
   }
 
 
@@ -215,6 +277,9 @@ export class IncrementalBatchedBuilder {
           state.instanceOccurrencePaths.slice() : null
       state.mesh.instanceGeometry = state.instanceGeometry.slice()
       state.mesh.instanceColors = state.instanceColors.slice()
+      // The mesh has stopped growing, so its exact requirement is finally
+      // known: release the reserved space nothing used (Share#1809).
+      this.trimCapacity_(state)
       // The mesh has stopped growing, so a bounding volume is finally
       // meaningful. Compute it and hand culling back — see ensureBatch_
       // for why it had to be off while streaming. assembleBatchedModel
@@ -326,6 +391,7 @@ export class IncrementalBatchedBuilder {
     if (geometryId === undefined) {
       geometryId = state.mesh.addGeometry(entry.geometry)
       entry.idByBatch.set(state, geometryId)
+      state.geometryCount++
     }
     const batchId = state.mesh.addInstance(geometryId)
     // Decide the model-wide origin-recenter offset from the first placement
@@ -501,6 +567,18 @@ export class IncrementalBatchedBuilder {
       maxIndices: this.initialIndices,
       usedVertices: 0,
       usedIndices: 0,
+      // Unique geometries added to THIS mesh. Tracked here rather than
+      // read off three's `_geometryInfo` because it is the same number
+      // (nothing ever deletes a geometry from these batches, so every
+      // entry stays active) without reaching into a private field — and it
+      // is what decides whether setGeometrySize can still be called, see
+      // PRESIZE_FROM_GEOMETRIES.
+      geometryCount: 0,
+      // Pump progress when this batch was created. The projection measures
+      // from here, not from zero: the transparent batch's first placement
+      // lands a third of the way through sp-946MB, and charging it for
+      // that whole prefix would over-reserve it by ~1.4x.
+      startDone: this.pumpDone,
       instanceParents: [],
       instanceOccurrenceIds: [],
       instanceGeometryIds: [],
@@ -515,18 +593,36 @@ export class IncrementalBatchedBuilder {
 
 
   /**
-   * Grow the batch in place (2x amortized) so the next instance — and,
-   * when the geometry is new to this batch, its vertex/index ranges —
-   * fit. three's setInstanceCount/setGeometrySize copy the underlying
-   * buffers; growth doubles so total copy work stays linear.
+   * Grow the batch in place so the next instance — and, when the geometry
+   * is new to this batch, its vertex/index ranges — fit. three's
+   * setInstanceCount/setGeometrySize copy the underlying buffers; growth
+   * doubles so total copy work stays linear, except once the batch is
+   * large enough to be sized for the whole model (projectCapacity_).
+   *
+   * BOOKKEEPING TRAILS THE three.js CALL, NEVER LEADS IT (Share#1809).
+   * `setGeometrySize` can throw — on three's own spread limit
+   * (PRESIZE_FROM_GEOMETRIES) and on an allocation failure — and it throws
+   * from its shrink checks, BEFORE it has touched the mesh, so three's
+   * real capacity is unchanged when it does. Raising
+   * `state.maxVertices`/`maxIndices` first, as this did until Share#1809,
+   * left Share believing in space three had never allocated: every later
+   * placement then took the "no growth needed" branch straight into
+   * `addGeometry`'s "Reserved space request exceeds the maximum buffer
+   * size", for the rest of the load, and `usedVertices` kept climbing for
+   * geometry that never landed. With warnBadRecord_ capped at 5 lines the
+   * only surviving signal was a count: 298,305 of 496,280 placements
+   * dropped on sp-946MB.ifc. Committing the numbers after the call returns
+   * keeps Share and three agreeing — a throw skips the one placement that
+   * could not fit, and every later placement that DOES fit still lands.
    *
    * @param {object} state batch state
    * @param {object} entry geometry cache entry
    */
   ensureCapacity_(state, entry) {
     if (state.cursor + 1 > state.maxInstances) {
-      state.maxInstances = Math.max(state.maxInstances * GROWTH, state.cursor + 1)
-      state.mesh.setInstanceCount(state.maxInstances)
+      const nextInstances = Math.max(state.maxInstances * GROWTH, state.cursor + 1)
+      state.mesh.setInstanceCount(nextInstances)
+      state.maxInstances = nextInstances
     }
     if (entry.idByBatch.has(state)) {
       return
@@ -534,15 +630,111 @@ export class IncrementalBatchedBuilder {
     const needVertices = state.usedVertices + entry.vertCount
     const needIndices = state.usedIndices + entry.indexCount
     if (needVertices > state.maxVertices || needIndices > state.maxIndices) {
-      while (state.maxVertices < needVertices) {
-        state.maxVertices *= GROWTH
+      let nextVertices = state.maxVertices
+      let nextIndices = state.maxIndices
+      while (nextVertices < needVertices) {
+        nextVertices *= GROWTH
       }
-      while (state.maxIndices < needIndices) {
-        state.maxIndices *= GROWTH
+      while (nextIndices < needIndices) {
+        nextIndices *= GROWTH
       }
-      state.mesh.setGeometrySize(state.maxVertices, state.maxIndices)
+      const projected = this.projectCapacity_(state, needVertices, needIndices)
+      if (projected !== null) {
+        nextVertices = Math.max(nextVertices, projected.vertices)
+        nextIndices = Math.max(nextIndices, projected.indices)
+      }
+      state.mesh.setGeometrySize(nextVertices, nextIndices)
+      state.maxVertices = nextVertices
+      state.maxIndices = nextIndices
     }
     state.usedVertices = needVertices
     state.usedIndices = needIndices
+  }
+
+
+  /**
+   * Project this batch's whole-model vertex/index requirement from the
+   * demand pump's product progress, so a batch that is about to run out of
+   * growths reserves once for the rest of the load instead of doubling
+   * into a call that will throw (see PRESIZE_FROM_GEOMETRIES).
+   *
+   * The estimator is linear in products, which is conservative in the
+   * right direction: geometry is deduplicated by `geometryExpressID`, so
+   * products seen early contribute proportionally MORE new vertices than
+   * products seen late, and the projection therefore lands above the true
+   * total. Measured on sp-946MB.ifc: +11% at the first trigger point,
+   * +12% at the last one before three's ceiling.
+   *
+   * Returns null — leaving the doubling in charge — whenever the estimate
+   * would be guesswork: no pump progress (every one-shot and unit-test
+   * caller), a batch still small enough that doubling can safely correct
+   * itself later, or too little of the model seen to divide by.
+   *
+   * @param {object} state batch state
+   * @param {number} needVertices vertices this batch needs including the
+   *   geometry being added
+   * @param {number} needIndices indices this batch needs, likewise
+   * @return {?{vertices: number, indices: number}} projected capacity, or
+   *   null when unprojectable
+   */
+  projectCapacity_(state, needVertices, needIndices) {
+    if (this.pumpTotal <= 0 || state.geometryCount < this.presizeFromGeometries) {
+      return null
+    }
+    const total = this.pumpTotal - state.startDone
+    if (total <= 0) {
+      return null
+    }
+    const fraction = Math.min((this.pumpDone - state.startDone) / total, 1)
+    if (fraction < PRESIZE_MIN_FRACTION) {
+      return null
+    }
+    const scale = PRESIZE_HEADROOM / fraction
+    return {
+      vertices: Math.ceil(needVertices * scale),
+      indices: Math.ceil(needIndices * scale),
+    }
+  }
+
+
+  /**
+   * Hand back a finished batch's reserved-but-unused vertex/index space.
+   *
+   * A streaming builder cannot know the exact requirement until the last
+   * placement lands, so both sizing policies above deliberately reserve
+   * too much: the projection by PRESIZE_HEADROOM, and a batch too small to
+   * project by whatever power of two first clears its need. That slack is
+   * retained for the life of the model — measured at 92.5 MB on
+   * sp-231MB.ifc, byte-lever 2 of the conway#679 attribution report. Once
+   * `finalize` runs the model has stopped growing and the exact figure is
+   * known, so give the rest back.
+   *
+   * `usedVertices`/`usedIndices` are exactly three's own high-water marks:
+   * `addGeometry` packs each geometry's reservation contiguously from 0
+   * and nothing here ever removes one, so the sum of what was added IS
+   * `max(vertexStart + reservedVertexCount)`, which is the figure
+   * setGeometrySize checks a shrink against.
+   *
+   * Cost and failure mode, both deliberate. The trim is one reallocation
+   * and copy of the batch buffers, so a steady-state saving is bought with
+   * a transient peak of capacity + used at the end of the load, after the
+   * parse-time transients have been released. And on a batch past three's
+   * spread limit it throws exactly like a growth would — and, like a
+   * growth, before it has touched the mesh — so it is best-effort: those
+   * batches keep their slack rather than losing their geometry to it.
+   *
+   * @param {object} state batch state
+   */
+  trimCapacity_(state) {
+    if (state.usedVertices >= state.maxVertices && state.usedIndices >= state.maxIndices) {
+      return
+    }
+    try {
+      state.mesh.setGeometrySize(state.usedVertices, state.usedIndices)
+      state.maxVertices = state.usedVertices
+      state.maxIndices = state.usedIndices
+    } catch (e) {
+      debug(WARN).warn('IncrementalBatchedBuilder: batch capacity trim skipped:', e)
+    }
   }
 }

--- a/src/viewer/ifc/incrementalBatchedBuilder.js
+++ b/src/viewer/ifc/incrementalBatchedBuilder.js
@@ -22,22 +22,35 @@ const INITIAL_INSTANCES = 1024
 const INITIAL_VERTICES = 1 << 18
 const INITIAL_INDICES = 1 << 19
 const GROWTH = 2
-// Geometry count from which a batch stops doubling blindly and is sized
-// for the whole model instead (see projectCapacity_).
-//
-// three r0.184's `BatchedMesh.setGeometrySize` spreads one argument per
-// ACTIVE geometry into `Math.max( ...validRanges.map( … ) )`
-// (node_modules/three/src/objects/BatchedMesh.js:1329 and :1339), so the
-// call throws `RangeError: Maximum call stack size exceeded` once a batch
-// holds more geometries than V8's argument limit. That limit is
-// stack-depth dependent, so it is a soft ceiling rather than a constant to
-// sit on: measured at 125,279 entries on the box that root-caused this
-// (Share#1809), reached by sp-946MB.ifc at roughly a quarter of its load.
-// Past it a batch can never grow again, so the last growth that still
-// works has to be the one that covers the rest of the model. Triggering at
-// well under half the measured limit leaves room for a shallower stack and
-// still gives the projection a sample of tens of thousands of geometries.
+// Upper bound for the spread probe below. Nothing is gained by knowing an
+// engine tolerates more than this: the thresholds derived from it are
+// already clamped by their own constants at that point.
+const SPREAD_PROBE_CEILING = 200000
+// Ceiling on the geometry count from which a batch stops doubling blindly
+// and is sized for the whole model instead (see projectCapacity_), and on
+// the count past which it is treated as having ONE resize left. Both are
+// clamped down to a fraction of the ENGINE's measured spread limit; these
+// are the caps that apply when the engine is roomy.
 export const PRESIZE_FROM_GEOMETRIES = 50000
+export const LAST_CHANCE_GEOMETRIES = 110000
+// Fractions of the probed spread limit the two thresholds sit at.
+//
+// The presize crossing has to happen early enough that a batch reaches it
+// before its FIRST natural resize, or the mechanism never runs at all: a
+// model of single-triangle geometries fills the initial 262,144-vertex
+// reservation at 87,382 geometries, which is above JavaScriptCore's spread
+// limit, so on Safari the first resize is already the one that throws
+// (codex round 4 on Share#1809). 0.6 puts it comfortably below any
+// engine's ceiling; 0.85 leaves the last-chance reservation as late as is
+// safe, so it projects from the largest sample it can get.
+//
+// Both also have to absorb the fact that the probe runs from a different
+// stack depth than three's resize will. Measured on this V8: the limit
+// falls from 125,263 at the probe's own depth to 122,851 with 200 extra
+// frames beneath it — 1.9%. A 15% margin covers that with room to spare;
+// sitting ON the probed number would not.
+const PRESIZE_SPREAD_SAFETY = 0.6
+const LAST_CHANCE_SPREAD_SAFETY = 0.85
 // Over-provision the projected whole-model requirement by this much. The
 // projection is re-run at every later growth, so this only has to cover
 // the error of the LAST projection made before the ceiling above; measured
@@ -47,17 +60,6 @@ const PRESIZE_HEADROOM = 1.15
 // Pump progress below which the projection is not trusted: dividing a
 // handful of dense products by a near-zero fraction reserves gigabytes.
 const PRESIZE_MIN_FRACTION = 0.02
-// Active-geometry count past which a batch is treated as having ONE resize
-// left, and reserves accordingly (see projectCapacity_).
-//
-// Deliberately well under the 125,279 measured above, because that number
-// is V8's argument cap on three's `Math.max(...)` spread and is therefore
-// stack-depth dependent: the same batch resized from a deeper call stack
-// fails earlier. 110,000 keeps ~12% of margin against a measurement taken
-// on one stack on one box, which is the right side to be wrong on — the
-// cost of triggering early is a slightly larger reservation, the cost of
-// triggering late is the reservation never happening at all.
-const LAST_CHANCE_GEOMETRIES = 110000
 // Headroom the last-chance reservation uses in place of PRESIZE_HEADROOM.
 //
 // The projection is linear in products, which is only conservative when
@@ -75,6 +77,68 @@ const LAST_CHANCE_HEADROOM = 1.5
 // the deferred pump path, which always reports totals — so this is what
 // keeps the branch total rather than a second estimator.
 const LAST_CHANCE_GROWTH = 2
+
+
+// Memoised result of probeSpreadLimit().
+let spreadLimitCache = null
+
+
+/**
+ * Largest argument count this engine's `Math.max(...)` survives.
+ *
+ * three r0.184's `BatchedMesh.setGeometrySize` spreads one argument per
+ * ACTIVE geometry into `Math.max( ...validRanges.map( … ) )`
+ * (node_modules/three/src/objects/BatchedMesh.js:1329 and :1339), so once a
+ * batch holds more geometries than the engine's argument limit, EVERY
+ * resize of it throws and the batch can never grow again. Everything this
+ * module does about that — when to stop doubling and project, when to take
+ * the last reservation — has to sit below this number.
+ *
+ * Probed rather than hard-coded because it is a property of the engine and
+ * of stack depth at the call site, not of three: measured at 125,279 on the
+ * V8 that root-caused Share#1809, while JavaScriptCore caps argument
+ * spreads near 65k and SpiderMonkey allows more. A constant encodes one
+ * engine, and the wrong one is not a smaller margin but no mechanism at
+ * all — a model of single-triangle geometries needs its first resize at
+ * 87,382 geometries, so on Safari a 110,000 threshold is never reached
+ * before the throw (codex round 4 on Share#1809).
+ *
+ * Binary search over hole-y arrays: `new Array(n)` allocates no elements
+ * and the spread reads holes as `undefined`, so each probe costs the spread
+ * itself and nothing else. ~18 iterations, memoised, and deliberately
+ * called from the builder's constructor rather than at import time so a
+ * module load never pays for it.
+ *
+ * @return {number} the largest n for which `Math.max(...new Array(n))`
+ *   does not throw, capped at SPREAD_PROBE_CEILING
+ */
+export function probeSpreadLimit() {
+  if (spreadLimitCache !== null) {
+    return spreadLimitCache
+  }
+  const survives = (n) => {
+    try {
+      Math.max(...new Array(n))
+      return true
+    } catch {
+      // RangeError on every engine that has a limit; catching broadly
+      // because the class of the throw is not part of any contract.
+      return false
+    }
+  }
+  let low = 1
+  let high = SPREAD_PROBE_CEILING
+  while (low < high) {
+    const mid = Math.ceil((low + high) / 2)
+    if (survives(mid)) {
+      low = mid
+    } else {
+      high = mid - 1
+    }
+  }
+  spreadLimitCache = low
+  return spreadLimitCache
+}
 // Console cap for per-record skip warnings (see warnBadRecord_): a model
 // with many budget-evicted geometries (conway#535) shouldn't flood the
 // console one line per id -- the load report's skipped* counts already
@@ -124,6 +188,10 @@ export class IncrementalBatchedBuilder {
    *   PRESIZE_FROM_GEOMETRIES real geometries.
    * @param {number} [opts.lastChanceGeometries] test hook: geometry count
    *   at which a resize is treated as the last one this batch will get.
+   * @param {number} [opts.spreadLimit] test hook: stand in for
+   *   probeSpreadLimit(), so the thresholds derived from a JavaScriptCore-
+   *   or V8-sized ceiling can be pinned without running on that engine.
+   *   Ignored for whichever of the two thresholds is given explicitly.
    */
   constructor(api, modelID, opts = {}) {
     this.api = api
@@ -132,8 +200,17 @@ export class IncrementalBatchedBuilder {
     this.initialInstances = opts.initialInstances ?? INITIAL_INSTANCES
     this.initialVertices = opts.initialVertices ?? INITIAL_VERTICES
     this.initialIndices = opts.initialIndices ?? INITIAL_INDICES
-    this.presizeFromGeometries = opts.presizeFromGeometries ?? PRESIZE_FROM_GEOMETRIES
-    this.lastChanceGeometries = opts.lastChanceGeometries ?? LAST_CHANCE_GEOMETRIES
+    // Both thresholds are the smaller of their own cap and a fraction of
+    // what this engine's `Math.max(...)` spread actually tolerates, so a
+    // roomy engine keeps the tuned numbers (V8 here: 50,000 and 106,486)
+    // and a tight one is pulled below its ceiling instead of past it
+    // (JavaScriptCore at ~65,536: 39,321 and 55,705). See
+    // probeSpreadLimit.
+    const spreadLimit = opts.spreadLimit ?? probeSpreadLimit()
+    this.presizeFromGeometries = opts.presizeFromGeometries ?? Math.min(
+      PRESIZE_FROM_GEOMETRIES, Math.floor(spreadLimit * PRESIZE_SPREAD_SAFETY))
+    this.lastChanceGeometries = opts.lastChanceGeometries ?? Math.min(
+      LAST_CHANCE_GEOMETRIES, Math.floor(spreadLimit * LAST_CHANCE_SPREAD_SAFETY))
     this.root = new Group()
     // geometryExpressID → {geometry, vertCount, indexCount, box,
     // idByBatch: Map(batchState → geometryId)} — geometry fetched from
@@ -636,10 +713,11 @@ export class IncrementalBatchedBuilder {
       // is what decides whether setGeometrySize can still be called, see
       // PRESIZE_FROM_GEOMETRIES.
       geometryCount: 0,
-      // Whether the one-shot widened reservation at LAST_CHANCE_GEOMETRIES
-      // has been made (see ensureCapacity_). Without it the crossing would
-      // re-trigger on every geometry past the threshold, one full buffer
-      // copy each.
+      // Whether the one-shot reservations at presizeFromGeometries and
+      // lastChanceGeometries have been made (see ensureCapacity_). Without
+      // these the crossings would re-trigger on every geometry past their
+      // thresholds, one full buffer copy each.
+      presizeReserved: false,
       lastChanceReserved: false,
       // Pump progress when this batch was created. The projection measures
       // from here, not from zero: the transparent batch's first placement
@@ -699,21 +777,36 @@ export class IncrementalBatchedBuilder {
     // Past the early return above, this geometry is NEW to the batch, so
     // the count it is about to reach is the one that matters here.
     const lastChance = state.geometryCount + 1 >= this.lastChanceGeometries
-    // Two things call for a resize, and the second is not obvious.
+    // THREE things call for a resize, and only the first is obvious.
     //
-    // Running out of room is the obvious one. The other is this geometry
-    // taking the batch across LAST_CHANCE_GEOMETRIES: resizing stops being
-    // reliable past that point, so the widened reservation has to be made
-    // HERE, on the crossing, while it still works. Waiting for the batch to
-    // run out — as this did until codex's second round on Share#1809 — hands
-    // the widening to whichever later placement happens to exhaust the
-    // reserve, and an ample 1.15 projection can postpone that well beyond
-    // the spread ceiling, at which point `setGeometrySize` throws and the
-    // widening arrives exactly one throw too late. One shot, so
-    // `lastChanceReserved` stops it becoming a resize per geometry.
+    // Running out of room is the obvious one. The other two are threshold
+    // crossings, and both exist because resizing is a privilege this batch
+    // loses partway through the load — so a reservation that matters has to
+    // be made while it still works, not when the batch happens to run out.
+    //
+    // `crossing` is the last-chance one: past lastChanceGeometries this is
+    // in expectation the final resize, so it is taken with the widened
+    // headroom. Hanging it off exhaustion — as this did until codex's
+    // second round — hands the widening to whichever later placement runs
+    // the reserve out, which an ample 1.15 projection can postpone past
+    // the ceiling.
+    //
+    // `presizeCrossing` is the earlier one, and without it the whole
+    // mechanism can be skipped on a tight engine: a model of
+    // single-triangle geometries first exhausts its 262,144-vertex initial
+    // reservation at 87,382 geometries, above JavaScriptCore's spread
+    // limit, so there the FIRST natural resize is already the one that
+    // throws and no projection is ever made (codex round 4). Crossing
+    // presizeFromGeometries therefore forces a projected resize on its own,
+    // whether or not the batch is short of room.
+    //
+    // Both are one-shot; the latches stop them becoming a resize per
+    // geometry for the rest of the load.
     const exhausted = needVertices > state.maxVertices || needIndices > state.maxIndices
     const crossing = lastChance && !state.lastChanceReserved
-    if (exhausted || crossing) {
+    const presizeCrossing = !state.presizeReserved &&
+      state.geometryCount + 1 >= this.presizeFromGeometries
+    if (exhausted || crossing || presizeCrossing) {
       let nextVertices = state.maxVertices
       let nextIndices = state.maxIndices
       while (nextVertices < needVertices) {
@@ -734,11 +827,14 @@ export class IncrementalBatchedBuilder {
         state.maxVertices = nextVertices
         state.maxIndices = nextIndices
       }
-      // Spent whether or not it changed the size — the question "has this
-      // batch taken its last-chance reservation" is about the crossing,
-      // not about whether the crossing needed more room.
+      // Spent whether or not they changed the size — the question "has
+      // this batch taken its reservation" is about the crossing, not about
+      // whether the crossing needed more room.
       if (crossing) {
         state.lastChanceReserved = true
+      }
+      if (presizeCrossing) {
+        state.presizeReserved = true
       }
     }
     state.usedVertices = needVertices
@@ -788,7 +884,11 @@ export class IncrementalBatchedBuilder {
    */
   projectCapacity_(state, needVertices, needIndices, lastChance) {
     let scale = 0
-    if (this.pumpTotal > 0 && state.geometryCount >= this.presizeFromGeometries) {
+    // `+ 1` for the same reason the caller's predicates use it: this runs
+    // only when a new geometry is being added, so the count that decides is
+    // the one it is about to reach. Without it the presize CROSSING would
+    // arrive one geometry before this guard opened and reserve nothing.
+    if (this.pumpTotal > 0 && state.geometryCount + 1 >= this.presizeFromGeometries) {
       const total = this.pumpTotal - state.startDone
       const fraction = total > 0 ?
         Math.min((this.pumpDone - state.startDone) / total, 1) : 0

--- a/src/viewer/ifc/incrementalBatchedBuilder.test.js
+++ b/src/viewer/ifc/incrementalBatchedBuilder.test.js
@@ -557,6 +557,84 @@ describe('IncrementalBatchedBuilder', () => {
     expect(stats.vertexCount).toBe(shapeCount * 3)
   })
 
+  it('widens the reservation once the batch has one resize left', () => {
+    // codex P1 on Share#1809: the linear projection tends to overshoot but
+    // does not bound a model whose late products carry denser or more
+    // novel geometry than its early ones. While resizes still work that
+    // self-corrects at the next growth; past LAST_CHANCE_GEOMETRIES there
+    // is no next growth, so the reservation widens from PRESIZE_HEADROOM
+    // (1.15) to LAST_CHANCE_HEADROOM (1.5) -- "the rest of the model may
+    // be up to 50% denser per product than everything so far".
+    const all = triangleShapes(4)
+    const builder = new IncrementalBatchedBuilder(makeApi(all), 0, {
+      initialVertices: 3,
+      initialIndices: 3,
+      presizeFromGeometries: 2,
+      lastChanceGeometries: 3,
+    })
+
+    // Three products in, 2 geometries held: projected, not yet last-chance.
+    // 47 = ceil(9 needed / (2/9 seen since this batch opened) * 1.15).
+    for (let i = 0; i < 3; i++) {
+      builder.setPumpProgress(i + 1, 10)
+      builder.appendBatch([flatMesh(i + 1, [{geomExpressID: 1000 + i, color: OPAQUE}])])
+    }
+    expect(builder.opaque.geometryCount).toBe(3)
+    expect(builder.opaque.maxVertices).toBe(47)
+
+    // Force one more resize with the batch now at the threshold. Need is
+    // 48 vertices, seen is 6/9, so the projection alone would ask for
+    // ceil(48 * 1.15 / (6/9)) = 83; the last-chance headroom asks for
+    // ceil(48 * 1.5 / (6/9)) = 108.
+    builder.opaque.usedVertices = 45
+    builder.opaque.usedIndices = 45
+    builder.setPumpProgress(7, 10)
+    builder.appendBatch([flatMesh(4, [{geomExpressID: 1003, color: OPAQUE}])])
+
+    expect(builder.opaque.maxVertices).toBe(108)
+    expect(builder.opaque.maxIndices).toBe(108)
+  })
+
+  it('retries a placement whose resize threw, instead of calling it a duplicate', () => {
+    // codex P2 on Share#1809. `seenPlacements` is a combined test-and-set
+    // with no remove, so marking a placement before securing its capacity
+    // records an identity for something that never landed: a later
+    // emission of the SAME placement is then dropped as a duplicate of
+    // nothing and counted as a coincident skip rather than appended.
+    //
+    // No path re-emits one today -- conway's pump promises each placed
+    // instance exactly once, and the degraded builds construct a fresh
+    // builder -- so this pins the invariant rather than a live bug, by
+    // re-appending the failed placement directly.
+    const all = triangleShapes(2)
+    const builder = new IncrementalBatchedBuilder(makeApi(all), 0, {
+      initialVertices: 3,
+      initialIndices: 3,
+    })
+    builder.appendBatch([flatMesh(1, [{geomExpressID: 1000, color: OPAQUE}])])
+
+    const {mesh} = builder.opaque
+    const realSetGeometrySize = mesh.setGeometrySize.bind(mesh)
+    mesh.setGeometrySize = () => {
+      throw new RangeError('Maximum call stack size exceeded')
+    }
+    const retried = flatMesh(2, [{geomExpressID: 1001, color: OPAQUE}])
+    builder.appendBatch([retried])
+    expect(builder.opaque.cursor).toBe(1)
+
+    // Capacity is available again and the identical placement comes back.
+    // It must be appended, not classified as coincident with the instance
+    // that was never created.
+    mesh.setGeometrySize = realSetGeometrySize
+    builder.appendBatch([retried])
+
+    const {stats, batches} = builder.finalize()
+    expect(stats.instanceCount).toBe(2)
+    expect(stats.skippedCoincidentPlacements).toBe(0)
+    expect(stats.skippedPlacedGeometries).toBe(1)
+    expect(Array.from(batches[0].instanceParents)).toEqual([1, 2])
+  })
+
   it('leaves capacity bookkeeping equal to three\'s when a resize throws', () => {
     // The second half of Share#1809: `ensureCapacity_` used to raise
     // maxVertices/maxIndices BEFORE calling setGeometrySize and never roll

--- a/src/viewer/ifc/incrementalBatchedBuilder.test.js
+++ b/src/viewer/ifc/incrementalBatchedBuilder.test.js
@@ -2,7 +2,8 @@
 import {BatchedMesh, BufferGeometry, Matrix4} from 'three'
 import {clearConwayDirectLogs, getConwayDirectLogs}
   from '../../../tools/jest/conwayDirectLogCapture'
-import {IncrementalBatchedBuilder, PRESIZE_FROM_GEOMETRIES} from './incrementalBatchedBuilder'
+import {IncrementalBatchedBuilder, PRESIZE_FROM_GEOMETRIES, probeSpreadLimit}
+  from './incrementalBatchedBuilder'
 import {flatMeshToBatchedModel} from './flatMeshToBatchedModel'
 import {payloadToPreviewMesh} from './parsePreviewMesh'
 
@@ -546,11 +547,11 @@ describe('IncrementalBatchedBuilder', () => {
     }
 
     // One reservation carried the whole model: nothing was skipped, and
-    // the capacity that survived the ceiling is the projected one -- 47 =
-    // ceil(9 vertices needed / (2/9 of the model seen since this batch
-    // opened) * 1.15 headroom), covering all 30 -- not the 12 that
-    // doubling would have reached before the ceiling shut it out.
-    expect(builder.opaque.maxVertices).toBe(47)
+    // the capacity that survived the ceiling is the projected one -- 63 =
+    // ceil(6 vertices needed / (1/9 of the model seen since this batch
+    // opened) * 1.15 headroom), covering all 30 -- not the 6 that doubling
+    // would have reached before the ceiling shut it out.
+    expect(builder.opaque.maxVertices).toBe(63)
     const {stats} = builder.finalize()
     expect(stats.instanceCount).toBe(shapeCount)
     expect(stats.skippedPlacedGeometries).toBe(0)
@@ -575,19 +576,92 @@ describe('IncrementalBatchedBuilder', () => {
       lastChanceGeometries: 3,
     })
 
+    // Pump totals chosen so the presize crossing at the second geometry
+    // sees too little of the model to project from (1/999, under
+    // PRESIZE_MIN_FRACTION) and reserves nothing -- isolating the
+    // last-chance crossing as the only thing that can resize here.
+    builder.setPumpProgress(1, 1000)
+    builder.appendBatch([flatMesh(1, [{geomExpressID: 1000, color: OPAQUE}])])
+    builder.setPumpProgress(2, 1000)
+    builder.appendBatch([flatMesh(2, [{geomExpressID: 1001, color: OPAQUE}])])
+    expect(builder.opaque.maxVertices).toBe(60)
+
+    builder.setPumpProgress(21, 1000)
+    builder.appendBatch([flatMesh(3, [{geomExpressID: 1002, color: OPAQUE}])])
+
+    // The third geometry took the count to the threshold. 675 =
+    // ceil(9 needed / (20/999 seen since this batch opened) * 1.5
+    // last-chance headroom) -- reserved proactively, with 51 of the old 60
+    // still unused.
+    expect(builder.opaque.geometryCount).toBe(3)
+    expect(builder.opaque.usedVertices).toBe(9)
+    expect(builder.opaque.maxVertices).toBe(675)
+    expect(builder.opaque.maxIndices).toBe(675)
+    expect(builder.opaque.lastChanceReserved).toBe(true)
+  })
+
+  it('forces a projected reservation when the presize count crosses', () => {
+    // codex round 4 on Share#1809: the presize threshold has to be a
+    // crossing of its own, not just a modifier on a resize that was
+    // happening anyway. On an engine with a tight spread limit -- JSC caps
+    // argument spreads near 65k -- a model of single-triangle geometries
+    // first runs out of its 262,144-vertex initial reservation at 87,382
+    // geometries, so the first natural resize is already past the ceiling
+    // and nothing would ever be projected.
+    //
+    // 60 vertices reserved against 9 needed: only the crossing can resize.
+    const all = triangleShapes(3)
+    const builder = new IncrementalBatchedBuilder(makeApi(all), 0, {
+      initialVertices: 60,
+      initialIndices: 60,
+      presizeFromGeometries: 3,
+    })
     for (let i = 0; i < 3; i++) {
-      builder.setPumpProgress(i + 1, 20)
+      builder.setPumpProgress(i + 1, 30)
       builder.appendBatch([flatMesh(i + 1, [{geomExpressID: 1000 + i, color: OPAQUE}])])
     }
 
-    // The third geometry took the count to the threshold. 129 =
-    // ceil(9 needed / (2/19 seen since this batch opened) * 1.5 last-chance
-    // headroom) -- reserved proactively, with 51 of the old 60 still unused.
-    expect(builder.opaque.geometryCount).toBe(3)
+    // 151 = ceil(9 needed / (2/29 seen since this batch opened) * 1.15).
     expect(builder.opaque.usedVertices).toBe(9)
-    expect(builder.opaque.maxVertices).toBe(129)
-    expect(builder.opaque.maxIndices).toBe(129)
-    expect(builder.opaque.lastChanceReserved).toBe(true)
+    expect(builder.opaque.maxVertices).toBe(151)
+    expect(builder.opaque.maxIndices).toBe(151)
+    expect(builder.opaque.presizeReserved).toBe(true)
+  })
+
+  it('derives both thresholds from the engine\'s own spread limit', () => {
+    // The limit is a property of the engine and of stack depth, not of
+    // three, so hard-coding V8's leaves the mechanism inert elsewhere. A
+    // roomy engine keeps the tuned caps; a tight one is pulled below its
+    // ceiling rather than past it.
+    const jsc = new IncrementalBatchedBuilder(makeApi({}), 0, {spreadLimit: 65536})
+    expect(jsc.presizeFromGeometries).toBe(39321) // floor(65536 * 0.6)
+    expect(jsc.lastChanceGeometries).toBe(55705) // floor(65536 * 0.85)
+    // ...and both stay under the ceiling that would have thrown.
+    expect(jsc.lastChanceGeometries).toBeLessThan(65536)
+
+    const v8 = new IncrementalBatchedBuilder(makeApi({}), 0, {spreadLimit: 125278})
+    expect(v8.presizeFromGeometries).toBe(PRESIZE_FROM_GEOMETRIES) // capped at 50,000
+    expect(v8.lastChanceGeometries).toBe(106486) // floor(125278 * 0.85), under the 110,000 cap
+  })
+
+  it('probes the running engine for a spread limit its thresholds fit under', () => {
+    // The one test that exercises the real Math.max rather than an
+    // injected number. It deliberately does NOT re-spread at the probed
+    // limit itself: that boundary moves with stack depth (measured 125,263
+    // at the probe's own depth, 122,851 with 200 extra frames), so
+    // asserting on it exactly is a flaky test, and the safety factors
+    // exist precisely because the resize happens from a different stack
+    // than the probe. What must hold is that the thresholds DERIVED from
+    // it are spreadable, with their margin intact.
+    const limit = probeSpreadLimit()
+    expect(Number.isInteger(limit)).toBe(true)
+    expect(limit).toBeGreaterThan(PRESIZE_FROM_GEOMETRIES)
+
+    const derived = new IncrementalBatchedBuilder(makeApi({}), 0)
+    expect(() => Math.max(...new Array(derived.presizeFromGeometries))).not.toThrow()
+    expect(() => Math.max(...new Array(derived.lastChanceGeometries))).not.toThrow()
+    // Memoised, so a load pays for the search once.
+    expect(probeSpreadLimit()).toBe(limit)
   })
 
   it('keeps widening on the exhaustion path once the batch is past the threshold', () => {
@@ -608,19 +682,19 @@ describe('IncrementalBatchedBuilder', () => {
       builder.appendBatch([flatMesh(i + 1, [{geomExpressID: 1000 + i, color: OPAQUE}])])
     }
     expect(builder.opaque.lastChanceReserved).toBe(true)
-    expect(builder.opaque.maxVertices).toBe(61)
+    expect(builder.opaque.maxVertices).toBe(63)
 
-    // Consume nearly all of it, then add a fourth geometry: 63 needed
-    // against 61 reserved, so this resize is driven by exhaustion, not by
-    // a crossing. 142 = ceil(63 * 1.5 / (6/9)); the 1.15 headroom would
-    // have left the doubling in charge at 122.
-    builder.opaque.usedVertices = 60
-    builder.opaque.usedIndices = 60
+    // Consume nearly all of it, then add a fourth geometry: 65 needed
+    // against 63 reserved, and both crossings are already spent, so this
+    // resize is driven by exhaustion alone. 147 = ceil(65 * 1.5 / (6/9));
+    // the 1.15 headroom would have left the doubling in charge at 126.
+    builder.opaque.usedVertices = 62
+    builder.opaque.usedIndices = 62
     builder.setPumpProgress(7, 10)
     builder.appendBatch([flatMesh(4, [{geomExpressID: 1003, color: OPAQUE}])])
 
-    expect(builder.opaque.maxVertices).toBe(142)
-    expect(builder.opaque.maxIndices).toBe(142)
+    expect(builder.opaque.maxVertices).toBe(147)
+    expect(builder.opaque.maxIndices).toBe(147)
   })
 
   it('lets a coincident duplicate mutate no capacity at an instance boundary', () => {
@@ -821,18 +895,6 @@ describe('IncrementalBatchedBuilder', () => {
     // removes the partial group and rebuilds the whole model from
     // `recapture()`, which is the correct outcome for a destroyed batch.
     expect(() => builder.finalize()).toThrow(/allocation failed/)
-  })
-
-  it('keeps growth working at the geometry count the presize takes over from', () => {
-    // PRESIZE_FROM_GEOMETRIES only buys anything if `setGeometrySize` still
-    // WORKS when the batch reaches it -- the whole point is to make the
-    // last surviving resize the one that covers the rest of the model. The
-    // limit is V8's argument cap on the `Math.max(...)` spread inside
-    // three's setGeometrySize, it is stack-depth dependent rather than a
-    // documented constant (measured at 125,279 entries when Share#1809 was
-    // root-caused), so this asserts the margin on the engine actually
-    // running rather than pinning the number.
-    expect(() => Math.max(...new Array(PRESIZE_FROM_GEOMETRIES).fill(0))).not.toThrow()
   })
 
   it('skips one unreadable FlatMesh without dropping the rest of the batch', () => {

--- a/src/viewer/ifc/incrementalBatchedBuilder.test.js
+++ b/src/viewer/ifc/incrementalBatchedBuilder.test.js
@@ -557,14 +557,45 @@ describe('IncrementalBatchedBuilder', () => {
     expect(stats.vertexCount).toBe(shapeCount * 3)
   })
 
-  it('widens the reservation once the batch has one resize left', () => {
-    // codex P1 on Share#1809: the linear projection tends to overshoot but
-    // does not bound a model whose late products carry denser or more
-    // novel geometry than its early ones. While resizes still work that
-    // self-corrects at the next growth; past LAST_CHANCE_GEOMETRIES there
-    // is no next growth, so the reservation widens from PRESIZE_HEADROOM
-    // (1.15) to LAST_CHANCE_HEADROOM (1.5) -- "the rest of the model may
-    // be up to 50% denser per product than everything so far".
+  it('widens the reservation when the geometry count crosses, not when the reserve runs out', () => {
+    // codex round 2, P1 on Share#1809. The widening used to live inside
+    // the capacity-exhaustion guard, so crossing the threshold did nothing
+    // until the CURRENT reservation ran out -- and an ample 1.15 reserve
+    // can postpone that past the spread ceiling, where setGeometrySize
+    // throws and the widening arrives one throw too late. The crossing
+    // itself has to be the trigger, while resizing still works.
+    //
+    // This batch has room to spare: 60 vertices reserved, 9 needed. Only
+    // the crossing can make it resize here.
+    const all = triangleShapes(3)
+    const builder = new IncrementalBatchedBuilder(makeApi(all), 0, {
+      initialVertices: 60,
+      initialIndices: 60,
+      presizeFromGeometries: 2,
+      lastChanceGeometries: 3,
+    })
+
+    for (let i = 0; i < 3; i++) {
+      builder.setPumpProgress(i + 1, 20)
+      builder.appendBatch([flatMesh(i + 1, [{geomExpressID: 1000 + i, color: OPAQUE}])])
+    }
+
+    // The third geometry took the count to the threshold. 129 =
+    // ceil(9 needed / (2/19 seen since this batch opened) * 1.5 last-chance
+    // headroom) -- reserved proactively, with 51 of the old 60 still unused.
+    expect(builder.opaque.geometryCount).toBe(3)
+    expect(builder.opaque.usedVertices).toBe(9)
+    expect(builder.opaque.maxVertices).toBe(129)
+    expect(builder.opaque.maxIndices).toBe(129)
+    expect(builder.opaque.lastChanceReserved).toBe(true)
+  })
+
+  it('keeps widening on the exhaustion path once the batch is past the threshold', () => {
+    // Belt and braces to the proactive trigger above: a batch that has
+    // already spent its last-chance reservation and later runs out anyway
+    // must still size that resize with LAST_CHANCE_HEADROOM (1.5) rather
+    // than falling back to PRESIZE_HEADROOM (1.15) -- it is still past the
+    // point where a further resize can be relied on.
     const all = triangleShapes(4)
     const builder = new IncrementalBatchedBuilder(makeApi(all), 0, {
       initialVertices: 3,
@@ -572,27 +603,52 @@ describe('IncrementalBatchedBuilder', () => {
       presizeFromGeometries: 2,
       lastChanceGeometries: 3,
     })
-
-    // Three products in, 2 geometries held: projected, not yet last-chance.
-    // 47 = ceil(9 needed / (2/9 seen since this batch opened) * 1.15).
     for (let i = 0; i < 3; i++) {
       builder.setPumpProgress(i + 1, 10)
       builder.appendBatch([flatMesh(i + 1, [{geomExpressID: 1000 + i, color: OPAQUE}])])
     }
-    expect(builder.opaque.geometryCount).toBe(3)
-    expect(builder.opaque.maxVertices).toBe(47)
+    expect(builder.opaque.lastChanceReserved).toBe(true)
+    expect(builder.opaque.maxVertices).toBe(61)
 
-    // Force one more resize with the batch now at the threshold. Need is
-    // 48 vertices, seen is 6/9, so the projection alone would ask for
-    // ceil(48 * 1.15 / (6/9)) = 83; the last-chance headroom asks for
-    // ceil(48 * 1.5 / (6/9)) = 108.
-    builder.opaque.usedVertices = 45
-    builder.opaque.usedIndices = 45
+    // Consume nearly all of it, then add a fourth geometry: 63 needed
+    // against 61 reserved, so this resize is driven by exhaustion, not by
+    // a crossing. 142 = ceil(63 * 1.5 / (6/9)); the 1.15 headroom would
+    // have left the doubling in charge at 122.
+    builder.opaque.usedVertices = 60
+    builder.opaque.usedIndices = 60
     builder.setPumpProgress(7, 10)
     builder.appendBatch([flatMesh(4, [{geomExpressID: 1003, color: OPAQUE}])])
 
-    expect(builder.opaque.maxVertices).toBe(108)
-    expect(builder.opaque.maxIndices).toBe(108)
+    expect(builder.opaque.maxVertices).toBe(142)
+    expect(builder.opaque.maxIndices).toBe(142)
+  })
+
+  it('lets a coincident duplicate mutate no capacity at an instance boundary', () => {
+    // codex round 2, P2 on Share#1809. Probing the duplicate set only
+    // after ensureCapacity_ meant a duplicate arriving with
+    // cursor === maxInstances doubled the instance buffers to make room
+    // for an instance that is never added. finalize's trim reclaims only
+    // geometry, so that doubling is retained for the life of the model --
+    // and an allocation failure there would turn a harmless duplicate into
+    // a failed placement.
+    const all = triangleShapes(1)
+    const builder = new IncrementalBatchedBuilder(makeApi(all), 0, {
+      initialInstances: 2,
+    })
+    const placement = [{geomExpressID: 1000, color: OPAQUE}]
+    builder.appendBatch([flatMesh(1, placement), flatMesh(2, placement)])
+    // Exactly full: the next placement to reach ensureCapacity_ doubles.
+    expect(builder.opaque.cursor).toBe(2)
+    expect(builder.opaque.maxInstances).toBe(2)
+
+    // ...and this one must not reach it. Same parent, geometry, transform
+    // and colour as the first, so it adds nothing.
+    builder.appendBatch([flatMesh(1, placement)])
+
+    expect(builder.opaque.maxInstances).toBe(2)
+    const {stats} = builder.finalize()
+    expect(stats.instanceCount).toBe(2)
+    expect(stats.skippedCoincidentPlacements).toBe(1)
   })
 
   it('retries a placement whose resize threw, instead of calling it a duplicate', () => {

--- a/src/viewer/ifc/incrementalBatchedBuilder.test.js
+++ b/src/viewer/ifc/incrementalBatchedBuilder.test.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-magic-numbers */
 import {BatchedMesh, Matrix4} from 'three'
-import {IncrementalBatchedBuilder} from './incrementalBatchedBuilder'
+import {IncrementalBatchedBuilder, PRESIZE_FROM_GEOMETRIES} from './incrementalBatchedBuilder'
 import {flatMeshToBatchedModel} from './flatMeshToBatchedModel'
 import {payloadToPreviewMesh} from './parsePreviewMesh'
 
@@ -435,6 +435,185 @@ describe('IncrementalBatchedBuilder', () => {
     const m = new Matrix4()
     batch.mesh.getMatrixAt(0, m)
     expect(m.elements[12]).toBeCloseTo(7)
+  })
+
+  // ---------------------------------------------------------------------
+  // Batch capacity (Share#1809). three r0.184's `setGeometrySize` spreads
+  // one argument per active geometry into `Math.max(...)`
+  // (three/src/objects/BatchedMesh.js:1329 and :1339), so past V8's
+  // argument limit -- ~125k entries -- every growth call throws and the
+  // batch can never be resized again. These pin both halves of the fix:
+  // the builder must stop needing growth before it gets there, and a
+  // growth that does throw must not leave its bookkeeping ahead of three's.
+  // ---------------------------------------------------------------------
+
+  /**
+   * @param {number} n how many shapes to make
+   * @return {object} `n` distinct single-triangle shapes, ids 1000..
+   */
+  function triangleShapes(n) {
+    const out = {}
+    for (let i = 0; i < n; i++) {
+      out[1000 + i] = {vertexData: unitTriangleVerts(), indexData: new Uint32Array([0, 1, 2])}
+    }
+    return out
+  }
+
+  /**
+   * Make a batch's `setGeometrySize` throw exactly the way three's does
+   * once the mesh holds more than `limit` geometries: `validRanges` is
+   * `[...this._geometryInfo].filter(info => info.active)`, and every entry
+   * this builder adds stays active, so its length is what gets spread.
+   *
+   * @param {object} state builder batch state
+   * @param {number} limit geometries the stand-in `Math.max(...)` survives
+   */
+  function capGeometrySize(state, limit) {
+    const {mesh} = state
+    const real = mesh.setGeometrySize.bind(mesh)
+    mesh.setGeometrySize = (vertices, indices) => {
+      if (mesh._geometryInfo.length > limit) {
+        throw new RangeError('Maximum call stack size exceeded')
+      }
+      return real(vertices, indices)
+    }
+  }
+
+  it('presizes past the growth ceiling so a large batch never needs another resize', () => {
+    // The sp-946MB.ifc failure in miniature: growth stops working once the
+    // batch holds more than SPREAD_LIMIT geometries, so the only way to
+    // finish the model is to have reserved for it while growth still
+    // worked. Ten shapes arrive one product at a time with the pump
+    // reporting its progress; the projection fires at the second geometry
+    // and must cover all ten. Without it the doubling walks into the
+    // ceiling and the tail of the model is silently dropped.
+    const SPREAD_LIMIT = 3
+    const shapeCount = 10
+    const all = triangleShapes(shapeCount)
+    const builder = new IncrementalBatchedBuilder(makeApi(all), 0, {
+      initialVertices: 3,
+      initialIndices: 3,
+      presizeFromGeometries: 2,
+    })
+
+    for (let i = 0; i < shapeCount; i++) {
+      builder.setPumpProgress(i + 1, shapeCount)
+      builder.appendBatch([flatMesh(i + 1, [{geomExpressID: 1000 + i, color: OPAQUE}])])
+      if (i === 0) {
+        capGeometrySize(builder.opaque, SPREAD_LIMIT)
+      }
+    }
+
+    // One reservation carried the whole model: nothing was skipped, and
+    // the capacity that survived the ceiling is the projected one -- 47 =
+    // ceil(9 vertices needed / (2/9 of the model seen since this batch
+    // opened) * 1.15 headroom), covering all 30 -- not the 12 that
+    // doubling would have reached before the ceiling shut it out.
+    expect(builder.opaque.maxVertices).toBe(47)
+    const {stats} = builder.finalize()
+    expect(stats.instanceCount).toBe(shapeCount)
+    expect(stats.skippedPlacedGeometries).toBe(0)
+    expect(stats.vertexCount).toBe(shapeCount * 3)
+  })
+
+  it('leaves capacity bookkeeping equal to three\'s when a resize throws', () => {
+    // The second half of Share#1809: `ensureCapacity_` used to raise
+    // maxVertices/maxIndices BEFORE calling setGeometrySize and never roll
+    // back, so after a throw Share believed in space three had never
+    // allocated. Every later placement then took the "no growth needed"
+    // branch straight into addGeometry's "Reserved space request exceeds
+    // the maximum buffer size" -- for the rest of the load.
+    const all = triangleShapes(3)
+    const builder = new IncrementalBatchedBuilder(makeApi(all), 0, {
+      initialVertices: 3,
+      initialIndices: 3,
+    })
+    builder.appendBatch([flatMesh(1, [{geomExpressID: 1000, color: OPAQUE}])])
+
+    const {mesh} = builder.opaque
+    const realSetGeometrySize = mesh.setGeometrySize.bind(mesh)
+    mesh.setGeometrySize = () => {
+      throw new RangeError('Maximum call stack size exceeded')
+    }
+    builder.appendBatch([flatMesh(2, [{geomExpressID: 1001, color: OPAQUE}])])
+
+    // three refused to grow, so Share must still be describing the buffer
+    // three actually has: 3 vertices, 3 indices, one geometry in it.
+    expect(builder.opaque.maxVertices).toBe(3)
+    expect(builder.opaque.maxIndices).toBe(3)
+    expect(builder.opaque.usedVertices).toBe(3)
+    expect(builder.opaque.cursor).toBe(1)
+
+    // ...and because the two agree, the next placement is still routed
+    // through growth rather than into a buffer that cannot hold it. With
+    // the bookkeeping left inflated this second shape needs 6 vertices,
+    // reads 6 as available, skips the resize and dies inside addGeometry.
+    mesh.setGeometrySize = realSetGeometrySize
+    builder.appendBatch([flatMesh(3, [{geomExpressID: 1002, color: OPAQUE}])])
+
+    const {stats} = builder.finalize()
+    expect(stats.instanceCount).toBe(2)
+    expect(stats.skippedPlacedGeometries).toBe(1)
+  })
+
+  it('returns reserved-but-unused batch space at finalize', () => {
+    // Byte-lever 2 of the conway#679 attribution report: 92.5 MB of the
+    // 231 MB model's settled heap was batch capacity nothing ever used.
+    // Here the three shapes need 9 vertices and the doubling reserved 12.
+    const all = triangleShapes(3)
+    const builder = new IncrementalBatchedBuilder(makeApi(all), 0, {
+      initialVertices: 3,
+      initialIndices: 3,
+    })
+    builder.appendBatch([
+      flatMesh(1, [{geomExpressID: 1000, color: OPAQUE}]),
+      flatMesh(2, [{geomExpressID: 1001, color: OPAQUE}]),
+      flatMesh(3, [{geomExpressID: 1002, color: OPAQUE}]),
+    ])
+    expect(builder.opaque.maxVertices).toBe(12)
+
+    const {batches, stats} = builder.finalize()
+    expect(builder.opaque.maxVertices).toBe(9)
+    // The buffer really shrank -- not just the number describing it.
+    expect(batches[0].mesh.geometry.attributes.position.count).toBe(9)
+    // ...and the model survived the copy intact.
+    expect(stats.instanceCount).toBe(3)
+    expect(stats.vertexCount).toBe(9)
+    expect(Array.from(batches[0].instanceParents)).toEqual([1, 2, 3])
+  })
+
+  it('keeps the model when the finalize trim is the call that throws', () => {
+    // A batch past three's spread limit cannot be resized in either
+    // direction, so the trim has to be best-effort: a model that assembled
+    // correctly must not be lost to an optimisation on the way out.
+    const all = triangleShapes(3)
+    const builder = new IncrementalBatchedBuilder(makeApi(all), 0, {
+      initialVertices: 3,
+      initialIndices: 3,
+    })
+    builder.appendBatch([
+      flatMesh(1, [{geomExpressID: 1000, color: OPAQUE}]),
+      flatMesh(2, [{geomExpressID: 1001, color: OPAQUE}]),
+      flatMesh(3, [{geomExpressID: 1002, color: OPAQUE}]),
+    ])
+    capGeometrySize(builder.opaque, 0)
+
+    const {batches, stats} = builder.finalize()
+    expect(stats.instanceCount).toBe(3)
+    expect(batches[0].mesh.geometry.attributes.position.count).toBe(12)
+    expect(builder.opaque.maxVertices).toBe(12)
+  })
+
+  it('keeps growth working at the geometry count the presize takes over from', () => {
+    // PRESIZE_FROM_GEOMETRIES only buys anything if `setGeometrySize` still
+    // WORKS when the batch reaches it -- the whole point is to make the
+    // last surviving resize the one that covers the rest of the model. The
+    // limit is V8's argument cap on the `Math.max(...)` spread inside
+    // three's setGeometrySize, it is stack-depth dependent rather than a
+    // documented constant (measured at 125,279 entries when Share#1809 was
+    // root-caused), so this asserts the margin on the engine actually
+    // running rather than pinning the number.
+    expect(() => Math.max(...new Array(PRESIZE_FROM_GEOMETRIES).fill(0))).not.toThrow()
   })
 
   it('skips one unreadable FlatMesh without dropping the rest of the batch', () => {

--- a/src/viewer/ifc/incrementalBatchedBuilder.test.js
+++ b/src/viewer/ifc/incrementalBatchedBuilder.test.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-magic-numbers */
-import {BatchedMesh, Matrix4} from 'three'
+import {BatchedMesh, BufferGeometry, Matrix4} from 'three'
 import {clearConwayDirectLogs, getConwayDirectLogs}
   from '../../../tools/jest/conwayDirectLogCapture'
 import {IncrementalBatchedBuilder, PRESIZE_FROM_GEOMETRIES} from './incrementalBatchedBuilder'
@@ -757,10 +757,14 @@ describe('IncrementalBatchedBuilder', () => {
     expect(Array.from(batches[0].instanceParents)).toEqual([1, 2, 3])
   })
 
-  it('keeps the model when the finalize trim is the call that throws', () => {
-    // A batch past three's spread limit cannot be resized in either
-    // direction, so the trim has to be best-effort: a model that assembled
-    // correctly must not be lost to an optimisation on the way out.
+  it('keeps the model when the finalize trim throws before touching the mesh', () => {
+    // The BENIGN half of the trim's failure handling: `capGeometrySize`
+    // throws from where three's own shrink checks do, before
+    // `oldGeometry.dispose()`, so the mesh is untouched. A batch past the
+    // spread limit cannot be resized in either direction, and a model that
+    // assembled correctly must not be lost to an optimisation on the way
+    // out -- it keeps its slack instead. The destructive half is the next
+    // test.
     const all = triangleShapes(3)
     const builder = new IncrementalBatchedBuilder(makeApi(all), 0, {
       initialVertices: 3,
@@ -777,6 +781,46 @@ describe('IncrementalBatchedBuilder', () => {
     expect(stats.instanceCount).toBe(3)
     expect(batches[0].mesh.geometry.attributes.position.count).toBe(12)
     expect(builder.opaque.maxVertices).toBe(12)
+  })
+
+  it('fails the assembly when a trim allocation destroys the batch', () => {
+    // codex round 3 on Share#1809, and the other half of the test above.
+    // three's `setGeometrySize` is only non-destructive up to its shrink
+    // checks. Past those (BatchedMesh.js:1350-1365) it disposes the old
+    // geometry, overwrites _maxVertexCount/_maxIndexCount, assigns a fresh
+    // BufferGeometry, and only THEN allocates the new typed arrays in
+    // `_initializeGeometry` -- so an allocation failure, which is the
+    // plausible one at the trim's capacity + used peak on a large model,
+    // leaves a gutted mesh. Swallowing that would hand back a hollow
+    // BatchedMesh and report a successful load.
+    //
+    // The stub reproduces that ordering rather than the error: dispose,
+    // replace the geometry, then throw.
+    const all = triangleShapes(3)
+    const builder = new IncrementalBatchedBuilder(makeApi(all), 0, {
+      initialVertices: 3,
+      initialIndices: 3,
+    })
+    builder.appendBatch([
+      flatMesh(1, [{geomExpressID: 1000, color: OPAQUE}]),
+      flatMesh(2, [{geomExpressID: 1001, color: OPAQUE}]),
+      flatMesh(3, [{geomExpressID: 1002, color: OPAQUE}]),
+    ])
+    // Slack to trim: 12 reserved, 9 used.
+    expect(builder.opaque.maxVertices).toBe(12)
+
+    const {mesh} = builder.opaque
+    mesh.setGeometrySize = () => {
+      mesh.geometry.dispose()
+      mesh.geometry = new BufferGeometry()
+      mesh._geometryInitialized = false
+      throw new RangeError('Array buffer allocation failed')
+    }
+
+    // finalize must NOT report success: ShareIfcLoader's catch around it
+    // removes the partial group and rebuilds the whole model from
+    // `recapture()`, which is the correct outcome for a destroyed batch.
+    expect(() => builder.finalize()).toThrow(/allocation failed/)
   })
 
   it('keeps growth working at the geometry count the presize takes over from', () => {


### PR DESCRIPTION
`sp-946MB.ifc` assembled 60% of itself and reported success. This fixes the
two bugs behind that and takes back the reserved-but-unused batch space the
conway#679 attribution report measured at 92.5 MB.

Part of #1809 — the mechanism fix is revert-proven here; the issue stays open
for the full-scale sp-946MB AFTER run (see the sp-946MB.ifc section) and
closes on that evidence. Part of bldrs-ai/conway#635; byte-lever 2 of
bldrs-ai/conway#679.

## Mechanism, verified on the path

**1. three r0.184 cannot resize a BatchedMesh past the engine's argument
limit.** `BatchedMesh.setGeometrySize` spreads one argument per active
geometry into `Math.max( ...validRanges.map( … ) )` —
`node_modules/three/src/objects/BatchedMesh.js:1329` and `:1339`. V8's limit
on this box, binary-searched: `Math.max(...new Array(n))` succeeds at
**125,278** and throws `RangeError: Maximum call stack size exceeded` at
**125,279**. It throws from the shrink checks, *before* touching the mesh,
so three's own capacity is unchanged.

**2. `ensureCapacity_` raised Share's capacity before that call and never
rolled back.** From then on Share believed in space three had never
allocated: `needVertices > state.maxVertices` was false, so every later
placement skipped the resize and went straight into `addGeometry`'s
"Reserved space request exceeds the maximum buffer size", and `usedVertices`
kept climbing for geometry that never landed. `warnBadRecord_` caps at 5
lines, so the loss surfaced only as a counter.

Instrumented run on `main` (79239b6) — one line per `setGeometrySize` call on
the opaque batch of `sp-946MB.ifc`:

```
grow opaque geoms=  9088 products= 2076 verts=   524300->  1048576
grow opaque geoms= 26972 products= 6978 verts=  2013868->  2097152
grow opaque geoms= 70054 products=18510 verts=  4083872->  4194304
grow opaque geoms= 72664 products=18998 verts=  4194538->  8388608   <- last one that worked
grow opaque geoms=143072 products=36771 idx= 16777230-> 33554432
THREW at geoms=143072: Maximum call stack size exceeded
grow opaque geoms=143076 products=37444 verts=  8388611-> 16777216
THREW at geoms=143076
grow opaque geoms=143076 products=72421 verts= 16080305-> 16777216   <- bookkeeping running away
THREW at geoms=143076
grow opaque geoms=143076 products=74660 verts= 16777288-> 33554432
THREW at geoms=143076
```

`geoms` freezes at 143,076 and `placements` at 173,331 from the first throw
onward: this model has 143k geometries to 173k placements, so almost every
remaining placement introduces a new geometry and is lost.

## The fix

**Pre-size from the pump's product total** (`incrementalBatchedBuilder.js`,
`conwayDirectIfcLoader.js`, `ShareIfcLoader.js`). One correction to the
issue's framing, from reading the pinned engine: the pump's `geometryTotal`
is a **product** count — `extracted + remaining` from the first
`ExtractGeometryBatch`, the same unit the `geometry` progress stage reports
as `products` — not a geometry count and not bytes. The engine exposes no
per-geometry size ahead of extraction (`ifc_api.d.ts:622`). So
`parseIfcWithConway` now hands `onMeshBatch` its `{done, total}` progress,
`ShareIfcLoader` forwards it to the builder before each `appendBatch`, and
past a geometry threshold the builder sizes the batch by linear
extrapolation from how far through the model the pump is, instead of
doubling. Below that threshold nothing changes.

Linear-in-products *tends* to overshoot, because geometry is deduplicated and
early products therefore contribute proportionally more new vertices than
late ones: measured on `sp-946MB.ifc` at +11% over the true requirement at
the first trigger point and +12% at the last one before three's ceiling.
`PRESIZE_HEADROOM` (1.15) is margin on top of that, and the projection is
re-run at every later growth.

### The thresholds are probed, not hard-coded (codex round 4)

The spread limit belongs to the **engine**, not to three: 125,278 on this
V8, ~65k on JavaScriptCore, higher on SpiderMonkey. Hard-coding V8's is not
a narrower margin on Safari — it is **no mechanism at all**. With the
production initial capacity, a model of single-triangle geometries first
needs a resize at `ceil(262144 / 3) = 87,382` geometries, already past JSC's
ceiling, so neither reservation would ever have run there.

So `probeSpreadLimit()` binary-searches the largest `n` for which
`Math.max(...new Array(n))` does not throw — hole-y arrays, so each probe
costs the spread and nothing else; ~18 iterations, memoised, called from the
builder constructor rather than at import time. Both thresholds are then
`min(own cap, floor(limit × safety))`:

| engine | probed limit | presize (×0.6) | last-chance (×0.85) |
|---|---|---|---|
| V8 (this box) | 125,278 | **50,000** (cap) | **106,486** |
| JavaScriptCore-sized | 65,536 | **39,321** | **55,705** |

The safety factors also absorb the probe running from a different stack
depth than three's resize will. Measured here: the limit falls from 125,263
at the probe's own depth to 122,851 with 200 extra frames beneath it —
**1.9%**, against a 15% margin.

### Two crossings, both one-shot

- **Presize crossing.** Reaching the presize threshold forces a projected
  resize *on its own*, whether or not the batch is short of room. Without
  this the threshold is only consulted when capacity runs out, and on a
  tight engine the first such resize is already past the ceiling.
- **Last-chance crossing.** Past the last-chance threshold this is in
  expectation the final resize, so it is taken with `LAST_CHANCE_HEADROOM`
  **1.50** (2x floor when no pump progress is available) instead of 1.15.
  Read 1.50 as the tolerance it is: *the remaining products may be up to
  50% denser per product than everything seen so far.* Hanging it off
  exhaustion — as the first attempt did — hands the widening to whichever
  later placement runs the reserve out, which an ample 1.15 projection can
  postpone past the ceiling. The exhaustion path keeps the widened headroom
  too, as belt and braces.

Both are latched so they cannot become a resize per geometry, and a crossing
whose reservation asks for no more than the batch already holds does not pay
a buffer copy for nothing.

**What remains true, stated plainly: the ceiling is steered around
probabilistically, not removed.** The projection is an estimate, not a bound,
so a sufficiently adversarial ordering — or an engine whose limit is below
what the model needs in one batch — can still under-reserve. What is
guaranteed is that it then degrades **honestly** rather than silently:
bookkeeping stays consistent with three's, the placements that cannot fit
are counted in `skippedPlacedGeometries`, and every later placement that does
fit still lands. Removing the ceiling means not putting that many geometries
in one `BatchedMesh` — the batch-splitting follow-up under "deliberately
left out".

**Bookkeeping now trails the three.js call.** `state.maxVertices` /
`maxIndices` / `maxInstances` are committed only after `setGeometrySize` /
`setInstanceCount` returns, so any residual throw leaves Share and three
agreeing.

**Duplicate probe, capacity, then commit** (codex P2, both rounds).
`CoincidenceSet`'s test-and-set is split into a non-mutating `probe()`
returning a token and a `commit(token)`; `add()` is now `probe` + `commit`,
so the one-shot builder is unchanged. `appendPlacement_` probes *before* any
capacity mutation — a coincident duplicate arriving at
`cursor === maxInstances` must not double the instance buffers for an
instance that is never added, since `finalize` trims only geometry and that
doubling would be retained for the life of the model — and commits *after*
`ensureCapacity_` succeeds, so a placement whose resize throws is not
recorded as seen. The split is what lets both hold while hashing once: 3
passes over ~20 words per placement, half a million placements on a large
model. Reachability of the second half is genuinely contested and the code
assumes the worse reading: conway's DELTA CONTRACT says *"each placed
instance is emitted exactly once across all calls"*, but this file's
long-standing test `drops an exact coincident duplicate that arrives in a
later delta batch` says the pump re-emits identical placements via
rel-aggregates re-extraction, which is why the cross-batch `CoincidenceSet`
exists at all.

**`finalize` returns the slack.** `setGeometrySize(usedVertices, usedIndices)`
once the model has stopped growing. `usedVertices` is exactly three's own
high-water mark (`addGeometry` packs reservations contiguously from 0 and
nothing here removes one). The cost is one reallocation and copy, so the
steady-state saving is bought with a transient peak of capacity + used at
the end of the load.

**Best-effort with a destroyed-mesh guard** (codex round 3).
`setGeometrySize` has two failure regions and they are not equivalent. The
shrink checks at the top run before anything is mutated, so a batch past the
spread limit throws with its mesh intact — swallowed, and that batch keeps
its slack. Everything after `oldGeometry.dispose()`
(`BatchedMesh.js:1350` onward) is destructive: three disposes the old
geometry, overwrites its maxima, replaces `this.geometry`, and only *then*
allocates the new typed arrays in `_initializeGeometry` — and an allocation
failure there is the plausible one, since the trim's own peak lands on
exactly the largest models. Swallowing that would report a gutted
`BatchedMesh` as a successful load. So the catch classifies by observable
effect — geometry object identity plus array lengths, captured before the
call — and re-raises when the mesh did not survive, failing `finalize` and
dropping `ShareIfcLoader` into its existing degraded rebuild from
`recapture()`.

Not changed: `node_modules/three`. The spread is three's bug — a loop-based
max would fix it upstream and is worth reporting — but Share should not
depend on that landing.

## Falsifiability — every new test against a revert of its source change

| test | source reverted | result |
|---|---|---|
| `presizes past the growth ceiling so a large batch never needs another resize` | drop the `projectCapacity_` call from `ensureCapacity_` | **RED** |
| `derives both thresholds from the engine's own spread limit` | thresholds back to bare constants (no probe) | **RED** |
| `forces a projected reservation when the presize count crosses` | drop `presizeCrossing` from the resize trigger | **RED** |
| `probes the running engine for a spread limit its thresholds fit under` | — | exercises the real `Math.max`; goes red if the derived thresholds stop being spreadable on the running engine |
| `widens the reservation when the geometry count crosses, not when the reserve runs out` | `if (exhausted \|\| crossing)` → `if (exhausted)` | **RED** |
| `keeps widening on the exhaustion path once the batch is past the threshold` | drop `LAST_CHANCE_HEADROOM` from `projectCapacity_` | **RED** (2 red, with the crossing test) |
| `lets a coincident duplicate mutate no capacity at an instance boundary` | move the probe back after `ensureCapacity_` | **RED** |
| `retries a placement whose resize threw, instead of calling it a duplicate` | commit the marker before `ensureCapacity_` | **RED** |
| `fails the assembly when a trim allocation destroys the batch` | drop the destroyed-mesh classification (swallow every trim throw) | **RED** |
| `keeps the model when the finalize trim throws before touching the mesh` | drop the trim's `try`/`catch` | **RED** (2 red with the presize test) |
| `leaves capacity bookkeeping equal to three's when a resize throws` | restore the pre-#1809 order (bookkeeping before `setGeometrySize`/`setInstanceCount`) | **RED** |
| `returns reserved-but-unused batch space at finalize` | drop `trimCapacity_` from `finalize` | **RED** |
| `hands each batch the pump product progress alongside it` | `onMeshBatch(batch, modelID)` without the progress argument | **RED** |
| `gives the builder the pump progress before the batch it sizes from` | forward the progress *after* `appendBatch` | **RED** |

Each revert reddens only its own row (the two noted exceptions widen to a
second row, never to an unrelated one).

The first is the whole issue in miniature and is the strongest evidence in
the PR: `setGeometrySize` is capped to throw past a geometry count, ten
shapes arrive one product at a time with the pump reporting progress, and
the builder must reserve for all ten while resizing still works. Fixed: 10
instances, `skippedPlaced=0`. Reverted: 4 instances, 6 skipped — the same
shape as the 946 MB failure.

Removed in round 4: `keeps growth working at the geometry count the presize
takes over from`. The probe test strictly subsumes it — same spread
assertion, but at the *derived* thresholds rather than at a constant that is
now only a cap.

## sp-946MB.ifc

Real browser load, `SHARE_CONFIG=playwright` build served by
`http-server docs -p 9081`, model at
`docs/__test_fixtures__/bldrs-ai/test-models/main/ifc/sp/sp-946MB.ifc`
(991,631,097 bytes), Playwright chromium, tab backgrounded.

**BEFORE — the reproduction, captured on `main` (79239b6):**

```
[conwayDirect] parsed modelID=0 — vertices=22407376 triangles=15140912 instances=197975
  parents=46774 materials=2 skippedFlatMeshes=0 skippedPlaced=298305 skippedCoincident=0
opaque batch: 143,076 geometries, 173,331 instances, capacity 8,388,608 v / 16,777,216 i
parse 840.3 s
```

**298,305 of 496,280 placements dropped — 60% of the model — reported as a
successful load.**

**AFTER — not obtained. The run is owed, and here is exactly why.** Three
attempts, none of which reached the `parsed` line:

| attempt | budget | outcome |
|---|---|---|
| 1 | 15 min | still loading at cutoff |
| 2 | 60 min | still loading at cutoff; renderer RSS 8.7 GB. GPU process at 170% CPU — with no GPU the EffectComposer runs through SwiftShader and outruns the renderer |
| 3 | 90 min | rendering paused at the `setRenderUpdate` seam (`pauseViewerRendering`, #1759) — GPU process dropped to 98 MB — but renderer growth stalled at ~13 MB/min |

The blocker is host memory, not the change: this box has **16 GB and no
swap**, and a parallel conway CI gate held 9–11 GB of jest workers
throughout. My renderer plateaued twice at ~8.1–8.3 GB with ~1.4 GB of
system memory left and no rlimit in play (`Max address space`,
`Max data size` and `Max resident set` all `unlimited` in the renderer's
`/proc/PID/limits`), i.e. it was being reclaim-throttled, not capped.

Worth stating plainly, because it cuts both ways: the BEFORE run finished in
840 s **because** it dropped 60% of the geometry — that is 60% of the
`addGeometry` calls, buffer copies and retained duplicates not happening.
Assembling this model correctly is genuinely more expensive, and whether it
fits in a browser tab at all is a separate question this PR does not answer.
What this PR does establish is that the *silent* failure is gone: the
mechanism is root-caused, reproduced, and pinned by a revert-proved test.

## Blast radius

On a V8-class engine the presize cap is unchanged at 50,000, so every model
that never reaches it in one batch keeps the doubling it had; the only
change such a model sees is that `finalize` gives its unused reservation
back. Controls, identical procedure, before vs after:

| model | vertices / triangles / instances / parents | capacity before | capacity after |
|---|---|---|---|
| `ifc/misc/box.ifc` | 24 / 12 / 1 / 1 — **byte-identical** | 262,144 v / 524,288 i | 24 v / 36 i |
| `ifc/openifcmodels/171210AISC_Sculpture_param.ifc` | 5,689 / 3,326 / 539 / 343 — **byte-identical** | 262,144 v / 524,288 i | 5,689 v / 9,978 i |

**Capacity ÷ used at finalize = 1.000 on both** — the doubling slack is gone
wherever three permits the shrink. On the box control that is 8.4 MB of
batch buffer returned for a single cube.

Files touched: `src/viewer/ifc/incrementalBatchedBuilder.js`,
`src/viewer/ifc/flatMeshToBatchedModel.js` (`CoincidenceSet` probe/commit
split; `add` unchanged in behaviour),
`src/viewer/ifc/conwayDirectIfcLoader.js` (one call site + its JSDoc),
`src/viewer/ifc/ShareIfcLoader.js` (one call site), plus their tests.
`onMeshBatch` gains a third argument; its only production caller is
`ShareIfcLoader`.

## Validation

Six commits: the change (0427fb4), a merge of `main` @ 6da12b0 (46efe6d),
and codex rounds 1–4 (559a310, 79981f5, e0a9ddf, 1d7b94f). The merge's one
conflict was the import block of `incrementalBatchedBuilder.test.js` — main
added the `conwayDirectLogCapture` import, this branch the
`PRESIZE_FROM_GEOMETRIES` named import; both kept.

**All three CI-only gates were re-run on `79981f5`** after the review rounds
so they no longer predate it. Rounds 3 and 4 are jest-only in effect
(`incrementalBatchedBuilder.js` + its test), so that trio still covers the
head's build and E2E surface; the full jest suite has run green on every
commit including the head.

| gate | result |
|---|---|
| `yarn lint` (eslint + tsc), at each commit | clean |
| `yarn test` on `main` @ 79239b6 (pre-merge baseline) | 259 suites / 2671 tests — 2666 passed, 5 skipped |
| `yarn build-prod` (re-run @ 79981f5) | pass, exit 0 (45.2 s) |
| `yarn test-ci` (coverage thresholds, re-run @ 79981f5) | pass, exit 0 — 264 suites / 2799 tests |
| `CI=true yarn test-flows conwayDirect.spec.ts indexStepLogo.spec.ts loadTiming.spec.ts --workers=1` (re-run @ 79981f5, fresh `test-flows-build` + `http-server docs -p 9081`) | **13 passed** (1.6 m) |
| husky gate, change commit | green (259 suites / 2678 tests — **+7** over baseline) |
| husky gate, merge commit, post `yarn install` to conway 1.1592.684 | green (264 suites / 2795 tests) |
| husky gate, codex round 1 | green (264 suites / 2797 tests) |
| husky gate, codex round 2 | green (264 suites / 2799 tests) |
| husky gate, codex round 3 | green (264 suites / 2800 tests) |
| husky gate, codex round 4 (head) | green (**264 suites / 2802 tests** — 2797 passed, 5 skipped, 13 snapshots) |

The builder suite was additionally run 3× consecutively at the head to
confirm the probe test is not stack-depth flaky: 29/29 each time.

## Deliberately left out

- **The settings-callback pinning cycle** noted at the bottom of the issue.
  Nulling `deferSettings.ON_PREVIEW_MESH` / `ON_PROGRESS` / `ON_MODEL_INFO`
  is four lines, but *where* is not obvious: conway's proxy still holds the
  settings object across `recapture()`, which on a windowed source drives
  `StreamAllMeshesAsync`, so a null landing before a callback conway still
  makes would fault inside the engine on exactly the degraded path that is
  hardest to reach in a test. The report measured 0.4 MB freed. Not worth
  that trade here.
- **Trimming the instance reservation** (`setInstanceCount(cursor)`). Same
  lever, no spread bug, ~22 MB on `sp-946MB` — but the measured 92.5 MB
  lever is the geometry buffers, and this keeps the change to what the issue
  evidences.
- **Splitting a batch into several `BatchedMesh`es** once it nears the
  spread limit. `finalize` already returns an array and `entry.idByBatch` is
  already keyed by batch state, so it is architecturally natural and is the
  only thing that actually *removes* the ceiling rather than steering around
  it — but it changes draw order, `materialCount`, and every batched
  consumer, which is a different PR from the one this issue asks for.