### PR TITLE
Bump @bldrs-ai/conway to 1.1596.704 and GLB cache schema to 0.20.0 — type-inherited materials

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@babel/plugin-syntax-import-assertions": "7.18.6",
     "@babel/preset-env": "7.18.10",
     "@babel/preset-react": "7.18.6",
-    "@bldrs-ai/conway": "1.1593.683-g9ff7aa12",
+    "@bldrs-ai/conway": "1.1596.704-gb0034dfe",
     "@bldrs-ai/ifclib": "5.3.3",
     "@emotion/react": "11.10.0",
     "@emotion/styled": "11.10.0",

--- a/src/loader/glbCacheKey.js
+++ b/src/loader/glbCacheKey.js
@@ -20,6 +20,18 @@
  * it (`BLDRS_GLB_BATCHED_SCHEMA_VERSION` below) — deliberately, since that
  * is the slot most users actually read. Nothing extra to do here; the note
  * exists so the coupling is visible from where the bump gets written.
+ * 0.20.0 — retires artifacts baked without type-inherited materials
+ *         (conway#704, issue test-models-private#61 — the follow-up to
+ *         0.18.0's colour fixes): a product with no direct
+ *         IfcRelAssociatesMaterial now inherits its type object's
+ *         association through IfcRelDefinesByType (occurrence still wins),
+ *         so doors/windows/fixtures whose material hangs off IfcDoorType /
+ *         IfcWindowType gain their authored colours. Colours are baked into
+ *         the artifact and nothing in the cache key identifies the engine,
+ *         so without this bump a returning user's cache hit keeps the
+ *         default-grey typed elements indefinitely while cache-miss users
+ *         see them coloured. Same failure shape and remedy as
+ *         0.18.0/0.17.0/0.16.0/0.15.0.
  * 0.19.0 — retires artifacts whose STEP occurrence paths mean something
  *         different from what the app now reads. conway#628
  *         (test-models-private#98) changed the path's own composition, not
@@ -218,7 +230,7 @@
  * 0.2.0 — generalised cache key from GitHub-only (owner/repo/branch) to a
  *         per-source-kind 3-level namespace (ns1/ns2/ns3).
  */
-export const BLDRS_GLB_SCHEMA_VERSION = '0.19.0'
+export const BLDRS_GLB_SCHEMA_VERSION = '0.20.0'
 
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -2473,10 +2473,10 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@bldrs-ai/conway@1.1593.683-g9ff7aa12":
-  version "1.1593.683-g9ff7aa12"
-  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.1593.683-g9ff7aa12.tgz#61e68d44c6bb684ee31297f1962ebd58b6ee459f"
-  integrity sha512-9n4CUnmUCfSXmBmWSvKVi1+pdXLoJVr1p0TqpdUQw7AcHPt2rsqay0ixSrLCuA0LRIuWxeX3A0jrhkd2V6UKnQ==
+"@bldrs-ai/conway@1.1596.704-gb0034dfe":
+  version "1.1596.704-gb0034dfe"
+  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.1596.704-gb0034dfe.tgz#e1b332a7e61b5008f62f071af13a750eca0493a5"
+  integrity sha512-uy1QdcrfQvPGfNSZXfQlIHr43afn3B+67eC6Az2Hblu01eXMwZWSZTIwtKxDQCC00YCUGfdeqFRLfIngPcLZVg==
   dependencies:
     gl-matrix "3.4.3"
     seedrandom "3.0.5"


### PR DESCRIPTION
Picks up [bldrs-ai/conway#704](https://github.com/bldrs-ai/conway/pull/704) — the type-material inheritance follow-up to #1817 for [bldrs-ai/test-models-private#61](https://github.com/bldrs-ai/test-models-private/issues/61): a product with no direct `IfcRelAssociatesMaterial` now inherits its type object's material association through `IfcRelDefinesByType` (occurrence associations still win), so doors, windows and fixtures whose material hangs off `IfcDoorType`/`IfcWindowType` gain their authored colours. Includes the windowed demand-prep residency fix so inheritance holds on store-backed opens.

Also bumps `BLDRS_GLB_SCHEMA_VERSION` to `0.20.0`: type-inherited colours are baked into cached GLB artifacts and the cache key doesn't identify the engine, so without the bump cache-hit users would keep the default-grey typed elements. Same pairing as the 0.18.0 entry from #1817.

Verified against this exact published build from Share's `node_modules`: the issue model resolves 5,262 of 5,351 placements (was 5,079 on the previous pin), with the new aluminium (windows, ×167) and dark-wood (doors, ×36) buckets matching the file's type associations and every other colour bucket byte-identical. Three-file diff: `package.json` pin, `yarn.lock`, `glbCacheKey.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HSPoDZwutgTofFsHaZ5jpA

---
_Generated by [Claude Code](https://claude.ai/code/session_01HSPoDZwutgTofFsHaZ5jpA)_