### PR TITLE
Report the engine's applied coordination frame on the model root (conway 1.1598.702)

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@babel/plugin-syntax-import-assertions": "7.18.6",
     "@babel/preset-env": "7.18.10",
     "@babel/preset-react": "7.18.6",
-    "@bldrs-ai/conway": "1.1596.704-gb0034dfe",
+    "@bldrs-ai/conway": "1.1598.702-gc37c5537",
     "@bldrs-ai/ifclib": "5.3.3",
     "@emotion/react": "11.10.0",
     "@emotion/styled": "11.10.0",

--- a/src/loader/Loader.convertToShareModel.test.js
+++ b/src/loader/Loader.convertToShareModel.test.js
@@ -8,7 +8,10 @@
 import {BufferAttribute, BufferGeometry, Mesh, Scene} from 'three'
 import {__sanitizeCachedTitleForTest, convertToShareModel} from './Loader'
 import {encodeElementProperties, makeElementPropertiesPayload} from './bldrsElementProperties'
-import {APPLIED_COORDINATION_KEY} from '../viewer/ifc/appliedCoordination'
+import {
+  APPLIED_COORDINATION_KEY,
+  COORDINATION_OFFSET_KEY,
+} from '../viewer/ifc/appliedCoordination'
 import {decorateShareModel, inferModelCapabilities} from '../viewer/ShareModel'
 import {attachElementSubsets} from '../viewer/three/elementSubsets'
 
@@ -765,5 +768,82 @@ describe('Loader/convertToShareModel — cached coordination frame (Share#1633 i
     const mesh = new Mesh(new BufferGeometry())
     convertToShareModel(mesh, makeViewerStub(), {fileName: 'index.ifc'})
     expect(APPLIED_COORDINATION_KEY in mesh.userData).toBe(false)
+  })
+})
+
+
+describe('Loader/convertToShareModel — cached backstop offset (Share#1633 item 1)', () => {
+  // The other half of `rendered = (A * world) - coordinationOffset`. On the
+  // degraded path where Share's backstop fired, the offset is baked into the
+  // cached geometry, so a hit that dropped it would leave a model whose
+  // documented inverse reconstructs coordinates displaced by exactly it —
+  // wrong rather than absent, and invisible.
+  const OFFSET = [2600000, 450, -1200000]
+
+  /**
+   * @param {*} value what the cache handed back under the offset key
+   * @return {Mesh} the model after conversion
+   */
+  function convertWithOffset(value) {
+    const mesh = new Mesh(new BufferGeometry())
+    mesh.userData[COORDINATION_OFFSET_KEY] = value
+    convertToShareModel(mesh, makeViewerStub(), {fileName: 'index.ifc'})
+    return mesh
+  }
+
+  it('keeps a well-formed cached offset at the same key a fresh parse uses', () => {
+    const mesh = convertWithOffset([...OFFSET])
+    expect(mesh.userData[COORDINATION_OFFSET_KEY]).toEqual(OFFSET)
+  })
+
+  it('restores both halves together', () => {
+    const frame = [
+      0.001, 0, 0, 0,
+      0, 0, -0.001, 0,
+      0, 0.001, 0, 0,
+      -2600, 450, 1200, 1,
+    ]
+    const mesh = new Mesh(new BufferGeometry())
+    mesh.userData[APPLIED_COORDINATION_KEY] = [...frame]
+    mesh.userData[COORDINATION_OFFSET_KEY] = [...OFFSET]
+    convertToShareModel(mesh, makeViewerStub(), {fileName: 'index.ifc'})
+
+    expect(mesh.userData[APPLIED_COORDINATION_KEY]).toEqual(frame)
+    expect(mesh.userData[COORDINATION_OFFSET_KEY]).toEqual(OFFSET)
+  })
+
+  it('drops a cached offset carrying non-finite numbers', () => {
+    const mesh = convertWithOffset([1, null, 3])
+    expect(COORDINATION_OFFSET_KEY in mesh.userData).toBe(false)
+  })
+
+  it('drops a cached offset of the wrong length', () => {
+    const mesh = convertWithOffset([1, 2])
+    expect(COORDINATION_OFFSET_KEY in mesh.userData).toBe(false)
+  })
+
+  it('dropping one half leaves the other intact', () => {
+    // A bad offset must not cost the frame, and vice versa — they are
+    // validated independently so a single corrupt key degrades to the state
+    // consumers already handle rather than losing the whole mapping.
+    const frame = [
+      0.001, 0, 0, 0,
+      0, 0, -0.001, 0,
+      0, 0.001, 0, 0,
+      -2600, 450, 1200, 1,
+    ]
+    const mesh = new Mesh(new BufferGeometry())
+    mesh.userData[APPLIED_COORDINATION_KEY] = [...frame]
+    mesh.userData[COORDINATION_OFFSET_KEY] = 'not an offset'
+    convertToShareModel(mesh, makeViewerStub(), {fileName: 'index.ifc'})
+
+    expect(mesh.userData[APPLIED_COORDINATION_KEY]).toEqual(frame)
+    expect(COORDINATION_OFFSET_KEY in mesh.userData).toBe(false)
+  })
+
+  it('leaves a model with no cached offset untouched', () => {
+    const mesh = new Mesh(new BufferGeometry())
+    convertToShareModel(mesh, makeViewerStub(), {fileName: 'index.ifc'})
+    expect(COORDINATION_OFFSET_KEY in mesh.userData).toBe(false)
   })
 })

--- a/src/loader/Loader.convertToShareModel.test.js
+++ b/src/loader/Loader.convertToShareModel.test.js
@@ -8,6 +8,7 @@
 import {BufferAttribute, BufferGeometry, Mesh, Scene} from 'three'
 import {__sanitizeCachedTitleForTest, convertToShareModel} from './Loader'
 import {encodeElementProperties, makeElementPropertiesPayload} from './bldrsElementProperties'
+import {APPLIED_COORDINATION_KEY} from '../viewer/ifc/appliedCoordination'
 import {decorateShareModel, inferModelCapabilities} from '../viewer/ShareModel'
 import {attachElementSubsets} from '../viewer/three/elementSubsets'
 
@@ -704,5 +705,65 @@ describe('Loader/convertToShareModel — root label filename composition (#1595)
     mesh.mimeType = 'glb'
     convertToShareModel(mesh, makeViewerStub(), {fileName: ' ‮<>'})
     expect(mesh.name).toBe('Scene')
+  })
+})
+
+
+describe('Loader/convertToShareModel — cached coordination frame (Share#1633 item 1)', () => {
+  // The reader half of the cache round-trip. GLTFLoader has already promoted
+  // `scenes[0].extras` onto `scene.userData` by the time this runs, so the
+  // frame needs no MOVING here — what it needs is validating, because a GLB
+  // artifact is an untrusted boundary in the originator-share design (same
+  // reason the cached title is scrubbed). A bad frame is worse than a missing
+  // one: absence is a state every consumer already handles, for pre-conway#702
+  // engines, while a NaN-bearing matrix inverts to NaN everywhere and looks
+  // like a real answer.
+  const FRAME = [
+    0.001, 0, 0, 0,
+    0, 0, -0.001, 0,
+    0, 0.001, 0, 0,
+    -2600, 450, 1200, 1,
+  ]
+
+  /**
+   * @param {*} value what the cache handed back under the frame key
+   * @return {Mesh} the model after conversion
+   */
+  function convertWithFrame(value) {
+    const mesh = new Mesh(new BufferGeometry())
+    mesh.userData[APPLIED_COORDINATION_KEY] = value
+    convertToShareModel(mesh, makeViewerStub(), {fileName: 'index.ifc'})
+    return mesh
+  }
+
+  it('keeps a well-formed cached frame at the same key a fresh parse uses', () => {
+    const mesh = convertWithFrame([...FRAME])
+    expect(mesh.userData[APPLIED_COORDINATION_KEY]).toEqual(FRAME)
+  })
+
+  it('drops a cached frame carrying non-finite numbers', () => {
+    // `undefined` becomes `null` through JSON, and null is what a truncated
+    // or hand-edited artifact most plausibly carries. 16 elements, so a
+    // length-only guard would have passed it straight through.
+    const bad = [...FRAME]
+    bad[5] = null
+    const mesh = convertWithFrame(bad)
+    expect(APPLIED_COORDINATION_KEY in mesh.userData).toBe(false)
+  })
+
+  it('drops a cached frame of the wrong length', () => {
+    const mesh = convertWithFrame(FRAME.slice(0, 12))
+    expect(APPLIED_COORDINATION_KEY in mesh.userData).toBe(false)
+  })
+
+  it('drops a cached frame that is not an array at all', () => {
+    const mesh = convertWithFrame({0: 1, 15: 1})
+    expect(APPLIED_COORDINATION_KEY in mesh.userData).toBe(false)
+  })
+
+  it('leaves a model with no cached frame untouched', () => {
+    const mesh = new Mesh(new BufferGeometry())
+    convertToShareModel(mesh, makeViewerStub(), {fileName: 'index.ifc'})
+    expect(APPLIED_COORDINATION_KEY in mesh.userData).toBe(false)
   })
 })

--- a/src/loader/Loader.js
+++ b/src/loader/Loader.js
@@ -47,6 +47,10 @@ import glbToThree from './glb'
 import {glbCacheKey} from './glbCacheKey'
 import {activeArtifactSpec, isGlbBatchedActive} from './glbCompress'
 import {BldrsInstanceTablesReader} from './bldrsInstanceTables'
+import {
+  APPLIED_COORDINATION_KEY,
+  validAppliedCoordination,
+} from '../viewer/ifc/appliedCoordination'
 import {hydrateBatchedModelFromInstancedGlb} from '../viewer/ifc/instancedGlbToBatchedModel'
 import {isBldrsGlbContainer, unpackGlbContainer} from './glbContainer'
 import {glbInfo, glbVerbose, glbWarn} from './glbLog'
@@ -1423,6 +1427,34 @@ export function convertToShareModel(model, viewer, {fileName = null} = {}) {
   }
 
   recursiveDecorate(model)
+
+  // Cache-hit coordination-frame hydration. The writer stamps the engine's
+  // applied frame into `scenes[0].extras[APPLIED_COORDINATION_KEY]` and
+  // GLTFLoader auto-copies scene extras onto `scene.userData`, so a cache-hit
+  // model arrives with the frame already at the same `userData` key a fresh
+  // conway parse stamps — one surface across both paths, which is the whole
+  // point of Share#1633 item 1. Nothing has to be MOVED here; what has to
+  // happen is validation. Like the cached title just below, this value came
+  // out of a GLB file, and a GLB file is an untrusted boundary in the
+  // originator-share design: a hand-edited artifact could carry any JSON
+  // under this key, and unlike a bad title a bad frame is not visible — it
+  // would quietly produce NaN world coordinates in every consumer that
+  // inverts it. Re-validate and drop rather than keep something unusable, so
+  // "absent" (which consumers already handle, for pre-conway#702 engines)
+  // is the only failure mode they ever see.
+  //
+  // Runs after the batched-native hydration in `Loader#load`, which merges
+  // the GLTF scene's userData onto the model it swaps in — so this one check
+  // covers the merged cache-hit model and the hydrated batched one alike.
+  if (model.userData && APPLIED_COORDINATION_KEY in model.userData) {
+    const frame = validAppliedCoordination(model.userData[APPLIED_COORDINATION_KEY])
+    if (frame === null) {
+      glbInfo('reader: cached appliedCoordination is not a usable mat4; dropping it')
+      delete model.userData[APPLIED_COORDINATION_KEY]
+    } else {
+      model.userData[APPLIED_COORDINATION_KEY] = frame
+    }
+  }
 
   // Override for root
   debug().log('Overriding project root name')

--- a/src/loader/Loader.js
+++ b/src/loader/Loader.js
@@ -49,7 +49,9 @@ import {activeArtifactSpec, isGlbBatchedActive} from './glbCompress'
 import {BldrsInstanceTablesReader} from './bldrsInstanceTables'
 import {
   APPLIED_COORDINATION_KEY,
+  COORDINATION_OFFSET_KEY,
   validAppliedCoordination,
+  validCoordinationOffset,
 } from '../viewer/ifc/appliedCoordination'
 import {hydrateBatchedModelFromInstancedGlb} from '../viewer/ifc/instancedGlbToBatchedModel'
 import {isBldrsGlbContainer, unpackGlbContainer} from './glbContainer'
@@ -1428,31 +1430,43 @@ export function convertToShareModel(model, viewer, {fileName = null} = {}) {
 
   recursiveDecorate(model)
 
-  // Cache-hit coordination-frame hydration. The writer stamps the engine's
-  // applied frame into `scenes[0].extras[APPLIED_COORDINATION_KEY]` and
-  // GLTFLoader auto-copies scene extras onto `scene.userData`, so a cache-hit
-  // model arrives with the frame already at the same `userData` key a fresh
-  // conway parse stamps — one surface across both paths, which is the whole
+  // Cache-hit coordination hydration. The writer stamps both halves of the
+  // render-frame mapping — the engine's applied frame and Share's backstop
+  // offset — into `scenes[0].extras`, and GLTFLoader auto-copies scene extras
+  // onto `scene.userData`, so a cache-hit model arrives with them already at
+  // the same `userData` keys a fresh conway parse stamps — one surface across both paths, which is the whole
   // point of Share#1633 item 1. Nothing has to be MOVED here; what has to
   // happen is validation. Like the cached title just below, this value came
   // out of a GLB file, and a GLB file is an untrusted boundary in the
   // originator-share design: a hand-edited artifact could carry any JSON
-  // under this key, and unlike a bad title a bad frame is not visible — it
+  // under these keys, and unlike a bad title a bad frame is not visible — it
   // would quietly produce NaN world coordinates in every consumer that
-  // inverts it. Re-validate and drop rather than keep something unusable, so
+  // inverts it, and a bad offset a model correctly placed somewhere else. Re-validate and drop rather than keep something unusable, so
   // "absent" (which consumers already handle, for pre-conway#702 engines)
   // is the only failure mode they ever see.
   //
   // Runs after the batched-native hydration in `Loader#load`, which merges
   // the GLTF scene's userData onto the model it swaps in — so this one check
   // covers the merged cache-hit model and the hydrated batched one alike.
-  if (model.userData && APPLIED_COORDINATION_KEY in model.userData) {
-    const frame = validAppliedCoordination(model.userData[APPLIED_COORDINATION_KEY])
-    if (frame === null) {
-      glbInfo('reader: cached appliedCoordination is not a usable mat4; dropping it')
-      delete model.userData[APPLIED_COORDINATION_KEY]
+  //
+  // BOTH halves of the mapping are restored, not just the engine frame: on
+  // the degraded path where Share's backstop fired, the offset is baked into
+  // the cached geometry, so dropping it here would leave a model whose
+  // documented inverse reconstructs coordinates displaced by exactly that
+  // offset.
+  for (const [key, validate] of [
+    [APPLIED_COORDINATION_KEY, validAppliedCoordination],
+    [COORDINATION_OFFSET_KEY, validCoordinationOffset],
+  ]) {
+    if (!model.userData || !(key in model.userData)) {
+      continue
+    }
+    const value = validate(model.userData[key])
+    if (value === null) {
+      glbInfo(`reader: cached ${key} is not usable; dropping it`)
+      delete model.userData[key]
     } else {
-      model.userData[APPLIED_COORDINATION_KEY] = frame
+      model.userData[key] = value
     }
   }
 

--- a/src/loader/glbBatchedRoundTrip.test.js
+++ b/src/loader/glbBatchedRoundTrip.test.js
@@ -92,9 +92,12 @@ function liveBatchedModel() {
  * parse with a real GLTFLoader carrying the reader plugin.
  *
  * @param {object} model live batched model
+ * @param {object} [sceneExtras] the `scenes[0].extras` map the writer stamps
+ *   in the same inject pass (title, applied coordination frame). Null for the
+ *   table-only cases, which is what the writer passes when neither exists.
  * @return {Promise<object>} the hydrated model (or null)
  */
-async function roundTrip(model) {
+async function roundTrip(model, sceneExtras = null) {
   const written = await exportBatchedModelAsInstancedGlb(model)
   expect(written).not.toBeNull()
 
@@ -102,7 +105,7 @@ async function roundTrip(model) {
     name: BLDRS_INSTANCE_TABLES_EXTENSION_NAME,
     data: buildInstanceTablesExtensionData(written.tableNodes),
     compress: true,
-  }], null, null)
+  }], sceneExtras, null)
 
   const loader = new GLTFLoader()
   loader.register((parser) => new BldrsInstanceTablesReader(parser))
@@ -154,6 +157,44 @@ describe('batched-native GLB round-trip (writer -> GLTFLoader -> hydrate)', () =
     expect(byParent.get(20)).not.toEqual(byParent.get(11))
     expect(byParent.get(11)).toEqual(live.instanceColors[0])
     expect(byParent.get(20)).toEqual(live.instanceColors[2])
+  })
+
+  it('carries the applied coordination frame across the artifact (Share#1633 item 1)', async () => {
+    // The batched-native writer's half of the frame round-trip (the merged
+    // writer's is in `glbExport.test.js`). This is the path that made the
+    // claim worth testing: `exportBatchedModelAsInstancedGlb` builds a fresh
+    // gltf-transform Document and never looks at `model.userData`, so a stamp
+    // left on the model reaches the artifact on NO path — the frame has to
+    // travel as scene extras, and this asserts it arrives all the way at the
+    // hydrated model, where a consumer reads it.
+    //
+    // Nothing between here and there is stubbed: real injection, real
+    // GLTFLoader (whose auto-promotion of `scenes[0].extras` onto
+    // `scene.userData` is the mechanism under test), real hydration (whose
+    // userData merge is the other half).
+    /* eslint-disable no-magic-numbers */
+    const frame = [
+      0.001, 0, 0, 0,
+      0, 0, -0.001, 0,
+      0, 0.001, 0, 0,
+      -2600, 450, 1200, 1,
+    ]
+    /* eslint-enable no-magic-numbers */
+
+    const hydrated = await roundTrip(liveBatchedModel(), {appliedCoordination: frame})
+
+    expect(hydrated).not.toBeNull()
+    // Same key a fresh conway parse stamps — one surface, both paths.
+    expect(hydrated.userData.appliedCoordination).toEqual(frame)
+  })
+
+  it('leaves no frame on the model when the writer stamped none', async () => {
+    // Pre-conway#702 engines and non-IFC sources: absence must stay absence,
+    // never an empty or zeroed frame that a consumer would invert.
+    const hydrated = await roundTrip(liveBatchedModel())
+
+    expect(hydrated).not.toBeNull()
+    expect(hydrated.userData.appliedCoordination).toBeUndefined()
   })
 
   it('round-trips instance transforms', async () => {

--- a/src/loader/glbBatchedRoundTrip.test.js
+++ b/src/loader/glbBatchedRoundTrip.test.js
@@ -159,7 +159,7 @@ describe('batched-native GLB round-trip (writer -> GLTFLoader -> hydrate)', () =
     expect(byParent.get(20)).toEqual(live.instanceColors[2])
   })
 
-  it('carries the applied coordination frame across the artifact (Share#1633 item 1)', async () => {
+  it('carries BOTH halves of the render-frame mapping across the artifact (Share#1633 item 1)', async () => {
     // The batched-native writer's half of the frame round-trip (the merged
     // writer's is in `glbExport.test.js`). This is the path that made the
     // claim worth testing: `exportBatchedModelAsInstancedGlb` builds a fresh
@@ -179,13 +179,20 @@ describe('batched-native GLB round-trip (writer -> GLTFLoader -> hydrate)', () =
       0, 0.001, 0, 0,
       -2600, 450, 1200, 1,
     ]
+    const offset = [2600000, 450, -1200000]
     /* eslint-enable no-magic-numbers */
 
-    const hydrated = await roundTrip(liveBatchedModel(), {appliedCoordination: frame})
+    const hydrated = await roundTrip(
+      liveBatchedModel(), {appliedCoordination: frame, coordinationOffset: offset})
 
     expect(hydrated).not.toBeNull()
-    // Same key a fresh conway parse stamps — one surface, both paths.
+    // Same keys a fresh conway parse stamps — one surface, both paths.
     expect(hydrated.userData.appliedCoordination).toEqual(frame)
+    // BOTH halves of `rendered = (A * world) - coordinationOffset`. The
+    // degraded path bakes the offset into the geometry in this very
+    // artifact, so a hit that restored only the frame would reconstruct
+    // coordinates displaced by exactly it.
+    expect(hydrated.userData.coordinationOffset).toEqual(offset)
   })
 
   it('leaves no frame on the model when the writer stamped none', async () => {
@@ -195,6 +202,26 @@ describe('batched-native GLB round-trip (writer -> GLTFLoader -> hydrate)', () =
 
     expect(hydrated).not.toBeNull()
     expect(hydrated.userData.appliedCoordination).toBeUndefined()
+    expect(hydrated.userData.coordinationOffset).toBeUndefined()
+  })
+
+  it('carries the frame alone on a healthy load (backstop never fired)', async () => {
+    // The normal case since the conway#680 fix chain — the two keys are
+    // independent, so a model with no backstop offset still gets its frame.
+    /* eslint-disable no-magic-numbers */
+    const frame = [
+      0.001, 0, 0, 0,
+      0, 0, -0.001, 0,
+      0, 0.001, 0, 0,
+      -2600, 450, 1200, 1,
+    ]
+    /* eslint-enable no-magic-numbers */
+
+    const hydrated = await roundTrip(liveBatchedModel(), {appliedCoordination: frame})
+
+    expect(hydrated).not.toBeNull()
+    expect(hydrated.userData.appliedCoordination).toEqual(frame)
+    expect(hydrated.userData.coordinationOffset).toBeUndefined()
   })
 
   it('round-trips instance transforms', async () => {

--- a/src/loader/glbCacheKey.js
+++ b/src/loader/glbCacheKey.js
@@ -20,6 +20,22 @@
  * it (`BLDRS_GLB_BATCHED_SCHEMA_VERSION` below) — deliberately, since that
  * is the slot most users actually read. Nothing extra to do here; the note
  * exists so the coupling is visible from where the bump gets written.
+ * 0.21.0 — retires artifacts baked before the engine's applied coordination
+ *         frame was carried across the cache. The writer now stamps
+ *         `scenes[0].extras.appliedCoordination` — conway#702's
+ *         `GetAppliedCoordinationMatrix`, the frame the engine composed into
+ *         every placement it emitted — beside the existing `bldrsTitle`, and
+ *         GLTFLoader auto-promotes it onto `scene.userData` so a cache hit
+ *         presents the same surface as a fresh parse (Share#1633 item 1,
+ *         Share#1634). Additive to the format, so this bump is not about
+ *         readability: 0.20.0 artifacts parse fine, they just carry NO frame,
+ *         and a georeferenced model that reads one back would silently keep
+ *         the very gap this closes — no way for a consumer to map a rendered
+ *         point back to authored coordinates, on exactly the models that need
+ *         it. Same reasoning as 0.10.0, which bumped for adding
+ *         `scenes[0].name` alongside an already-working title. Retiring them
+ *         costs one re-parse each and makes the frame's presence a property
+ *         of the schema rather than of when a user last loaded the model.
  * 0.20.0 — retires artifacts baked without type-inherited materials
  *         (conway#704, issue test-models-private#61 — the follow-up to
  *         0.18.0's colour fixes): a product with no direct
@@ -230,7 +246,7 @@
  * 0.2.0 — generalised cache key from GitHub-only (owner/repo/branch) to a
  *         per-source-kind 3-level namespace (ns1/ns2/ns3).
  */
-export const BLDRS_GLB_SCHEMA_VERSION = '0.20.0'
+export const BLDRS_GLB_SCHEMA_VERSION = '0.21.0'
 
 
 /**

--- a/src/loader/glbCacheKey.js
+++ b/src/loader/glbCacheKey.js
@@ -20,14 +20,18 @@
  * it (`BLDRS_GLB_BATCHED_SCHEMA_VERSION` below) — deliberately, since that
  * is the slot most users actually read. Nothing extra to do here; the note
  * exists so the coupling is visible from where the bump gets written.
- * 0.21.0 — retires artifacts baked before the engine's applied coordination
- *         frame was carried across the cache. The writer now stamps
- *         `scenes[0].extras.appliedCoordination` — conway#702's
+ * 0.21.0 — retires artifacts baked before the render-frame mapping was
+ *         carried across the cache. The writer now stamps BOTH halves into
+ *         `scenes[0].extras` beside the existing `bldrsTitle`:
+ *         `appliedCoordination` (conway#702's
  *         `GetAppliedCoordinationMatrix`, the frame the engine composed into
- *         every placement it emitted — beside the existing `bldrsTitle`, and
- *         GLTFLoader auto-promotes it onto `scene.userData` so a cache hit
- *         presents the same surface as a fresh parse (Share#1633 item 1,
- *         Share#1634). Additive to the format, so this bump is not about
+ *         every placement it emitted) and `coordinationOffset` (Share's own
+ *         backstop recentre, which the degraded path bakes into the exported
+ *         geometry). GLTFLoader auto-promotes both onto `scene.userData`, so
+ *         a cache hit presents the same surface as a fresh parse (Share#1633
+ *         item 1, Share#1634). They travel together by necessity: an artifact
+ *         carrying only the frame reads back displaced by exactly the offset
+ *         its documented inverse then fails to add. Additive to the format, so this bump is not about
  *         readability: 0.20.0 artifacts parse fine, they just carry NO frame,
  *         and a georeferenced model that reads one back would silently keep
  *         the very gap this closes — no way for a consumer to map a rendered

--- a/src/loader/glbExport.js
+++ b/src/loader/glbExport.js
@@ -41,6 +41,10 @@ import {
   BLDRS_SPATIAL_TREE_EXTENSION_NAME,
   captureBldrsSpatialTree,
 } from './bldrsSpatialTree'
+import {
+  APPLIED_COORDINATION_KEY,
+  validAppliedCoordination,
+} from '../viewer/ifc/appliedCoordination'
 import {eachBatch} from '../viewer/ifc/batchedModel'
 import {
   batchedModelOccurrenceTables,
@@ -285,6 +289,20 @@ export async function exportAndCacheGlb({model, kindLabel, cacheKeyArgs, ifcMana
     // the raw bytes. Non-IFC sources (drag-dropped OBJ etc.)
     // generally have no `.name`; the inject step no-ops on nullish.
     const titleForExtras = (typeof model?.name === 'string' && model.name) ? model.name : null
+    // The engine's applied coordination frame, carried across the cache
+    // round-trip beside the title (see ../viewer/ifc/appliedCoordination for
+    // the contract). It rides in `scenes[0].extras`, NOT in the model's own
+    // userData, and that is what makes it survive: BOTH writers below drop
+    // userData — the batched-native writer builds a fresh gltf-transform
+    // Document, and the merged bake (`batchedModelToMergedMesh`) copies only
+    // matrix + name — so a stamp left to `GLTFExporter`'s userData
+    // serialisation would reach the artifact on neither path. The inject pass
+    // runs downstream of both, on the packed bytes, so one capture here
+    // covers every layout. Validated rather than passed through: a frame that
+    // reads back wrong is worse than none, and the cache is the boundary
+    // where a bad one would persist across sessions.
+    const appliedCoordinationForExtras =
+      validAppliedCoordination(model?.userData?.[APPLIED_COORDINATION_KEY])
     // Yield to the event loop between major phases so hover-pick /
     // camera-controls can interleave with the writer. Each `yieldToBrowser`
     // is a single macrotask boundary; the cost is one event-loop turn,
@@ -494,9 +512,17 @@ export async function exportAndCacheGlb({model, kindLabel, cacheKeyArgs, ifcMana
     // sandbox — show the model name instead of GLTFExporter's
     // 'AuxScene' placeholder. Null when no title is available so
     // `injectGlbExtensions` no-ops both scene mutations.
-    const sceneExtrasForInject = titleForExtras ?
-      {[BLDRS_TITLE_EXTRAS_KEY]: titleForExtras} :
-      null
+    // Built by accumulation rather than a ternary per key: the extras map is
+    // now shared by two independent callers, and `injectGlbExtensions` treats
+    // a null map and an empty map differently (the null case is its
+    // pass-through). Stay null when NEITHER key is available so a titleless,
+    // frameless model still short-circuits the parse/serialize as before.
+    const sceneExtrasForInject = (titleForExtras || appliedCoordinationForExtras) ? {
+      ...(titleForExtras ? {[BLDRS_TITLE_EXTRAS_KEY]: titleForExtras} : {}),
+      ...(appliedCoordinationForExtras ?
+        {[APPLIED_COORDINATION_KEY]: appliedCoordinationForExtras} :
+        {}),
+    } : null
     let packed
     let extStats
     try {

--- a/src/loader/glbExport.js
+++ b/src/loader/glbExport.js
@@ -43,7 +43,9 @@ import {
 } from './bldrsSpatialTree'
 import {
   APPLIED_COORDINATION_KEY,
+  COORDINATION_OFFSET_KEY,
   validAppliedCoordination,
+  validCoordinationOffset,
 } from '../viewer/ifc/appliedCoordination'
 import {eachBatch} from '../viewer/ifc/batchedModel'
 import {
@@ -303,6 +305,14 @@ export async function exportAndCacheGlb({model, kindLabel, cacheKeyArgs, ifcMana
     // where a bad one would persist across sessions.
     const appliedCoordinationForExtras =
       validAppliedCoordination(model?.userData?.[APPLIED_COORDINATION_KEY])
+    // Share's own backstop offset travels WITH the frame, never without it.
+    // On the degraded path where the backstop fired, the offset is already
+    // baked into the geometry being exported here — so an artifact carrying
+    // only the frame reads back displaced by exactly the offset the
+    // documented inverse would then fail to add back. Half a composition is
+    // worse than none: it is wrong rather than absent, and silently so.
+    const coordinationOffsetForExtras =
+      validCoordinationOffset(model?.userData?.[COORDINATION_OFFSET_KEY])
     // Yield to the event loop between major phases so hover-pick /
     // camera-controls can interleave with the writer. Each `yieldToBrowser`
     // is a single macrotask boundary; the cost is one event-loop turn,
@@ -517,12 +527,19 @@ export async function exportAndCacheGlb({model, kindLabel, cacheKeyArgs, ifcMana
     // a null map and an empty map differently (the null case is its
     // pass-through). Stay null when NEITHER key is available so a titleless,
     // frameless model still short-circuits the parse/serialize as before.
-    const sceneExtrasForInject = (titleForExtras || appliedCoordinationForExtras) ? {
-      ...(titleForExtras ? {[BLDRS_TITLE_EXTRAS_KEY]: titleForExtras} : {}),
-      ...(appliedCoordinationForExtras ?
-        {[APPLIED_COORDINATION_KEY]: appliedCoordinationForExtras} :
-        {}),
-    } : null
+    const sceneExtrasCandidates = {
+      [BLDRS_TITLE_EXTRAS_KEY]: titleForExtras,
+      [APPLIED_COORDINATION_KEY]: appliedCoordinationForExtras,
+      [COORDINATION_OFFSET_KEY]: coordinationOffsetForExtras,
+    }
+    const sceneExtrasPairs =
+      Object.entries(sceneExtrasCandidates).filter(([, v]) => v !== null && v !== undefined)
+    // Stay null when NO key is available, so a titleless, frameless model
+    // still short-circuits the parse/serialize as before —
+    // `injectGlbExtensions` treats a null map and an empty one differently
+    // (the null case is its pass-through).
+    const sceneExtrasForInject =
+      sceneExtrasPairs.length > 0 ? Object.fromEntries(sceneExtrasPairs) : null
     let packed
     let extStats
     try {

--- a/src/loader/glbExport.test.js
+++ b/src/loader/glbExport.test.js
@@ -52,6 +52,7 @@ jest.mock('./injectGlbExtensions', () => {
 
 import {BLDRS_GLB_SCHEMA_VERSION} from './glbCacheKey'
 import {BLDRS_TITLE_EXTRAS_KEY, exportAndCacheGlb, exportThreeModelAsGlb} from './glbExport'
+import {APPLIED_COORDINATION_KEY} from '../viewer/ifc/appliedCoordination'
 import {parseGlb, serializeGlb} from './injectGlbExtensions'
 import {gitHubCacheKey} from './sourceCacheKey'
 import {flatMeshToBatchedModel} from '../viewer/ifc/flatMeshToBatchedModel'
@@ -598,6 +599,130 @@ describe('loader/glbExport', () => {
       // title into scenes[0].name — the field generic viewers show.
       expect(json.scenes[0].name).toBe('Momentum')
       expect(injectResult.stats.addedSceneName).toBe(1)
+    })
+  })
+
+  describe('exportAndCacheGlb — applied coordination frame (Share#1633 item 1)', () => {
+    // The MERGED writer path (this file mocks `isGlbBatchedActive` false).
+    // The batched-native writer's half of the same round-trip is in
+    // `glbBatchedRoundTrip.test.js`, against a real GLTFLoader.
+    //
+    // Why the frame must ride in scene extras at all: both writers DROP
+    // `model.userData` — the merged bake (`batchedModelToMergedMesh`) copies
+    // only matrix + name, so `GLTFExporter` serialises an empty userData —
+    // which is exactly how a stamped model could reach the cache unstamped
+    // and come back out that way on every subsequent load.
+    const cacheKeyArgs = gitHubCacheKey({
+      owner: 'bldrs-ai',
+      repo: 'share',
+      branch: 'main',
+      filePath: 'sub/dir/index.ifc',
+      shaHash: 'abc123',
+    })
+    const ctx = {kindLabel: 'github', cacheKeyArgs}
+    // scale(mm) * NormalizeMat(Z-up -> Y-up) * translate(-anchor), the shape
+    // conway derives — distinctive enough that a dropped or reordered stamp
+    // cannot pass the assertions below.
+    /* eslint-disable no-magic-numbers */
+    const FRAME = [
+      0.001, 0, 0, 0,
+      0, 0, -0.001, 0,
+      0, 0.001, 0, 0,
+      -2600, 450, 1200, 1,
+    ]
+    /* eslint-enable no-magic-numbers */
+
+    /**
+     * @param {object} userData
+     * @return {object} a model stub shaped for the writer's tail
+     */
+    function modelWith(userData) {
+      return {name: 'Momentum', userData}
+    }
+
+    it('passes the stamped frame to injectGlbExtensions via sceneExtras', async () => {
+      const validGlb = makeValidEmptyGlb()
+      mockExporterParse.mockImplementation((_input, onDone) => onDone(validGlb.buffer))
+
+      const ok = await exportAndCacheGlb({
+        model: modelWith({[APPLIED_COORDINATION_KEY]: FRAME}), ...ctx,
+      })
+      expect(ok).toBe(true)
+
+      const [, , sceneExtrasArg] = mockInjectGlbExtensions.mock.calls[0]
+      // Alongside the title, in the SAME inject pass — one parse/serialize.
+      expect(sceneExtrasArg).toEqual({
+        [BLDRS_TITLE_EXTRAS_KEY]: 'Momentum',
+        [APPLIED_COORDINATION_KEY]: FRAME,
+      })
+    })
+
+    it('omits the key when the model carries no frame', async () => {
+      // Pre-conway#702 engines, and every non-IFC source. The title must
+      // still go out on its own, so the two keys are independent.
+      const validGlb = makeValidEmptyGlb()
+      mockExporterParse.mockImplementation((_input, onDone) => onDone(validGlb.buffer))
+
+      const ok = await exportAndCacheGlb({model: modelWith({}), ...ctx})
+      expect(ok).toBe(true)
+
+      const [, , sceneExtrasArg] = mockInjectGlbExtensions.mock.calls[0]
+      expect(sceneExtrasArg).toEqual({[BLDRS_TITLE_EXTRAS_KEY]: 'Momentum'})
+    })
+
+    it('stamps the frame even when the model has no title', async () => {
+      // The two keys are gathered independently, so a titleless model (a
+      // drag-dropped IFC with no project name) must still get its frame —
+      // the shape a single `titleForExtras ? … : null` ternary would drop.
+      const validGlb = makeValidEmptyGlb()
+      mockExporterParse.mockImplementation((_input, onDone) => onDone(validGlb.buffer))
+
+      const ok = await exportAndCacheGlb({
+        model: {userData: {[APPLIED_COORDINATION_KEY]: FRAME}}, ...ctx,
+      })
+      expect(ok).toBe(true)
+
+      const [, , sceneExtrasArg, sceneNameArg] = mockInjectGlbExtensions.mock.calls[0]
+      expect(sceneExtrasArg).toEqual({[APPLIED_COORDINATION_KEY]: FRAME})
+      expect(sceneNameArg).toBeNull()
+    })
+
+    it('refuses to cache a malformed frame', async () => {
+      // Validated at the write, not just at the read: an artifact persists
+      // across sessions, so a frame that would read back as NaN must never
+      // reach one. 16 elements, so length alone would have let it through.
+      const validGlb = makeValidEmptyGlb()
+      mockExporterParse.mockImplementation((_input, onDone) => onDone(validGlb.buffer))
+      const bad = [...FRAME]
+      bad[5] = null
+
+      const ok = await exportAndCacheGlb({
+        model: modelWith({[APPLIED_COORDINATION_KEY]: bad}), ...ctx,
+      })
+      expect(ok).toBe(true)
+
+      const [, , sceneExtrasArg] = mockInjectGlbExtensions.mock.calls[0]
+      expect(sceneExtrasArg).toEqual({[BLDRS_TITLE_EXTRAS_KEY]: 'Momentum'})
+    })
+
+    it('end-to-end: the frame round-trips into scenes[0].extras', async () => {
+      // REAL injectGlbExtensions, as in the title's end-to-end above: the
+      // spy default would swallow sceneExtras and hide a writer bug.
+      const actual = jest.requireActual('./injectGlbExtensions')
+      mockInjectGlbExtensions.mockImplementation(actual.injectGlbExtensions)
+
+      const validGlb = makeValidEmptyGlb()
+      mockExporterParse.mockImplementation((_input, onDone) => onDone(validGlb.buffer))
+
+      const ok = await exportAndCacheGlb({
+        model: modelWith({[APPLIED_COORDINATION_KEY]: FRAME}), ...ctx,
+      })
+      expect(ok).toBe(true)
+
+      const injectResult = mockInjectGlbExtensions.mock.results[0].value
+      const {json} = parseGlb(injectResult.bytes)
+      expect(json.scenes[0].extras[APPLIED_COORDINATION_KEY]).toEqual(FRAME)
+      expect(injectResult.stats.addedSceneExtras).toBe(2)
     })
   })
 })

--- a/src/loader/glbExport.test.js
+++ b/src/loader/glbExport.test.js
@@ -52,7 +52,10 @@ jest.mock('./injectGlbExtensions', () => {
 
 import {BLDRS_GLB_SCHEMA_VERSION} from './glbCacheKey'
 import {BLDRS_TITLE_EXTRAS_KEY, exportAndCacheGlb, exportThreeModelAsGlb} from './glbExport'
-import {APPLIED_COORDINATION_KEY} from '../viewer/ifc/appliedCoordination'
+import {
+  APPLIED_COORDINATION_KEY,
+  COORDINATION_OFFSET_KEY,
+} from '../viewer/ifc/appliedCoordination'
 import {parseGlb, serializeGlb} from './injectGlbExtensions'
 import {gitHubCacheKey} from './sourceCacheKey'
 import {flatMeshToBatchedModel} from '../viewer/ifc/flatMeshToBatchedModel'
@@ -723,6 +726,95 @@ describe('loader/glbExport', () => {
       const {json} = parseGlb(injectResult.bytes)
       expect(json.scenes[0].extras[APPLIED_COORDINATION_KEY]).toEqual(FRAME)
       expect(injectResult.stats.addedSceneExtras).toBe(2)
+    })
+
+    // Share's backstop offset is the OTHER half of the documented mapping
+    // (`rendered = (A * world) - coordinationOffset`). On the degraded path
+    // where the backstop fired, the offset is baked into the geometry being
+    // exported — so persisting only the frame yields a cache hit whose
+    // documented inverse reconstructs coordinates displaced by exactly it.
+    // Half a composition is wrong rather than absent, and silently so.
+    /* eslint-disable no-magic-numbers */
+    const OFFSET = [2600000, 450, -1200000]
+    /* eslint-enable no-magic-numbers */
+
+    it('carries the backstop offset alongside the frame', async () => {
+      const validGlb = makeValidEmptyGlb()
+      mockExporterParse.mockImplementation((_input, onDone) => onDone(validGlb.buffer))
+
+      const ok = await exportAndCacheGlb({
+        model: modelWith({
+          [APPLIED_COORDINATION_KEY]: FRAME,
+          [COORDINATION_OFFSET_KEY]: OFFSET,
+        }),
+        ...ctx,
+      })
+      expect(ok).toBe(true)
+
+      const [, , sceneExtrasArg] = mockInjectGlbExtensions.mock.calls[0]
+      expect(sceneExtrasArg).toEqual({
+        [BLDRS_TITLE_EXTRAS_KEY]: 'Momentum',
+        [APPLIED_COORDINATION_KEY]: FRAME,
+        [COORDINATION_OFFSET_KEY]: OFFSET,
+      })
+    })
+
+    it('omits the offset key on a healthy load (backstop never fired)', async () => {
+      // The normal case since the conway#680 fix chain: absence must stay
+      // absence, so consumers read it as `[0, 0, 0]` rather than finding a
+      // zeroed key they cannot distinguish from a real one.
+      const validGlb = makeValidEmptyGlb()
+      mockExporterParse.mockImplementation((_input, onDone) => onDone(validGlb.buffer))
+
+      const ok = await exportAndCacheGlb({
+        model: modelWith({[APPLIED_COORDINATION_KEY]: FRAME}), ...ctx,
+      })
+      expect(ok).toBe(true)
+
+      const [, , sceneExtrasArg] = mockInjectGlbExtensions.mock.calls[0]
+      expect(COORDINATION_OFFSET_KEY in sceneExtrasArg).toBe(false)
+    })
+
+    it('refuses to cache a malformed offset', async () => {
+      const validGlb = makeValidEmptyGlb()
+      mockExporterParse.mockImplementation((_input, onDone) => onDone(validGlb.buffer))
+
+      const ok = await exportAndCacheGlb({
+        model: modelWith({
+          [APPLIED_COORDINATION_KEY]: FRAME,
+          [COORDINATION_OFFSET_KEY]: [1, NaN, 3],
+        }),
+        ...ctx,
+      })
+      expect(ok).toBe(true)
+
+      const [, , sceneExtrasArg] = mockInjectGlbExtensions.mock.calls[0]
+      expect(COORDINATION_OFFSET_KEY in sceneExtrasArg).toBe(false)
+      // The frame still goes out — one bad key must not cost the other.
+      expect(sceneExtrasArg[APPLIED_COORDINATION_KEY]).toEqual(FRAME)
+    })
+
+    it('end-to-end: both halves round-trip into scenes[0].extras', async () => {
+      const actual = jest.requireActual('./injectGlbExtensions')
+      mockInjectGlbExtensions.mockImplementation(actual.injectGlbExtensions)
+
+      const validGlb = makeValidEmptyGlb()
+      mockExporterParse.mockImplementation((_input, onDone) => onDone(validGlb.buffer))
+
+      const ok = await exportAndCacheGlb({
+        model: modelWith({
+          [APPLIED_COORDINATION_KEY]: FRAME,
+          [COORDINATION_OFFSET_KEY]: OFFSET,
+        }),
+        ...ctx,
+      })
+      expect(ok).toBe(true)
+
+      const injectResult = mockInjectGlbExtensions.mock.results[0].value
+      const {json} = parseGlb(injectResult.bytes)
+      expect(json.scenes[0].extras[APPLIED_COORDINATION_KEY]).toEqual(FRAME)
+      expect(json.scenes[0].extras[COORDINATION_OFFSET_KEY]).toEqual(OFFSET)
+      expect(injectResult.stats.addedSceneExtras).toBe(3)
     })
   })
 })

--- a/src/viewer/ifc/ShareIfcLoader.coordination.test.js
+++ b/src/viewer/ifc/ShareIfcLoader.coordination.test.js
@@ -1,0 +1,362 @@
+/* eslint-disable no-magic-numbers */
+// The engine coordination stamp (Share#1633 item 1 / Share#1634, engine side
+// conway#702). `ShareIfcLoader#parse` reads `GetAppliedCoordinationMatrix` at
+// load completion and stamps it as `userData.appliedCoordination`, so Share
+// has a world-frame handle on the georeferenced models the ENGINE recentres
+// — which after conway#680 is every one of them, and none of which populate
+// Share's own `userData.coordinationOffset` backstop.
+//
+// Why these are unit tests over a mocked IfcAPI rather than a fixture load:
+// no jest test in this repo instantiates the conway wasm engine (the whole
+// `viewer/ifc` suite mocks the boundary), so a georeferenced fixture load is
+// not available here. What CAN be pinned without wasm is the part Share owns
+// — that the engine's frame reaches the model root unmangled, in the engine's
+// element order — and the round-trip below does exactly that: it inverts the
+// array read back OFF THE MODEL and requires it to carry a rendered point
+// home to authored LV95 coordinates. A transposed, truncated, elided or
+// identity stamp all fail it.
+
+import {Matrix4, Vector3} from 'three'
+import ShareIfcLoader from './ShareIfcLoader'
+import {assembleBatchedModel, buildBatchedConwayModel} from './buildBatchedConwayModel'
+import {buildConwayIfcModel} from './buildConwayIfcModel'
+import {IncrementalBatchedBuilder} from './incrementalBatchedBuilder'
+import {parseIfcWithConway} from './conwayDirectIfcLoader'
+import {isFeatureEnabled} from '../../FeatureFlags'
+import {getConwayDirectLogs} from '../../../tools/jest/conwayDirectLogCapture'
+
+
+jest.mock('./conwayDirectIfcLoader', () => ({
+  parseIfcWithConway: jest.fn(),
+  decorateConwayDirectIfcModel: jest.fn(),
+}))
+jest.mock('./buildBatchedConwayModel', () => ({
+  buildBatchedConwayModel: jest.fn(),
+  assembleBatchedModel: jest.fn(),
+}))
+jest.mock('./buildConwayIfcModel', () => ({buildConwayIfcModel: jest.fn()}))
+jest.mock('./incrementalBatchedBuilder', () => ({IncrementalBatchedBuilder: jest.fn()}))
+jest.mock('./flatMeshToBufferGeometry', () => ({flatMeshToBufferGeometry: jest.fn()}))
+jest.mock('./flatMeshToInstancedModel', () => ({flatMeshToInstancedModel: jest.fn()}))
+jest.mock('./parsePreviewMesh', () => ({payloadToPreviewMesh: jest.fn(() => null)}))
+jest.mock('./ifcItemsMapParity', () => ({runIfcItemsMapParityCheck: jest.fn()}))
+// `conwayDirectLog` is deliberately NOT mocked: the malformed-frame case
+// below asserts the diagnostic, and `setupTests.js` already redirects the
+// whole `[conwayDirect]` channel into a buffer, so the real module is both
+// assertable and console-clean here.
+jest.mock('../../FeatureFlags', () => ({isFeatureEnabled: jest.fn()}))
+jest.mock('../../utils/location', () => ({hasParams: jest.fn(() => false)}))
+jest.mock('../ProgressiveLoadSession', () => jest.fn().mockImplementation(() => ({
+  previewGroup: {add: jest.fn(), remove: jest.fn(), children: []},
+  report: jest.fn(),
+  beginAssembly: jest.fn(),
+  notifyBounds: jest.fn(),
+  addPreviewMesh: jest.fn(),
+  setSummary: jest.fn(),
+  finish: jest.fn(),
+  abort: jest.fn(),
+})))
+
+
+const PUMPED = [{expressID: 101, geometries: {size: () => 1}}]
+
+const BUILD_STATS = {
+  vertexCount: 3,
+  triangleCount: 1,
+  instanceCount: 1,
+  parentCount: 1,
+  materialCount: 1,
+  skippedFlatMeshes: 0,
+  skippedPlacedGeometries: 0,
+}
+
+/** Column-major identity, the shape the classic `GetCoordinationMatrix` returns. */
+const IDENTITY = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]
+
+/**
+ * Millimetres per metre — conway's `linearScalingFactor` for a model authored
+ * in mm, and the `scale` factor of `A`. Picked over 1 so the round-trip below
+ * actually exercises the unit half of the frame.
+ */
+const MM = 0.001
+
+/**
+ * A Swiss LV95 anchor in SOURCE units (mm, Z-up): easting 2 600 000 m,
+ * northing 1 200 000 m, 450 m up. This is the magnitude that made the models
+ * in Share#1633 jitter, and it is far enough from the origin that an identity
+ * or transposed stamp cannot accidentally pass the round-trip.
+ */
+const LV95_ANCHOR_MM = [2600000000, 1200000000, 450000]
+
+/**
+ * How close a recovered authored coordinate must be, in source units — one
+ * micron out of a 2.6e9 mm easting. Absolute rather than jest's
+ * `toBeCloseTo` digit count, which cannot express a tolerance this tight
+ * relative to a magnitude this large.
+ */
+const ROUND_TRIP_TOLERANCE_MM = 1e-3
+
+
+/**
+ * Assert a recovered point is the authored one, component-wise.
+ *
+ * @param {Vector3} recovered `inverse(A) * rendered`
+ * @param {Vector3} authored the point the file declares
+ */
+function expectRecovered(recovered, authored) {
+  expect(Math.abs(recovered.x - authored.x)).toBeLessThan(ROUND_TRIP_TOLERANCE_MM)
+  expect(Math.abs(recovered.y - authored.y)).toBeLessThan(ROUND_TRIP_TOLERANCE_MM)
+  expect(Math.abs(recovered.z - authored.z)).toBeLessThan(ROUND_TRIP_TOLERANCE_MM)
+}
+
+
+/**
+ * The Z-up -> Y-up change of basis conway composes into `A` as `NormalizeMat`:
+ * `(x, y, z) -> (x, z, -y)`. Written row-major because that is `Matrix4#set`'s
+ * argument order.
+ *
+ * @return {Matrix4}
+ */
+function normalizeMat() {
+  return new Matrix4().set(
+    1, 0, 0, 0,
+    0, 0, 1, 0,
+    0, -1, 0, 0,
+    0, 0, 0, 1)
+}
+
+
+/**
+ * `A = scale(linearScalingFactor) * NormalizeMat * translate(-anchor)`, built
+ * from the three factors conway's doc comment names, in that order. Standing
+ * in for what the engine derives so the test can state the frame it expects
+ * rather than assert whatever came back.
+ *
+ * @param {Array<number>} anchorInSourceUnits `[x, y, z]`, pre-rotation
+ * @param {number} [scale] metres per source unit
+ * @return {Matrix4}
+ */
+function appliedFrame(anchorInSourceUnits, scale = MM) {
+  const s = new Matrix4().makeScale(scale, scale, scale)
+  const t = new Matrix4().makeTranslation(
+    -anchorInSourceUnits[0], -anchorInSourceUnits[1], -anchorInSourceUnits[2])
+  return s.multiply(normalizeMat()).multiply(t)
+}
+
+
+/**
+ * A model object shaped enough for the tail of `parse` to run over it, with
+ * the `userData` a real three.js `Object3D` always has.
+ *
+ * @param {string} tag which build produced it
+ * @param {object} [userData] pre-existing userData (e.g. the incremental
+ *   root's `coordinationOffset`)
+ * @return {object}
+ */
+function makeModel(tag, userData = {}) {
+  return {tag, matrix: null, geometry: null, capabilities: {}, userData}
+}
+
+
+/**
+ * @param {?Array<number>} appliedMatrix what `GetAppliedCoordinationMatrix`
+ *   answers, or null to stand in for an engine pin predating conway#702
+ * @return {object} Conway IfcAPI stub for the post-build tail of `parse`
+ */
+function makeIfcAPI(appliedMatrix) {
+  const api = {
+    GetCoordinationMatrix: jest.fn().mockResolvedValue(IDENTITY),
+    OpenModel: jest.fn(),
+    StreamAllMeshes: jest.fn(),
+    properties: {},
+  }
+  if (appliedMatrix !== null) {
+    api.GetAppliedCoordinationMatrix = jest.fn(() => appliedMatrix)
+  }
+  return api
+}
+
+
+/** @return {object} a `viewer.IFC` stub with the scene `parse` needs */
+function makeIfcNamespace() {
+  return {
+    ifcLastError: null,
+    addIfcModel: jest.fn(),
+    context: {
+      items: {ifcModels: []},
+      getScene: () => ({add: jest.fn(), remove: jest.fn()}),
+      ifcCamera: {cameraControls: null, perspectiveCamera: null},
+    },
+  }
+}
+
+
+describe('viewer/ifc/ShareIfcLoader engine coordination stamp (Share#1634)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    // `demandGeometry` on is what gives the session a preview group, which is
+    // what gives `parse` an `onMeshBatch`, which is what puts the load on the
+    // incremental path — the production path for every real model.
+    isFeatureEnabled.mockImplementation((name) => name === 'demandGeometry')
+    parseIfcWithConway.mockImplementation(
+      // eslint-disable-next-line require-await
+      async (buffer, api, settings, onProgress, onMeshBatch) => {
+        if (onMeshBatch) {
+          onMeshBatch(PUMPED, 7, {done: 1, total: 1})
+        }
+        // eslint-disable-next-line require-await
+        return {modelID: 7, captured: [], recapture: async () => PUMPED}
+      })
+    IncrementalBatchedBuilder.mockImplementation(() => ({
+      root: {parent: null},
+      appendBatch: jest.fn(),
+      setPumpProgress: jest.fn(),
+      hasContent: () => true,
+      finalize: () => ({batches: [], stats: BUILD_STATS}),
+    }))
+    assembleBatchedModel.mockReturnValue(makeModel('incremental'))
+    buildConwayIfcModel.mockReturnValue({mesh: makeModel('merged'), stats: BUILD_STATS})
+    buildBatchedConwayModel.mockReturnValue({model: makeModel('batched'), stats: BUILD_STATS})
+  })
+
+  /**
+   * @param {object} ifcAPI
+   * @return {Promise<object>} the model `parse` resolved with
+   */
+  async function parseWith(ifcAPI) {
+    const loader = new ShareIfcLoader({ifcAPI, ifc: makeIfcNamespace()})
+    return await loader.parse(new ArrayBuffer(4), jest.fn(), jest.fn())
+  }
+
+  it('stamps the frame the engine reports, as its own copy', async () => {
+    const frame = appliedFrame(LV95_ANCHOR_MM)
+    const reported = Array.from(frame.elements)
+    const ifcAPI = makeIfcAPI(reported)
+
+    const model = await parseWith(ifcAPI)
+
+    expect(ifcAPI.GetAppliedCoordinationMatrix).toHaveBeenCalledWith(7)
+    expect(model.userData.appliedCoordination).toEqual(reported)
+    // A COPY, not the engine's array: conway documents the return as "a fresh
+    // array the caller owns", but a future passthrough handing back a live
+    // view must not be able to rewrite the model's frame after the fact.
+    expect(model.userData.appliedCoordination).not.toBe(reported)
+  })
+
+  it('inverts the stamp back to authored LV95 coordinates', async () => {
+    // The contract Share#1634 asked the engine for, exercised end to end:
+    //   rendered = A * world      world = inverse(A) * rendered
+    // `world` is the point the FILE declares — source units (mm here), Z-up.
+    const frame = appliedFrame(LV95_ANCHOR_MM)
+    const authored = new Vector3(
+      LV95_ANCHOR_MM[0] + 12000, // 12 m east of the anchor
+      LV95_ANCHOR_MM[1] - 3000, // 3 m south
+      LV95_ANCHOR_MM[2] + 5000) // 5 m up
+    const rendered = authored.clone().applyMatrix4(frame)
+
+    // The frame really is the recentring one: a point ~2,900 km from the
+    // origin in the file renders within metres of it. Without this the round
+    // trip below would also pass for an identity frame.
+    expect(rendered.length()).toBeLessThan(100)
+    expect(authored.length()).toBeGreaterThan(1e9)
+
+    const model = await parseWith(makeIfcAPI(Array.from(frame.elements)))
+
+    // Read the frame back OFF THE MODEL — the stamp is what is under test,
+    // not `Matrix4#invert`.
+    const inverse = new Matrix4()
+      .fromArray(model.userData.appliedCoordination)
+      .invert()
+    expectRecovered(rendered.clone().applyMatrix4(inverse), authored)
+  })
+
+  it('stamps a near-origin frame whose translation is zero but rotation is live', async () => {
+    // conway's explicit do-not-shortcut clause: under COORDINATE_TO_ORIGIN a
+    // model that needed no recentre still gets NormalizeMat and the unit
+    // scale, so "no offset applied" is NOT "no transform applied". Eliding
+    // the stamp on a zero translation would strand such a model Z-up and in
+    // the wrong units.
+    const frame = appliedFrame([0, 0, 0])
+    const model = await parseWith(makeIfcAPI(Array.from(frame.elements)))
+
+    const stamped = model.userData.appliedCoordination
+    expect([stamped[12], stamped[13], stamped[14]]).toEqual([0, 0, 0])
+    expect(stamped).not.toEqual(IDENTITY)
+
+    const authored = new Vector3(4000, 7000, 2000) // mm, Z-up
+    const rendered = authored.clone().applyMatrix4(frame)
+    // m, Y-up: the mm scale and the Z-up -> Y-up basis swap, no translation.
+    expect(rendered.x).toBeCloseTo(4, 9)
+    expect(rendered.y).toBeCloseTo(2, 9)
+    expect(rendered.z).toBeCloseTo(-7, 9)
+
+    expectRecovered(
+      rendered.clone().applyMatrix4(new Matrix4().fromArray(stamped).invert()), authored)
+  })
+
+  it('stamps on the merged fallback path too', async () => {
+    // One read point for every conway load path: incremental, batchedMesh and
+    // merged all converge on the same `ifcModel` before it is installed, so
+    // the degraded builds are stamped exactly like the healthy one.
+    IncrementalBatchedBuilder.mockImplementation(() => {
+      throw new Error('builder construction failed')
+    })
+    const frame = appliedFrame(LV95_ANCHOR_MM)
+    const model = await parseWith(makeIfcAPI(Array.from(frame.elements)))
+
+    expect(model.tag).toBe('merged')
+    expect(model.userData.appliedCoordination).toEqual(Array.from(frame.elements))
+  })
+
+  it('leaves the Share-side backstop offset untouched', async () => {
+    // `coordinationOffset` keeps its meaning: SHARE's recentre, stamped by
+    // `IncrementalBatchedBuilder` on the root it hands up, and present only
+    // when the engine declined to recentre. The two surfaces compose
+    // (`rendered = (A * world) - coordinationOffset`); neither overwrites the
+    // other.
+    const backstop = [2600000, 450, -1200000]
+    assembleBatchedModel.mockReturnValue(
+      makeModel('incremental', {coordinationOffset: backstop}))
+    const frame = appliedFrame(LV95_ANCHOR_MM)
+
+    const model = await parseWith(makeIfcAPI(Array.from(frame.elements)))
+
+    expect(model.userData.coordinationOffset).toEqual(backstop)
+    expect(model.userData.appliedCoordination).toEqual(Array.from(frame.elements))
+  })
+
+  it('loads unstamped against an engine that predates the frame contract', async () => {
+    // Feature-detect, as conway's doc comment instructs: stock web-ifc (the
+    // USE_WEBIFC_SHIM=false engine) and any pin before conway#702 have no
+    // such method, and a missing diagnostic must never cost a load.
+    const model = await parseWith(makeIfcAPI(null))
+
+    expect(model.tag).toBe('incremental')
+    expect(model.userData.appliedCoordination).toBeUndefined()
+    // And SILENTLY: an absent method is the expected state of an older pin,
+    // not a fault, so it must not put a line in every such load's report.
+    // This is what distinguishes the feature-detect from letting the call
+    // throw into the catch below it, which would look identical on the model.
+    expect(getConwayDirectLogs().filter(({text}) => /appliedCoordination/.test(text)))
+      .toEqual([])
+  })
+
+  it('refuses a malformed frame rather than stamping it', async () => {
+    // A short array would silently become a garbage `Matrix4` in every
+    // consumer (`fromArray` reads 16 slots regardless), so the reply is
+    // shape-checked and the model is left with no frame at all — which
+    // consumers can detect — instead of a wrong one, which they cannot.
+    const model = await parseWith(makeIfcAPI([1, 0, 0, 0, 1, 0, 0, 0, 1]))
+
+    expect(model.tag).toBe('incremental')
+    expect(model.userData.appliedCoordination).toBeUndefined()
+    // And it says so on the pipeline's own channel, which the load report
+    // tees. Silent coordination behaviour is what Share#1632 cost days to.
+    expect(getConwayDirectLogs().filter(({text}) => /appliedCoordination/.test(text)))
+      .toEqual([{
+        level: 'warn',
+        text: 'appliedCoordination: engine returned a non-mat4 frame ' +
+          '(length=9); model left unstamped',
+      }])
+  })
+})

--- a/src/viewer/ifc/ShareIfcLoader.coordination.test.js
+++ b/src/viewer/ifc/ShareIfcLoader.coordination.test.js
@@ -341,6 +341,21 @@ describe('viewer/ifc/ShareIfcLoader engine coordination stamp (Share#1634)', () 
       .toEqual([])
   })
 
+  it('refuses a right-length frame of non-finite numbers', async () => {
+    // Length alone would pass this: `Matrix4#fromArray` reads all 16 slots
+    // whatever they hold, so a NaN-bearing reply becomes a matrix whose
+    // inverse is NaN everywhere — an answer that looks real. Shared shape
+    // rules live in `./appliedCoordination`; this pins that the ENGINE
+    // boundary actually applies them.
+    const bad = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, NaN, 0, 1]
+    const model = await parseWith(makeIfcAPI(bad))
+
+    expect(model.tag).toBe('incremental')
+    expect(model.userData.appliedCoordination).toBeUndefined()
+    expect(getConwayDirectLogs().filter(({text}) => /appliedCoordination/.test(text)))
+      .toHaveLength(1)
+  })
+
   it('refuses a malformed frame rather than stamping it', async () => {
     // A short array would silently become a garbage `Matrix4` in every
     // consumer (`fromArray` reads 16 slots regardless), so the reply is

--- a/src/viewer/ifc/ShareIfcLoader.js
+++ b/src/viewer/ifc/ShareIfcLoader.js
@@ -21,7 +21,7 @@ import {Mesh} from 'three'
 import {assembleBatchedModel, buildBatchedConwayModel} from './buildBatchedConwayModel'
 import {IncrementalBatchedBuilder} from './incrementalBatchedBuilder'
 import {buildConwayIfcModel} from './buildConwayIfcModel'
-import {conwayDirectError, conwayDirectInfo} from './conwayDirectLog'
+import {conwayDirectError, conwayDirectInfo, conwayDirectWarn} from './conwayDirectLog'
 import {decorateConwayDirectIfcModel, parseIfcWithConway} from './conwayDirectIfcLoader'
 import {flatMeshToBufferGeometry} from './flatMeshToBufferGeometry'
 import {flatMeshToInstancedModel} from './flatMeshToInstancedModel'
@@ -103,6 +103,10 @@ async function logInstancedModelStats(ifcAPI, modelID, getCaptured, force = fals
  *   and the only whole-model ask a windowed deferred model can answer.
  *   Absent on pins predating it — feature-detect, never assume.
  * @property {Function} GetCoordinationMatrix Get the coord matrix.
+ * @property {Function} [GetAppliedCoordinationMatrix] conway#702: the frame
+ *   the engine ACTUALLY composed into the placements it emitted. Absent on
+ *   pins predating it and on stock web-ifc — feature-detect, never assume
+ *   (conway's own doc comment says so).
  * @property {Function} getStatistics Per-load load statistics.
  * @property {Function} getConwayVersion Conway engine version string.
  * @property {object} properties Conway properties namespace.
@@ -246,6 +250,148 @@ export function clearAabbImposters(ring, session) {
   // The replace key map holds a strong ref to every accepted plate —
   // clearing the list alone would keep the whole ring alive past teardown.
   ring.byExpressID.clear()
+}
+
+
+/**
+ * A column-major mat4 has exactly this many elements. Anything else coming
+ * back from the engine is a malformed reply, not a frame — see
+ * `stampAppliedCoordination`.
+ */
+const MAT4_LENGTH = 16
+
+
+/**
+ * Stamp the engine's applied coordination frame onto the model root as
+ * `userData.appliedCoordination`, and hand it back.
+ *
+ * ## The one reported offset surface (Share#1633 item 1, Share#1634)
+ *
+ * Two frames can sit between a file's authored coordinates and what the GPU
+ * draws, and until this stamp Share reported only the second — which since
+ * the conway#680 fix chain landed (conway#685, pinned by Share#1816)
+ * essentially never fires, leaving a georeferenced model with no world-frame
+ * handle at all:
+ *
+ *  1. **`userData.appliedCoordination`** — `A`, the frame CONWAY composed
+ *     into every `flatTransformation` it emitted, from
+ *     `GetAppliedCoordinationMatrix` (conway#702). This is the normal case:
+ *     the engine does the georeferenced recentre itself, so this is where a
+ *     Swiss LV95 model's offset actually lives — the ~2.6e6 m scale
+ *     Share#1816 measured on Ecobau.
+ *  2. **`userData.coordinationOffset`** — `[x, y, z]`, SHARE's own backstop
+ *     recentre, stamped by `IncrementalBatchedBuilder` only when a placement
+ *     still arrives beyond `LARGE_COORD_THRESHOLD` *after* the engine has had
+ *     its turn (`decideCoordinationOffset`, Share#1632). Semantics unchanged
+ *     by this stamp, and absent on a healthy load.
+ *
+ * **TOTAL render-frame mapping is the composition** — Share's offset applied
+ * outside the engine's frame, because the backstop subtracts from placements
+ * the engine had already composed under `A`:
+ *
+ * ```
+ *   rendered = (A * world) - coordinationOffset
+ *   world    = inverse(A) * (rendered + coordinationOffset)
+ * ```
+ *
+ * with `coordinationOffset` read as `[0, 0, 0]` when absent. On a healthy
+ * load that degenerates to conway's own `world = inverse(A) * rendered`.
+ *
+ * ## The engine's contract, verbatim from conway's doc comment
+ *
+ * (`compat/web-ifc/ifc_api.ts#GetAppliedCoordinationMatrix` — read it before
+ * changing anything here; only the fenced blocks are quoted.)
+ *
+ * > Every `flatTransformation` the model emits was composed as
+ * > ```
+ * >   flatTransformation = A * placement [ * translate(geomCentre) ]
+ * > ```
+ * > So for any vertex `v` a consumer uploads and renders,
+ * > ```
+ * >   rendered = flatTransformation * v = A * world
+ * >   world    = inverse(A) * rendered            <- the inverse you want
+ * > ```
+ * > `A` carries all three factors the recentre composed, in this order:
+ * > ```
+ * >   A = scale(linearScalingFactor) * NormalizeMat * translate(-anchor)
+ * > ```
+ *
+ * `world` is the point in the model's AUTHORED world space — the file's own
+ * coordinates, in the file's units, Z-up. Inverting `A` is the whole of it:
+ * it undoes the unit scale and the Z-up→Y-up change of basis as well as the
+ * offset, so nothing else about the model is needed.
+ *
+ * Two clauses of that contract are easy to get wrong, and both are quoted
+ * here because a consumer of this stamp will hit them:
+ *
+ *  - `A` is identity ONLY when nothing was composed AND nothing was supplied
+ *    (an open without COORDINATE_TO_ORIGIN, a suppressed shard, a model that
+ *    emitted no geometry). Identity never means "ask again later".
+ *  - A near-origin model under COORDINATE_TO_ORIGIN returns a frame whose
+ *    TRANSLATION is exactly zero — no recentre was needed — but whose
+ *    rotation and scale are still live. **Do not shortcut on "no offset
+ *    applied"; invert the matrix.** That is why the stamp is unconditional
+ *    rather than elided when the translation is zero.
+ *
+ * ## Why the read happens here, at load completion
+ *
+ * conway's timing contract: a deferred open that adopted its parse-time
+ * preview channel's frame reports that adopted frame from the moment the
+ * model opens, and the durable walk — the authority — revalidates it against
+ * its own first geometry, so **the value can change exactly once**, at the
+ * first durable batch, if the adoption is rejected. Read any earlier (at open,
+ * or from inside `onMeshBatch`) and the stamp could be the rejected frame.
+ * By the time `parse` reaches this call every durable batch has landed, so the
+ * value is final for the life of the model.
+ *
+ * ## Why a plain Array
+ *
+ * `Array.from` of conway's reply: JS numbers are float64, so this is the
+ * float64 mat4 the contract asks for, it matches conway's own `Array<number>`
+ * return type, and — unlike a `Float64Array` — it survives the GLB cache's
+ * `userData` → glTF `extras` round-trip, which `GLTFExporter` performs by
+ * JSON-serialising `userData` (a typed array would come back as
+ * `{"0": …, "1": …}`). The copy also means a future engine handing back a
+ * live view cannot alias into the model.
+ *
+ * Best-effort throughout: a missing method, a malformed reply or a throw
+ * leaves the model unstamped rather than discarding a successful parse.
+ *
+ * @param {object} ifcModel the assembled model root (`ifcModel.userData` is
+ *   created if the object does not already have one — mocked three.js Mesh
+ *   stand-ins in unit tests do not)
+ * @param {ConwayIfcAPI} ifcAPI
+ * @param {number} modelID
+ * @return {?Array<number>} the stamped column-major mat4, or null when the
+ *   engine could not answer
+ */
+export function stampAppliedCoordination(ifcModel, ifcAPI, modelID) {
+  if (typeof ifcAPI?.GetAppliedCoordinationMatrix !== 'function') {
+    return null
+  }
+  try {
+    // eslint-disable-next-line new-cap
+    const applied = ifcAPI.GetAppliedCoordinationMatrix(modelID)
+    if (!Array.isArray(applied) || applied.length !== MAT4_LENGTH) {
+      // On the `[conwayDirect]` channel, not `debug()`: this is a designed
+      // diagnostic for this pipeline, and warn is the level the load report
+      // tees (see `decideCoordinationOffset`'s note on the same channel).
+      // Share#1632's lesson was that silent coordination behaviour is what
+      // costs the days — an engine answering with a non-frame is exactly that
+      // class of problem and must not pass unremarked.
+      conwayDirectWarn(
+        `appliedCoordination: engine returned a non-mat4 frame ` +
+        `(length=${applied?.length}); model left unstamped`)
+      return null
+    }
+    const frame = Array.from(applied)
+    ifcModel.userData = ifcModel.userData ?? {}
+    ifcModel.userData.appliedCoordination = frame
+    return frame
+  } catch (e) {
+    conwayDirectWarn(`appliedCoordination stamp skipped: ${e}`)
+    return null
+  }
 }
 
 
@@ -500,10 +646,24 @@ export default class ShareIfcLoader {
       clearAabbImposters(aabbRing, session)
       session.finish()
 
+      // The engine frame, stamped once for every conway load path (incremental
+      // / batchedMesh / merged all converge on this `ifcModel`) and before the
+      // model is installed, so nothing can observe a model without it. Read
+      // here and not earlier: the value is only final once the durable walk
+      // has run — see stampAppliedCoordination for the timing contract, the
+      // inverse, and how it composes with `userData.coordinationOffset`.
+      stampAppliedCoordination(ifcModel, ifcAPI, modelID)
+
       ifc.addIfcModel(ifcModel)
 
       // eslint-disable-next-line new-cap
       const matrixArr = await ifcAPI.GetCoordinationMatrix(modelID)
+      // NOT the engine's applied frame — conway keeps this CLASSIC web-ifc
+      // surface at identity precisely because consumers stamp it onto the
+      // model transform, and a non-identity value would apply the recentre a
+      // second time on top of placements that already carry it. The applied
+      // frame is `userData.appliedCoordination`, stamped above.
+      //
       // Apply the coordination matrix to the model directly. Wit-three's
       // `setupCoordinationMatrix` set this on the model + told the
       // IFCParser to re-apply on every subsequent mesh; with Conway-

--- a/src/viewer/ifc/ShareIfcLoader.js
+++ b/src/viewer/ifc/ShareIfcLoader.js
@@ -18,6 +18,7 @@
 // attached to it. Now we own the loader so we hold direct refs.
 
 import {Mesh} from 'three'
+import {APPLIED_COORDINATION_KEY, validAppliedCoordination} from './appliedCoordination'
 import {assembleBatchedModel, buildBatchedConwayModel} from './buildBatchedConwayModel'
 import {IncrementalBatchedBuilder} from './incrementalBatchedBuilder'
 import {buildConwayIfcModel} from './buildConwayIfcModel'
@@ -254,86 +255,16 @@ export function clearAabbImposters(ring, session) {
 
 
 /**
- * A column-major mat4 has exactly this many elements. Anything else coming
- * back from the engine is a malformed reply, not a frame — see
- * `stampAppliedCoordination`.
- */
-const MAT4_LENGTH = 16
-
-
-/**
  * Stamp the engine's applied coordination frame onto the model root as
- * `userData.appliedCoordination`, and hand it back.
+ * `userData[APPLIED_COORDINATION_KEY]`, and hand it back.
  *
- * ## The one reported offset surface (Share#1633 item 1, Share#1634)
+ * **The contract itself — what `A` is, how it inverts, how it composes with
+ * `userData.coordinationOffset`, and the two clauses consumers get wrong —
+ * lives in `./appliedCoordination`.** Read that module before changing
+ * anything here. What is specific to this call site, and so documented here,
+ * is only WHEN the frame may be read.
  *
- * Two frames can sit between a file's authored coordinates and what the GPU
- * draws, and until this stamp Share reported only the second — which since
- * the conway#680 fix chain landed (conway#685, pinned by Share#1816)
- * essentially never fires, leaving a georeferenced model with no world-frame
- * handle at all:
- *
- *  1. **`userData.appliedCoordination`** — `A`, the frame CONWAY composed
- *     into every `flatTransformation` it emitted, from
- *     `GetAppliedCoordinationMatrix` (conway#702). This is the normal case:
- *     the engine does the georeferenced recentre itself, so this is where a
- *     Swiss LV95 model's offset actually lives — the ~2.6e6 m scale
- *     Share#1816 measured on Ecobau.
- *  2. **`userData.coordinationOffset`** — `[x, y, z]`, SHARE's own backstop
- *     recentre, stamped by `IncrementalBatchedBuilder` only when a placement
- *     still arrives beyond `LARGE_COORD_THRESHOLD` *after* the engine has had
- *     its turn (`decideCoordinationOffset`, Share#1632). Semantics unchanged
- *     by this stamp, and absent on a healthy load.
- *
- * **TOTAL render-frame mapping is the composition** — Share's offset applied
- * outside the engine's frame, because the backstop subtracts from placements
- * the engine had already composed under `A`:
- *
- * ```
- *   rendered = (A * world) - coordinationOffset
- *   world    = inverse(A) * (rendered + coordinationOffset)
- * ```
- *
- * with `coordinationOffset` read as `[0, 0, 0]` when absent. On a healthy
- * load that degenerates to conway's own `world = inverse(A) * rendered`.
- *
- * ## The engine's contract, verbatim from conway's doc comment
- *
- * (`compat/web-ifc/ifc_api.ts#GetAppliedCoordinationMatrix` — read it before
- * changing anything here; only the fenced blocks are quoted.)
- *
- * > Every `flatTransformation` the model emits was composed as
- * > ```
- * >   flatTransformation = A * placement [ * translate(geomCentre) ]
- * > ```
- * > So for any vertex `v` a consumer uploads and renders,
- * > ```
- * >   rendered = flatTransformation * v = A * world
- * >   world    = inverse(A) * rendered            <- the inverse you want
- * > ```
- * > `A` carries all three factors the recentre composed, in this order:
- * > ```
- * >   A = scale(linearScalingFactor) * NormalizeMat * translate(-anchor)
- * > ```
- *
- * `world` is the point in the model's AUTHORED world space — the file's own
- * coordinates, in the file's units, Z-up. Inverting `A` is the whole of it:
- * it undoes the unit scale and the Z-up→Y-up change of basis as well as the
- * offset, so nothing else about the model is needed.
- *
- * Two clauses of that contract are easy to get wrong, and both are quoted
- * here because a consumer of this stamp will hit them:
- *
- *  - `A` is identity ONLY when nothing was composed AND nothing was supplied
- *    (an open without COORDINATE_TO_ORIGIN, a suppressed shard, a model that
- *    emitted no geometry). Identity never means "ask again later".
- *  - A near-origin model under COORDINATE_TO_ORIGIN returns a frame whose
- *    TRANSLATION is exactly zero — no recentre was needed — but whose
- *    rotation and scale are still live. **Do not shortcut on "no offset
- *    applied"; invert the matrix.** That is why the stamp is unconditional
- *    rather than elided when the translation is zero.
- *
- * ## Why the read happens here, at load completion
+ * ## Why the read happens at load completion
  *
  * conway's timing contract: a deferred open that adopted its parse-time
  * preview channel's frame reports that adopted frame from the moment the
@@ -344,15 +275,9 @@ const MAT4_LENGTH = 16
  * By the time `parse` reaches this call every durable batch has landed, so the
  * value is final for the life of the model.
  *
- * ## Why a plain Array
- *
- * `Array.from` of conway's reply: JS numbers are float64, so this is the
- * float64 mat4 the contract asks for, it matches conway's own `Array<number>`
- * return type, and — unlike a `Float64Array` — it survives the GLB cache's
- * `userData` → glTF `extras` round-trip, which `GLTFExporter` performs by
- * JSON-serialising `userData` (a typed array would come back as
- * `{"0": …, "1": …}`). The copy also means a future engine handing back a
- * live view cannot alias into the model.
+ * It is also the one point every conway load path converges on — incremental,
+ * `?feature=batchedMesh`, and the merged fallback all produce this same
+ * `ifcModel` — so a single call covers them all.
  *
  * Best-effort throughout: a missing method, a malformed reply or a throw
  * leaves the model unstamped rather than discarding a successful parse.
@@ -372,7 +297,8 @@ export function stampAppliedCoordination(ifcModel, ifcAPI, modelID) {
   try {
     // eslint-disable-next-line new-cap
     const applied = ifcAPI.GetAppliedCoordinationMatrix(modelID)
-    if (!Array.isArray(applied) || applied.length !== MAT4_LENGTH) {
+    const frame = validAppliedCoordination(applied)
+    if (frame === null) {
       // On the `[conwayDirect]` channel, not `debug()`: this is a designed
       // diagnostic for this pipeline, and warn is the level the load report
       // tees (see `decideCoordinationOffset`'s note on the same channel).
@@ -384,9 +310,8 @@ export function stampAppliedCoordination(ifcModel, ifcAPI, modelID) {
         `(length=${applied?.length}); model left unstamped`)
       return null
     }
-    const frame = Array.from(applied)
     ifcModel.userData = ifcModel.userData ?? {}
-    ifcModel.userData.appliedCoordination = frame
+    ifcModel.userData[APPLIED_COORDINATION_KEY] = frame
     return frame
   } catch (e) {
     conwayDirectWarn(`appliedCoordination stamp skipped: ${e}`)

--- a/src/viewer/ifc/appliedCoordination.js
+++ b/src/viewer/ifc/appliedCoordination.js
@@ -1,0 +1,156 @@
+// The georeferenced frame contract: how a rendered point maps back to the
+// coordinates a model's file actually declares.
+//
+// This module is the ONE place that contract is written. Four subsystems
+// touch the frame and each imports from here rather than restating it:
+//
+//   - `ShareIfcLoader#stampAppliedCoordination` reads the frame off the
+//     engine and stamps it on a freshly parsed model;
+//   - `loader/glbExport.js` carries the stamp into the GLB cache artifact;
+//   - `loader/Loader.js#convertToShareModel` re-validates it coming back
+//     out of that artifact (the cache file is an untrusted boundary);
+//   - `IncrementalBatchedBuilder` / `coordinationOffsetFor` own the OTHER
+//     half of the mapping and point here for how the two compose.
+//
+// ## The two surfaces (Share#1633 item 1, Share#1634)
+//
+// Two frames can sit between a file's authored coordinates and what the GPU
+// draws. Until the `appliedCoordination` stamp Share reported only the
+// second — which since the conway#680 fix chain landed (conway#685, pinned
+// by Share#1816) essentially never fires, leaving a georeferenced model with
+// no world-frame handle at all:
+//
+//  1. `userData.appliedCoordination` — `A`, the frame CONWAY composed into
+//     every `flatTransformation` it emitted, from conway#702's
+//     `GetAppliedCoordinationMatrix`. This is the normal case: the engine
+//     does the georeferenced recentre itself, so this is where a Swiss LV95
+//     model's offset actually lives — the ~2.6e6 m scale Share#1816
+//     measured on Ecobau.
+//  2. `userData.coordinationOffset` — `[x, y, z]`, SHARE's own backstop
+//     recentre, stamped by `IncrementalBatchedBuilder` only when a placement
+//     still arrives beyond `LARGE_COORD_THRESHOLD` *after* the engine has
+//     had its turn (`decideCoordinationOffset`, Share#1632). Absent on a
+//     healthy load.
+//
+// TOTAL render-frame mapping is the composition — Share's offset applied
+// OUTSIDE the engine's frame, because the backstop subtracts from placements
+// the engine had already composed under `A`:
+//
+//     rendered = (A * world) - coordinationOffset
+//     world    = inverse(A) * (rendered + coordinationOffset)
+//
+// with `coordinationOffset` read as `[0, 0, 0]` when absent. On a healthy
+// load that degenerates to conway's own `world = inverse(A) * rendered`.
+//
+// ## The engine's contract, verbatim from conway's doc comment
+//
+// (`compat/web-ifc/ifc_api.ts#GetAppliedCoordinationMatrix` — read it before
+// changing anything here; only the fenced blocks are quoted.)
+//
+// > Every `flatTransformation` the model emits was composed as
+// >
+// >     flatTransformation = A * placement [ * translate(geomCentre) ]
+// >
+// > So for any vertex `v` a consumer uploads and renders,
+// >
+// >     rendered = flatTransformation * v = A * world
+// >     world    = inverse(A) * rendered            <- the inverse you want
+// >
+// > `A` carries all three factors the recentre composed, in this order:
+// >
+// >     A = scale(linearScalingFactor) * NormalizeMat * translate(-anchor)
+//
+// `world` is the point in the model's AUTHORED world space — the file's own
+// coordinates, in the file's units, Z-up. Inverting `A` is the whole of it:
+// it undoes the unit scale and the Z-up->Y-up change of basis as well as the
+// offset, so nothing else about the model is needed.
+//
+// Two clauses of that contract are easy to get wrong, and both are quoted
+// here because a consumer of the stamp will hit them:
+//
+//  - `A` is identity ONLY when nothing was composed AND nothing was supplied
+//    (an open without COORDINATE_TO_ORIGIN, a suppressed shard, a model that
+//    emitted no geometry). Identity never means "ask again later".
+//  - A near-origin model under COORDINATE_TO_ORIGIN returns a frame whose
+//    TRANSLATION is exactly zero — no recentre was needed — but whose
+//    rotation and scale are still live. DO NOT shortcut on "no offset
+//    applied"; invert the matrix. That is why the stamp is unconditional
+//    rather than elided when the translation is zero.
+//
+// ## Why a plain Array, and why the key is not `bldrs`-prefixed
+//
+// The frame is a plain `Array<number>` (JS numbers are float64, so this IS
+// the float64 mat4 the contract asks for) and never a `Float64Array`, because
+// it has to cross the GLB cache as JSON: the writer stamps it into the glTF
+// JSON chunk under `scenes[0].extras`, and a typed array serialises there as
+// `{"0": …, "1": …}` and never comes back a matrix.
+//
+// Note WHERE it crosses, because it is not where you would guess. It does NOT
+// ride on the model's own `userData` via `GLTFExporter`: both cache writers
+// drop userData — the batched-native writer builds a fresh gltf-transform
+// Document, and the merged bake (`batchedToMergedMesh`) copies only matrix and
+// name — so a stamp left on the model reaches the artifact on NEITHER path.
+// It travels as scene extras, injected downstream of both writers on the
+// packed bytes (`glbExport.js`), which is what makes one capture cover every
+// layout.
+//
+// `APPLIED_COORDINATION_KEY` is deliberately un-prefixed, unlike the
+// neighbouring `bldrsTitle` extras key. three.js GLTFLoader auto-promotes
+// `scenes[0].extras` onto `scene.userData` VERBATIM, so the extras key IS
+// the userData key — and it has to be the same name a fresh parse stamps, or
+// a cache hit would present a second, differently-named surface and defeat
+// the whole point of the issue. Keep it disjoint from other extras callers
+// (see `injectGlbExtensions`'s last-write-wins note).
+//
+// The batched cache-hit path adds one more hop: `hydrateBatchedModelFromInstancedGlb`
+// swaps the GLTFLoader scene for a rebuilt BatchedMesh model and merges the
+// scene's userData onto it, so the frame survives that swap too. Both hops
+// are pinned end to end in `loader/glbBatchedRoundTrip.test.js`.
+
+
+/** A column-major mat4 has exactly this many elements. */
+export const MAT4_LENGTH = 16
+
+
+/**
+ * The key the frame lives under, on `Object3D.userData` after a fresh parse
+ * and inside `scenes[0].extras` in a GLB cache artifact. One constant, so
+ * writer and reader can never drift apart. See the module header for why it
+ * carries no `bldrs` prefix.
+ */
+export const APPLIED_COORDINATION_KEY = 'appliedCoordination'
+
+
+/**
+ * The value as a usable frame, or null when it is not one.
+ *
+ * Used at three boundaries, all of which need the same answer: the engine
+ * reply (an older or non-conway engine can answer anything), the cache write
+ * (never persist a frame that would read back wrong), and the cache read
+ * (per `Loader.js`'s cached-title note, a GLB artifact is an untrusted
+ * boundary in the originator-share design — a hand-edited file could carry
+ * any JSON under this key).
+ *
+ * Length alone is not enough. `Matrix4#fromArray` reads 16 slots whatever
+ * they hold, so an array of the right length full of `null` / `undefined` /
+ * `NaN` — which JSON round-trips produce readily, `undefined` becoming
+ * `null` — would silently become a garbage matrix in every consumer, and an
+ * inverse of it is `NaN` everywhere. Refusing outright leaves the model with
+ * NO frame, which a consumer can detect; a wrong frame it cannot.
+ *
+ * Returns a fresh copy rather than the input, so a caller can hand it to a
+ * model without the source (an engine buffer, a parsed JSON blob) staying
+ * able to mutate it.
+ *
+ * @param {*} value candidate frame
+ * @return {?Array<number>} a fresh 16-element column-major mat4, or null
+ */
+export function validAppliedCoordination(value) {
+  if (!Array.isArray(value) || value.length !== MAT4_LENGTH) {
+    return null
+  }
+  if (!value.every((n) => typeof n === 'number' && Number.isFinite(n))) {
+    return null
+  }
+  return Array.from(value)
+}

--- a/src/viewer/ifc/appliedCoordination.js
+++ b/src/viewer/ifc/appliedCoordination.js
@@ -42,6 +42,25 @@
 // with `coordinationOffset` read as `[0, 0, 0]` when absent. On a healthy
 // load that degenerates to conway's own `world = inverse(A) * rendered`.
 //
+// BOTH halves cross the GLB cache, and they have to travel together. The
+// offset is baked into the exported geometry, so an artifact carrying only
+// `A` reads back as a model whose rendered points are displaced by exactly
+// the offset the inverse above then fails to add — the composition is only
+// correct if a cache hit restores everything a fresh parse stamped. That is
+// why both keys ride the same capture and are dropped, on read, by the same
+// rules.
+//
+// SCOPE: persistence covers what was STAMPED. `coordinationOffset` is
+// stamped only by `IncrementalBatchedBuilder`; the `?feature=batchedMesh`
+// and merged fallback builders DECIDE and APPLY an offset without ever
+// putting it on `userData` (`collectGroups`'s `totals.coordOffset`,
+// `flatMeshToBufferGeometry`'s return — the shared per-load `coordination`
+// object carries only the log latch, not the value). On those paths a
+// backstop offset is applied but unreported, so there is nothing here to
+// cache — you cannot persist what was never stamped. That apply-but-don't-
+// stamp gap predates this module and is #1633 item 2's follow-up; nothing
+// here widens or narrows it.
+//
 // ## The engine's contract, verbatim from conway's doc comment
 //
 // (`compat/web-ifc/ifc_api.ts#GetAppliedCoordinationMatrix` — read it before
@@ -119,6 +138,45 @@ export const MAT4_LENGTH = 16
  * carries no `bldrs` prefix.
  */
 export const APPLIED_COORDINATION_KEY = 'appliedCoordination'
+
+
+/** A recentre offset is `[x, y, z]`. */
+export const OFFSET_LENGTH = 3
+
+
+/**
+ * The key SHARE's own backstop recentre lives under, on `Object3D.userData`
+ * after a fresh parse and inside `scenes[0].extras` in a GLB cache artifact.
+ *
+ * Un-prefixed for the same reason as `APPLIED_COORDINATION_KEY`, and it must
+ * keep the name `IncrementalBatchedBuilder` already stamps — this constant
+ * names an EXISTING surface rather than introducing one, so renaming it here
+ * would silently orphan the builder's stamp.
+ */
+export const COORDINATION_OFFSET_KEY = 'coordinationOffset'
+
+
+/**
+ * The value as a usable backstop offset, or null when it is not one.
+ *
+ * Same three boundaries and the same reasoning as
+ * {@link validAppliedCoordination} — with the difference that a bad offset
+ * is subtracted rather than inverted, so it corrupts by translation instead
+ * of by `NaN`. Refused all the same: a model displaced by a garbage vector
+ * looks like a correctly placed model somewhere else.
+ *
+ * @param {*} value candidate offset
+ * @return {?Array<number>} a fresh `[x, y, z]`, or null
+ */
+export function validCoordinationOffset(value) {
+  if (!Array.isArray(value) || value.length !== OFFSET_LENGTH) {
+    return null
+  }
+  if (!value.every((n) => typeof n === 'number' && Number.isFinite(n))) {
+    return null
+  }
+  return Array.from(value)
+}
 
 
 /**

--- a/src/viewer/ifc/appliedCoordination.test.js
+++ b/src/viewer/ifc/appliedCoordination.test.js
@@ -8,8 +8,11 @@
 
 import {
   APPLIED_COORDINATION_KEY,
+  COORDINATION_OFFSET_KEY,
   MAT4_LENGTH,
+  OFFSET_LENGTH,
   validAppliedCoordination,
+  validCoordinationOffset,
 } from './appliedCoordination'
 
 
@@ -69,5 +72,49 @@ describe('viewer/ifc/appliedCoordination', () => {
     for (const bad of [null, undefined, 0, 'frame', {0: 1}, new Float64Array(16)]) {
       expect(validAppliedCoordination(bad)).toBeNull()
     }
+  })
+})
+
+
+describe('viewer/ifc/appliedCoordination — backstop offset', () => {
+  it('keys the offset under the name IncrementalBatchedBuilder already stamps', () => {
+    // This constant NAMES an existing surface rather than introducing one:
+    // renaming it here would orphan the builder's stamp, and (being an extras
+    // key too) would split the cache-hit surface from the fresh-parse one.
+    expect(COORDINATION_OFFSET_KEY).toBe('coordinationOffset')
+    expect(OFFSET_LENGTH).toBe(3)
+  })
+
+  it('accepts a well-formed offset and returns a copy', () => {
+    const input = [2600000, 450, -1200000]
+    const out = validCoordinationOffset(input)
+
+    expect(out).toEqual(input)
+    expect(out).not.toBe(input)
+  })
+
+  it('refuses a non-finite component', () => {
+    // A bad offset corrupts by TRANSLATION rather than by NaN, so it looks
+    // like a correctly placed model somewhere else — worth refusing for the
+    // same reason a bad frame is.
+    for (const bad of [NaN, Infinity, null, undefined, '0']) {
+      expect(validCoordinationOffset([1, bad, 3])).toBeNull()
+    }
+  })
+
+  it('refuses a wrong-length or non-array offset', () => {
+    expect(validCoordinationOffset([1, 2])).toBeNull()
+    expect(validCoordinationOffset([1, 2, 3, 4])).toBeNull()
+    expect(validCoordinationOffset([])).toBeNull()
+    for (const bad of [null, undefined, 0, 'offset', {0: 1}, new Float64Array(3)]) {
+      expect(validCoordinationOffset(bad)).toBeNull()
+    }
+  })
+
+  it('keeps the two validators independent', () => {
+    // Guards against a copy-paste that points one key at the other's length.
+    expect(validCoordinationOffset(new Array(MAT4_LENGTH).fill(1))).toBeNull()
+    expect(validAppliedCoordination([1, 2, 3])).toBeNull()
+    expect(APPLIED_COORDINATION_KEY).not.toBe(COORDINATION_OFFSET_KEY)
   })
 })

--- a/src/viewer/ifc/appliedCoordination.test.js
+++ b/src/viewer/ifc/appliedCoordination.test.js
@@ -1,0 +1,73 @@
+/* eslint-disable no-magic-numbers */
+// The frame validator guards three boundaries (engine reply, cache write,
+// cache read) and every one of them can hand it JSON-shaped garbage. The
+// cases below are the shapes actually reachable there, not an exhaustive
+// type sweep: `undefined` from an engine that returns nothing, `null` from a
+// JSON round-trip (which is what `undefined` becomes in `JSON.stringify`),
+// and `NaN` from arithmetic on a frame that was never derived.
+
+import {
+  APPLIED_COORDINATION_KEY,
+  MAT4_LENGTH,
+  validAppliedCoordination,
+} from './appliedCoordination'
+
+
+/** @return {Array<number>} a distinguishable well-formed frame */
+function frame() {
+  return [
+    0.001, 0, 0, 0,
+    0, 0, -0.001, 0,
+    0, 0.001, 0, 0,
+    -2600, 450, 1200, 1,
+  ]
+}
+
+
+describe('viewer/ifc/appliedCoordination', () => {
+  it('keys the frame under the name a fresh parse and a cache hit share', () => {
+    // Un-prefixed on purpose: GLTFLoader promotes `scenes[0].extras` onto
+    // `userData` verbatim, so the extras key IS the userData key. If this
+    // ever gains a `bldrs` prefix, a cache hit starts presenting a second,
+    // differently-named surface — which is the bug Share#1633 item 1 is about.
+    expect(APPLIED_COORDINATION_KEY).toBe('appliedCoordination')
+    expect(MAT4_LENGTH).toBe(16)
+  })
+
+  it('accepts a well-formed frame and returns a copy', () => {
+    const input = frame()
+    const out = validAppliedCoordination(input)
+
+    expect(out).toEqual(input)
+    // A copy, so a parsed-JSON blob or an engine buffer cannot keep mutating
+    // a frame already handed to a model.
+    expect(out).not.toBe(input)
+  })
+
+  it('refuses a right-length frame of non-finite numbers', () => {
+    // The case length alone misses, and the reason the guard is not just
+    // `length === 16`: `Matrix4#fromArray` reads all 16 slots whatever they
+    // hold, so these become a garbage matrix whose inverse is NaN
+    // everywhere — wrong, and undetectable by the consumer.
+    for (const bad of [NaN, Infinity, -Infinity, null, undefined, '0']) {
+      const f = frame()
+      f[5] = bad
+      expect(validAppliedCoordination(f)).toBeNull()
+    }
+  })
+
+  it('refuses a wrong-length array', () => {
+    expect(validAppliedCoordination(frame().slice(0, 15))).toBeNull()
+    expect(validAppliedCoordination([...frame(), 1])).toBeNull()
+    expect(validAppliedCoordination([])).toBeNull()
+  })
+
+  it('refuses anything that is not an array', () => {
+    // A `Float64Array` is refused deliberately, not incidentally: it is what
+    // a typed-array stamp would produce, and it does NOT survive the JSON
+    // boundaries the frame has to cross (it comes back as `{"0": …}`).
+    for (const bad of [null, undefined, 0, 'frame', {0: 1}, new Float64Array(16)]) {
+      expect(validAppliedCoordination(bad)).toBeNull()
+    }
+  })
+})

--- a/src/viewer/ifc/flatMeshToBatchedModel.js
+++ b/src/viewer/ifc/flatMeshToBatchedModel.js
@@ -369,6 +369,14 @@ export const LARGE_COORD_THRESHOLD = 1e4
  * metres so the offset is exactly float-representable and stable across the
  * incremental demand batches (every batch subtracts the same value).
  *
+ * SHARE's BACKSTOP, not the whole story. It reads a placement the engine has
+ * already composed its own coordination frame into, so it only fires when the
+ * engine declined to recentre — which since the conway#680 fix chain landed
+ * (conway-geom#202 -> conway#685, pinned by Share#1816) is essentially never.
+ * The engine's frame is reported separately as
+ * `userData.appliedCoordination`, and the composition of the two is written
+ * once, on `ShareIfcLoader#stampAppliedCoordination`.
+ *
  * @param {Array<number>} flatTransformation 16-element column-major matrix
  * @return {?Array<number>} `[x, y, z]` to subtract, or null
  */

--- a/src/viewer/ifc/flatMeshToBatchedModel.js
+++ b/src/viewer/ifc/flatMeshToBatchedModel.js
@@ -375,7 +375,7 @@ export const LARGE_COORD_THRESHOLD = 1e4
  * (conway-geom#202 -> conway#685, pinned by Share#1816) is essentially never.
  * The engine's frame is reported separately as
  * `userData.appliedCoordination`, and the composition of the two is written
- * once, on `ShareIfcLoader#stampAppliedCoordination`.
+ * once, in `./appliedCoordination`.
  *
  * @param {Array<number>} flatTransformation 16-element column-major matrix
  * @return {?Array<number>} `[x, y, z]` to subtract, or null

--- a/src/viewer/ifc/flatMeshToBufferGeometry.js
+++ b/src/viewer/ifc/flatMeshToBufferGeometry.js
@@ -343,6 +343,10 @@ export function flatMeshToBufferGeometry(flatMeshes, api, modelID, opts = {}) {
     // `[x,y,z]` origin offset already folded into the baked vertices for a
     // georeferenced model (null for near-origin), so a rendered point maps
     // back to true world coordinates.
+    //
+    // Only SHARE's backstop half of that mapping — the engine's own frame is
+    // reported separately as `userData.appliedCoordination`, and the two
+    // compose. See `ShareIfcLoader#stampAppliedCoordination` for the contract.
     coordinationOffset: coordOffset,
   }
 }

--- a/src/viewer/ifc/flatMeshToBufferGeometry.js
+++ b/src/viewer/ifc/flatMeshToBufferGeometry.js
@@ -346,7 +346,7 @@ export function flatMeshToBufferGeometry(flatMeshes, api, modelID, opts = {}) {
     //
     // Only SHARE's backstop half of that mapping — the engine's own frame is
     // reported separately as `userData.appliedCoordination`, and the two
-    // compose. See `ShareIfcLoader#stampAppliedCoordination` for the contract.
+    // compose. See `./appliedCoordination` for the contract.
     coordinationOffset: coordOffset,
   }
 }

--- a/src/viewer/ifc/incrementalBatchedBuilder.js
+++ b/src/viewer/ifc/incrementalBatchedBuilder.js
@@ -552,6 +552,13 @@ export class IncrementalBatchedBuilder {
     // at ~1e7 m. See decideCoordinationOffset (also logs the decision once,
     // Share#1632). Stamped on the root for consumers that need to map a
     // rendered point back to true world coordinates.
+    //
+    // This is only SHARE's backstop half of that mapping, and since the
+    // conway#680 fix chain (conway#685, pinned by Share#1816) it essentially
+    // never fires — the engine recentres first, and its frame
+    // is stamped alongside as `userData.appliedCoordination`. The two compose
+    // as `rendered = (A * world) - coordinationOffset`; the whole contract is
+    // written once, on `ShareIfcLoader#stampAppliedCoordination`.
     if (this.coordination.offset === undefined) {
       this.coordination.offset = decideCoordinationOffset(matrix.elements, this.coordination)
     }

--- a/src/viewer/ifc/incrementalBatchedBuilder.js
+++ b/src/viewer/ifc/incrementalBatchedBuilder.js
@@ -558,7 +558,7 @@ export class IncrementalBatchedBuilder {
     // never fires — the engine recentres first, and its frame
     // is stamped alongside as `userData.appliedCoordination`. The two compose
     // as `rendered = (A * world) - coordinationOffset`; the whole contract is
-    // written once, on `ShareIfcLoader#stampAppliedCoordination`.
+    // written once, in `./appliedCoordination`.
     if (this.coordination.offset === undefined) {
       this.coordination.offset = decideCoordinationOffset(matrix.elements, this.coordination)
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2473,10 +2473,10 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@bldrs-ai/conway@1.1596.704-gb0034dfe":
-  version "1.1596.704-gb0034dfe"
-  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.1596.704-gb0034dfe.tgz#e1b332a7e61b5008f62f071af13a750eca0493a5"
-  integrity sha512-uy1QdcrfQvPGfNSZXfQlIHr43afn3B+67eC6Az2Hblu01eXMwZWSZTIwtKxDQCC00YCUGfdeqFRLfIngPcLZVg==
+"@bldrs-ai/conway@1.1598.702-gc37c5537":
+  version "1.1598.702-gc37c5537"
+  resolved "https://registry.yarnpkg.com/@bldrs-ai/conway/-/conway-1.1598.702-gc37c5537.tgz#356e56749d2d7556f3a496f496bd52cb4d1ecf73"
+  integrity sha512-LpbX5ckvVx7pVu6A6Qx4eJCDaQ94b0YdKIfWcAPGUVuK+Wq8aNjoAboMMhpPC2PVNuBB0xWSdDPaSQzjYEuPug==
   dependencies:
     gl-matrix "3.4.3"
     seedrandom "3.0.5"


### PR DESCRIPTION
Closes the last open acceptance item on #1634 and delivers item 1 of the
#1633 reframing: **one reported offset surface**, so a georeferenced model
finally has a world-frame handle in the case that actually happens — and
keeps it across the GLB cache.

## The problem

Post-#1816 the recentre is the *engine's*: conway derives the frame in
float64 from the first durable geometry and recentres transforms and vertex
buffers itself. Share's own `coordinationOffsetFor` heuristic became a
backstop that essentially never fires — and `userData.coordinationOffset`,
the only offset Share reported, is stamped *only* when that backstop fires.
So on every real georeferenced load Share rendered a model ~2.6e6 m off its
authored position with nothing on the model saying so. `GetCoordinationMatrix`
could not help: conway deliberately keeps that classic web-ifc surface at
identity, because consumers stamp it onto the model transform and a
non-identity value would apply the recentre a second time.

## What this delivers

`ShareIfcLoader#parse` reads conway's `GetAppliedCoordinationMatrix`
(feature-detected) and stamps it on the model root as
**`userData.appliedCoordination`** — the 16-element column-major float64
mat4 `A` the engine actually composed into every `flatTransformation` it
emitted.

**Read point** is load completion, immediately before `ifc.addIfcModel`, and
that placement is load-bearing rather than incidental. Per conway's timing
contract a deferred open that adopted its parse-time preview frame reports
that adopted frame from the moment the model opens, and the durable walk —
the authority — revalidates it, so the value can change **exactly once**, at
the first durable batch. Reading at open or from inside `onMeshBatch` could
stamp a frame that was subsequently rejected. By the time `parse` reaches
this call every durable batch has landed. It is also the single point all
three conway load paths converge on (incremental / `?feature=batchedMesh` /
merged fallback), so one call covers them all.

**Composition with `coordinationOffset`.** Its semantics are unchanged — it
stays Share's own backstop offset, stamped by `IncrementalBatchedBuilder`
only when the backstop fires, and absent on a healthy load. The two compose,
Share's offset outside the engine's frame:

```
rendered = (A * world) - coordinationOffset
world    = inverse(A) * (rendered + coordinationOffset)
```

with `coordinationOffset` read as `[0, 0, 0]` when absent, which degenerates
to conway's own `world = inverse(A) * rendered`. That whole contract —
including the two clauses easy to get wrong (identity means "nothing was
composed AND nothing supplied"; a near-origin model returns a **zero
translation but live rotation and scale**, so never shortcut on "no offset
applied") — is written once, in `src/viewer/ifc/appliedCoordination.js`,
with the engine contract quoted verbatim and pointed at conway's own doc
comment. The four subsystems that touch the frame import from there rather
than restating it.

## Surviving the cache

Both review rounds landed here, and between them they turned the cache from
a hole into the part of this PR with the most test coverage.

**Round 1** found the stamp did not reach a cache hit on the **default**
path. `demandGeometry` is default-on, so the durable model is BatchedMesh-based
and `glbExport`'s `isBatched` branch runs — and **both** its writers drop
`userData`: `exportBatchedModelAsInstancedGlb` builds a fresh gltf-transform
Document that never reads it, and the merged bake (`batchedModelToMergedMesh`)
copies only matrix + name, so `GLTFExporter` serialises an empty userData.
Fresh parse stamped → cache write dropped it → cache hit came back unstamped.

Fixed by making the claim true rather than narrowing it. The mapping travels
as `scenes[0].extras`, the same carrier `bldrsTitle` uses, captured once in
`exportAndCacheGlb`. That placement is what makes one capture sufficient:
**the inject pass runs downstream of both writers**, on the packed bytes, so
it covers every layout without a per-writer hook. Reading back:

- **merged cache hit** — three.js GLTFLoader auto-promotes scene extras onto
  `scene.userData`, so no reader plugin is needed;
- **batched cache hit** — `hydrateBatchedModelFromInstancedGlb` already
  merges the GLTF scene's userData onto the model it swaps in.

**Round 2** (codex P2) found the follow-on: only `appliedCoordination` was
being persisted. On the degraded path where the backstop fires, the offset
is *baked into the exported geometry*, so an artifact carrying only the
frame reads back displaced by exactly the offset the documented inverse then
fails to add. Half a composition is worse than none — absent is a state
consumers already handle, wrong is one they cannot detect. **Both halves now
ride the same capture**, dropped on read by the same rules, absent meaning
omitted rather than zeroed.

The extras keys are deliberately **un-prefixed**, unlike `bldrsTitle`:
GLTFLoader promotes extras verbatim, so the extras key *is* the userData
key, and it has to be the name a fresh parse stamps — otherwise a cache hit
would present a second, differently-named surface, which is the exact thing
#1633 item 1 is about.

**Scope, recorded in the module doc:** persistence covers what was
*stamped*. `coordinationOffset` is stamped only by `IncrementalBatchedBuilder`;
the `?feature=batchedMesh` and merged fallback builders decide and apply an
offset without ever putting it on `userData`, so on those paths there is
nothing to cache. That apply-but-don't-stamp gap predates this work and
remains #1633 item 2's follow-up; this PR neither widens nor narrows it.

**GLB schema 0.20.0 → 0.21.0.** The format change is additive, so this is
not about readability: 0.20.0 artifacts parse fine, they just carry no
mapping, and a georeferenced model reading one back would silently keep the
very gap this closes. Same reasoning as 0.10.0, which bumped for adding
`scenes[0].name` beside an already-working title.

**Validation at all three boundaries.** `validAppliedCoordination` and
`validCoordinationOffset` guard the engine reply, the cache write (never
persist something that reads back wrong) and the cache read — a GLB artifact
is an untrusted boundary in the originator-share design, exactly as the
cached title already assumes. They validate independently, so one corrupt
key degrades to the state consumers handle rather than losing the whole
mapping. This also closes round 1's nit: 16 elements of `NaN`/`null` passed
the old length-only guard, and `Matrix4#fromArray` reads all 16 slots
whatever they hold, so such a frame became a matrix whose inverse is `NaN`
everywhere — an answer that looks real. A bad offset is refused for the
mirror reason: it corrupts by translation, so it looks like a correctly
placed model somewhere else.

Best-effort throughout: an engine without the method (stock web-ifc, any pin
before conway#702) loads unstamped and **silently**, since that is an
expected state and not a fault; a malformed reply is reported on the
`[conwayDirect]` channel that the load report tees.

## Engine pin

`@bldrs-ai/conway` 1.1596.704-gb0034dfe → **1.1598.702-gc37c5537**, whose
`g` suffix resolves to conway `c37c553760ce` — the merge of
bldrs-ai/conway#702, which states the frame contract, makes every open path
honour it and finishes the `Normalize()` invariant. Verified live in the
Playwright build's load report (`Conway v1.1598.702-gc37c5537`).

## Tests

No jest test in this repo instantiates the conway wasm engine (the whole
`viewer/ifc` suite mocks that boundary), so a georeferenced fixture load is
not available — what is pinned instead is the part Share owns, via a
synthetic `A = scale(0.001) * NormalizeMat * translate(-anchor)` at Swiss
LV95 magnitude.

`ShareIfcLoader.coordination.test.js` (8) — the stamp carries the engine's
frame as its own copy; **`inverse(A)` read back off the model maps a
rendered point home to authored LV95 coordinates** (a ~2,900 km authored
point that renders within metres of the origin, so a transposed, truncated,
elided or identity stamp all fail it); a near-origin frame is stamped
despite its zero translation and still round-trips through the unit scale
and Z-up→Y-up basis; the merged fallback path is stamped identically;
`coordinationOffset` is untouched alongside it; an engine predating the
contract loads unstamped and logs nothing; malformed and non-finite replies
are refused with the diagnostic asserted from the `[conwayDirect]` buffer.

Cache round-trip, both writers × both keys:

- `glbExport.test.js` — merged writer: capture into `sceneExtras`, key
  independence, refusal to cache a malformed frame or offset, and end-to-end
  passes through the **real** `injectGlbExtensions` into `scenes[0].extras`.
- `glbBatchedRoundTrip.test.js` — batched-native writer, nothing stubbed:
  real injection → **real GLTFLoader** (whose extras promotion is the
  mechanism under test) → real hydration, asserting both halves arrive where
  a consumer reads them. Plus absence staying absence.
- `Loader.convertToShareModel.test.js` — reader-side validation, including
  the 16-element non-finite frame a length-only guard would pass, and that
  dropping one half leaves the other intact.
- `appliedCoordination.test.js` — both validators' shape rules, and their
  independence.

Every case was verified red before being taken green, against the specific
arm it covers: stamp removed / transposed / feature-detect dropped / shape
guard dropped; writer capture disabled; hydration userData merge dropped;
reader validation removed; offset dropped from the capture; offset dropped
from reader validation.

No E2E spec: this is engine-boundary and cache plumbing with no UI surface,
matching what #1816 did for the same seam.

## Checks run locally

- `eslint src netlify tools --max-warnings 0` + `yarn typecheck` — clean.
- `yarn test-ci` — 267 suites / 2,864 tests, coverage above thresholds.
- `yarn build-prod` — green.
- Playwright against `test-flows-build-and-serve`: `src/loader` +
  `src/viewer` + `Share.spec.ts` + camera + the cache-adjacent `Properties`
  + `NavTree` + `src/tests/e2e` — 58 passed.
- The build's version stamp was restored per #1747; only the pin bump
  reaches the commits.

## Links

- Share #1633 (item 1 of the reframing comment), Share #1634, Share #1632
- conway https://github.com/bldrs-ai/conway/pull/702, conway
  https://github.com/bldrs-ai/conway/issues/680

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011fg59i61cnUofhTpnaJHtR
