### PR TITLE
Re-bake batched subsets from three's own ranges, not a retained copy

### DIFF
--- a/design/new/model-display-controls.md
+++ b/design/new/model-display-controls.md
@@ -210,7 +210,8 @@ group, not a separate story.
 
 ## 5. Residency for every format (ask 4)
 
-`ResidencyController` requires `isBatchedMesh` + `instanceGeometry` +
+`ResidencyController` requires `isBatchedMesh` + readable batch buffers
+(`getGeometryRangeAt` / `getBoundingSphereAt`, see `batchedInstanceGeometry`) +
 `setVisibleAt`, so it renders nothing outside `?feature=batchedMesh` IFC/STEP.
 `ResidencyControl` self-gates on `instanceCount > 0`, which is the right shape
 — it just needs more ways to count.

--- a/design/new/viewer-replacement.md
+++ b/design/new/viewer-replacement.md
@@ -785,7 +785,11 @@ Three settled conclusions:
   - *Isolate / hide (`src/viewer/ifc/batchedSubset.js`).* `IfcIsolator`
     drives the batched model unchanged through a `createSubset` /
     `removeSubset` surface that re-bakes the kept instances (`getMatrixAt` +
-    the retained `instanceGeometry`) into world-aligned subset Meshes
+    the shape read back out of the batch's own buffers,
+    `src/viewer/ifc/batchedInstanceGeometry.js` — the retained
+    `instanceGeometry` table it used to bake from was a full duplicate of the
+    batch, 171.5 MB on a 231 MB model, dropped in Share#1810) into
+    world-aligned subset Meshes
     carrying a synthetic per-vertex `expressID` (so the isolated subset
     stays pickable). `visualElementsIds` is unioned from `instanceParents`.
   - *BVH picking.* `three-mesh-bvh` accelerated raycast validated on

--- a/design/roadmap.md
+++ b/design/roadmap.md
@@ -287,7 +287,7 @@ multi-worker; etc.*
   narrowing on the batched path; `EXT_mesh_gpu_instancing` batched-native GLB cache
   (§3b.v) so the round-trip stays instanced and the artifact shrinks.
 - Open: **residency backends** — the B2 slider is gated on the batched path
-  (`isBatchedMesh` + `instanceGeometry`), so it's invisible for GLB, OBJ and
+  (`isBatchedMesh` + readable batch buffers), so it's invisible for GLB, OBJ and
   friends. Extract a backend interface and add a scene-graph backend
   (`Object3D.visible`) plus a merged backend (index compaction over
   `IfcInstanceMap`'s per-instance triangle ranges) so the cached GLB re-load of

--- a/src/Components/Residency/ResidencyControl.test.jsx
+++ b/src/Components/Residency/ResidencyControl.test.jsx
@@ -35,9 +35,9 @@ const grey = () => ({x: DEFAULT_COLOR.x, y: DEFAULT_COLOR.y, z: DEFAULT_COLOR.z,
 
 /**
  * Batched-model double carrying the tables the color section reads. No
- * `instanceGeometry` / `setVisibleAt`, so `ResidencyController` finds nothing
- * to evict and the residency section stays hidden — which is exactly the case
- * that proves the color section gates independently.
+ * batch-geometry surface / `setVisibleAt`, so `ResidencyController` finds
+ * nothing to evict and the residency section stays hidden — which is exactly
+ * the case that proves the color section gates independently.
  *
  * @param {Array<object>} sourceColors the file's own colors
  * @return {object} model double
@@ -65,10 +65,21 @@ function colorOnlyModel(sourceColors = [grey(), grey(), grey()]) {
  */
 function residencyModel() {
   const model = colorOnlyModel()
-  model.instanceGeometry = [1, 2, 3].map((radius) => ({
-    boundingSphere: new Sphere(new Vector3(), radius),
-    getAttribute: () => ({count: radius * 100}),
-  }))
+  const radii = [1, 2, 3]
+  // The batch surface `ResidencyController` reads since Share#1810: one
+  // geometry per instance, sized and bounded through three's own per-geometry
+  // accessors instead of a retained `instanceGeometry` table.
+  model.geometry = {attributes: {position: {}}, index: {}}
+  model.getGeometryIdAt = (index) => index
+  model.getGeometryRangeAt = (geometryId, target = {}) => {
+    target.vertexStart = 0
+    target.vertexCount = radii[geometryId] * 100
+    target.indexStart = 0
+    target.indexCount = radii[geometryId] * 100
+    return target
+  }
+  model.getBoundingSphereAt = (geometryId, target) =>
+    target.copy(new Sphere(new Vector3(), radii[geometryId]))
   model.getMatrixAt = (index, matrix) => matrix.identity()
   model.setVisibleAt = jest.fn()
   return model

--- a/src/loader/glbBatchedExport.js
+++ b/src/loader/glbBatchedExport.js
@@ -1,4 +1,8 @@
 import {Color, Matrix4, Quaternion, Vector3} from 'three'
+import {
+  hasBatchedGeometry,
+  makeInstanceGeometryReader,
+} from '../viewer/ifc/batchedInstanceGeometry'
 import {eachBatch} from '../viewer/ifc/batchedModel'
 import {glbVerbose} from './glbLog'
 
@@ -74,8 +78,15 @@ function decomposeStrict(matrix) {
 function collectInstanceGroups(model) {
   const groups = new Map()
   let failed = false
+  // Geometry is read back out of the batch buffers instead of from a
+  // retained per-instance table (Share#1810). ONE reader for the whole
+  // model, because the dedup this writer exists for — one accessor set per
+  // unique shape, `accessorsFor` keyed by geometry identity — needs a
+  // shape used by both batches to come back as the same object, which is
+  // what the retained table used to guarantee.
+  const geometryAt = makeInstanceGeometryReader()
   eachBatch(model, (mesh) => {
-    if (failed || !mesh.instanceParents || !mesh.instanceGeometry ||
+    if (failed || !mesh.instanceParents || !hasBatchedGeometry(mesh) ||
         typeof mesh.getMatrixAt !== 'function') {
       return
     }
@@ -89,7 +100,7 @@ function collectInstanceGroups(model) {
     }
     const scratch = new Matrix4()
     for (let batchId = 0; batchId < mesh.instanceParents.length; batchId++) {
-      const geometry = mesh.instanceGeometry[batchId]
+      const geometry = geometryAt(mesh, batchId)
       const color = colors[batchId]
       if (!geometry || !color) {
         failed = true

--- a/src/loader/glbBatchedExport.test.js
+++ b/src/loader/glbBatchedExport.test.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-magic-numbers */
-import {BufferAttribute, BufferGeometry, Matrix4} from 'three'
+import {BatchedMesh, BufferAttribute, BufferGeometry, Matrix4} from 'three'
 import {exportBatchedModelAsInstancedGlb} from './glbBatchedExport'
 import {parseGlb} from './injectGlbExtensions'
 
@@ -21,40 +21,39 @@ function triangleGeometry() {
 
 
 /**
- * Decorated-BatchedMesh double in the `assembleBatchedModel` table shape,
- * with real geometries and matrices so the export exercises the actual
- * serialization path.
+ * A decorated batch as `assembleBatchedModel` leaves it: a REAL
+ * `THREE.BatchedMesh` holding the geometry (the writer reads its shapes back
+ * out of the batch buffers since Share#1810, so a plain object double would
+ * exercise nothing) plus the per-instance side tables.
  *
- * @param {object} [overrides]
- * @return {object} mesh double
+ * Two instances of one part and one of another — the dedup case the
+ * EXT_mesh_gpu_instancing layout exists for.
+ *
+ * @param {object} [overrides] own properties to stamp over the mesh
+ * @return {BatchedMesh}
  */
 function batchedDouble(overrides = {}) {
-  const shared = triangleGeometry()
-  const other = triangleGeometry()
+  const mesh = new BatchedMesh(3, 6, 6)
+  const sharedId = mesh.addGeometry(triangleGeometry())
+  const otherId = mesh.addGeometry(triangleGeometry())
   const matrices = [
     new Matrix4().makeTranslation(1, 0, 0),
     new Matrix4().makeTranslation(2, 0, 0),
     new Matrix4().makeTranslation(0, 3, 0),
   ]
-  return {
-    isBatchedMesh: true,
-    // Two instances of one part (shared geometry), one of another — the
-    // dedup case the layout exists for.
-    instanceGeometry: [shared, shared, other],
-    instanceParents: [11, 12, 20],
-    instanceOccurrenceIds: [0, 1, 2],
-    instanceGeometryIds: [500, 500, 600],
-    instanceOccurrencePaths: [[3, 7], [3, 8], [4]],
-    instanceSourceColors: [
-      {x: 0.8, y: 0.8, z: 0.8, w: 1},
-      {x: 0.8, y: 0.8, z: 0.8, w: 1},
-      {x: 0.8, y: 0.8, z: 0.8, w: 1},
-    ],
-    getMatrixAt(i, m) {
-      m.copy(matrices[i])
-    },
-    ...overrides,
+  for (const [i, geometryId] of [sharedId, sharedId, otherId].entries()) {
+    mesh.setMatrixAt(mesh.addInstance(geometryId), matrices[i])
   }
+  mesh.instanceParents = [11, 12, 20]
+  mesh.instanceOccurrenceIds = [0, 1, 2]
+  mesh.instanceGeometryIds = [500, 500, 600]
+  mesh.instanceOccurrencePaths = [[3, 7], [3, 8], [4]]
+  mesh.instanceSourceColors = [
+    {x: 0.8, y: 0.8, z: 0.8, w: 1},
+    {x: 0.8, y: 0.8, z: 0.8, w: 1},
+    {x: 0.8, y: 0.8, z: 0.8, w: 1},
+  ]
+  return Object.assign(mesh, overrides)
 }
 
 
@@ -142,12 +141,18 @@ describe('loader/glbBatchedExport', () => {
     expect(await exportBatchedModelAsInstancedGlb(double)).toBeNull()
   })
 
-  it('declines a geometry missing normals or index', async () => {
+  it('declines a batch whose geometry has no normals or index', async () => {
+    // An un-indexed, normal-less batch: `hasBatchedGeometry` refuses to read
+    // shapes out of it at all, so the writer declines rather than emitting a
+    // primitive with no NORMAL/indices.
     const bare = new BufferGeometry()
     bare.setAttribute('position', new BufferAttribute(new Float32Array([0, 0, 0]), 3))
-    const double = batchedDouble()
-    double.instanceGeometry = [bare, bare, bare]
-    expect(await exportBatchedModelAsInstancedGlb(double)).toBeNull()
+    const mesh = new BatchedMesh(1, 3, 0)
+    mesh.setMatrixAt(mesh.addInstance(mesh.addGeometry(bare)), new Matrix4())
+    mesh.instanceParents = [11]
+    mesh.instanceOccurrenceIds = [0]
+    mesh.instanceSourceColors = [{x: 0.8, y: 0.8, z: 0.8, w: 1}]
+    expect(await exportBatchedModelAsInstancedGlb(mesh)).toBeNull()
   })
 
   it('declines an undecorated model', async () => {

--- a/src/loader/glbBatchedRoundTrip.test.js
+++ b/src/loader/glbBatchedRoundTrip.test.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-magic-numbers */
-import {BufferAttribute, BufferGeometry, Matrix4} from 'three'
+import {BatchedMesh, BufferAttribute, BufferGeometry, Matrix4} from 'three'
 import {GLTFLoader} from 'three/examples/jsm/loaders/GLTFLoader.js'
 import {
   BLDRS_INSTANCE_TABLES_EXTENSION_NAME,
@@ -57,32 +57,33 @@ function triangleGeometry() {
  * @return {object} model double
  */
 function liveBatchedModel() {
-  const shared = triangleGeometry()
-  const other = triangleGeometry()
+  // A REAL BatchedMesh: since Share#1810 the writer reads each shape back out
+  // of the batch buffers rather than from a retained per-instance table, so
+  // the geometry has to actually be in the batch.
+  const mesh = new BatchedMesh(3, 6, 6)
+  const sharedId = mesh.addGeometry(triangleGeometry())
+  const otherId = mesh.addGeometry(triangleGeometry())
   const matrices = [
     new Matrix4().makeTranslation(1, 0, 0),
     new Matrix4().makeTranslation(2, 0, 0),
     new Matrix4().makeTranslation(0, 3, 0),
   ]
-  return {
-    isBatchedMesh: true,
-    instanceGeometry: [shared, shared, other],
-    instanceParents: [11, 12, 20],
-    instanceOccurrenceIds: [0, 1, 2],
-    instanceGeometryIds: [500, 500, 600],
-    instanceOccurrencePaths: [[3, 7], [3, 8], [4]],
-    instanceSourceColors: [{...GREY}, {...GREY}, {...GREY}],
-    // What the live scene shows after the palette ran — must NOT be what
-    // gets baked.
-    instanceColors: [
-      {x: 0.306, y: 0.475, z: 0.655, w: 1},
-      {x: 0.306, y: 0.475, z: 0.655, w: 1},
-      {x: 0.949, y: 0.557, z: 0.169, w: 1},
-    ],
-    getMatrixAt(i, m) {
-      m.copy(matrices[i])
-    },
+  for (const [i, geometryId] of [sharedId, sharedId, otherId].entries()) {
+    mesh.setMatrixAt(mesh.addInstance(geometryId), matrices[i])
   }
+  mesh.instanceParents = [11, 12, 20]
+  mesh.instanceOccurrenceIds = [0, 1, 2]
+  mesh.instanceGeometryIds = [500, 500, 600]
+  mesh.instanceOccurrencePaths = [[3, 7], [3, 8], [4]]
+  mesh.instanceSourceColors = [{...GREY}, {...GREY}, {...GREY}]
+  // What the live scene shows after the palette ran — must NOT be what
+  // gets baked.
+  mesh.instanceColors = [
+    {x: 0.306, y: 0.475, z: 0.655, w: 1},
+    {x: 0.306, y: 0.475, z: 0.655, w: 1},
+    {x: 0.949, y: 0.557, z: 0.169, w: 1},
+  ]
+  return mesh
 }
 
 

--- a/src/loader/glbExport.test.js
+++ b/src/loader/glbExport.test.js
@@ -93,7 +93,6 @@ function buildDecoratedBatchedMesh() {
   const batch = batches[0]
   batch.mesh.instanceParents = batch.instanceParents
   batch.mesh.instanceOccurrenceIds = batch.instanceOccurrenceIds
-  batch.mesh.instanceGeometry = batch.instanceGeometry
   batch.mesh.instanceColors = batch.instanceColors
   return batch.mesh
 }
@@ -149,7 +148,6 @@ function buildDecoratedBatchedMeshWithOccurrences() {
   const batch = batches[0]
   batch.mesh.instanceParents = batch.instanceParents
   batch.mesh.instanceOccurrenceIds = batch.instanceOccurrenceIds
-  batch.mesh.instanceGeometry = batch.instanceGeometry
   batch.mesh.instanceColors = batch.instanceColors
   batch.mesh.instanceGeometryIds = batch.instanceGeometryIds ?? null
   batch.mesh.instanceOccurrencePaths = batch.instanceOccurrencePaths ?? null

--- a/src/viewer/ifc/batchedInstanceGeometry.js
+++ b/src/viewer/ifc/batchedInstanceGeometry.js
@@ -1,0 +1,205 @@
+import {BufferAttribute, BufferGeometry} from 'three'
+
+
+/**
+ * batchedInstanceGeometry — read one instance's SOURCE geometry back out of
+ * the `THREE.BatchedMesh` that already holds it, instead of retaining a
+ * second copy of every shape for the life of the model.
+ *
+ * The batched consumers — isolation subsets (`batchedSubset`), the merged
+ * and batched GLB writers (`batchedToMergedMesh`, `glbBatchedExport`) and
+ * the residency controller — all used to read a per-instance table of the
+ * local-space `BufferGeometry` objects the batch was assembled from,
+ * stamped on the mesh as `instanceGeometry`. Those objects are a full
+ * DUPLICATE of data three already owns: `addGeometry` copies every
+ * position / normal / index component into the batch's own buffers and
+ * keeps no reference to the source (`BatchedMesh.setGeometryAt`,
+ * node_modules/three/src/objects/BatchedMesh.js:743-792). Measured at
+ * **171.5 MB** retained on a 231 MB model — 24% of the whole external
+ * ArrayBuffer bucket — to serve occasional selection re-bakes (Share#1810,
+ * byte-lever 1 of the conway#679 attribution). This module is the
+ * replacement: given a `batchId` it reconstructs the identical geometry
+ * from the batch's own buffers on demand, so the payload is stored once.
+ *
+ * **Public accessors only.** `getGeometryIdAt` and `getGeometryRangeAt` are
+ * documented API in three r0.184 (BatchedMesh.js:1217 and :1237) and return
+ * exactly the `{vertexStart, vertexCount, indexStart, indexCount}` this
+ * needs, so nothing here reaches into `_geometryInfo`. Both validate their
+ * id and THROW on an inactive or out-of-range one, which is why the range
+ * read below is wrapped: the callers' old contract for a missing entry was
+ * "skip this instance", not "fail the pass".
+ *
+ * **Ranges are read fresh, never snapshotted.** A batch's ranges move: this
+ * repo's own `finalize()` trims capacity with `setGeometrySize`, which
+ * disposes the batch geometry and reallocates every buffer
+ * (BatchedMesh.js:1350-1378), and three's `optimize()` compacts starts
+ * outright. A cached range or a cached view onto an old array reads
+ * garbage after either. The per-pass cache below therefore keys on the
+ * SOURCE shape and holds finished copies, and every entry it misses goes
+ * back to `getGeometryRangeAt` for the current numbers.
+ */
+
+
+/** Item size of an unindexed scalar attribute (the rebuilt index). */
+const SCALAR = 1
+
+
+/**
+ * Whether a mesh can serve geometry reads through the batch buffers — the
+ * replacement for the old `mesh.instanceGeometry` truthiness guard.
+ *
+ * @param {object} mesh candidate THREE.BatchedMesh
+ * @return {boolean}
+ */
+export function hasBatchedGeometry(mesh) {
+  return Boolean(
+    mesh?.isBatchedMesh &&
+    typeof mesh.getGeometryIdAt === 'function' &&
+    typeof mesh.getGeometryRangeAt === 'function' &&
+    mesh.geometry?.attributes?.position &&
+    mesh.geometry.index)
+}
+
+
+/**
+ * The batch-buffer range backing one instance, plus the geometry id it
+ * resolved through.
+ *
+ * @param {object} mesh a THREE.BatchedMesh
+ * @param {number} batchId instance id
+ * @param {object} [target] reused result object
+ * @return {?object} `{geometryId, vertexStart, vertexCount, indexStart,
+ *   indexCount, …}` or null when the instance has no live geometry
+ */
+export function instanceGeometryRangeAt(mesh, batchId, target = {}) {
+  if (!hasBatchedGeometry(mesh)) {
+    return null
+  }
+  let geometryId
+  try {
+    geometryId = mesh.getGeometryIdAt(batchId)
+    mesh.getGeometryRangeAt(geometryId, target)
+  } catch {
+    // Deleted / never-added instance or geometry: three throws from its id
+    // validators. The consumers' pre-existing behaviour for a table entry
+    // that wasn't there is to skip that instance, so keep it.
+    return null
+  }
+  if (!(target.vertexCount > 0) || !(target.indexCount > 0)) {
+    return null
+  }
+  target.geometryId = geometryId
+  return target
+}
+
+
+/**
+ * Rebuild one shape's local-space geometry from a batch range.
+ *
+ * Byte-identical to what `localGeometry` produced for the same shape:
+ * `setGeometryAt` copies positions and normals component-wise into the same
+ * float32 slots, and writes each index as `vertexStart + srcIndex`
+ * (BatchedMesh.js:778) — so subtracting `vertexStart` here recovers the
+ * original local index values exactly. The index is rebuilt as a
+ * `Uint32Array` regardless of the batch's own index width, matching
+ * `localGeometry`'s `Uint32Array.from(rawIndices)`; a batch small enough to
+ * use a Uint16 index holds values that fit either way.
+ *
+ * @param {object} mesh a THREE.BatchedMesh
+ * @param {object} range from {@link instanceGeometryRangeAt}
+ * @return {BufferGeometry}
+ */
+function rebuildGeometry(mesh, range) {
+  const batch = mesh.geometry
+  const {vertexStart, vertexCount, indexStart, indexCount} = range
+  const geometry = new BufferGeometry()
+  for (const name of ['position', 'normal']) {
+    const attribute = batch.attributes[name]
+    if (!attribute) {
+      continue
+    }
+    const {itemSize} = attribute
+    const slice = attribute.array.slice(
+      vertexStart * itemSize, (vertexStart + vertexCount) * itemSize)
+    geometry.setAttribute(name, new BufferAttribute(slice, itemSize))
+  }
+  const batchIndex = batch.index.array
+  const indices = new Uint32Array(indexCount)
+  for (let i = 0; i < indexCount; i++) {
+    indices[i] = batchIndex[indexStart + i] - vertexStart
+  }
+  geometry.setIndex(new BufferAttribute(indices, SCALAR))
+  return geometry
+}
+
+
+/**
+ * Cache key for the SOURCE shape behind an instance.
+ *
+ * Object identity used to carry this: both builders add one
+ * `BufferGeometry` per `geometryExpressID` and push that same object into
+ * every instance's table, including across the opaque/transparent split, so
+ * consumers that dedupe by geometry reference (the GLB writer's accessor
+ * table, the residency controller's per-shape use counts) saw one entry for
+ * a shape used in both batches. Keying on `instanceGeometryIds` — the same
+ * source id the builders dedupe by — reproduces that exactly. Meshes
+ * without that table (older BatchHandle shapes, artifacts that carried no
+ * geometry ids) fall back to per-mesh geometry ids, which dedupes within a
+ * batch and never across one.
+ *
+ * @param {object} mesh a THREE.BatchedMesh
+ * @param {number} batchId instance id
+ * @param {number} geometryId the batch's own geometry id
+ * @return {string}
+ */
+function sourceKey(mesh, batchId, geometryId) {
+  const sourceIds = mesh.instanceGeometryIds
+  const sourceId = sourceIds ? sourceIds[batchId] : undefined
+  return sourceId === undefined ? `${mesh.uuid}#${geometryId}` : `src#${sourceId}`
+}
+
+
+/**
+ * Read one instance's source geometry, optionally memoising per shape.
+ *
+ * @param {object} mesh a THREE.BatchedMesh
+ * @param {number} batchId instance id
+ * @param {?Map} [cache] per-pass shape cache (see
+ *   {@link makeInstanceGeometryReader}); omit for a fresh copy every call
+ * @return {?BufferGeometry} local-space geometry, or null when the instance
+ *   has no live geometry in the batch
+ */
+export function instanceGeometryAt(mesh, batchId, cache = null) {
+  const range = instanceGeometryRangeAt(mesh, batchId)
+  if (range === null) {
+    return null
+  }
+  if (cache === null) {
+    return rebuildGeometry(mesh, range)
+  }
+  const key = sourceKey(mesh, batchId, range.geometryId)
+  let geometry = cache.get(key)
+  if (geometry === undefined) {
+    geometry = rebuildGeometry(mesh, range)
+    cache.set(key, geometry)
+  }
+  return geometry
+}
+
+
+/**
+ * A reader that returns ONE geometry object per source shape for as long as
+ * it is alive — the identity the consumers' dedup relies on — and releases
+ * every copy the moment the caller drops it.
+ *
+ * Scope it to a single pass (one export, one subset build). Holding a
+ * reader for the life of the model would re-create the duplicate this
+ * module exists to remove; holding one across a batch mutation is worse,
+ * because its copies then describe the batch as it used to be.
+ *
+ * @return {Function} `(mesh, batchId) => BufferGeometry|null`
+ */
+export function makeInstanceGeometryReader() {
+  const cache = new Map()
+  return (mesh, batchId) => instanceGeometryAt(mesh, batchId, cache)
+}

--- a/src/viewer/ifc/batchedInstanceGeometry.test.js
+++ b/src/viewer/ifc/batchedInstanceGeometry.test.js
@@ -1,0 +1,287 @@
+/* eslint-disable no-magic-numbers */
+import {BatchedMesh, BufferAttribute, BufferGeometry, Matrix3, Matrix4, Vector3} from 'three'
+import {
+  hasBatchedGeometry,
+  instanceGeometryAt,
+  instanceGeometryRangeAt,
+  makeInstanceGeometryReader,
+} from './batchedInstanceGeometry'
+import {buildBatchedSubsetMesh} from './batchedSubset'
+import {localGeometry} from './flatMeshToBatchedModel'
+
+
+/** Floats per position / normal vector. */
+const VEC3 = 3
+
+
+/**
+ * Conway-shaped interleaved `[p,n]` vertex data for a triangle whose
+ * positions and normals are all distinct, so a swapped attribute or a
+ * misaligned slice cannot pass by coincidence.
+ *
+ * @return {Float32Array}
+ */
+function triangleVerts() {
+  return new Float32Array([
+    0.5, 1.5, 2.5, 0.1, 0.2, 0.3,
+    3.5, 4.5, 5.5, 0.4, 0.5, 0.6,
+    6.5, 7.5, 8.5, 0.7, 0.8, 0.9,
+  ])
+}
+
+
+/**
+ * A four-vertex quad, so the SECOND shape added to a batch lands at a
+ * non-zero `vertexStart` — the offset the index rebase has to undo.
+ *
+ * @return {Float32Array}
+ */
+function quadVerts() {
+  return new Float32Array([
+    10, 0, 0, 1, 0, 0,
+    11, 0, 0, 0, 1, 0,
+    11, 1, 0, 0, 0, 1,
+    10, 1, 0, 1, 1, 0,
+  ])
+}
+
+
+/** @return {Array<BufferGeometry>} the two source shapes, in batch order. */
+function sourceGeometries() {
+  return [
+    localGeometry(triangleVerts(), new Uint32Array([0, 1, 2]), 3),
+    localGeometry(quadVerts(), new Uint32Array([0, 1, 2, 0, 2, 3]), 4),
+  ]
+}
+
+
+/**
+ * A decorated batch holding both shapes: instance 0 and 2 are the triangle
+ * (shared shape), instance 1 is the quad, each at its own translation.
+ *
+ * @param {Array<BufferGeometry>} sources the shapes to add
+ * @return {BatchedMesh}
+ */
+function decoratedBatch(sources) {
+  const mesh = new BatchedMesh(3, 16, 24)
+  const triangleId = mesh.addGeometry(sources[0])
+  const quadId = mesh.addGeometry(sources[1])
+  const placements = [
+    {geometryId: triangleId, x: 0, parent: 100, geometryExpressId: 900},
+    {geometryId: quadId, x: 10, parent: 200, geometryExpressId: 901},
+    {geometryId: triangleId, x: 20, parent: 300, geometryExpressId: 900},
+  ]
+  const parents = []
+  const geometryIds = []
+  for (const placement of placements) {
+    const batchId = mesh.addInstance(placement.geometryId)
+    mesh.setMatrixAt(batchId, new Matrix4().makeTranslation(placement.x, 0, 0))
+    parents[batchId] = placement.parent
+    geometryIds[batchId] = placement.geometryExpressId
+  }
+  mesh.instanceParents = Uint32Array.from(parents)
+  mesh.instanceGeometryIds = Uint32Array.from(geometryIds)
+  mesh.instanceOccurrenceIds = Uint32Array.from([0, 1, 2])
+  return mesh
+}
+
+
+/**
+ * Bake a subset the way `batchedSubset` did BEFORE Share#1810: straight off
+ * a per-instance table of the retained source geometries. The reference the
+ * re-bake has to reproduce byte for byte.
+ *
+ * @param {object} mesh a decorated BatchedMesh
+ * @param {Array<BufferGeometry>} table `batchId → source geometry`
+ * @param {Set<number>} idSet parent expressIDs to keep
+ * @return {object} `{positions, normals, expressIDs, indices}`
+ */
+function bakeFromRetainedTable(mesh, table, idSet) {
+  const parents = mesh.instanceParents
+  const selected = []
+  let vertexTotal = 0
+  let indexTotal = 0
+  for (let batchId = 0; batchId < parents.length; batchId++) {
+    if (!idSet.has(parents[batchId])) {
+      continue
+    }
+    selected.push(batchId)
+    vertexTotal += table[batchId].attributes.position.count
+    indexTotal += table[batchId].index.count
+  }
+  const positions = new Float32Array(vertexTotal * VEC3)
+  const normals = new Float32Array(vertexTotal * VEC3)
+  const expressIDs = new Uint32Array(vertexTotal)
+  const indices = new Uint32Array(indexTotal)
+  const matrix = new Matrix4()
+  const normalMatrix = new Matrix3()
+  const p = new Vector3()
+  const n = new Vector3()
+  let vOff = 0
+  let iOff = 0
+  for (const batchId of selected) {
+    const geom = table[batchId]
+    const pos = geom.attributes.position
+    const nrm = geom.attributes.normal
+    const idx = geom.index
+    mesh.getMatrixAt(batchId, matrix)
+    normalMatrix.getNormalMatrix(matrix)
+    const base = vOff
+    for (let v = 0; v < pos.count; v++) {
+      p.fromBufferAttribute(pos, v).applyMatrix4(matrix)
+      const dst = (vOff + v) * VEC3
+      positions[dst] = p.x
+      positions[dst + 1] = p.y
+      positions[dst + 2] = p.z
+      n.fromBufferAttribute(nrm, v).applyMatrix3(normalMatrix).normalize()
+      normals[dst] = n.x
+      normals[dst + 1] = n.y
+      normals[dst + 2] = n.z
+      expressIDs[vOff + v] = parents[batchId]
+    }
+    for (let i = 0; i < idx.array.length; i++) {
+      indices[iOff + i] = idx.array[i] + base
+    }
+    vOff += pos.count
+    iOff += idx.count
+  }
+  return {positions, normals, expressIDs, indices}
+}
+
+
+describe('viewer/ifc/batchedInstanceGeometry', () => {
+  it('reads back each instance\'s source geometry byte for byte', () => {
+    const sources = sourceGeometries()
+    const mesh = decoratedBatch(sources)
+    // batchId → which source shape it was added from.
+    for (const [batchId, source] of [sources[0], sources[1], sources[0]].entries()) {
+      const read = instanceGeometryAt(mesh, batchId)
+      for (const name of ['position', 'normal']) {
+        expect(read.attributes[name].array)
+          .toEqual(source.attributes[name].array)
+      }
+      // The index has to come back in SOURCE-local numbering: three stores
+      // it in the batch offset by `vertexStart` (BatchedMesh.js:778), which
+      // is non-zero for everything after the first shape.
+      expect(Array.from(read.index.array)).toEqual(Array.from(source.index.array))
+    }
+    // The pin above is only worth something if some shape actually sits at a
+    // non-zero offset — otherwise a missing rebase would pass.
+    expect(instanceGeometryRangeAt(mesh, 1).vertexStart).toBeGreaterThan(0)
+  })
+
+
+  it('bakes a subset identical to the pre-#1810 retained-table path', () => {
+    const sources = sourceGeometries()
+    const mesh = decoratedBatch(sources)
+    // The same model both ways: the retained per-instance table the builders
+    // used to stamp on the mesh, and the batch buffers alone.
+    const table = [sources[0], sources[1], sources[0]]
+    const idSet = new Set([100, 200, 300])
+    const reference = bakeFromRetainedTable(mesh, table, idSet)
+    const subset = buildBatchedSubsetMesh(mesh, idSet, {})
+
+    expect(subset.geometry.attributes.position.array).toEqual(reference.positions)
+    expect(subset.geometry.attributes.normal.array).toEqual(reference.normals)
+    expect(subset.geometry.attributes.expressID.array).toEqual(reference.expressIDs)
+    expect(subset.geometry.index.array).toEqual(reference.indices)
+    // Not a vacuous pass on empty buffers.
+    expect(reference.positions.length).toBe(10 * VEC3)
+    expect(reference.indices.length).toBe(12)
+  })
+
+
+  it('reflects the CURRENT ranges after the batch is resized and extended',
+    () => {
+      const sources = sourceGeometries()
+      const mesh = decoratedBatch(sources)
+      const before = buildBatchedSubsetMesh(mesh, new Set([100]), {})
+
+      // Everything `finalize()` does to a live batch after the first read:
+      // grow, add another shape and instance, then trim back to the exact
+      // requirement. `setGeometrySize` disposes and reallocates the batch
+      // buffers, so any cached range or cached view is stale afterwards.
+      mesh.setGeometrySize(64, 96)
+      const extraSource = localGeometry(quadVerts(), new Uint32Array([0, 1, 2, 0, 2, 3]), 4)
+      const extraId = mesh.addGeometry(extraSource)
+      mesh.setInstanceCount(4)
+      const extraBatchId = mesh.addInstance(extraId)
+      mesh.setMatrixAt(extraBatchId, new Matrix4().makeTranslation(0, 30, 0))
+      mesh.instanceParents = Uint32Array.from([100, 200, 300, 400])
+      mesh.instanceGeometryIds = Uint32Array.from([900, 901, 900, 902])
+      mesh.setGeometrySize(14, 21)
+
+      // The instance read before the mutations still reads identically...
+      const after = buildBatchedSubsetMesh(mesh, new Set([100]), {})
+      expect(after.geometry.attributes.position.array)
+        .toEqual(before.geometry.attributes.position.array)
+      // ...and the shape added after them is readable at its new range.
+      const extra = instanceGeometryAt(mesh, extraBatchId)
+      expect(extra.attributes.position.array)
+        .toEqual(extraSource.attributes.position.array)
+      expect(Array.from(extra.index.array)).toEqual([0, 1, 2, 0, 2, 3])
+    })
+
+
+  it('follows a shape whose range MOVES under it', () => {
+    // The failure mode a snapshotted range hides: three is free to relocate
+    // a shape inside the batch buffers (`optimize` compacts around deleted
+    // geometry, BatchedMesh.js:878-960). Read the range once and cache it and
+    // the re-bake silently returns whatever now occupies the old offsets.
+    const filler = localGeometry(quadVerts(), new Uint32Array([0, 1, 2, 0, 2, 3]), 4)
+    const shape = localGeometry(triangleVerts(), new Uint32Array([0, 1, 2]), 3)
+    const mesh = new BatchedMesh(1, 16, 24)
+    const fillerId = mesh.addGeometry(filler)
+    const shapeId = mesh.addGeometry(shape)
+    mesh.setMatrixAt(mesh.addInstance(shapeId), new Matrix4())
+    mesh.instanceParents = Uint32Array.from([100])
+
+    const before = instanceGeometryRangeAt(mesh, 0).vertexStart
+    expect(before).toBe(filler.attributes.position.count)
+    mesh.deleteGeometry(fillerId)
+    mesh.optimize()
+    expect(instanceGeometryRangeAt(mesh, 0).vertexStart).toBeLessThan(before)
+
+    const read = instanceGeometryAt(mesh, 0)
+    expect(read.attributes.position.array).toEqual(shape.attributes.position.array)
+    expect(read.attributes.normal.array).toEqual(shape.attributes.normal.array)
+    expect(Array.from(read.index.array)).toEqual([0, 1, 2])
+  })
+
+
+  it('hands one geometry object per source shape to a reader, across batches',
+    () => {
+      const sources = sourceGeometries()
+      const opaque = decoratedBatch(sources)
+      const transparent = decoratedBatch(sourceGeometries())
+      const read = makeInstanceGeometryReader()
+      // Instances 0 and 2 are the same shape in one batch; the other batch
+      // holds the same source ids. The GLB writer's accessor dedup and the
+      // residency controller's per-shape use counts both key on this
+      // identity, which the retained table used to provide by reference.
+      expect(read(opaque, 0)).toBe(read(opaque, 2))
+      expect(read(opaque, 0)).toBe(read(transparent, 0))
+      expect(read(opaque, 0)).not.toBe(read(opaque, 1))
+      // Without a reader every call is a fresh copy — no retention.
+      expect(instanceGeometryAt(opaque, 0)).not.toBe(instanceGeometryAt(opaque, 0))
+    })
+
+
+  it('refuses meshes it cannot read, and instances that are not there', () => {
+    const mesh = decoratedBatch(sourceGeometries())
+    expect(hasBatchedGeometry(mesh)).toBe(true)
+    expect(hasBatchedGeometry(null)).toBe(false)
+    expect(hasBatchedGeometry({isBatchedMesh: true})).toBe(false)
+    // A batch whose geometry has no index (three keeps `geometry.index` null)
+    // cannot serve a re-bake: the consumers all need triangles.
+    const unindexed = new BatchedMesh(1, 3, 0)
+    const bare = new BufferGeometry()
+    bare.setAttribute('position', new BufferAttribute(new Float32Array(9), VEC3))
+    unindexed.addInstance(unindexed.addGeometry(bare))
+    expect(hasBatchedGeometry(unindexed)).toBe(false)
+    // Out-of-range / deleted instance: three throws from its validators and
+    // this reports "nothing here", which is what the consumers skip on.
+    expect(instanceGeometryRangeAt(mesh, 99)).toBeNull()
+    expect(instanceGeometryAt(mesh, 99)).toBeNull()
+  })
+})

--- a/src/viewer/ifc/batchedSubset.js
+++ b/src/viewer/ifc/batchedSubset.js
@@ -6,6 +6,7 @@ import {
   Mesh,
   Vector3,
 } from 'three'
+import {hasBatchedGeometry, makeInstanceGeometryReader} from './batchedInstanceGeometry'
 import {eachBatch} from './batchedModel'
 
 
@@ -24,6 +25,12 @@ import {eachBatch} from './batchedModel'
  * (`getMatrixAt`) into a fresh world-aligned `BufferGeometry` — the same
  * end product (a plain `Mesh` the OutlineEffect / picker understands) by a
  * different route.
+ *
+ * That local geometry is read back out of the batch's own buffers
+ * (`batchedInstanceGeometry`) rather than from a retained per-instance
+ * table of the source geometries: the batch already holds every byte, and
+ * keeping the second copy alive for the occasional isolate cost 171.5 MB on
+ * a 231 MB model (Share#1810).
  *
  * The reconstructed geometry also carries a synthetic per-vertex
  * `expressID` attribute (every vertex of instance *i* tagged with its
@@ -58,8 +65,7 @@ const VEC3 = 3
  * Returns `null` when the mesh isn't a decorated BatchedMesh or no
  * instance matches — callers treat null as "nothing to highlight here".
  *
- * @param {object} mesh a THREE.BatchedMesh carrying `instanceParents` +
- *   `instanceGeometry`
+ * @param {object} mesh a THREE.BatchedMesh carrying `instanceParents`
  * @param {Set<number>} idSet parent IFC product expressIDs to keep
  * @param {object} [opts]
  * @param {object} [opts.material] subset material (defaults to the batch's)
@@ -71,11 +77,16 @@ const VEC3 = 3
  * @return {Mesh|null}
  */
 export function buildBatchedSubsetMesh(mesh, idSet, opts = {}) {
-  if (!mesh || !mesh.isBatchedMesh || !mesh.instanceParents || !mesh.instanceGeometry) {
+  if (!mesh || !mesh.instanceParents || !hasBatchedGeometry(mesh)) {
     return null
   }
   const parents = mesh.instanceParents
-  const geometries = mesh.instanceGeometry
+  // Source geometry comes back out of the batch's own buffers, ONE copy per
+  // selected shape, and is released with this reader when the bake returns —
+  // the model no longer carries a second copy for the rest of its life
+  // (Share#1810). Reading each selected instance twice (sizing pass, then
+  // bake) is why the reader memoises rather than rebuilding per call.
+  const geometryAt = makeInstanceGeometryReader()
   const occurrenceIds = mesh.instanceOccurrenceIds
   const exclude = (opts.excludeInstances && opts.excludeInstances.size > 0 && occurrenceIds) ?
     opts.excludeInstances : null
@@ -90,7 +101,7 @@ export function buildBatchedSubsetMesh(mesh, idSet, opts = {}) {
     if (exclude !== null && exclude.has(occurrenceIds[batchId])) {
       continue
     }
-    const geom = geometries[batchId]
+    const geom = geometryAt(mesh, batchId)
     const pos = geom?.attributes?.position
     const idx = geom?.index
     if (!pos || !idx) {
@@ -118,7 +129,7 @@ export function buildBatchedSubsetMesh(mesh, idSet, opts = {}) {
   let iOff = 0
 
   for (const batchId of selected) {
-    const geom = geometries[batchId]
+    const geom = geometryAt(mesh, batchId)
     const pos = geom.attributes.position
     const nrm = geom.attributes.normal
     const idx = geom.index

--- a/src/viewer/ifc/batchedSubset.test.js
+++ b/src/viewer/ifc/batchedSubset.test.js
@@ -75,7 +75,6 @@ function decoratedBatch() {
   const batch = batches[0]
   batch.mesh.instanceParents = batch.instanceParents
   batch.mesh.instanceOccurrenceIds = batch.instanceOccurrenceIds
-  batch.mesh.instanceGeometry = batch.instanceGeometry
   return batch.mesh
 }
 

--- a/src/viewer/ifc/batchedToMergedMesh.js
+++ b/src/viewer/ifc/batchedToMergedMesh.js
@@ -7,6 +7,7 @@ import {
   Mesh,
   Vector3,
 } from 'three'
+import {hasBatchedGeometry, makeInstanceGeometryReader} from './batchedInstanceGeometry'
 import {eachBatch} from './batchedModel'
 import {makeSurfaceColor, makeSurfaceMaterial} from '../lookMaterial'
 
@@ -83,17 +84,23 @@ function colorKey(color) {
 function collectInstanceEntries(model) {
   const entries = []
   const scratch = new Matrix4()
+  // One shared reader for the whole model, so a shape used by both the
+  // opaque and the transparent batch is rebuilt once — the identity the
+  // retained `instanceGeometry` table used to provide (Share#1810). It is
+  // scoped to this collection pass and released with it; the entries it
+  // hands out are held only until `batchedModelToMergedMesh` has copied
+  // them into the merged slab.
+  const geometryAt = makeInstanceGeometryReader()
   eachBatch(model, (mesh) => {
     // Only a decorated batch (carrying the side tables) is convertible; a
     // bare BatchedMesh has no source ids to bake in. Skip it — the caller
     // treats an empty entry list as "nothing to export".
-    if (!mesh.instanceParents || !mesh.instanceGeometry ||
+    if (!mesh.instanceParents || !hasBatchedGeometry(mesh) ||
         typeof mesh.getMatrixAt !== 'function') {
       return
     }
     const parents = mesh.instanceParents
     const occurrences = mesh.instanceOccurrenceIds
-    const geometries = mesh.instanceGeometry
     // KNOWN-LOSSY (view-140): this bakes the *displayed* colors, which for a
     // colorless auto-colored model (productPalette) are the palette, not the
     // file's grey. So a cache-hit GLB carries the palette and the source is
@@ -105,7 +112,7 @@ function collectInstanceEntries(model) {
     // control apply directly — rather than a throwaway merged-mesh recolor.
     const colors = mesh.instanceColors
     for (let batchId = 0; batchId < parents.length; batchId++) {
-      const geom = geometries[batchId]
+      const geom = geometryAt(mesh, batchId)
       const pos = geom?.attributes?.position
       const idx = geom?.index
       if (!pos || !idx) {

--- a/src/viewer/ifc/batchedToMergedMesh.test.js
+++ b/src/viewer/ifc/batchedToMergedMesh.test.js
@@ -74,7 +74,6 @@ function batchedModel(flatMeshes) {
   for (const batch of batches) {
     batch.mesh.instanceParents = batch.instanceParents
     batch.mesh.instanceOccurrenceIds = batch.instanceOccurrenceIds
-    batch.mesh.instanceGeometry = batch.instanceGeometry
     batch.mesh.instanceColors = batch.instanceColors
     // STEP per-occurrence side tables, wired exactly as buildBatchedConwayModel
     // does — the source batchedModelOccurrenceTables re-keys for the cache.

--- a/src/viewer/ifc/buildBatchedConwayModel.js
+++ b/src/viewer/ifc/buildBatchedConwayModel.js
@@ -137,12 +137,13 @@ export function decorateBatchMeshes(batches) {
   }
 
   // Each batch carries its own pick tables; CadView reads them off the
-  // raycast-hit child (`intersection.object`). `instanceGeometry` feeds
-  // `batchedSubset` (selection / preselection / isolation re-baking).
+  // raycast-hit child (`intersection.object`). The shape data is NOT among
+  // them — `batchedSubset` re-bakes isolation subsets from the batch's own
+  // buffers (`batchedInstanceGeometry`), so nothing here pins a second copy
+  // of the model's geometry for the life of the model (Share#1810).
   for (const batch of batches) {
     batch.mesh.instanceParents = batch.instanceParents
     batch.mesh.instanceOccurrenceIds = batch.instanceOccurrenceIds
-    batch.mesh.instanceGeometry = batch.instanceGeometry
     batch.mesh.instanceColors = batch.instanceColors
     // The pre-override color table (see the snapshot above). `?? null` keeps
     // older BatchHandle shapes (tests, external callers) working — consumers

--- a/src/viewer/ifc/flatMeshToBatchedModel.js
+++ b/src/viewer/ifc/flatMeshToBatchedModel.js
@@ -441,7 +441,11 @@ export function decideCoordinationOffset(flatTransformation, loadState = undefin
 /**
  * @typedef {object} BatchHandle
  * @property {BatchedMesh} mesh the batch (one geometry per unique shape it
- *   uses, one instance per placement).
+ *   uses, one instance per placement). It is also the ONLY copy of the
+ *   shape data: a consumer that needs one instance's local geometry back
+ *   reads it out of these buffers (`batchedInstanceGeometry`) rather than
+ *   from a retained per-instance table, which cost 171.5 MB on a 231 MB
+ *   model (Share#1810).
  * @property {import('three').Material} material the batch material.
  * @property {boolean} transparent whether this is the blended batch.
  * @property {Uint32Array} instanceParents `batchId → parent IFC product
@@ -457,10 +461,6 @@ export function decideCoordinationOffset(flatTransformation, loadState = undefin
  *   `PlacedGeometry.occurrencePath`. Null (whole table) for IFC / engines
  *   that don't emit paths, so nothing downstream pays; per-entry null when
  *   a single placement has no path.
- * @property {Array<BufferGeometry>} instanceGeometry `batchId → the shared
- *   local-space shape geometry` this instance was added from. Retained so
- *   `batchedSubset` can re-bake a selection/isolation subset (the packed
- *   batch buffers aren't conveniently re-readable per instance).
  * @property {Array<object>} instanceColors `batchId → original `{x,y,z,w}`
  *   RGBA`. Retained so `batchedHighlight` can recolor a selected instance
  *   via `setColorAt` and restore the exact original afterwards (alpha
@@ -676,7 +676,6 @@ function buildBatch(groups, transparent, coordOffset) {
   const instanceGeometryIds = new Uint32Array(instanceCount)
   const instanceOccurrencePaths = new Array(instanceCount)
   let hasOccurrencePaths = false
-  const instanceGeometry = new Array(instanceCount)
   const instanceColors = new Array(instanceCount)
   const matrix = new Matrix4()
   const rgba = new Vector4()
@@ -704,13 +703,12 @@ function buildBatch(groups, transparent, coordOffset) {
       if (placement.occurrencePath) {
         hasOccurrencePaths = true
       }
-      instanceGeometry[batchId] = group.geometry
       instanceColors[batchId] = placement.color
     }
   }
   return {
     mesh, material, transparent,
-    instanceParents, instanceOccurrenceIds, instanceGeometry, instanceColors,
+    instanceParents, instanceOccurrenceIds, instanceColors,
     instanceGeometryIds,
     // Null (not an all-null array) for IFC so consumers can cheaply skip
     // occurrence lookups — mirrors the merged path's IfcInstanceMap.

--- a/src/viewer/ifc/incrementalBatchedBuilder.js
+++ b/src/viewer/ifc/incrementalBatchedBuilder.js
@@ -159,7 +159,10 @@ const MAX_BAD_RECORD_WARNINGS = 5
  * `THREE.BatchedMesh` (created lazily, grown in place with 2x
  * amortization), and accumulates the per-instance pick tables the
  * batched consumers read (`instanceParents`, `instanceOccurrenceIds`,
- * `instanceGeometry`, `instanceColors`).
+ * `instanceGeometryIds`, `instanceColors`). The SOURCE geometries are not
+ * among them: the batch buffers already hold every byte, and the consumers
+ * that need a shape back read it out of them (`batchedInstanceGeometry`),
+ * so nothing here outlives `finalize` (Share#1810).
  *
  * `root` is a stable `Group` — install it in the scene on the first
  * batch and geometry simply appears as it extracts. `finalize`
@@ -383,7 +386,6 @@ export class IncrementalBatchedBuilder {
       state.mesh.instanceOccurrencePaths =
         state.instanceOccurrencePaths.some((p) => p !== null) ?
           state.instanceOccurrencePaths.slice() : null
-      state.mesh.instanceGeometry = state.instanceGeometry.slice()
       state.mesh.instanceColors = state.instanceColors.slice()
       // The mesh has stopped growing, so its exact requirement is finally
       // known: release the reserved space nothing used (Share#1809).
@@ -405,7 +407,6 @@ export class IncrementalBatchedBuilder {
         instanceOccurrenceIds: state.mesh.instanceOccurrenceIds,
         instanceGeometryIds: state.mesh.instanceGeometryIds,
         instanceOccurrencePaths: state.mesh.instanceOccurrencePaths,
-        instanceGeometry: state.mesh.instanceGeometry,
         instanceColors: state.mesh.instanceColors,
       })
     }
@@ -419,10 +420,23 @@ export class IncrementalBatchedBuilder {
     // at the end of the load — nothing reads it afterwards, so release it
     // rather than retaining it for the life of the model (conway#636).
     this.seenPlacements.clear()
+    // Same for the source geometries. `addGeometry` copied each one into the
+    // batch buffers and kept no reference, so past this point the cache is
+    // the ONLY owner of a full duplicate of the model's geometry — 171.5 MB
+    // on sp-231MB.ifc, byte-lever 1 of the conway#679 attribution. Dropping
+    // `mesh.instanceGeometry` alone would not have freed a byte of it
+    // (Share#1810): the cache is reachable from `ShareIfcLoader.parse`'s
+    // closure for as long as conway's proxy holds the open `settings`
+    // object, so the release has to happen here, where the builder knows it
+    // is done. Nothing re-enters the builder after finalize — the degraded
+    // end-of-load rebuilds construct a fresh one from `recapture()`. Read
+    // the count the load report wants BEFORE emptying it.
+    const uniqueGeometryCount = this.geometryCache.size
+    this.geometryCache.clear()
     return {
       batches,
       stats: {
-        uniqueGeometryCount: this.geometryCache.size,
+        uniqueGeometryCount,
         instanceCount: this.totals.placements,
         vertexCount: this.totals.vertexCount,
         triangleCount: (this.totals.indexCount / INDICES_PER_TRIANGLE) | 0,
@@ -555,7 +569,6 @@ export class IncrementalBatchedBuilder {
     // the batched consumers can narrow selection / hide to one occurrence.
     state.instanceGeometryIds.push(geomExpressID)
     state.instanceOccurrencePaths.push(occurrencePath)
-    state.instanceGeometry.push(entry.geometry)
     state.instanceColors.push(color)
     state.cursor++
     this.occurrenceId++
@@ -728,7 +741,6 @@ export class IncrementalBatchedBuilder {
       instanceOccurrenceIds: [],
       instanceGeometryIds: [],
       instanceOccurrencePaths: [],
-      instanceGeometry: [],
       instanceColors: [],
     }
     this[key] = state

--- a/src/viewer/ifc/incrementalBatchedBuilder.test.js
+++ b/src/viewer/ifc/incrementalBatchedBuilder.test.js
@@ -468,7 +468,7 @@ describe('IncrementalBatchedBuilder', () => {
     expect(batch.mesh.instanceCount).toBe(stats.instanceCount)
     expect(builder.opaque.cursor).toBe(stats.instanceCount)
     for (const table of [batch.instanceParents, batch.instanceOccurrenceIds,
-      batch.instanceGeometryIds, batch.instanceGeometry, batch.instanceColors]) {
+      batch.instanceGeometryIds, batch.instanceColors]) {
       expect(table).toHaveLength(stats.instanceCount)
     }
     // ...and row i really describes instance i: parent 2's translated

--- a/src/viewer/ifc/instancedGlbToBatchedModel.js
+++ b/src/viewer/ifc/instancedGlbToBatchedModel.js
@@ -128,7 +128,6 @@ function buildPartition(pairs, transparent) {
   const instanceOccurrenceIds = new Uint32Array(instanceCount)
   const instanceGeometryIds = new Uint32Array(instanceCount)
   const instanceOccurrencePaths = new Array(instanceCount)
-  const instanceGeometry = new Array(instanceCount)
   const instanceColors = new Array(instanceCount)
   let hasOccurrencePaths = false
   let hasGeometryIds = false
@@ -159,7 +158,6 @@ function buildPartition(pairs, transparent) {
       if (Array.isArray(path)) {
         hasOccurrencePaths = true
       }
-      instanceGeometry[batchId] = node.geometry
       // Fresh objects per instance: these become the live `instanceColors`
       // AND (via decorateBatchMeshes' snapshot) the source table — sharing
       // one object per node would let a later per-instance write alias.
@@ -169,7 +167,7 @@ function buildPartition(pairs, transparent) {
 
   return {
     mesh, material, transparent,
-    instanceParents, instanceOccurrenceIds, instanceGeometry, instanceColors,
+    instanceParents, instanceOccurrenceIds, instanceColors,
     // Null (not zero-filled) when the artifact carried none, so the palette
     // keys fall back to parents exactly as on a table-less live build.
     instanceGeometryIds: hasGeometryIds ? instanceGeometryIds : null,

--- a/src/viewer/residency/ResidencyController.js
+++ b/src/viewer/residency/ResidencyController.js
@@ -1,4 +1,8 @@
-import {Matrix4, Vector3} from 'three'
+import {Matrix4, Sphere, Vector3} from 'three'
+import {
+  hasBatchedGeometry,
+  instanceGeometryRangeAt,
+} from '../ifc/batchedInstanceGeometry'
 
 
 /** Guard against division by zero when the eye sits on an instance. */
@@ -28,9 +32,14 @@ export const ResidencyMetric = Object.freeze({
  * true tile release when the pool integration lands (slice C).
  *
  * The controller walks the model for BatchedMesh children carrying the
- * batched pick tables (`instanceParents`, `instanceGeometry`) and
- * precomputes per-instance centers/radii/amortized-bytes once; metric
- * evaluation is a flat array pass, cheap enough to run per slider tick.
+ * batched pick tables (`instanceParents`) and precomputes per-instance
+ * centers/radii/amortized-bytes once; metric evaluation is a flat array
+ * pass, cheap enough to run per slider tick.
+ *
+ * Per-shape bounds and vertex counts come from the batch itself
+ * (`getBoundingSphereAt` / `getGeometryRangeAt`), not from a retained table
+ * of the source geometries — Share#1810 dropped that table, and this
+ * precompute never needed the vertex data, only two numbers per shape.
  */
 export class ResidencyController {
   /**
@@ -58,33 +67,46 @@ export class ResidencyController {
       }
     })
     const BYTES_PER_VERTEX = 32
+    const scratchRange = {}
+    const scratchSphere = new Sphere()
     for (const mesh of meshes) {
-      const geometries = mesh.instanceGeometry
-      if (!geometries || typeof mesh.setVisibleAt !== 'function') {
+      if (!hasBatchedGeometry(mesh) || typeof mesh.setVisibleAt !== 'function' ||
+          typeof mesh.getBoundingSphereAt !== 'function') {
         continue
       }
-      // Amortize each geometry's bytes over its instance count so a
-      // heavily shared shape is cheap per instance.
+      // `instanceParents` sizes the walk now that there is no per-instance
+      // geometry table to iterate; it is the same length by construction
+      // (both builders push one entry per appended instance).
+      const instanceCount = mesh.instanceParents?.length ?? 0
+      // Amortize each shape's bytes over its instance count so a heavily
+      // shared shape is cheap per instance. Keyed by the batch's own
+      // geometry id, which is what "the same shape" means within one mesh —
+      // exactly the grouping the retained geometry objects gave by
+      // reference identity.
       const geometryUses = new Map()
-      for (const geometry of geometries) {
-        geometryUses.set(geometry, (geometryUses.get(geometry) ?? 0) + 1)
-      }
-      for (let index = 0; index < geometries.length; index++) {
-        const geometry = geometries[index]
-        if (!geometry) {
+      for (let index = 0; index < instanceCount; index++) {
+        const range = instanceGeometryRangeAt(mesh, index, scratchRange)
+        if (range === null) {
           continue
         }
-        if (!geometry.boundingSphere) {
-          geometry.computeBoundingSphere()
+        geometryUses.set(range.geometryId, (geometryUses.get(range.geometryId) ?? 0) + 1)
+      }
+      for (let index = 0; index < instanceCount; index++) {
+        const range = instanceGeometryRangeAt(mesh, index, scratchRange)
+        // three computes (and caches on the batch) a per-geometry sphere
+        // over the shape's own index range. It is the source geometry's
+        // sphere for every shape whose vertices are all referenced — which
+        // is every shape Conway emits; a shape with orphan vertices gets
+        // the tighter, more correct sphere here rather than the source's.
+        if (range === null || !mesh.getBoundingSphereAt(range.geometryId, scratchSphere)) {
+          continue
         }
-        const sphere = geometry.boundingSphere
         mesh.getMatrixAt(index, scratchMatrix)
-        const center = new Vector3().copy(sphere.center).applyMatrix4(scratchMatrix)
+        const center = new Vector3().copy(scratchSphere.center).applyMatrix4(scratchMatrix)
         const scale = new Vector3().setFromMatrixScale(scratchMatrix)
-        const radius = sphere.radius * Math.max(scale.x, scale.y, scale.z)
-        const vertexCount = geometry.getAttribute('position')?.count ?? 0
-        const bytes =
-          (vertexCount * BYTES_PER_VERTEX) / (geometryUses.get(geometry) ?? 1)
+        const radius = scratchSphere.radius * Math.max(scale.x, scale.y, scale.z)
+        const bytes = (range.vertexCount * BYTES_PER_VERTEX) /
+          (geometryUses.get(range.geometryId) ?? 1)
         this.instances.push({
           mesh, index, center, radius, bytes,
           expressID: mesh.instanceParents?.[index],

--- a/src/viewer/residency/ResidencyController.test.js
+++ b/src/viewer/residency/ResidencyController.test.js
@@ -10,13 +10,13 @@ import {ResidencyController, ResidencyMetric} from './ResidencyController'
 function makeModel(placements) {
   const mesh = new BatchedMesh(placements.length, 8 * 36 * placements.length, 36 * placements.length)
   mesh.instanceParents = new Uint32Array(placements.map((p) => p.expressID))
-  mesh.instanceGeometry = []
+  // No per-instance geometry table: the controller reads each shape's
+  // bounds and vertex count off the batch itself (Share#1810).
   for (const placement of placements) {
     const geometry = new BoxGeometry(placement.size, placement.size, placement.size)
     const geometryId = mesh.addGeometry(geometry)
     const instanceId = mesh.addInstance(geometryId)
     mesh.setMatrixAt(instanceId, new Matrix4().makeTranslation(placement.x, 0, 0))
-    mesh.instanceGeometry.push(geometry)
   }
   const group = new Group()
   group.add(mesh)

--- a/src/viewer/three/IfcIsolator.test.js
+++ b/src/viewer/three/IfcIsolator.test.js
@@ -948,7 +948,6 @@ describe('viewer/three/IfcIsolator', () => {
       const mesh = batch.mesh
       mesh.instanceParents = batch.instanceParents
       mesh.instanceOccurrenceIds = batch.instanceOccurrenceIds
-      mesh.instanceGeometry = batch.instanceGeometry
       mesh.instanceColors = batch.instanceColors
       attachBatchedSubsets(mesh, null, {})
       return mesh


### PR DESCRIPTION
Part of bldrs-ai/conway#635; byte-lever 1 of bldrs-ai/conway#679

Fixes #1810

The batched model kept a second, complete copy of its own geometry. Each
builder pushed the local-space `BufferGeometry` it fed `addGeometry` into a
per-instance table, `finalize()` sliced that table onto the durable mesh as
`mesh.instanceGeometry`, and it stayed there for the life of the model so an
occasional isolate could re-bake a subset from it. `addGeometry` had already
copied every one of those bytes into the batch buffers and kept no reference
to the source (`BatchedMesh.setGeometryAt`, three r0.184
`BatchedMesh.js:743-792`), so the table bought nothing but a duplicate:
**171.5 MB on sp-231MB.ifc, 24% of the whole external-ArrayBuffer bucket**,
measured by scene traversal in the conway#679 attribution.

## Every reader of `instanceGeometry`, enumerated

Repo-wide grep, production and tests. The attribution named `batchedSubset`;
there were four readers, and re-pointing all four is what this PR is.

| reader | what it took from the table | where it reads now |
|---|---|---|
| `src/viewer/ifc/batchedSubset.js` | per-instance `position` / `normal` / `index` to bake isolation subsets | rebuilt from the batch range, one copy per selected shape, released when the bake returns |
| `src/viewer/ifc/batchedToMergedMesh.js` | same, to bake the merged GLB cache artifact | one memoising reader per collection pass |
| `src/loader/glbBatchedExport.js` | the geometry OBJECT, both for its arrays and as the dedup key (`geometry.uuid`) for shared accessors | same reader; identity restored by keying it on `instanceGeometryIds` |
| `src/viewer/residency/ResidencyController.js` | `boundingSphere`, `position.count`, and object identity for per-shape use counts | `getBoundingSphereAt` + `getGeometryRangeAt` — it never needed vertex data, only two numbers per shape |

Writers removed: `incrementalBatchedBuilder` (the `state.instanceGeometry`
accumulator and the `finalize()` slice), `flatMeshToBatchedModel` and
`instancedGlbToBatchedModel` (the `BatchHandle` field), and
`buildBatchedConwayModel.decorateBatchMeshes` (the stamp onto the mesh).
Test-only readers updated in place; the two hand-rolled doubles in
`glbBatchedExport.test.js` / `glbBatchedRoundTrip.test.js` became real
`BatchedMesh`es, because a plain object with an `instanceGeometry` array no
longer exercises anything.

`instanceGeometryIds` is a different table — `batchId → geometryExpressID`,
a `Uint32Array` — and stays.

## The re-bake

`src/viewer/ifc/batchedInstanceGeometry.js` resolves an instance through
three's **public** accessors, `getGeometryIdAt` and `getGeometryRangeAt`
(`BatchedMesh.js:1217` and `:1237` in the pinned r0.184 — nothing reaches
into `_geometryInfo`), and rebuilds the shape from the batch's own buffers:
slice `position` / `normal` over `[vertexStart, vertexStart + vertexCount)`,
and rebuild the index over `[indexStart, indexStart + indexCount)` minus
`vertexStart`, because three stores every batch index offset by the shape's
vertex start (`BatchedMesh.js:778`). That subtraction is the whole
correctness story, and it is what the byte-identity tests pin.

Two properties the consumers depended on and the module preserves:

- **Identity.** Both builders added one `BufferGeometry` per
  `geometryExpressID` and put that same object in every instance's slot,
  including across the opaque/transparent split, so the GLB writer's
  accessor dedup and the residency controller's use counts grouped by
  reference. `makeInstanceGeometryReader()` memoises per source shape, keyed
  on `instanceGeometryIds`, and reproduces exactly that grouping — for one
  pass, then releases it.
- **Freshness.** Ranges are read on every call and never snapshotted:
  `finalize()`'s capacity trim reallocates the batch buffers (Share#1809),
  and three's `optimize()` compacts shape offsets outright.

Dropping the table alone would have freed nothing. The incremental builder's
`geometryCache` is the *other* owner of those geometries, and the
attribution found it still reachable from `ShareIfcLoader.parse`'s closure
(104,991 entries) because conway's proxy pins the open `settings` object. So
`finalize()` now releases it beside `seenPlacements`, once the batches are
stamped and trimmed.

## Falsifiability

Every new assertion was run against a reverted mechanism.

| revert | test that goes red |
|---|---|
| drop the `- vertexStart` index rebase | `reads back each instance's source geometry byte for byte`, `bakes a subset identical to the pre-#1810 retained-table path`, `reflects the CURRENT ranges…` (3 failures) |
| cache the range per instance instead of re-reading it | `follows a shape whose range MOVES under it` |
| key the reader per mesh+geometryId instead of per source shape | `hands one geometry object per source shape to a reader, across batches` |

The parity test is the one the issue asks for: it builds one model, bakes a
subset the pre-#1810 way from a retained table (the old algorithm, kept in
the test) and the new way from the batch, and compares `position`, `normal`,
`expressID` and `index` array-for-array.

## Measurement

`sp-231MB.ifc`, windowed conway-direct load
(`?feature=conwayDirectIfc`), same box, same procedure before and after:
chromium with `--enable-precise-memory-info --js-flags=--expose-gc`, tab
backgrounded (a foreground tab rasterises through SwiftShader here and runs
~10x slower for identical allocation), wait for `store.model`, settle 30 s,
`gc()` x3, then one scene traversal that sums `attributes[*].array.byteLength`
+ index bytes, deduped by backing store — the stable instrument from the
attribution, not the run-to-run-noisy external-ArrayBuffer bucket. Both runs
loaded the same model: 5,601,739 vertices, 139,264 instance slots, identical
batch capacity (5,388,081 / 10,970,532 and 213,658 / 385,044 verts/indices).
The 256 MiB canary moved the heap counter 248.4 MB / 251.5 MB, so both reads
are live rather than latched.

| settled, post-GC | before | after | delta |
|---|---:|---:|---:|
| **`mesh.instanceGeometry` copies** | **171.5 MB** (104,991 geometries) | **0.0 MB** (0) | **-171.5 MB** |
| batch vertex attributes | 128.2 MB | 128.2 MB | 0 |
| batch indices | 43.3 MB | 43.3 MB | 0 |
| batch per-instance tables | 13.8 MB | 13.8 MB | 0 |
| wasm linear memory | 514.8 MB | 514.8 MB | 0 |
| `usedJSHeapSize` | 2,288.5 MB | 1,983.9 MB | **-304.5 MB (-13.3%)** |

171.5 MB and 104,991 geometries reproduce the attribution's figures exactly.

Two things worth naming rather than rounding off:

- **The heap fell by more than the geometry bytes** — 304.5 MB against
  171.5 MB of ArrayBuffers. The difference is the V8 side of the same
  release: 104,991 `BufferGeometry` objects, their three `BufferAttribute`
  wrappers each, and the `geometryCache` entry + `Box3` per shape, all of
  which the traversal above does not count. The attribution's own V8
  breakdown put `localGeometry` at 60.5 MB as the largest single allocation
  site; ~1.3 KB of object graph per shape accounts for the rest. So the
  scene-traversal number is the conservative one.
- **Geometry amplification is now 1.00x**, not the report's predicted 1.08x:
  the batch holds 171.5 MB to deliver 171.5 MB. The report measured 2.62x
  against a build without Share#1809, whose trim has since removed the 92.5
  MB of doubling slack — visible above as capacity == used in both runs.
  This lever removes the other duplicate, so 343.0 MB -> 171.5 MB stored for
  the same payload.

## Blast radius

- Selection / preselection never touched this path (they recolour in place
  via `batchedHighlight`); isolate / hide bake through `batchedSubset`, and
  the subset geometry is byte-identical by the parity test above.
- The two GLB writers produce the same artifact: same geometry values, same
  accessor dedup (identity preserved), same instance tables.
- `ResidencyController` is the one place with a behavioural note rather than
  a byte-identity claim: three's per-geometry sphere is computed over the
  shape's index range, while `BufferGeometry.computeBoundingSphere` walks
  every position. They agree for every shape whose vertices are all
  referenced — which is every shape Conway emits — and differ (tighter, more
  correct) only for a shape with orphan vertices. It feeds eviction
  ordering, not geometry.
- A batch with no index buffer is now refused up front by
  `hasBatchedGeometry` rather than per instance by the old `geom.index`
  check; same outcome (nothing to bake), one branch earlier.

## Validation

Baseline first, on `origin/main` at e2c38e0 before any edit: `yarn lint`
clean, `yarn test` 264 suites / 2802 tests (5 skipped).

- `yarn lint` (eslint + tsc): clean.
- `yarn test`: **265 suites / 2808 tests**, 5 skipped, 0 failures — +1 suite
  and +6 tests, all in `batchedInstanceGeometry.test.js`. Run again by the
  husky pre-commit hook on the commit itself.
- Playwright, against a `SHARE_CONFIG=playwright` build of this branch:
  `IfcIsolator.spec.ts` + `HideFeat.spec.ts` + `conwayDirect.spec.ts` — 12
  passed; `navTreeOccurrenceSelection.spec.ts` + `batchedGlbCache.spec.ts` +
  `Properties.cacheHit.spec.ts` — passed; `indexStepLogo.spec.ts` +
  `loadTiming.spec.ts` — 10 passed; `sceneHighlightPermalink.spec.ts` — 6
  passed.
- One confounder, named: in the 4-worker run, the three **desktop**
  `sceneHighlightPermalink` tests timed out waiting for `data-model-ready`
  (their mobile twins passed in the same run). Re-run alone with
  `--workers=1`, all 6 pass. This box has no GPU, so four concurrent
  SwiftShader contexts miss the spec's 15 s ready timeout; the failure is
  contention, not the diff. `yarn build-prod` / `yarn test-ci` /
  the full flows run are for the pre-flip pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ScPZ6RarXvYmSdz6BUXF78)_