### PR TITLE
ViewCube navigation gizmo with enable/disable toggle

### DIFF
--- a/src/Components/ElementsControl.jsx
+++ b/src/Components/ElementsControl.jsx
@@ -8,6 +8,7 @@ import {
   Close as CloseIcon,
   FilterCenterFocus as FilterCenterFocusIcon,
   HideSourceOutlined as HideSourceOutlinedIcon,
+  ViewInArOutlined as ViewInArOutlinedIcon,
   VisibilityOutlined as VisibilityOutlinedIcon,
 } from '@mui/icons-material'
 
@@ -39,6 +40,8 @@ export default function ElementsControl({deselectItems}) {
   const selectedElement = useStore((state) => state.selectedElement)
   const isTempIsolationModeOn = useStore((state) => state.isTempIsolationModeOn)
   const hiddenElements = useStore((state) => state.hiddenElements)
+  const isViewCubeVisible = useStore((state) => state.isViewCubeVisible)
+  const toggleIsViewCubeVisible = useStore((state) => state.toggleIsViewCubeVisible)
   const isSelected = selectedElement !== null
   // `hiddenElements` is a sparse map keyed by expressID with `true`
   // for currently-hidden, `false` for explicitly-unhidden, missing
@@ -62,6 +65,24 @@ export default function ElementsControl({deselectItems}) {
          * (which replaces the model's geometry slot).
          */}
         {!isTempIsolationModeOn && <CutPlaneMenu/>}
+
+        {/*
+         * View cube toggle. A viewport navigation aid grouped with the
+         * cut plane; hidden during isolation to match CutPlaneMenu (the
+         * gizmo would orbit the isolation subset, not the whole model).
+         * Enables/disables the ViewCube widget; state persists via the
+         * store's ViewCubeSlice.
+         */}
+        {!isTempIsolationModeOn &&
+         <TooltipIconButton
+           title='View cube'
+           onClick={toggleIsViewCubeVisible}
+           icon={<ViewInArOutlinedIcon className='icon-share'/>}
+           placement='top'
+           variant='control'
+           selected={isViewCubeVisible}
+           dataTestId='control-button-view-cube'
+         />}
 
         {/*
          * Residency (demand-model eviction / infill). Grouped with the

--- a/src/Components/ElementsControl.test.jsx
+++ b/src/Components/ElementsControl.test.jsx
@@ -208,4 +208,21 @@ describe('ElementsControl', () => {
       expect(queryByTitle('Show all')).not.toBeInTheDocument()
     })
   })
+
+  it('should toggle ViewCube visibility when the View cube button is clicked', async () => {
+    const {result} = renderHook(() => useStore((state) => state))
+    await act(() => {
+      result.current.setIsViewCubeVisible(false)
+    })
+    const {getByTitle} = render(
+      <ShareMock initialEntries={['/v/p/index.ifc#p:x']}>
+        <ElementsControl deselectItems={deselectItems}/>
+      </ShareMock>,
+    )
+    const viewCubeButton = getByTitle('View cube')
+    fireEvent.click(viewCubeButton)
+    expect(result.current.isViewCubeVisible).toBe(true)
+    fireEvent.click(viewCubeButton)
+    expect(result.current.isViewCubeVisible).toBe(false)
+  })
 })

--- a/src/Components/ViewCube/ViewCube.jsx
+++ b/src/Components/ViewCube/ViewCube.jsx
@@ -21,6 +21,7 @@ import Menu from '@mui/material/Menu'
 import MenuItem from '@mui/material/MenuItem'
 import Tooltip from '@mui/material/Tooltip'
 import {
+  Close as CloseIcon,
   Home as HomeIcon,
   KeyboardArrowDown as TiltDownIcon,
   KeyboardArrowUp as TiltUpIcon,
@@ -51,6 +52,7 @@ import debug from '../../utils/debug'
  */
 export default function ViewCube() {
   const viewer = useStore((state) => state.viewer)
+  const setIsViewCubeVisible = useStore((state) => state.setIsViewCubeVisible)
   // Right-drawer state so the widget can sit clear of any open drawer.
   const isNotesVisible = useStore((state) => state.isNotesVisible)
   const isAppsVisible = useStore((state) => state.isAppsVisible)
@@ -306,6 +308,12 @@ export default function ViewCube() {
       }}
       data-testid='view-cube'
     >
+      <RingButton
+        title='Close view cube'
+        onClick={() => setIsViewCubeVisible(false)}
+        icon={<CloseIcon/>}
+        sx={{gridColumn: 3, gridRow: 1}}
+      />
       <RingButton
         title='Rotate up'
         onClick={() => orbit(0, -TILT_STEP_RAD)}

--- a/src/Components/ViewCube/ViewCube.jsx
+++ b/src/Components/ViewCube/ViewCube.jsx
@@ -22,6 +22,7 @@ import {
   RotateLeft as RotateLeftIcon,
   RotateRight as RotateRightIcon,
 } from '@mui/icons-material'
+import {useIsMobile} from '../Hooks'
 import useStore from '../../store/useStore'
 import debug from '../../utils/debug'
 
@@ -48,6 +49,8 @@ export default function ViewCube() {
   const isAppsVisible = useStore((state) => state.isAppsVisible)
   const rightDrawerWidth = useStore((state) => state.rightDrawerWidth)
   const appsDrawerWidth = useStore((state) => state.appsDrawerWidth)
+  // On mobile the drawers are bottom sheets, so they don't push the widget aside.
+  const isMobile = useIsMobile()
 
   const mountRef = useRef(null)
   // Live handles so the ring buttons and fit calls can reach the viewer.
@@ -102,24 +105,45 @@ export default function ViewCube() {
     }
     renderLoop()
 
-    // --- Pointer handling: click a face/corner to snap, drag to orbit freely ---
+    // --- Pointer handling: click a face/corner to snap, drag to orbit freely,
+    // hover to highlight the face under the cursor. ---
     const raycaster = new Raycaster()
     const pointer = new Vector2()
     let isPointerDown = false
     let isDragging = false
     let lastX = 0
     let lastY = 0
+    let hoveredIndex = -1
 
-    const snapFromPointer = (event) => {
+    const raycastFromPointer = (event) => {
       const rect = renderer.domElement.getBoundingClientRect()
       pointer.x = (((event.clientX - rect.left) / rect.width) * 2) - 1
       pointer.y = (-((event.clientY - rect.top) / rect.height) * 2) + 1
       raycaster.setFromCamera(pointer, camera)
       const hits = raycaster.intersectObject(cube)
-      if (hits.length === 0) {
+      return hits.length > 0 ? hits[0] : null
+    }
+
+    // Tint the face under the cursor by multiplying its texture with a highlight.
+    const setHover = (index) => {
+      if (index === hoveredIndex) {
         return
       }
-      const direction = pickDirection(hits[0], cube)
+      if (hoveredIndex >= 0) {
+        materials[hoveredIndex].color.setHex(BASE_HEX)
+      }
+      if (index >= 0) {
+        materials[index].color.setHex(HOVER_HEX)
+      }
+      hoveredIndex = index
+    }
+
+    const snapFromPointer = (event) => {
+      const hit = raycastFromPointer(event)
+      if (!hit) {
+        return
+      }
+      const direction = pickDirection(hit, cube)
       snapToDirection(cameraControls, direction)
       fitModelToFrame()
       debug().log('ViewCube: snap to', direction)
@@ -134,6 +158,8 @@ export default function ViewCube() {
     }
     const onPointerMove = (event) => {
       if (!isPointerDown) {
+        const hit = raycastFromPointer(event)
+        setHover(hit ? hit.face.materialIndex : -1)
         return
       }
       const dx = event.clientX - lastX
@@ -142,6 +168,7 @@ export default function ViewCube() {
         return
       }
       isDragging = true
+      setHover(-1) // Clear the highlight while dragging.
       lastX = event.clientX
       lastY = event.clientY
       const {azimuth, polar} = dragRotation(dx, dy, ROTATE_SENSITIVITY)
@@ -158,9 +185,11 @@ export default function ViewCube() {
       isPointerDown = false
       isDragging = false
     }
+    const onPointerLeave = () => setHover(-1)
     renderer.domElement.addEventListener('pointerdown', onPointerDown)
     renderer.domElement.addEventListener('pointermove', onPointerMove)
     renderer.domElement.addEventListener('pointerup', onPointerUp)
+    renderer.domElement.addEventListener('pointerleave', onPointerLeave)
     renderer.domElement.style.cursor = 'grab'
     renderer.domElement.style.touchAction = 'none'
 
@@ -169,6 +198,7 @@ export default function ViewCube() {
       renderer.domElement.removeEventListener('pointerdown', onPointerDown)
       renderer.domElement.removeEventListener('pointermove', onPointerMove)
       renderer.domElement.removeEventListener('pointerup', onPointerUp)
+      renderer.domElement.removeEventListener('pointerleave', onPointerLeave)
       controlsRef.current = null
       contextRef.current = null
       cube.geometry.dispose()
@@ -215,10 +245,11 @@ export default function ViewCube() {
     }
   }
 
-  // Sit clear of any open right-side drawer (Notes, Apps).
-  const rightInset = MARGIN_PX +
-    (isNotesVisible ? rightDrawerWidth : 0) +
-    (isAppsVisible ? appsDrawerWidth : 0)
+  // Sit clear of any open right-side drawer (Notes, Apps).  On mobile the
+  // drawers are bottom sheets, so only the base margin applies.
+  const drawerInset = isMobile ? 0 :
+    (isNotesVisible ? rightDrawerWidth : 0) + (isAppsVisible ? appsDrawerWidth : 0)
+  const rightInset = MARGIN_PX + drawerInset
 
   return (
     <Box
@@ -303,9 +334,10 @@ function RingButton({title, onClick, icon, sx}) {
 /**
  * Determine the model-space view direction for a click on the cube.  Because
  * the cube's local axes map to the model's axes (local +Z is the model front),
- * the clicked zone in cube-local space is the direction to look from.  Corner
- * clicks (all three coordinates near an edge) yield a diagonal isometric
- * direction; face and edge clicks resolve to the clicked face normal.
+ * the clicked zone in cube-local space is the direction to look from.  A click
+ * near a corner (three active axes) or an edge (two active axes) yields the
+ * corresponding diagonal direction; a face-center click (one or zero active
+ * axes) resolves to the clicked face's outward normal.
  *
  * @param {object} hit Raycaster intersection against the cube
  * @param {Mesh} cube The cube mesh
@@ -318,12 +350,13 @@ export function pickDirection(hit, cube) {
     zoneSign(local.y),
     zoneSign(local.z),
   )
-  const cornerAxes = 3
-  const isCorner = (Math.abs(zone.x) + Math.abs(zone.y) + Math.abs(zone.z)) === cornerAxes
-  if (isCorner) {
+  const activeAxes = Math.abs(zone.x) + Math.abs(zone.y) + Math.abs(zone.z)
+  // Two active axes = edge, three = corner; both look along the diagonal.
+  const edgeAxes = 2
+  if (activeAxes >= edgeAxes) {
     return zone.normalize()
   }
-  // Face or edge: snap to the clicked face's outward normal.
+  // Face center: snap to the clicked face's outward normal.
   return hit.face.normal.clone().normalize()
 }
 
@@ -432,6 +465,8 @@ const TILT_STEP_RAD = Math.PI / 4 // 45 degrees
 const POLAR_EPS = 0.001
 const DRAG_THRESHOLD_PX = 4
 const ROTATE_SENSITIVITY = 0.008 // radians per pixel of drag
+const BASE_HEX = 0xffffff // Face texture shown untinted.
+const HOVER_HEX = 0xbfe0ff // Light-blue tint for the hovered face.
 // Half the cube's edge length; a face spans [-CUBE_HALF, CUBE_HALF] locally.
 const CUBE_HALF = 0.5
 const FACE_THIRDS = 3

--- a/src/Components/ViewCube/ViewCube.jsx
+++ b/src/Components/ViewCube/ViewCube.jsx
@@ -455,7 +455,10 @@ const CUBE_FACES = [
 ]
 
 const CUBE_SIZE_PX = 96
-const WIDGET_SIZE_PX = 150
+// Wide enough to contain the 96px cube plus a ~48px ring button on each side,
+// so the right-column buttons (Rotate right, Home) stay inside the widget
+// instead of overflowing off-screen / onto an open drawer.
+const WIDGET_SIZE_PX = 200
 const TOP_INSET_PX = 80
 const MARGIN_PX = 20
 const NEAR_PLANE = 0.1

--- a/src/Components/ViewCube/ViewCube.jsx
+++ b/src/Components/ViewCube/ViewCube.jsx
@@ -1,7 +1,10 @@
 import React, {ReactElement, useEffect, useRef} from 'react'
 import {
-  BoxGeometry,
+  BufferGeometry,
   CanvasTexture,
+  DoubleSide,
+  Float32BufferAttribute,
+  Group,
   LinearFilter,
   Mesh,
   MeshBasicMaterial,
@@ -28,17 +31,19 @@ import debug from '../../utils/debug'
 
 
 /**
- * ViewCube is an Autodesk-style navigation gizmo rendered in the top-right
- * corner of the viewer.  It shows a labeled cube whose orientation mirrors the
- * main camera; clicking a face or corner snaps the main camera to that standard
- * view and fits the model to frame.  Dragging the cube orbits the view freely
- * (fine rotation), and a ring of arrows around the cube orbits in fixed steps
- * with an isometric home button.
+ * ViewCube is an Autodesk-style navigation gizmo rendered in a corner of the
+ * viewer.  It shows a chamfered, labeled cube whose orientation mirrors the
+ * main camera.  Clicking a face, chamfered edge, or corner snaps the main
+ * camera to that standard view and fits the model to frame; hovering a region
+ * highlights it (edges/corners in the bldrs green).  Dragging the cube orbits
+ * the view freely, and a ring of arrows orbits in fixed steps with a home
+ * button.
  *
  * The cube is drawn in its own tiny Three.js scene (independent of the main
- * viewer) so face/corner picking stays simple and self-contained.  The main
- * camera is read from `viewer.IFC.context` and driven via the camera-controls
- * instance the rest of Share already uses (see CameraControl.jsx).
+ * viewer): 6 face quads, 12 edge bevels and 8 corner triangles, each a
+ * pickable sub-mesh carrying its own view direction.  The main camera is read
+ * from `viewer.IFC.context` and driven via the camera-controls instance the
+ * rest of Share already uses (see CameraControl.jsx).
  *
  * @return {ReactElement}
  */
@@ -84,12 +89,8 @@ export default function ViewCube() {
     renderer.setSize(CUBE_SIZE_PX, CUBE_SIZE_PX)
     mount.appendChild(renderer.domElement)
 
-    const materials = CUBE_FACES.map((face) => new MeshBasicMaterial({
-      map: makeFaceTexture(face.label),
-      transparent: true,
-    }))
-    const cube = new Mesh(new BoxGeometry(1, 1, 1), materials)
-    scene.add(cube)
+    const {group, regions, dispose: disposeCube} = createViewCube()
+    scene.add(group)
 
     // --- Keep the cube oriented to match what the main camera sees ---
     let frameId = 0
@@ -98,44 +99,45 @@ export default function ViewCube() {
       if (active) {
         // Rotating the cube by the inverse of the camera rotation reproduces the
         // model's on-screen orientation inside the gizmo.
-        cube.quaternion.copy(active.quaternion).invert()
+        group.quaternion.copy(active.quaternion).invert()
       }
       renderer.render(scene, camera)
       frameId = requestAnimationFrame(renderLoop)
     }
     renderLoop()
 
-    // --- Pointer handling: click a face/corner to snap, drag to orbit freely,
-    // hover to highlight the face under the cursor. ---
+    // --- Pointer handling: click a region to snap, drag to orbit freely,
+    // hover to highlight the region under the cursor. ---
     const raycaster = new Raycaster()
     const pointer = new Vector2()
     let isPointerDown = false
     let isDragging = false
     let lastX = 0
     let lastY = 0
-    let hoveredIndex = -1
+    let hoveredMesh = null
 
     const raycastFromPointer = (event) => {
       const rect = renderer.domElement.getBoundingClientRect()
       pointer.x = (((event.clientX - rect.left) / rect.width) * 2) - 1
       pointer.y = (-((event.clientY - rect.top) / rect.height) * 2) + 1
       raycaster.setFromCamera(pointer, camera)
-      const hits = raycaster.intersectObject(cube)
+      const hits = raycaster.intersectObjects(regions, false)
       return hits.length > 0 ? hits[0] : null
     }
 
-    // Tint the face under the cursor by multiplying its texture with a highlight.
-    const setHover = (index) => {
-      if (index === hoveredIndex) {
+    // Highlight the region under the cursor; edges/corners use the bldrs green.
+    const setHover = (mesh) => {
+      if (mesh === hoveredMesh) {
         return
       }
-      if (hoveredIndex >= 0) {
-        materials[hoveredIndex].color.setHex(BASE_HEX)
+      if (hoveredMesh) {
+        hoveredMesh.material.color.setHex(hoveredMesh.userData.baseColor)
       }
-      if (index >= 0) {
-        materials[index].color.setHex(HOVER_HEX)
+      if (mesh) {
+        const hl = mesh.userData.kind === 'face' ? FACE_HOVER_HEX : BLDRS_GREEN_HEX
+        mesh.material.color.setHex(hl)
       }
-      hoveredIndex = index
+      hoveredMesh = mesh
     }
 
     const snapFromPointer = (event) => {
@@ -143,10 +145,10 @@ export default function ViewCube() {
       if (!hit) {
         return
       }
-      const direction = pickDirection(hit, cube)
+      const direction = hit.object.userData.dir
       snapToDirection(cameraControls, direction)
       fitModelToFrame()
-      debug().log('ViewCube: snap to', direction)
+      debug().log('ViewCube: snap to', hit.object.userData.kind, direction)
     }
 
     const onPointerDown = (event) => {
@@ -159,7 +161,7 @@ export default function ViewCube() {
     const onPointerMove = (event) => {
       if (!isPointerDown) {
         const hit = raycastFromPointer(event)
-        setHover(hit ? hit.face.materialIndex : -1)
+        setHover(hit ? hit.object : null)
         return
       }
       const dx = event.clientX - lastX
@@ -168,7 +170,7 @@ export default function ViewCube() {
         return
       }
       isDragging = true
-      setHover(-1) // Clear the highlight while dragging.
+      setHover(null) // Clear the highlight while dragging.
       lastX = event.clientX
       lastY = event.clientY
       const {azimuth, polar} = dragRotation(dx, dy, ROTATE_SENSITIVITY)
@@ -185,7 +187,7 @@ export default function ViewCube() {
       isPointerDown = false
       isDragging = false
     }
-    const onPointerLeave = () => setHover(-1)
+    const onPointerLeave = () => setHover(null)
     renderer.domElement.addEventListener('pointerdown', onPointerDown)
     renderer.domElement.addEventListener('pointermove', onPointerMove)
     renderer.domElement.addEventListener('pointerup', onPointerUp)
@@ -201,13 +203,7 @@ export default function ViewCube() {
       renderer.domElement.removeEventListener('pointerleave', onPointerLeave)
       controlsRef.current = null
       contextRef.current = null
-      cube.geometry.dispose()
-      materials.forEach((m) => {
-        if (m.map) {
-          m.map.dispose()
-        }
-        m.dispose()
-      })
+      disposeCube()
       renderer.dispose()
       if (renderer.domElement.parentNode === mount) {
         mount.removeChild(renderer.domElement)
@@ -332,36 +328,6 @@ function RingButton({title, onClick, icon, sx}) {
 
 
 /**
- * Determine the model-space view direction for a click on the cube.  Because
- * the cube's local axes map to the model's axes (local +Z is the model front),
- * the clicked zone in cube-local space is the direction to look from.  A click
- * near a corner (three active axes) or an edge (two active axes) yields the
- * corresponding diagonal direction; a face-center click (one or zero active
- * axes) resolves to the clicked face's outward normal.
- *
- * @param {object} hit Raycaster intersection against the cube
- * @param {Mesh} cube The cube mesh
- * @return {Vector3} Unit direction, in model space, to place the camera along
- */
-export function pickDirection(hit, cube) {
-  const local = cube.worldToLocal(hit.point.clone())
-  const zone = new Vector3(
-    zoneSign(local.x),
-    zoneSign(local.y),
-    zoneSign(local.z),
-  )
-  const activeAxes = Math.abs(zone.x) + Math.abs(zone.y) + Math.abs(zone.z)
-  // Two active axes = edge, three = corner; both look along the diagonal.
-  const edgeAxes = 2
-  if (activeAxes >= edgeAxes) {
-    return zone.normalize()
-  }
-  // Face center: snap to the clicked face's outward normal.
-  return hit.face.normal.clone().normalize()
-}
-
-
-/**
  * Snap the main camera to look from `direction`, keeping the current target and
  * distance.  Converts the direction to the camera-controls (azimuth, polar)
  * spherical angles and animates there.
@@ -398,20 +364,129 @@ export function dragRotation(dx, dy, sensitivity) {
 
 
 /**
- * Bucket a cube-local coordinate (range [-0.5, 0.5]) into -1, 0 or 1 by which
- * third of the face it falls in.
+ * Build the chamfered ViewCube as a group of pickable sub-meshes: 6 labeled
+ * face quads, 12 edge bevels and 8 corner triangles.  Each mesh carries its
+ * view direction and highlight base color in userData.
  *
- * @param {number} coord
- * @return {number} -1, 0 or 1
+ * @return {{group: Group, regions: Array<Mesh>, dispose: Function}}
  */
-function zoneSign(coord) {
-  if (coord > ZONE_THRESHOLD) {
-    return 1
+export function createViewCube() {
+  const group = new Group()
+  const regions = []
+  const disposables = []
+  const H = CUBE_HALF
+  const S = FACE_HALF
+  const vec = (x, y, z) => new Vector3(x, y, z)
+
+  const addRegion = (geometry, material, dir, kind, baseColor) => {
+    const mesh = new Mesh(geometry, material)
+    mesh.userData = {dir, kind, baseColor}
+    group.add(mesh)
+    regions.push(mesh)
+    disposables.push(geometry, material)
   }
-  if (coord < -ZONE_THRESHOLD) {
-    return -1
+
+  // Faces: an inset quad on each of the 6 outer planes, carrying its label.
+  CUBE_FACES.forEach(({n, u, v, label}) => {
+    const nn = vec(...n)
+    const uu = vec(...u)
+    const vv = vec(...v)
+    const center = nn.clone().multiplyScalar(H)
+    const corner = (su, sv) =>
+      center.clone().addScaledVector(uu, su * S).addScaledVector(vv, sv * S)
+    const bl = corner(-1, -1)
+    const br = corner(1, -1)
+    const tr = corner(1, 1)
+    const tl = corner(-1, 1)
+    const geo = geomFromTris(
+      [bl, br, tr, bl, tr, tl],
+      [0, 0, 1, 0, 1, 1, 0, 0, 1, 1, 0, 1])
+    const tex = makeFaceTexture(label)
+    disposables.push(tex)
+    const mat = new MeshBasicMaterial({map: tex, side: DoubleSide})
+    addRegion(geo, mat, nn.clone().normalize(), 'face', FACE_BASE_HEX)
+  })
+
+  // Edge bevels: a chamfer strip between each pair of perpendicular faces.
+  const normals = CUBE_FACES.map((f) => vec(...f.n))
+  for (let i = 0; i < normals.length; i++) {
+    for (let j = i + 1; j < normals.length; j++) {
+      const nA = normals[i]
+      const nB = normals[j]
+      if (nA.dot(nB) !== 0) {
+        continue // Opposite (or same) faces share no edge.
+      }
+      const axisA = nonZeroAxis(nA)
+      const axisB = nonZeroAxis(nB)
+      const axisC = THREE_AXES - axisA - axisB
+      const sgnA = nA.getComponent(axisA)
+      const sgnB = nB.getComponent(axisB)
+      const at = (onA, onB, onC) => {
+        const out = new Vector3()
+        out.setComponent(axisA, onA)
+        out.setComponent(axisB, onB)
+        out.setComponent(axisC, onC)
+        return out
+      }
+      const pA1 = at(H * sgnA, S * sgnB, S)
+      const pA2 = at(H * sgnA, S * sgnB, -S)
+      const pB2 = at(S * sgnA, H * sgnB, -S)
+      const pB1 = at(S * sgnA, H * sgnB, S)
+      const geo = geomFromTris([pA1, pA2, pB2, pA1, pB2, pB1])
+      const mat = new MeshBasicMaterial({color: CHAMFER_GREY_HEX, side: DoubleSide})
+      addRegion(geo, mat, nA.clone().add(nB).normalize(), 'edge', CHAMFER_GREY_HEX)
+    }
   }
-  return 0
+
+  // Corner triangles: a chamfer at each of the 8 cube corners.
+  const signs = [-1, 1]
+  signs.forEach((sx) => signs.forEach((sy) => signs.forEach((sz) => {
+    const pX = vec(H * sx, S * sy, S * sz)
+    const pY = vec(S * sx, H * sy, S * sz)
+    const pZ = vec(S * sx, S * sy, H * sz)
+    const geo = geomFromTris([pX, pY, pZ])
+    const mat = new MeshBasicMaterial({color: CHAMFER_GREY_HEX, side: DoubleSide})
+    addRegion(geo, mat, vec(sx, sy, sz).normalize(), 'corner', CHAMFER_GREY_HEX)
+  })))
+
+  const dispose = () => disposables.forEach((d) => d.dispose && d.dispose())
+  return {group, regions, dispose}
+}
+
+
+/**
+ * Build a BufferGeometry from a flat list of triangle vertices.
+ *
+ * @param {Array<Vector3>} verts Triangle vertices (length a multiple of 3)
+ * @param {Array<number>} [uvs] Optional UV pairs, one per vertex
+ * @return {BufferGeometry}
+ */
+function geomFromTris(verts, uvs) {
+  const geo = new BufferGeometry()
+  const pos = new Float32Array(verts.length * 3)
+  verts.forEach((vtx, i) => {
+    pos[i * 3] = vtx.x
+    pos[(i * 3) + 1] = vtx.y
+    pos[(i * 3) + 2] = vtx.z
+  })
+  geo.setAttribute('position', new Float32BufferAttribute(pos, 3))
+  if (uvs) {
+    geo.setAttribute('uv', new Float32BufferAttribute(new Float32Array(uvs), 2))
+  }
+  geo.computeVertexNormals()
+  return geo
+}
+
+
+/**
+ * @param {Vector3} axisVector A unit vector aligned to one axis
+ * @return {number} The index (0, 1 or 2) of its non-zero component
+ */
+function nonZeroAxis(axisVector) {
+  if (axisVector.x !== 0) {
+    return 0
+  }
+  return axisVector.y !== 0 ? 1 : 2
 }
 
 
@@ -443,21 +518,18 @@ function makeFaceTexture(label) {
 }
 
 
-// BoxGeometry material order: +X, -X, +Y, -Y, +Z, -Z.
-// Model space (Y-up, loader-aligned): +Z front, +X right, +Y top.
+// Model space (Y-up, loader-aligned): +Z front, +X right, +Y top.  Each face
+// has a right (u) and up (v) tangent with u x v = n so labels read upright.
 const CUBE_FACES = [
-  {label: 'RIGHT'},
-  {label: 'LEFT'},
-  {label: 'TOP'},
-  {label: 'BOTTOM'},
-  {label: 'FRONT'},
-  {label: 'BACK'},
+  {n: [0, 0, 1], u: [1, 0, 0], v: [0, 1, 0], label: 'FRONT'},
+  {n: [0, 0, -1], u: [-1, 0, 0], v: [0, 1, 0], label: 'BACK'},
+  {n: [1, 0, 0], u: [0, 0, -1], v: [0, 1, 0], label: 'RIGHT'},
+  {n: [-1, 0, 0], u: [0, 0, 1], v: [0, 1, 0], label: 'LEFT'},
+  {n: [0, 1, 0], u: [1, 0, 0], v: [0, 0, -1], label: 'TOP'},
+  {n: [0, -1, 0], u: [1, 0, 0], v: [0, 0, 1], label: 'BOTTOM'},
 ]
 
 const CUBE_SIZE_PX = 96
-// Wide enough to contain the 96px cube plus a ~48px ring button on each side,
-// so the right-column buttons (Rotate right, Home) stay inside the widget
-// instead of overflowing off-screen / onto an open drawer.
 const WIDGET_SIZE_PX = 200
 const BOTTOM_INSET_PX = 80
 const MARGIN_PX = 20
@@ -468,11 +540,12 @@ const TILT_STEP_RAD = Math.PI / 4 // 45 degrees
 const POLAR_EPS = 0.001
 const DRAG_THRESHOLD_PX = 4
 const ROTATE_SENSITIVITY = 0.008 // radians per pixel of drag
-const BASE_HEX = 0xffffff // Face texture shown untinted.
-const HOVER_HEX = 0xbfe0ff // Light-blue tint for the hovered face.
-// Half the cube's edge length; a face spans [-CUBE_HALF, CUBE_HALF] locally.
-const CUBE_HALF = 0.5
-const FACE_THIRDS = 3
-// The center third of a face (a face view) is |coord| < CUBE_HALF / 3.
-const ZONE_THRESHOLD = CUBE_HALF / FACE_THIRDS
+const THREE_AXES = 3 // axis indices 0, 1, 2 sum to 3
+const CUBE_HALF = 0.5 // half the cube's edge length
+const CHAMFER = 0.16 // how far faces are inset to form the chamfer
+const FACE_HALF = CUBE_HALF - CHAMFER // face half-span
+const BLDRS_GREEN_HEX = 0x459a47 // brand green (Logo_Buildings.svg)
+const CHAMFER_GREY_HEX = 0xd8d8d8 // edge/corner bevel base color
+const FACE_BASE_HEX = 0xffffff // face texture shown untinted
+const FACE_HOVER_HEX = 0xbfe0ff // light-blue tint for a hovered face
 const ISO_DIRECTION = new Vector3(1, 1, 1).normalize()

--- a/src/Components/ViewCube/ViewCube.jsx
+++ b/src/Components/ViewCube/ViewCube.jsx
@@ -132,17 +132,27 @@ export default function ViewCube() {
       return hits.length > 0 ? hits[0] : null
     }
 
-    // Highlight the region under the cursor; edges/corners use the bldrs green.
+    // Highlight the region under the cursor in the bldrs green.  Faces get a
+    // translucent wash (so the label stays legible); edges/corners stay solid.
     const setHover = (mesh) => {
       if (mesh === hoveredMesh) {
         return
       }
       if (hoveredMesh) {
-        hoveredMesh.material.color.setHex(hoveredMesh.userData.baseColor)
+        const prev = hoveredMesh.material
+        prev.color.setHex(hoveredMesh.userData.baseColor)
+        prev.opacity = 1
+        prev.transparent = false
+        prev.needsUpdate = true
       }
       if (mesh) {
-        const hl = mesh.userData.kind === 'face' ? FACE_HOVER_HEX : BLDRS_GREEN_HEX
-        mesh.material.color.setHex(hl)
+        const mat = mesh.material
+        mat.color.setHex(BLDRS_GREEN_HEX)
+        if (mesh.userData.kind === 'face') {
+          mat.opacity = FACE_HOVER_OPACITY
+          mat.transparent = true
+          mat.needsUpdate = true
+        }
       }
       hoveredMesh = mesh
     }
@@ -597,7 +607,7 @@ const FACE_HALF = CUBE_HALF - CHAMFER // face half-span
 const BLDRS_GREEN_HEX = 0x459a47 // brand green (Logo_Buildings.svg)
 const CHAMFER_GREY_HEX = 0xd8d8d8 // edge/corner bevel base color
 const FACE_BASE_HEX = 0xffffff // face texture shown untinted
-const FACE_HOVER_HEX = 0xbfe0ff // light-blue tint for a hovered face
+const FACE_HOVER_OPACITY = 0.6 // translucent green wash for a hovered face
 const ISO_DIRECTION = new Vector3(1, 1, 1).normalize()
 
 const DEFAULT_POSITION = 'bottom-right'

--- a/src/Components/ViewCube/ViewCube.jsx
+++ b/src/Components/ViewCube/ViewCube.jsx
@@ -1,4 +1,4 @@
-import React, {ReactElement, useEffect, useRef} from 'react'
+import React, {ReactElement, useEffect, useRef, useState} from 'react'
 import {
   BufferGeometry,
   CanvasTexture,
@@ -17,6 +17,8 @@ import {
 } from 'three'
 import Box from '@mui/material/Box'
 import IconButton from '@mui/material/IconButton'
+import Menu from '@mui/material/Menu'
+import MenuItem from '@mui/material/MenuItem'
 import Tooltip from '@mui/material/Tooltip'
 import {
   Home as HomeIcon,
@@ -56,6 +58,11 @@ export default function ViewCube() {
   const appsDrawerWidth = useStore((state) => state.appsDrawerWidth)
   // On mobile the drawers are bottom sheets, so they don't push the widget aside.
   const isMobile = useIsMobile()
+
+  // Which corner the widget sits in, chosen via right-click; persisted locally.
+  const [position, setPosition] = useState(readStoredPosition)
+  // Cursor anchor for the right-click position menu ({top, left} or null).
+  const [menuAnchor, setMenuAnchor] = useState(null)
 
   const mountRef = useRef(null)
   // Live handles so the ring buttons and fit calls can reach the viewer.
@@ -152,6 +159,9 @@ export default function ViewCube() {
     }
 
     const onPointerDown = (event) => {
+      if (event.button !== 0) {
+        return // Let right/middle click through to the context menu.
+      }
       isPointerDown = true
       isDragging = false
       lastX = event.clientX
@@ -241,6 +251,27 @@ export default function ViewCube() {
     }
   }
 
+  /**
+   * Open the position menu at the cursor (right-click on the cube).
+   *
+   * @param {object} event The context-menu event
+   */
+  const openMenu = (event) => {
+    event.preventDefault()
+    setMenuAnchor({top: event.clientY, left: event.clientX})
+  }
+
+  /**
+   * Move the widget to the chosen corner and remember the choice.
+   *
+   * @param {string} pos One of the POSITION_OPTIONS keys
+   */
+  const choosePosition = (pos) => {
+    setPosition(pos)
+    storePosition(pos)
+    setMenuAnchor(null)
+  }
+
   // Sit clear of any open right-side drawer (Notes, Apps).  On mobile the
   // drawers are bottom sheets, so only the base margin applies.
   const drawerInset = isMobile ? 0 :
@@ -251,8 +282,7 @@ export default function ViewCube() {
     <Box
       sx={{
         'position': 'absolute',
-        'bottom': `${BOTTOM_INSET_PX}px`,
-        'right': `${rightInset}px`,
+        ...anchorSx(position, rightInset),
         'width': `${WIDGET_SIZE_PX}px`,
         'height': `${WIDGET_SIZE_PX}px`,
         'display': 'grid',
@@ -278,7 +308,11 @@ export default function ViewCube() {
         icon={<RotateLeftIcon/>}
         sx={{gridColumn: 1, gridRow: 2}}
       />
-      <Box ref={mountRef} sx={{gridColumn: 2, gridRow: 2, lineHeight: 0}}/>
+      <Box
+        ref={mountRef}
+        onContextMenu={openMenu}
+        sx={{gridColumn: 2, gridRow: 2, lineHeight: 0}}
+      />
       <RingButton
         title='Rotate right'
         onClick={() => orbit(ORBIT_STEP_RAD, 0)}
@@ -297,6 +331,22 @@ export default function ViewCube() {
         icon={<HomeIcon/>}
         sx={{gridColumn: 3, gridRow: 3}}
       />
+      <Menu
+        open={Boolean(menuAnchor)}
+        onClose={() => setMenuAnchor(null)}
+        anchorReference='anchorPosition'
+        anchorPosition={menuAnchor || undefined}
+      >
+        {POSITION_OPTIONS.map(({key, label}) => (
+          <MenuItem
+            key={key}
+            selected={key === position}
+            onClick={() => choosePosition(key)}
+          >
+            {label}
+          </MenuItem>
+        ))}
+      </Menu>
     </Box>
   )
 }
@@ -531,7 +581,7 @@ const CUBE_FACES = [
 
 const CUBE_SIZE_PX = 96
 const WIDGET_SIZE_PX = 200
-const BOTTOM_INSET_PX = 80
+const VERTICAL_INSET_PX = 80 // top/bottom offset, clear of the toolbars
 const MARGIN_PX = 20
 const NEAR_PLANE = 0.1
 const FAR_PLANE = 100
@@ -549,3 +599,62 @@ const CHAMFER_GREY_HEX = 0xd8d8d8 // edge/corner bevel base color
 const FACE_BASE_HEX = 0xffffff // face texture shown untinted
 const FACE_HOVER_HEX = 0xbfe0ff // light-blue tint for a hovered face
 const ISO_DIRECTION = new Vector3(1, 1, 1).normalize()
+
+const DEFAULT_POSITION = 'bottom-right'
+const VIEWCUBE_POSITION_KEY = 'bldrs-viewcube-position'
+// Corner options offered by the right-click menu.
+const POSITION_OPTIONS = [
+  {key: 'upper-left', label: 'Upper left'},
+  {key: 'upper-center', label: 'Upper center'},
+  {key: 'upper-right', label: 'Upper right'},
+  {key: 'bottom-left', label: 'Bottom left'},
+  {key: 'bottom-right', label: 'Bottom right'},
+]
+
+
+/**
+ * Absolute-position styles for the chosen corner.  Right-anchored positions
+ * respect the drawer inset; the centered position is centered horizontally.
+ *
+ * @param {string} position One of the POSITION_OPTIONS keys
+ * @param {number} rightInset Right offset in px (accounts for open drawers)
+ * @return {object} sx position fragment
+ */
+function anchorSx(position, rightInset) {
+  const top = `${VERTICAL_INSET_PX}px`
+  const bottom = `${VERTICAL_INSET_PX}px`
+  const left = `${MARGIN_PX}px`
+  const right = `${rightInset}px`
+  switch (position) {
+    case 'upper-left': return {top, left}
+    case 'upper-center': return {top, left: '50%', transform: 'translateX(-50%)'}
+    case 'upper-right': return {top, right}
+    case 'bottom-left': return {bottom, left}
+    default: return {bottom, right}
+  }
+}
+
+
+/** @return {string} The persisted widget position, or the default. */
+function readStoredPosition() {
+  try {
+    const stored = window.localStorage.getItem(VIEWCUBE_POSITION_KEY)
+    return POSITION_OPTIONS.some((o) => o.key === stored) ? stored : DEFAULT_POSITION
+  } catch {
+    return DEFAULT_POSITION
+  }
+}
+
+
+/**
+ * Persist the chosen widget position.
+ *
+ * @param {string} position One of the POSITION_OPTIONS keys
+ */
+function storePosition(position) {
+  try {
+    window.localStorage.setItem(VIEWCUBE_POSITION_KEY, position)
+  } catch (e) {
+    debug().warn('ViewCube: could not persist position', e)
+  }
+}

--- a/src/Components/ViewCube/ViewCube.jsx
+++ b/src/Components/ViewCube/ViewCube.jsx
@@ -30,8 +30,9 @@ import debug from '../../utils/debug'
  * ViewCube is an Autodesk-style navigation gizmo rendered in the top-right
  * corner of the viewer.  It shows a labeled cube whose orientation mirrors the
  * main camera; clicking a face or corner snaps the main camera to that standard
- * view.  A ring of arrows around the cube orbits the view in 90/45 degree steps
- * and a home button returns to an isometric view.
+ * view and fits the model to frame.  Dragging the cube orbits the view freely
+ * (fine rotation), and a ring of arrows around the cube orbits in fixed steps
+ * with an isometric home button.
  *
  * The cube is drawn in its own tiny Three.js scene (independent of the main
  * viewer) so face/corner picking stays simple and self-contained.  The main
@@ -42,9 +43,16 @@ import debug from '../../utils/debug'
  */
 export default function ViewCube() {
   const viewer = useStore((state) => state.viewer)
+  // Right-drawer state so the widget can sit clear of any open drawer.
+  const isNotesVisible = useStore((state) => state.isNotesVisible)
+  const isAppsVisible = useStore((state) => state.isAppsVisible)
+  const rightDrawerWidth = useStore((state) => state.rightDrawerWidth)
+  const appsDrawerWidth = useStore((state) => state.appsDrawerWidth)
+
   const mountRef = useRef(null)
-  // Holds the live camera-controls handle so the ring buttons can drive it.
+  // Live handles so the ring buttons and fit calls can reach the viewer.
   const controlsRef = useRef(null)
+  const contextRef = useRef(null)
 
   useEffect(() => {
     const context = viewer && viewer.IFC && viewer.IFC.context
@@ -58,6 +66,7 @@ export default function ViewCube() {
 
     const cameraControls = context.ifcCamera.cameraControls
     controlsRef.current = cameraControls
+    contextRef.current = context
 
     // --- Mini scene: a fixed orthographic camera looking at a rotating cube ---
     const scene = new Scene()
@@ -93,10 +102,15 @@ export default function ViewCube() {
     }
     renderLoop()
 
-    // --- Picking: click a face/corner to snap the main camera to that view ---
+    // --- Pointer handling: click a face/corner to snap, drag to orbit freely ---
     const raycaster = new Raycaster()
     const pointer = new Vector2()
-    const onClick = (event) => {
+    let isPointerDown = false
+    let isDragging = false
+    let lastX = 0
+    let lastY = 0
+
+    const snapFromPointer = (event) => {
       const rect = renderer.domElement.getBoundingClientRect()
       pointer.x = (((event.clientX - rect.left) / rect.width) * 2) - 1
       pointer.y = (-((event.clientY - rect.top) / rect.height) * 2) + 1
@@ -107,15 +121,56 @@ export default function ViewCube() {
       }
       const direction = pickDirection(hits[0], cube)
       snapToDirection(cameraControls, direction)
+      fitModelToFrame()
       debug().log('ViewCube: snap to', direction)
     }
-    renderer.domElement.addEventListener('click', onClick)
-    renderer.domElement.style.cursor = 'pointer'
+
+    const onPointerDown = (event) => {
+      isPointerDown = true
+      isDragging = false
+      lastX = event.clientX
+      lastY = event.clientY
+      renderer.domElement.setPointerCapture(event.pointerId)
+    }
+    const onPointerMove = (event) => {
+      if (!isPointerDown) {
+        return
+      }
+      const dx = event.clientX - lastX
+      const dy = event.clientY - lastY
+      if (!isDragging && (Math.abs(dx) + Math.abs(dy)) < DRAG_THRESHOLD_PX) {
+        return
+      }
+      isDragging = true
+      lastX = event.clientX
+      lastY = event.clientY
+      const {azimuth, polar} = dragRotation(dx, dy, ROTATE_SENSITIVITY)
+      cameraControls.rotate(azimuth, polar, false)
+    }
+    const onPointerUp = (event) => {
+      if (isPointerDown && renderer.domElement.hasPointerCapture(event.pointerId)) {
+        renderer.domElement.releasePointerCapture(event.pointerId)
+      }
+      if (isPointerDown && !isDragging) {
+        // A click (not a drag): snap to the picked view.
+        snapFromPointer(event)
+      }
+      isPointerDown = false
+      isDragging = false
+    }
+    renderer.domElement.addEventListener('pointerdown', onPointerDown)
+    renderer.domElement.addEventListener('pointermove', onPointerMove)
+    renderer.domElement.addEventListener('pointerup', onPointerUp)
+    renderer.domElement.style.cursor = 'grab'
+    renderer.domElement.style.touchAction = 'none'
 
     return () => {
       cancelAnimationFrame(frameId)
-      renderer.domElement.removeEventListener('click', onClick)
+      renderer.domElement.removeEventListener('pointerdown', onPointerDown)
+      renderer.domElement.removeEventListener('pointermove', onPointerMove)
+      renderer.domElement.removeEventListener('pointerup', onPointerUp)
       controlsRef.current = null
+      contextRef.current = null
       cube.geometry.dispose()
       materials.forEach((m) => {
         if (m.map) {
@@ -130,6 +185,15 @@ export default function ViewCube() {
     }
   }, [viewer])
 
+  /** Fit the loaded model to the frame, preserving the current view direction. */
+  const fitModelToFrame = () => {
+    const context = contextRef.current
+    const navMode = context && context.ifcCamera && context.ifcCamera.currentNavMode
+    if (navMode && typeof navMode.fitModelToFrame === 'function') {
+      navMode.fitModelToFrame()
+    }
+  }
+
   /**
    * Orbit the main camera by a relative step, guarding against an unmounted
    * viewer.
@@ -143,19 +207,25 @@ export default function ViewCube() {
     }
   }
 
-  /** Snap to a front-right-top isometric "home" view. */
+  /** Snap to a front-right-top isometric "home" view and fit the model. */
   const goHome = () => {
     if (controlsRef.current) {
       snapToDirection(controlsRef.current, ISO_DIRECTION.clone())
+      fitModelToFrame()
     }
   }
+
+  // Sit clear of any open right-side drawer (Notes, Apps).
+  const rightInset = MARGIN_PX +
+    (isNotesVisible ? rightDrawerWidth : 0) +
+    (isAppsVisible ? appsDrawerWidth : 0)
 
   return (
     <Box
       sx={{
         'position': 'absolute',
-        'top': '80px',
-        'right': '20px',
+        'top': `${TOP_INSET_PX}px`,
+        'right': `${rightInset}px`,
         'width': `${WIDGET_SIZE_PX}px`,
         'height': `${WIDGET_SIZE_PX}px`,
         'display': 'grid',
@@ -164,6 +234,7 @@ export default function ViewCube() {
         'placeItems': 'center',
         'zIndex': 100,
         'pointerEvents': 'none',
+        'transition': 'right 0.2s ease',
         '& > *': {pointerEvents: 'auto'},
       }}
       data-testid='view-cube'
@@ -279,6 +350,21 @@ export function snapToDirection(cameraControls, direction) {
 
 
 /**
+ * Convert a pointer drag delta (in pixels) into a relative camera-controls
+ * rotation.  Horizontal drag maps to azimuth, vertical drag to polar; both are
+ * negated so the model appears to follow the cursor.
+ *
+ * @param {number} dx Horizontal pixels moved
+ * @param {number} dy Vertical pixels moved
+ * @param {number} sensitivity Radians per pixel
+ * @return {{azimuth: number, polar: number}} Relative rotation in radians
+ */
+export function dragRotation(dx, dy, sensitivity) {
+  return {azimuth: -dx * sensitivity, polar: -dy * sensitivity}
+}
+
+
+/**
  * Bucket a cube-local coordinate (range [-0.5, 0.5]) into -1, 0 or 1 by which
  * third of the face it falls in.
  *
@@ -337,11 +423,15 @@ const CUBE_FACES = [
 
 const CUBE_SIZE_PX = 96
 const WIDGET_SIZE_PX = 150
+const TOP_INSET_PX = 80
+const MARGIN_PX = 20
 const NEAR_PLANE = 0.1
 const FAR_PLANE = 100
 const ORBIT_STEP_RAD = Math.PI / 2 // 90 degrees
 const TILT_STEP_RAD = Math.PI / 4 // 45 degrees
 const POLAR_EPS = 0.001
+const DRAG_THRESHOLD_PX = 4
+const ROTATE_SENSITIVITY = 0.008 // radians per pixel of drag
 // Half the cube's edge length; a face spans [-CUBE_HALF, CUBE_HALF] locally.
 const CUBE_HALF = 0.5
 const FACE_THIRDS = 3

--- a/src/Components/ViewCube/ViewCube.jsx
+++ b/src/Components/ViewCube/ViewCube.jsx
@@ -255,7 +255,7 @@ export default function ViewCube() {
     <Box
       sx={{
         'position': 'absolute',
-        'top': `${TOP_INSET_PX}px`,
+        'bottom': `${BOTTOM_INSET_PX}px`,
         'right': `${rightInset}px`,
         'width': `${WIDGET_SIZE_PX}px`,
         'height': `${WIDGET_SIZE_PX}px`,
@@ -459,7 +459,7 @@ const CUBE_SIZE_PX = 96
 // so the right-column buttons (Rotate right, Home) stay inside the widget
 // instead of overflowing off-screen / onto an open drawer.
 const WIDGET_SIZE_PX = 200
-const TOP_INSET_PX = 80
+const BOTTOM_INSET_PX = 80
 const MARGIN_PX = 20
 const NEAR_PLANE = 0.1
 const FAR_PLANE = 100

--- a/src/Components/ViewCube/ViewCube.jsx
+++ b/src/Components/ViewCube/ViewCube.jsx
@@ -1,0 +1,350 @@
+import React, {ReactElement, useEffect, useRef} from 'react'
+import {
+  BoxGeometry,
+  CanvasTexture,
+  LinearFilter,
+  Mesh,
+  MeshBasicMaterial,
+  OrthographicCamera,
+  Raycaster,
+  Scene,
+  Vector2,
+  Vector3,
+  WebGLRenderer,
+} from 'three'
+import Box from '@mui/material/Box'
+import IconButton from '@mui/material/IconButton'
+import Tooltip from '@mui/material/Tooltip'
+import {
+  Home as HomeIcon,
+  KeyboardArrowDown as TiltDownIcon,
+  KeyboardArrowUp as TiltUpIcon,
+  RotateLeft as RotateLeftIcon,
+  RotateRight as RotateRightIcon,
+} from '@mui/icons-material'
+import useStore from '../../store/useStore'
+import debug from '../../utils/debug'
+
+
+/**
+ * ViewCube is an Autodesk-style navigation gizmo rendered in the top-right
+ * corner of the viewer.  It shows a labeled cube whose orientation mirrors the
+ * main camera; clicking a face or corner snaps the main camera to that standard
+ * view.  A ring of arrows around the cube orbits the view in 90/45 degree steps
+ * and a home button returns to an isometric view.
+ *
+ * The cube is drawn in its own tiny Three.js scene (independent of the main
+ * viewer) so face/corner picking stays simple and self-contained.  The main
+ * camera is read from `viewer.IFC.context` and driven via the camera-controls
+ * instance the rest of Share already uses (see CameraControl.jsx).
+ *
+ * @return {ReactElement}
+ */
+export default function ViewCube() {
+  const viewer = useStore((state) => state.viewer)
+  const mountRef = useRef(null)
+  // Holds the live camera-controls handle so the ring buttons can drive it.
+  const controlsRef = useRef(null)
+
+  useEffect(() => {
+    const context = viewer && viewer.IFC && viewer.IFC.context
+    if (!context || !context.ifcCamera) {
+      return undefined
+    }
+    const mount = mountRef.current
+    if (!mount) {
+      return undefined
+    }
+
+    const cameraControls = context.ifcCamera.cameraControls
+    controlsRef.current = cameraControls
+
+    // --- Mini scene: a fixed orthographic camera looking at a rotating cube ---
+    const scene = new Scene()
+    const halfExtent = 0.9
+    const camera = new OrthographicCamera(
+      -halfExtent, halfExtent, halfExtent, -halfExtent, NEAR_PLANE, FAR_PLANE)
+    camera.position.set(0, 0, 10)
+    camera.lookAt(0, 0, 0)
+
+    const renderer = new WebGLRenderer({alpha: true, antialias: true})
+    renderer.setPixelRatio(window.devicePixelRatio)
+    renderer.setSize(CUBE_SIZE_PX, CUBE_SIZE_PX)
+    mount.appendChild(renderer.domElement)
+
+    const materials = CUBE_FACES.map((face) => new MeshBasicMaterial({
+      map: makeFaceTexture(face.label),
+      transparent: true,
+    }))
+    const cube = new Mesh(new BoxGeometry(1, 1, 1), materials)
+    scene.add(cube)
+
+    // --- Keep the cube oriented to match what the main camera sees ---
+    let frameId = 0
+    const renderLoop = () => {
+      const active = context.getCamera()
+      if (active) {
+        // Rotating the cube by the inverse of the camera rotation reproduces the
+        // model's on-screen orientation inside the gizmo.
+        cube.quaternion.copy(active.quaternion).invert()
+      }
+      renderer.render(scene, camera)
+      frameId = requestAnimationFrame(renderLoop)
+    }
+    renderLoop()
+
+    // --- Picking: click a face/corner to snap the main camera to that view ---
+    const raycaster = new Raycaster()
+    const pointer = new Vector2()
+    const onClick = (event) => {
+      const rect = renderer.domElement.getBoundingClientRect()
+      pointer.x = (((event.clientX - rect.left) / rect.width) * 2) - 1
+      pointer.y = (-((event.clientY - rect.top) / rect.height) * 2) + 1
+      raycaster.setFromCamera(pointer, camera)
+      const hits = raycaster.intersectObject(cube)
+      if (hits.length === 0) {
+        return
+      }
+      const direction = pickDirection(hits[0], cube)
+      snapToDirection(cameraControls, direction)
+      debug().log('ViewCube: snap to', direction)
+    }
+    renderer.domElement.addEventListener('click', onClick)
+    renderer.domElement.style.cursor = 'pointer'
+
+    return () => {
+      cancelAnimationFrame(frameId)
+      renderer.domElement.removeEventListener('click', onClick)
+      controlsRef.current = null
+      cube.geometry.dispose()
+      materials.forEach((m) => {
+        if (m.map) {
+          m.map.dispose()
+        }
+        m.dispose()
+      })
+      renderer.dispose()
+      if (renderer.domElement.parentNode === mount) {
+        mount.removeChild(renderer.domElement)
+      }
+    }
+  }, [viewer])
+
+  /**
+   * Orbit the main camera by a relative step, guarding against an unmounted
+   * viewer.
+   *
+   * @param {number} deltaAzimuthRad Azimuth delta in radians
+   * @param {number} deltaPolarRad Polar delta in radians
+   */
+  const orbit = (deltaAzimuthRad, deltaPolarRad) => {
+    if (controlsRef.current) {
+      controlsRef.current.rotate(deltaAzimuthRad, deltaPolarRad, true)
+    }
+  }
+
+  /** Snap to a front-right-top isometric "home" view. */
+  const goHome = () => {
+    if (controlsRef.current) {
+      snapToDirection(controlsRef.current, ISO_DIRECTION.clone())
+    }
+  }
+
+  return (
+    <Box
+      sx={{
+        'position': 'absolute',
+        'top': '80px',
+        'right': '20px',
+        'width': `${WIDGET_SIZE_PX}px`,
+        'height': `${WIDGET_SIZE_PX}px`,
+        'display': 'grid',
+        'gridTemplateColumns': '1fr auto 1fr',
+        'gridTemplateRows': '1fr auto 1fr',
+        'placeItems': 'center',
+        'zIndex': 100,
+        'pointerEvents': 'none',
+        '& > *': {pointerEvents: 'auto'},
+      }}
+      data-testid='view-cube'
+    >
+      <RingButton
+        title='Rotate up'
+        onClick={() => orbit(0, -TILT_STEP_RAD)}
+        icon={<TiltUpIcon/>}
+        sx={{gridColumn: 2, gridRow: 1}}
+      />
+      <RingButton
+        title='Rotate left'
+        onClick={() => orbit(-ORBIT_STEP_RAD, 0)}
+        icon={<RotateLeftIcon/>}
+        sx={{gridColumn: 1, gridRow: 2}}
+      />
+      <Box ref={mountRef} sx={{gridColumn: 2, gridRow: 2, lineHeight: 0}}/>
+      <RingButton
+        title='Rotate right'
+        onClick={() => orbit(ORBIT_STEP_RAD, 0)}
+        icon={<RotateRightIcon/>}
+        sx={{gridColumn: 3, gridRow: 2}}
+      />
+      <RingButton
+        title='Rotate down'
+        onClick={() => orbit(0, TILT_STEP_RAD)}
+        icon={<TiltDownIcon/>}
+        sx={{gridColumn: 2, gridRow: 3}}
+      />
+      <RingButton
+        title='Home (isometric)'
+        onClick={goHome}
+        icon={<HomeIcon/>}
+        sx={{gridColumn: 3, gridRow: 3}}
+      />
+    </Box>
+  )
+}
+
+
+/**
+ * A compact icon button used for the ring of orbit controls around the cube.
+ *
+ * @property {string} title Tooltip + aria label
+ * @property {Function} onClick Callback
+ * @property {ReactElement} icon Icon element
+ * @property {object} sx Grid placement styles
+ * @return {ReactElement}
+ */
+function RingButton({title, onClick, icon, sx}) {
+  return (
+    <Tooltip title={title} placement='left'>
+      <IconButton
+        onClick={onClick}
+        size='small'
+        aria-label={title}
+        sx={sx}
+      >
+        {icon}
+      </IconButton>
+    </Tooltip>
+  )
+}
+
+
+/**
+ * Determine the model-space view direction for a click on the cube.  Because
+ * the cube's local axes map to the model's axes (local +Z is the model front),
+ * the clicked zone in cube-local space is the direction to look from.  Corner
+ * clicks (all three coordinates near an edge) yield a diagonal isometric
+ * direction; face and edge clicks resolve to the clicked face normal.
+ *
+ * @param {object} hit Raycaster intersection against the cube
+ * @param {Mesh} cube The cube mesh
+ * @return {Vector3} Unit direction, in model space, to place the camera along
+ */
+export function pickDirection(hit, cube) {
+  const local = cube.worldToLocal(hit.point.clone())
+  const zone = new Vector3(
+    zoneSign(local.x),
+    zoneSign(local.y),
+    zoneSign(local.z),
+  )
+  const cornerAxes = 3
+  const isCorner = (Math.abs(zone.x) + Math.abs(zone.y) + Math.abs(zone.z)) === cornerAxes
+  if (isCorner) {
+    return zone.normalize()
+  }
+  // Face or edge: snap to the clicked face's outward normal.
+  return hit.face.normal.clone().normalize()
+}
+
+
+/**
+ * Snap the main camera to look from `direction`, keeping the current target and
+ * distance.  Converts the direction to the camera-controls (azimuth, polar)
+ * spherical angles and animates there.
+ *
+ * @param {object} cameraControls camera-controls instance from the viewer
+ * @param {Vector3} direction Unit direction to place the camera along
+ */
+export function snapToDirection(cameraControls, direction) {
+  if (!cameraControls) {
+    return
+  }
+  const clampedY = Math.min(1, Math.max(-1, direction.y))
+  let polar = Math.acos(clampedY)
+  // Nudge off the exact poles so azimuth stays well-defined for top/bottom.
+  polar = Math.min(Math.PI - POLAR_EPS, Math.max(POLAR_EPS, polar))
+  const azimuth = Math.atan2(direction.x, direction.z)
+  cameraControls.rotateTo(azimuth, polar, true)
+}
+
+
+/**
+ * Bucket a cube-local coordinate (range [-0.5, 0.5]) into -1, 0 or 1 by which
+ * third of the face it falls in.
+ *
+ * @param {number} coord
+ * @return {number} -1, 0 or 1
+ */
+function zoneSign(coord) {
+  if (coord > ZONE_THRESHOLD) {
+    return 1
+  }
+  if (coord < -ZONE_THRESHOLD) {
+    return -1
+  }
+  return 0
+}
+
+
+/**
+ * Render a face label onto a canvas for use as a cube-face texture.
+ *
+ * @param {string} label Face label, e.g. 'FRONT'
+ * @return {CanvasTexture}
+ */
+function makeFaceTexture(label) {
+  const size = 128
+  const canvas = document.createElement('canvas')
+  canvas.width = size
+  canvas.height = size
+  const ctx = canvas.getContext('2d')
+  ctx.fillStyle = '#f5f5f5'
+  ctx.fillRect(0, 0, size, size)
+  ctx.strokeStyle = '#888'
+  ctx.lineWidth = 6
+  ctx.strokeRect(0, 0, size, size)
+  ctx.fillStyle = '#333'
+  ctx.font = 'bold 20px Helvetica, Arial, sans-serif'
+  ctx.textAlign = 'center'
+  ctx.textBaseline = 'middle'
+  ctx.fillText(label, size / 2, size / 2)
+  const texture = new CanvasTexture(canvas)
+  texture.minFilter = LinearFilter
+  return texture
+}
+
+
+// BoxGeometry material order: +X, -X, +Y, -Y, +Z, -Z.
+// Model space (Y-up, loader-aligned): +Z front, +X right, +Y top.
+const CUBE_FACES = [
+  {label: 'RIGHT'},
+  {label: 'LEFT'},
+  {label: 'TOP'},
+  {label: 'BOTTOM'},
+  {label: 'FRONT'},
+  {label: 'BACK'},
+]
+
+const CUBE_SIZE_PX = 96
+const WIDGET_SIZE_PX = 150
+const NEAR_PLANE = 0.1
+const FAR_PLANE = 100
+const ORBIT_STEP_RAD = Math.PI / 2 // 90 degrees
+const TILT_STEP_RAD = Math.PI / 4 // 45 degrees
+const POLAR_EPS = 0.001
+// Half the cube's edge length; a face spans [-CUBE_HALF, CUBE_HALF] locally.
+const CUBE_HALF = 0.5
+const FACE_THIRDS = 3
+// The center third of a face (a face view) is |coord| < CUBE_HALF / 3.
+const ZONE_THRESHOLD = CUBE_HALF / FACE_THIRDS
+const ISO_DIRECTION = new Vector3(1, 1, 1).normalize()

--- a/src/Components/ViewCube/ViewCube.test.jsx
+++ b/src/Components/ViewCube/ViewCube.test.jsx
@@ -1,57 +1,13 @@
-import {BoxGeometry, Mesh, Vector3} from 'three'
-import {dragRotation, pickDirection, snapToDirection} from './ViewCube'
+import {Vector3} from 'three'
+import {dragRotation, snapToDirection} from './ViewCube'
 
 
-// Cube half-edge and a small in-face offset, kept as named values so the
-// coordinate literals below do not trip the no-magic-numbers rule.
-const HALF = 0.5
-const NEAR_CENTER = 0.05
+// Named values so the coordinate literals below do not trip no-magic-numbers.
 const SMALL = 0.01
 const SENSITIVITY = 0.008
 
+
 describe('ViewCube', () => {
-  const cube = new Mesh(new BoxGeometry(1, 1, 1))
-
-  /**
-   * Build a fake raycaster hit against the cube.
-   *
-   * @param {Array<number>} point Local/world hit point (cube is at origin)
-   * @param {Array<number>} normal Face normal
-   * @return {object}
-   */
-  function makeHit(point, normal) {
-    return {
-      point: new Vector3(...point),
-      face: {normal: new Vector3(...normal)},
-    }
-  }
-
-  describe('pickDirection', () => {
-    it('resolves a face-center click to the face normal', () => {
-      const hit = makeHit([NEAR_CENTER, -NEAR_CENTER, HALF], [0, 0, 1])
-      expect(pickDirection(hit, cube)).toStrictEqual(new Vector3(0, 0, 1))
-    })
-
-    it('resolves an edge click to a normalized edge diagonal', () => {
-      // Near the top edge of the front face: the front and top axes are active.
-      const hit = makeHit([NEAR_CENTER, HALF, HALF], [0, 0, 1])
-      const dir = pickDirection(hit, cube)
-      const expected = new Vector3(0, 1, 1).normalize()
-      expect(dir.x).toBeCloseTo(expected.x)
-      expect(dir.y).toBeCloseTo(expected.y)
-      expect(dir.z).toBeCloseTo(expected.z)
-    })
-
-    it('resolves a corner click to a normalized diagonal', () => {
-      const hit = makeHit([HALF, HALF, HALF], [0, 0, 1])
-      const dir = pickDirection(hit, cube)
-      const expected = new Vector3(1, 1, 1).normalize()
-      expect(dir.x).toBeCloseTo(expected.x)
-      expect(dir.y).toBeCloseTo(expected.y)
-      expect(dir.z).toBeCloseTo(expected.z)
-    })
-  })
-
   describe('snapToDirection', () => {
     it('snaps FRONT to azimuth 0, polar pi/2', () => {
       const controls = {rotateTo: jest.fn()}

--- a/src/Components/ViewCube/ViewCube.test.jsx
+++ b/src/Components/ViewCube/ViewCube.test.jsx
@@ -1,0 +1,80 @@
+import {BoxGeometry, Mesh, Vector3} from 'three'
+import {pickDirection, snapToDirection} from './ViewCube'
+
+
+// Cube half-edge and a small in-face offset, kept as named values so the
+// coordinate literals below do not trip the no-magic-numbers rule.
+const HALF = 0.5
+const NEAR_CENTER = 0.05
+const SMALL = 0.01
+
+describe('ViewCube', () => {
+  const cube = new Mesh(new BoxGeometry(1, 1, 1))
+
+  /**
+   * Build a fake raycaster hit against the cube.
+   *
+   * @param {Array<number>} point Local/world hit point (cube is at origin)
+   * @param {Array<number>} normal Face normal
+   * @return {object}
+   */
+  function makeHit(point, normal) {
+    return {
+      point: new Vector3(...point),
+      face: {normal: new Vector3(...normal)},
+    }
+  }
+
+  describe('pickDirection', () => {
+    it('resolves a face-center click to the face normal', () => {
+      const hit = makeHit([NEAR_CENTER, -NEAR_CENTER, HALF], [0, 0, 1])
+      expect(pickDirection(hit, cube)).toStrictEqual(new Vector3(0, 0, 1))
+    })
+
+    it('resolves an edge click to the clicked face normal', () => {
+      // Near the top edge of the front face: two coords are at the boundary.
+      const hit = makeHit([NEAR_CENTER, HALF, HALF], [0, 0, 1])
+      expect(pickDirection(hit, cube)).toStrictEqual(new Vector3(0, 0, 1))
+    })
+
+    it('resolves a corner click to a normalized diagonal', () => {
+      const hit = makeHit([HALF, HALF, HALF], [0, 0, 1])
+      const dir = pickDirection(hit, cube)
+      const expected = new Vector3(1, 1, 1).normalize()
+      expect(dir.x).toBeCloseTo(expected.x)
+      expect(dir.y).toBeCloseTo(expected.y)
+      expect(dir.z).toBeCloseTo(expected.z)
+    })
+  })
+
+  describe('snapToDirection', () => {
+    it('snaps FRONT to azimuth 0, polar pi/2', () => {
+      const controls = {rotateTo: jest.fn()}
+      snapToDirection(controls, new Vector3(0, 0, 1))
+      const [azimuth, polar, transition] = controls.rotateTo.mock.calls[0]
+      expect(azimuth).toBeCloseTo(0)
+      expect(polar).toBeCloseTo(Math.PI / 2)
+      expect(transition).toBe(true)
+    })
+
+    it('snaps RIGHT to azimuth pi/2', () => {
+      const controls = {rotateTo: jest.fn()}
+      snapToDirection(controls, new Vector3(1, 0, 0))
+      const [azimuth, polar] = controls.rotateTo.mock.calls[0]
+      expect(azimuth).toBeCloseTo(Math.PI / 2)
+      expect(polar).toBeCloseTo(Math.PI / 2)
+    })
+
+    it('snaps TOP near the pole without hitting it exactly', () => {
+      const controls = {rotateTo: jest.fn()}
+      snapToDirection(controls, new Vector3(0, 1, 0))
+      const [, polar] = controls.rotateTo.mock.calls[0]
+      expect(polar).toBeGreaterThan(0)
+      expect(polar).toBeLessThan(SMALL)
+    })
+
+    it('is a no-op when controls are missing', () => {
+      expect(() => snapToDirection(null, new Vector3(0, 0, 1))).not.toThrow()
+    })
+  })
+})

--- a/src/Components/ViewCube/ViewCube.test.jsx
+++ b/src/Components/ViewCube/ViewCube.test.jsx
@@ -32,10 +32,14 @@ describe('ViewCube', () => {
       expect(pickDirection(hit, cube)).toStrictEqual(new Vector3(0, 0, 1))
     })
 
-    it('resolves an edge click to the clicked face normal', () => {
-      // Near the top edge of the front face: two coords are at the boundary.
+    it('resolves an edge click to a normalized edge diagonal', () => {
+      // Near the top edge of the front face: the front and top axes are active.
       const hit = makeHit([NEAR_CENTER, HALF, HALF], [0, 0, 1])
-      expect(pickDirection(hit, cube)).toStrictEqual(new Vector3(0, 0, 1))
+      const dir = pickDirection(hit, cube)
+      const expected = new Vector3(0, 1, 1).normalize()
+      expect(dir.x).toBeCloseTo(expected.x)
+      expect(dir.y).toBeCloseTo(expected.y)
+      expect(dir.z).toBeCloseTo(expected.z)
     })
 
     it('resolves a corner click to a normalized diagonal', () => {

--- a/src/Components/ViewCube/ViewCube.test.jsx
+++ b/src/Components/ViewCube/ViewCube.test.jsx
@@ -1,5 +1,5 @@
 import {BoxGeometry, Mesh, Vector3} from 'three'
-import {pickDirection, snapToDirection} from './ViewCube'
+import {dragRotation, pickDirection, snapToDirection} from './ViewCube'
 
 
 // Cube half-edge and a small in-face offset, kept as named values so the
@@ -7,6 +7,7 @@ import {pickDirection, snapToDirection} from './ViewCube'
 const HALF = 0.5
 const NEAR_CENTER = 0.05
 const SMALL = 0.01
+const SENSITIVITY = 0.008
 
 describe('ViewCube', () => {
   const cube = new Mesh(new BoxGeometry(1, 1, 1))
@@ -75,6 +76,20 @@ describe('ViewCube', () => {
 
     it('is a no-op when controls are missing', () => {
       expect(() => snapToDirection(null, new Vector3(0, 0, 1))).not.toThrow()
+    })
+  })
+
+  describe('dragRotation', () => {
+    it('maps horizontal drag to negated azimuth', () => {
+      const {azimuth, polar} = dragRotation(10, 0, SENSITIVITY)
+      expect(azimuth).toBeCloseTo(-10 * SENSITIVITY)
+      expect(polar).toBeCloseTo(0)
+    })
+
+    it('maps vertical drag to negated polar', () => {
+      const {azimuth, polar} = dragRotation(0, 10, SENSITIVITY)
+      expect(azimuth).toBeCloseTo(0)
+      expect(polar).toBeCloseTo(-10 * SENSITIVITY)
     })
   })
 })

--- a/src/Containers/CadView.jsx
+++ b/src/Containers/CadView.jsx
@@ -88,6 +88,7 @@ export default function CadView({
   const accessToken = useStore((state) => state.accessToken)
   const isAuthResolved = useStore((state) => state.isAuthResolved)
   const connections = useStore((state) => state.connections)
+  const isViewCubeVisible = useStore((state) => state.isViewCubeVisible)
   const customViewSettings = useStore((state) => state.customViewSettings)
   const elementTypesMap = useStore((state) => state.elementTypesMap)
   const preselectedElementIds = useStore((state) => state.preselectedElementIds)
@@ -1510,7 +1511,7 @@ export default function CadView({
   return (
     <Box sx={{...absTop, left: 0, width: '100vw', height: isMobile ? `${vh}px` : '100vh', m: 0, p: 0}}>
       {<ViewerContainer/>}
-      {viewer && <ViewCube/>}
+      {viewer && isViewCubeVisible && <ViewCube/>}
       {viewer && (
         <RootLandscape
           pathPrefix={pathPrefix}

--- a/src/Containers/CadView.jsx
+++ b/src/Containers/CadView.jsx
@@ -54,6 +54,7 @@ import {isOutOfMemoryError} from '../utils/oom'
 import {setKeydownListeners} from '../utils/shortcutKeys'
 import Picker from '../viewer/three/Picker'
 import {DEFAULT_LOOK} from '../viewer/looks'
+import ViewCube from '../Components/ViewCube/ViewCube'
 import RootLandscape from './RootLandscape'
 import ViewerContainer from './ViewerContainer'
 import {
@@ -1509,6 +1510,7 @@ export default function CadView({
   return (
     <Box sx={{...absTop, left: 0, width: '100vw', height: isMobile ? `${vh}px` : '100vh', m: 0, p: 0}}>
       {<ViewerContainer/>}
+      {viewer && <ViewCube/>}
       {viewer && (
         <RootLandscape
           pathPrefix={pathPrefix}

--- a/src/store/ViewCubeSlice.js
+++ b/src/store/ViewCubeSlice.js
@@ -1,0 +1,54 @@
+import debug from '../utils/debug'
+
+
+const VIEWCUBE_VISIBLE_KEY = 'bldrs-viewcube-visible'
+
+
+/** @return {boolean} The persisted visibility, or false (hidden) by default. */
+function readStoredVisibility() {
+  try {
+    return window.localStorage.getItem(VIEWCUBE_VISIBLE_KEY) === 'true'
+  } catch {
+    return false
+  }
+}
+
+
+/**
+ * Persist whether the ViewCube widget is shown so it is remembered across
+ * reloads, alongside its corner position (see ViewCube.jsx).
+ *
+ * @param {boolean} isVisible
+ */
+function storeVisibility(isVisible) {
+  try {
+    window.localStorage.setItem(VIEWCUBE_VISIBLE_KEY, isVisible ? 'true' : 'false')
+  } catch (e) {
+    debug().warn('ViewCube: could not persist visibility', e)
+  }
+}
+
+
+/**
+ * Data stored in Zustand for ViewCube state: whether the navigation widget is
+ * currently shown.  Toggled from the bottom toolbar and the widget's own close
+ * control; persisted to localStorage.
+ *
+ * @param {Function} set
+ * @param {Function} get
+ * @return {object} Zustand slice.
+ */
+export default function createViewCubeSlice(set, get) {
+  return {
+    isViewCubeVisible: readStoredVisibility(),
+    setIsViewCubeVisible: (is) => set(() => {
+      storeVisibility(is)
+      return {isViewCubeVisible: is}
+    }),
+    toggleIsViewCubeVisible: () => {
+      const next = !get().isViewCubeVisible
+      storeVisibility(next)
+      set(() => ({isViewCubeVisible: next}))
+    },
+  }
+}

--- a/src/store/useStore.js
+++ b/src/store/useStore.js
@@ -21,6 +21,7 @@ import createUIEnabledSlice from './UIEnabledSlice'
 import createUISlice from './UISlice'
 import createVersionsSlice from './VersionsSlice'
 import createWorkspaceSlice from './WorkspaceSlice'
+import createViewCubeSlice from './ViewCubeSlice'
 
 
 const useStore = create((set, get) => ({
@@ -46,6 +47,7 @@ const useStore = create((set, get) => ({
   ...createUISlice(set, get),
   ...createVersionsSlice(set, get),
   ...createWorkspaceSlice(set, get),
+  ...createViewCubeSlice(set, get),
 }))
 
 // Expose the store on `window` for console-based debugging of user-


### PR DESCRIPTION
## What

Adds an Autodesk-style **ViewCube** navigation gizmo to the viewer, plus a toolbar control to enable/disable it.

- **View cube toggle** in the bottom toolbar (`ElementsControl`), grouped with Section/Residency — click to show the gizmo, click again (or the ⨉ on the widget) to hide it. Hidden by default; hidden during isolation to match `CutPlaneMenu`.
- **The gizmo** (`src/Components/ViewCube/ViewCube.jsx`): a chamfered, labeled cube whose orientation mirrors the main camera. Clicking a face / chamfered edge / corner snaps the camera to that standard view and fits to frame; hovering highlights the region (edges/corners in bldrs green). Drag the cube to orbit freely; a ring of arrows orbits in fixed steps with a Home (isometric) button. Rendered in its own tiny Three.js scene, driven via the same `camera-controls` instance the rest of Share uses.
- **Right-click placement menu** to move the widget between corners; **(⨉) close control** in its upper-right.
- **State persistence** via a new `ViewCubeSlice` — both visibility and corner position persist to `localStorage`.

## Notes

- Rebased onto current `main`; only 7 files touched (all ViewCube-scoped).
- Local checks green: `yarn lint` (eslint + tsc) and the affected Jest suites (`ElementsControl`, `ViewCube`, store — 231 tests).

## TODO before ready-for-review

- [ ] Desktop + mobile happy-path E2E (`describeMobileAndDesktop`) per the repo's UI test rule.
- [ ] Track under an epic-labeled issue with per-story sub-issues.

Opening as **draft**.