### PR TITLE
Loader: evict truncated part-21 sources and empty GLB cache artifacts

### DIFF
--- a/src/loader/Loader.cover.test.js
+++ b/src/loader/Loader.cover.test.js
@@ -557,6 +557,25 @@ describe('load() error/edge paths with OPFS enabled', () => {
   })
 
 
+  it('does not evict a GitHub OBJ whose header mentions ISO-10303-21', async () => {
+    const obj = new MockFile('# exported from ISO-10303-21 STEP\nv 0 0 0\n')
+    dereferenceAndProxyDownloadContents.mockResolvedValue([
+      'https://raw.githubusercontent.com/owner/repo/main/model.obj',
+      'abc123sha',
+      true,
+      false,
+    ])
+    doesFileExistInOPFS.mockResolvedValue(true)
+    downloadModel.mockResolvedValue(obj)
+
+    await load('https://github.com/owner/repo/blob/main/model.obj',
+      viewer, onProgress, true, setOpfsFile, '')
+
+    expect(deleteFileFromOPFS).not.toHaveBeenCalled()
+    expect(axios.get).not.toHaveBeenCalled()
+  })
+
+
   it('still throws when an uploaded file fails in OPFS (no fallback URL)', async () => {
     // Uploaded files only exist in OPFS — there's no remote URL to fall
     // back to. The resilience fix MUST re-throw rather than try axios

--- a/src/loader/Loader.cover.test.js
+++ b/src/loader/Loader.cover.test.js
@@ -7,7 +7,13 @@
 
 import axios from 'axios'
 import {getConwayDirectLogs} from '../../tools/jest/conwayDirectLogCapture'
-import {downloadToOPFS, downloadModel, getModelFromOPFS} from '../OPFS/utils'
+import {
+  deleteFileFromOPFS,
+  doesFileExistInOPFS,
+  downloadToOPFS,
+  downloadModel,
+  getModelFromOPFS,
+} from '../OPFS/utils'
 import ShareIfcLoader from '../viewer/ifc/ShareIfcLoader'
 import {constructUploadedBlobPath, load, NotFoundError} from './Loader'
 import {dereferenceAndProxyDownloadContents} from './urls'
@@ -23,6 +29,8 @@ jest.mock('../OPFS/utils', () => ({
   downloadModel: jest.fn(),
   doesFileExistInOPFS: jest.fn(),
   writeBase64Model: jest.fn(),
+  deleteFileFromOPFS: jest.fn(),
+  readModelByPathFromOPFS: jest.fn(),
 }))
 
 // Mock urls.js so we can force specific dereference results (and avoid
@@ -428,6 +436,8 @@ describe('load() error/edge paths with OPFS enabled', () => {
     dereferenceAndProxyDownloadContents.mockReset()
     downloadToOPFS.mockReset()
     downloadModel.mockReset()
+    deleteFileFromOPFS.mockReset()
+    doesFileExistInOPFS.mockReset()
 
     viewer = makeViewerStub()
     onProgress = jest.fn()
@@ -516,6 +526,34 @@ describe('load() error/edge paths with OPFS enabled', () => {
     expect(downloadModel).toHaveBeenCalledTimes(1)
     expect(axios.get).toHaveBeenCalledTimes(1)
     expect(axios.get.mock.calls[0][0]).toBe('https://raw.example.com/owner/repo/main/model.ifc')
+  })
+
+
+  it('evicts a truncated GitHub part-21 OPFS hit and re-fetches', async () => {
+    // GitHub cache HIT keys off remote sha + OPFS existence. A prefix
+    // written under that sha (truncate(0) then crash) is otherwise served
+    // forever; Conway then reports every tail ref as "not in the index".
+    const truncated = new MockFile(
+      'ISO-10303-21;\nHEADER;\nFILE_SCHEMA((\'AUTOMOTIVE_DESIGN\'));\nENDSEC;\nDATA;\n#1=X();\n')
+    dereferenceAndProxyDownloadContents.mockResolvedValue([
+      'https://raw.githubusercontent.com/owner/repo/main/Arty_Z7.stp',
+      'abc123sha',
+      true,
+      false,
+    ])
+    doesFileExistInOPFS.mockResolvedValue(true)
+    downloadModel.mockResolvedValue(truncated)
+    axios.get.mockResolvedValue({data: new ArrayBuffer(64)})
+
+    await expect(
+      load('https://github.com/owner/repo/blob/main/Arty_Z7.stp',
+        viewer, onProgress, true, setOpfsFile, ''),
+    ).rejects.toThrow()
+
+    expect(deleteFileFromOPFS).toHaveBeenCalledTimes(1)
+    expect(axios.get).toHaveBeenCalledTimes(1)
+    expect(axios.get.mock.calls[0][0]).toBe(
+      'https://raw.githubusercontent.com/owner/repo/main/Arty_Z7.stp')
   })
 
 

--- a/src/loader/Loader.github.test.js
+++ b/src/loader/Loader.github.test.js
@@ -26,7 +26,7 @@ import {dereferenceAndProxyDownloadContents} from './urls'
 
 
 const EPOCH_MS = 1663842627000
-const MOCK_BLOB_AB = new ArrayBuffer(0)
+const MOCK_BLOB_AB = new ArrayBuffer(8)
 
 
 /**
@@ -116,7 +116,7 @@ describe('Loader GitHub lastModifiedGithub integration', () => {
 
     // Fake blob that returns empty array buffer for model parsing
     const mockFile = Object.assign(
-      new Blob([''], {type: 'application/octet-stream'}),
+      new Blob(['not-part-21'], {type: 'application/octet-stream'}),
       {arrayBuffer: jest.fn().mockResolvedValue(MOCK_BLOB_AB)},
     )
 
@@ -161,7 +161,7 @@ describe('Loader GitHub lastModifiedGithub integration', () => {
       (_url, _sha, _fp, _token, _owner, _repo, _branch, _setFile, _onProgress, _onLastModifiedGithub) =>
         Promise.resolve(
           Object.assign(
-            new Blob([''], {type: 'application/octet-stream'}),
+            new Blob(['not-part-21'], {type: 'application/octet-stream'}),
             {arrayBuffer: jest.fn().mockResolvedValue(MOCK_BLOB_AB)},
           ),
         ),

--- a/src/loader/Loader.js
+++ b/src/loader/Loader.js
@@ -42,10 +42,13 @@ import {BldrsElementPropertiesReader} from './bldrsElementProperties'
 import {BldrsFaceIdsReader} from './bldrsFaceIds'
 import {BldrsSpatialTreeReader} from './bldrsSpatialTree'
 import {ExtBldrsPropertiesPayload} from './ExtBldrsPropertiesPayload'
-import {BLDRS_TITLE_EXTRAS_KEY, exportAndCacheGlb} from './glbExport'
-import glbToThree from './glb'
+import {cachedGlbHasRenderableGeometry} from './glbArtifactHealth'
 import {glbCacheKey} from './glbCacheKey'
 import {activeArtifactSpec, isGlbBatchedActive} from './glbCompress'
+import {isBldrsGlbContainer, unpackGlbContainer} from './glbContainer'
+import {BLDRS_TITLE_EXTRAS_KEY, exportAndCacheGlb} from './glbExport'
+import {glbInfo, glbVerbose, glbWarn} from './glbLog'
+import glbToThree from './glb'
 import {BldrsInstanceTablesReader} from './bldrsInstanceTables'
 import {
   APPLIED_COORDINATION_KEY,
@@ -54,10 +57,8 @@ import {
   validCoordinationOffset,
 } from '../viewer/ifc/appliedCoordination'
 import {hydrateBatchedModelFromInstancedGlb} from '../viewer/ifc/instancedGlbToBatchedModel'
-import {isBldrsGlbContainer, unpackGlbContainer} from './glbContainer'
-import {glbInfo, glbVerbose, glbWarn} from './glbLog'
 import {spillModelSource} from './opfsSourceByteStore'
-import {STORE_DETECT_PREFIX_BYTES, isConwayIfcFormat} from './stepFormat'
+import {STORE_DETECT_PREFIX_BYTES, isConwayIfcFormat, looksLikeTruncatedPart21Blob} from './stepFormat'
 import {
   externalCacheKey,
   gitHubCacheKey,
@@ -376,6 +377,25 @@ export async function load(
                   const sharePath = navigateBaseOnModelPath(owner, repo, branch, `/${filePath}`)
                   updateRecentFileLastModified(sharePath, lastModifiedGithub)
                 })
+            }
+            // GitHub HIT keys off remote sha + OPFS existence, not local
+            // completeness. A truncated part-21 prefix under the right sha
+            // is served forever and Conway reports every tail ref as
+            // "not in the index". Same eviction shape as the LFS-pointer
+            // guard: GitHub only, because a re-fetch can repair it.
+            if (file && await looksLikeTruncatedPart21Blob(file)) {
+              debug().warn(
+                'Loader#load: OPFS source is truncated part-21; evicting and re-fetching')
+              try {
+                await deleteFileFromOPFS(filePath, shaHash, owner, repo, branch)
+              } catch (evictError) {
+                debug().warn('Loader#load: could not evict truncated source:', evictError)
+              }
+              setOpfsFile(null)
+              reportSourceInfo(
+                'Source: OPFS entry was truncated — evicted, re-fetching from network')
+              file = null
+              glbExportContext = null
             }
           }
         } else {
@@ -2072,6 +2092,19 @@ async function tryLoadCachedGlb(cacheKeyArgs) {
       glbInfo(
         `reader: cached artifact mode mismatch (cached=${peek.mode || 'none'}, ` +
         `requested=${requestedMode || 'none'}); treating as miss`)
+      return null
+    }
+    // Empty artifacts are a poisoned HIT: the writer used to cache a
+    // 0-mesh scene after a failed extract, and every later load skipped
+    // the source parse. Evict so this load (and the next) re-parse.
+    if (!cachedGlbHasRenderableGeometry(bytes)) {
+      glbInfo('reader: cached artifact has no geometry; evicting and treating as miss')
+      try {
+        await deleteFileFromOPFS(
+          key.originalFilePath, key.commitHash, key.owner, key.repo, key.branch)
+      } catch (evictError) {
+        glbInfo('reader: could not evict empty artifact:', evictError)
+      }
       return null
     }
     return file

--- a/src/loader/Loader.js
+++ b/src/loader/Loader.js
@@ -383,7 +383,12 @@ export async function load(
             // is served forever and Conway reports every tail ref as
             // "not in the index". Same eviction shape as the LFS-pointer
             // guard: GitHub only, because a re-fetch can repair it.
-            if (file && await looksLikeTruncatedPart21Blob(file)) {
+            // Footer sniff is IFC/STEP only — an OBJ whose first comment
+            // mentions ISO-10303-21 is a valid cache entry, not truncated
+            // part-21. 0-byte files of any type are always unusable.
+            const truncatedPart21 = PART21_LOADER_TYPES.has(loader.type) &&
+              await looksLikeTruncatedPart21Blob(file)
+            if (file && (file.size === 0 || truncatedPart21)) {
               debug().warn(
                 'Loader#load: OPFS source is truncated part-21; evicting and re-fetching')
               try {

--- a/src/loader/Loader.js
+++ b/src/loader/Loader.js
@@ -42,10 +42,10 @@ import {BldrsElementPropertiesReader} from './bldrsElementProperties'
 import {BldrsFaceIdsReader} from './bldrsFaceIds'
 import {BldrsSpatialTreeReader} from './bldrsSpatialTree'
 import {ExtBldrsPropertiesPayload} from './ExtBldrsPropertiesPayload'
-import {cachedGlbHasRenderableGeometry} from './glbArtifactHealth'
+import {glbChunksHaveRenderableGeometry} from './glbArtifactHealth'
 import {glbCacheKey} from './glbCacheKey'
 import {activeArtifactSpec, isGlbBatchedActive} from './glbCompress'
-import {isBldrsGlbContainer, unpackGlbContainer} from './glbContainer'
+import {isBldrsGlbContainer, unpackGlbContainer, viewGlbContainerChunks} from './glbContainer'
 import {BLDRS_TITLE_EXTRAS_KEY, exportAndCacheGlb} from './glbExport'
 import {glbInfo, glbVerbose, glbWarn} from './glbLog'
 import glbToThree from './glb'
@@ -2087,7 +2087,10 @@ async function tryLoadCachedGlb(cacheKeyArgs) {
       glbInfo('reader: found OPFS file but it is not a Bldrs container; treating as miss')
       return null
     }
-    const peek = unpackGlbContainer(bytes)
+    // Views, not copies: `bytes` is already the whole artifact in
+    // memory. unpackGlbContainer would allocate a second full-size
+    // buffer just to read the mode byte and JSON mesh list.
+    const peek = viewGlbContainerChunks(bytes)
     if (peek.mode !== requestedMode) {
       glbInfo(
         `reader: cached artifact mode mismatch (cached=${peek.mode || 'none'}, ` +
@@ -2097,7 +2100,7 @@ async function tryLoadCachedGlb(cacheKeyArgs) {
     // Empty artifacts are a poisoned HIT: the writer used to cache a
     // 0-mesh scene after a failed extract, and every later load skipped
     // the source parse. Evict so this load (and the next) re-parse.
-    if (!cachedGlbHasRenderableGeometry(bytes)) {
+    if (!glbChunksHaveRenderableGeometry(peek.chunks)) {
       glbInfo('reader: cached artifact has no geometry; evicting and treating as miss')
       try {
         await deleteFileFromOPFS(

--- a/src/loader/glbArtifactHealth.js
+++ b/src/loader/glbArtifactHealth.js
@@ -4,7 +4,7 @@
 // caches whatever is on screen — including a 0-mesh scene. The next load
 // is a cache HIT of that empty file, so the user never re-parses. Refuse
 // those artifacts on write and evict them on read (Loader#tryLoadCachedGlb).
-import {unpackGlbContainer} from './glbContainer'
+import {viewGlbContainerChunks} from './glbContainer'
 import {parseGlb} from './injectGlbExtensions'
 
 
@@ -39,28 +39,49 @@ export function sceneHasRenderableGeometry(model) {
 
 
 /**
- * True when a packed Bldrs GLB container's JSON names at least one
- * primitive with a POSITION attribute. Chunks that fail to parse count
- * as empty — unreadable is the same failure mode as 0 meshes, and the
- * reader evicts either way.
+ * True when already-viewed inner GLB chunks name at least one primitive
+ * with a POSITION attribute. Callers that have walked the container
+ * (Loader#tryLoadCachedGlb) must pass those views so this does not
+ * unpack — and copy — the artifact a second time.
  *
- * @param {ArrayBuffer|Uint8Array} bytes Packed container (or a thrown
- *   unpack will be treated as empty)
+ * Unreadable chunks count as empty: same failure mode as 0 meshes, and
+ * the reader evicts either way.
+ *
+ * @param {Array<Uint8Array|ArrayBuffer>} chunks Inner GLB views or copies
  * @return {boolean}
  */
-export function cachedGlbHasRenderableGeometry(bytes) {
+export function glbChunksHaveRenderableGeometry(chunks) {
+  if (!Array.isArray(chunks) || chunks.length === 0) {
+    return false
+  }
   try {
-    const {chunks} = unpackGlbContainer(bytes)
-    if (!Array.isArray(chunks) || chunks.length === 0) {
-      return false
-    }
     for (const chunk of chunks) {
-      const {json} = parseGlb(new Uint8Array(chunk))
+      const view = chunk instanceof Uint8Array ? chunk : new Uint8Array(chunk)
+      const {json} = parseGlb(view)
       if (glbJsonHasPositionedPrimitive(json)) {
         return true
       }
     }
     return false
+  } catch {
+    return false
+  }
+}
+
+
+/**
+ * Packed-container convenience for tests. Walks via views — no
+ * payload copies. Production lookup should prefer
+ * {@link glbChunksHaveRenderableGeometry} on a walk it already did
+ * for the mode check.
+ *
+ * @param {ArrayBuffer|Uint8Array} bytes Packed Bldrs container
+ * @return {boolean}
+ */
+export function cachedGlbHasRenderableGeometry(bytes) {
+  try {
+    const {chunks} = viewGlbContainerChunks(bytes)
+    return glbChunksHaveRenderableGeometry(chunks)
   } catch {
     return false
   }

--- a/src/loader/glbArtifactHealth.js
+++ b/src/loader/glbArtifactHealth.js
@@ -1,0 +1,82 @@
+// Health checks for cached GLB artifacts and live Three scenes.
+//
+// A failed Conway extract can still return COMPLETE and the writer then
+// caches whatever is on screen — including a 0-mesh scene. The next load
+// is a cache HIT of that empty file, so the user never re-parses. Refuse
+// those artifacts on write and evict them on read (Loader#tryLoadCachedGlb).
+import {unpackGlbContainer} from './glbContainer'
+import {parseGlb} from './injectGlbExtensions'
+
+
+/**
+ * True when `model` has at least one mesh with a POSITION attribute that
+ * carries vertices. Used by the writer to refuse caching an empty scene.
+ *
+ * Objects without `traverse` (the writer's unit-test stubs) return true:
+ * we cannot tell, and blocking them would skip the cache-key tests.
+ *
+ * @param {object|null|undefined} model Three.js root or a test stub
+ * @return {boolean}
+ */
+export function sceneHasRenderableGeometry(model) {
+  if (model === null || model === undefined) {
+    return false
+  }
+  if (typeof model.traverse !== 'function') {
+    return true
+  }
+  let vertices = 0
+  model.traverse((obj) => {
+    if (obj.isMesh || obj.isInstancedMesh || obj.isBatchedMesh) {
+      const n = obj.geometry?.attributes?.position?.count
+      if (typeof n === 'number') {
+        vertices += n
+      }
+    }
+  })
+  return vertices > 0
+}
+
+
+/**
+ * True when a packed Bldrs GLB container's JSON names at least one
+ * primitive with a POSITION attribute. Chunks that fail to parse count
+ * as empty — unreadable is the same failure mode as 0 meshes, and the
+ * reader evicts either way.
+ *
+ * @param {ArrayBuffer|Uint8Array} bytes Packed container (or a thrown
+ *   unpack will be treated as empty)
+ * @return {boolean}
+ */
+export function cachedGlbHasRenderableGeometry(bytes) {
+  try {
+    const {chunks} = unpackGlbContainer(bytes)
+    if (!Array.isArray(chunks) || chunks.length === 0) {
+      return false
+    }
+    for (const chunk of chunks) {
+      const {json} = parseGlb(new Uint8Array(chunk))
+      if (glbJsonHasPositionedPrimitive(json)) {
+        return true
+      }
+    }
+    return false
+  } catch {
+    return false
+  }
+}
+
+
+/**
+ * @param {object} json glTF JSON document
+ * @return {boolean}
+ */
+function glbJsonHasPositionedPrimitive(json) {
+  const meshes = json?.meshes
+  if (!Array.isArray(meshes) || meshes.length === 0) {
+    return false
+  }
+  return meshes.some((mesh) =>
+    Array.isArray(mesh?.primitives) &&
+    mesh.primitives.some((p) => p?.attributes?.POSITION !== undefined))
+}

--- a/src/loader/glbArtifactHealth.js
+++ b/src/loader/glbArtifactHealth.js
@@ -94,10 +94,18 @@ export function cachedGlbHasRenderableGeometry(bytes) {
  */
 function glbJsonHasPositionedPrimitive(json) {
   const meshes = json?.meshes
-  if (!Array.isArray(meshes) || meshes.length === 0) {
+  const accessors = json?.accessors
+  if (!Array.isArray(meshes) || meshes.length === 0 || !Array.isArray(accessors)) {
     return false
   }
   return meshes.some((mesh) =>
     Array.isArray(mesh?.primitives) &&
-    mesh.primitives.some((p) => p?.attributes?.POSITION !== undefined))
+    mesh.primitives.some((p) => {
+      const pos = p?.attributes?.POSITION
+      if (typeof pos !== 'number' || pos < 0) {
+        return false
+      }
+      const count = accessors[pos]?.count
+      return typeof count === 'number' && count > 0
+    }))
 }

--- a/src/loader/glbArtifactHealth.test.js
+++ b/src/loader/glbArtifactHealth.test.js
@@ -1,0 +1,78 @@
+import {packGlbChunks} from './glbContainer'
+import {serializeGlb} from './injectGlbExtensions'
+import {
+  cachedGlbHasRenderableGeometry,
+  sceneHasRenderableGeometry,
+} from './glbArtifactHealth'
+
+
+/**
+ * Pack a JSON-only glTF document as a Bldrs container.
+ *
+ * @param {object} json
+ * @return {Uint8Array}
+ */
+function packedFromJson(json) {
+  return packGlbChunks([serializeGlb(json, null)])
+}
+
+
+describe('glbArtifactHealth', () => {
+  describe('sceneHasRenderableGeometry', () => {
+    it('returns false for nullish', () => {
+      expect(sceneHasRenderableGeometry(null)).toBe(false)
+      expect(sceneHasRenderableGeometry(undefined)).toBe(false)
+    })
+
+    it('returns true for stubs without traverse (writer unit tests)', () => {
+      expect(sceneHasRenderableGeometry({fake: 'model'})).toBe(true)
+    })
+
+    it('returns false for a traversed scene with no POSITION vertices', () => {
+      const empty = {
+        traverse: (fn) => {
+          fn({isMesh: true, geometry: {attributes: {position: {count: 0}}}})
+          fn({isMesh: false})
+        },
+      }
+      expect(sceneHasRenderableGeometry(empty)).toBe(false)
+    })
+
+    it('returns true when any mesh carries vertices', () => {
+      const scene = {
+        traverse: (fn) => {
+          fn({isMesh: true, geometry: {attributes: {position: {count: 3}}}})
+        },
+      }
+      expect(sceneHasRenderableGeometry(scene)).toBe(true)
+    })
+  })
+
+
+  describe('cachedGlbHasRenderableGeometry', () => {
+    it('returns false for an empty meshes array', () => {
+      const packed = packedFromJson({asset: {version: '2.0'}, meshes: []})
+      expect(cachedGlbHasRenderableGeometry(packed)).toBe(false)
+    })
+
+    it('returns false for a mesh whose primitives have no POSITION', () => {
+      const packed = packedFromJson({
+        asset: {version: '2.0'},
+        meshes: [{primitives: [{attributes: {}}]}],
+      })
+      expect(cachedGlbHasRenderableGeometry(packed)).toBe(false)
+    })
+
+    it('returns true when a primitive names POSITION', () => {
+      const packed = packedFromJson({
+        asset: {version: '2.0'},
+        meshes: [{primitives: [{attributes: {POSITION: 0}}]}],
+      })
+      expect(cachedGlbHasRenderableGeometry(packed)).toBe(true)
+    })
+
+    it('returns false for bytes that are not a Bldrs container', () => {
+      expect(cachedGlbHasRenderableGeometry(new Uint8Array([1, 2, 3]))).toBe(false)
+    })
+  })
+})

--- a/src/loader/glbArtifactHealth.test.js
+++ b/src/loader/glbArtifactHealth.test.js
@@ -1,7 +1,8 @@
-import {packGlbChunks} from './glbContainer'
+import {packGlbChunks, viewGlbContainerChunks} from './glbContainer'
 import {serializeGlb} from './injectGlbExtensions'
 import {
   cachedGlbHasRenderableGeometry,
+  glbChunksHaveRenderableGeometry,
   sceneHasRenderableGeometry,
 } from './glbArtifactHealth'
 
@@ -73,6 +74,17 @@ describe('glbArtifactHealth', () => {
 
     it('returns false for bytes that are not a Bldrs container', () => {
       expect(cachedGlbHasRenderableGeometry(new Uint8Array([1, 2, 3]))).toBe(false)
+    })
+
+    it('inspects inner GLBs as views over the packed buffer, not copies', () => {
+      const packed = packedFromJson({
+        asset: {version: '2.0'},
+        meshes: [{primitives: [{attributes: {POSITION: 0}}]}],
+      })
+      const {chunks} = viewGlbContainerChunks(packed)
+      expect(chunks).toHaveLength(1)
+      expect(chunks[0].buffer).toBe(packed.buffer)
+      expect(glbChunksHaveRenderableGeometry(chunks)).toBe(true)
     })
   })
 })

--- a/src/loader/glbArtifactHealth.test.js
+++ b/src/loader/glbArtifactHealth.test.js
@@ -64,9 +64,19 @@ describe('glbArtifactHealth', () => {
       expect(cachedGlbHasRenderableGeometry(packed)).toBe(false)
     })
 
-    it('returns true when a primitive names POSITION', () => {
+    it('returns false when POSITION points at a zero-count accessor', () => {
       const packed = packedFromJson({
         asset: {version: '2.0'},
+        accessors: [{count: 0}],
+        meshes: [{primitives: [{attributes: {POSITION: 0}}]}],
+      })
+      expect(cachedGlbHasRenderableGeometry(packed)).toBe(false)
+    })
+
+    it('returns true when POSITION points at an accessor with vertices', () => {
+      const packed = packedFromJson({
+        asset: {version: '2.0'},
+        accessors: [{count: 3}],
         meshes: [{primitives: [{attributes: {POSITION: 0}}]}],
       })
       expect(cachedGlbHasRenderableGeometry(packed)).toBe(true)
@@ -79,6 +89,7 @@ describe('glbArtifactHealth', () => {
     it('inspects inner GLBs as views over the packed buffer, not copies', () => {
       const packed = packedFromJson({
         asset: {version: '2.0'},
+        accessors: [{count: 3}],
         meshes: [{primitives: [{attributes: {POSITION: 0}}]}],
       })
       const {chunks} = viewGlbContainerChunks(packed)

--- a/src/loader/glbContainer.js
+++ b/src/loader/glbContainer.js
@@ -137,13 +137,16 @@ export function packGlbChunks(chunks, mode = null) {
 
 
 /**
- * Unpack a container into its constituent GLB chunks plus the recorded
- * compression mode. v1 containers (no mode byte) return mode=null.
+ * Layout of a packed container: inner GLB chunks as **views** over
+ * `buffer`, not copies. The cache-hit health check must not allocate
+ * another artifact-sized buffer (a hundreds-of-MB CAD HIT already holds
+ * `file.arrayBuffer()`); `unpackGlbContainer` copies for the actual
+ * parse path, where the caller needs independent chunk buffers.
  *
  * @param {ArrayBuffer|Uint8Array} buffer
- * @return {{chunks: ArrayBuffer[], mode: GlbCompressionMode, version: number}}
+ * @return {{chunks: Uint8Array[], mode: GlbCompressionMode, version: number}}
  */
-export function unpackGlbContainer(buffer) {
+export function viewGlbContainerChunks(buffer) {
   if (!isBldrsGlbContainer(buffer)) {
     throw new Error('unpackGlbContainer: missing BLDR magic')
   }
@@ -172,10 +175,28 @@ export function unpackGlbContainer(buffer) {
     if (offset + len > view.byteLength) {
       throw new Error(`unpackGlbContainer: truncated chunk ${i} (need ${len}B)`)
     }
-    const ab = new ArrayBuffer(len)
-    new Uint8Array(ab).set(view.subarray(offset, offset + len))
-    out.push(ab)
+    out.push(view.subarray(offset, offset + len))
     offset += len
   }
   return {chunks: out, mode, version}
+}
+
+
+/**
+ * Unpack a container into its constituent GLB chunks plus the recorded
+ * compression mode. v1 containers (no mode byte) return mode=null.
+ * Chunks are copies, so the packed buffer can be released after unpack.
+ *
+ * @param {ArrayBuffer|Uint8Array} buffer
+ * @return {{chunks: ArrayBuffer[], mode: GlbCompressionMode, version: number}}
+ */
+export function unpackGlbContainer(buffer) {
+  const {chunks, mode, version} = viewGlbContainerChunks(buffer)
+  const copies = []
+  for (const view of chunks) {
+    const ab = new ArrayBuffer(view.byteLength)
+    new Uint8Array(ab).set(view)
+    copies.push(ab)
+  }
+  return {chunks: copies, mode, version}
 }

--- a/src/loader/glbContainer.test.js
+++ b/src/loader/glbContainer.test.js
@@ -3,10 +3,23 @@ import {
   isBldrsGlbContainer,
   packGlbChunks,
   unpackGlbContainer,
+  viewGlbContainerChunks,
 } from './glbContainer'
 
 
 describe('loader/glbContainer', () => {
+  it('viewGlbContainerChunks yields subarray views, not payload copies', () => {
+    const chunk = new Uint8Array([0x67, 0x6c, 0x54, 0x46, 1, 2, 3])
+    const packed = packGlbChunks([chunk])
+    const {chunks, mode, version} = viewGlbContainerChunks(packed)
+    expect(version).toBe(2)
+    expect(mode).toBeNull()
+    expect(chunks).toHaveLength(1)
+    expect(chunks[0].buffer).toBe(packed.buffer)
+    expect(Array.from(chunks[0])).toEqual(Array.from(chunk))
+  })
+
+
   it('round-trips a single chunk', () => {
     const chunk = new Uint8Array([0x67, 0x6c, 0x54, 0x46, 1, 2, 3]) // "glTF" + payload
     const packed = packGlbChunks([chunk])

--- a/src/loader/glbExport.js
+++ b/src/loader/glbExport.js
@@ -65,6 +65,7 @@ import {
   buildInstanceTablesExtensionData,
 } from './bldrsInstanceTables'
 import {exportBatchedModelAsInstancedGlb} from './glbBatchedExport'
+import {sceneHasRenderableGeometry} from './glbArtifactHealth'
 import {packGlbChunks} from './glbContainer'
 import {glbInfo, glbVerbose, glbWarn} from './glbLog'
 import {injectAndPackInWorker} from './GlbWriterService'
@@ -233,6 +234,15 @@ export async function exportAndCacheGlb({model, kindLabel, cacheKeyArgs, ifcMana
       `writer: ${kindLabel} source, key=${cacheKeyArgs.ns1}/${cacheKeyArgs.ns2}/${cacheKeyArgs.ns3}/` +
       `${filePath} sha=${cacheKeyArgs.sourceHash} requestedCompression=${requestedMode || 'none'}`)
     glbVerbose('writer: cacheKeyArgs =', cacheKeyArgs)
+
+    // A failed extract can still return COMPLETE with 0 meshes on screen.
+    // Caching that artifact turns the next load into a HIT of an empty
+    // scene, so the user never re-parses. Refuse here; the reader also
+    // evicts any empty artifact that already landed (tryLoadCachedGlb).
+    if (!sceneHasRenderableGeometry(model)) {
+      glbInfo('writer: skipped (no renderable geometry — refusing to cache an empty artifact)')
+      return false
+    }
 
     // Batched-NATIVE layout (S9, `glbBatched`, default-on): keep the batch
     // structure via EXT_mesh_gpu_instancing + per-instance tables instead

--- a/src/loader/glbExport.test.js
+++ b/src/loader/glbExport.test.js
@@ -325,6 +325,18 @@ describe('loader/glbExport', () => {
       expect(mockWriteGlbBytesToOPFS).not.toHaveBeenCalled()
     })
 
+    it('skips a traversed scene with no vertices so an empty artifact cannot poison the cache', async () => {
+      const model = {
+        traverse: (fn) => {
+          fn({isMesh: true, geometry: {attributes: {position: {count: 0}}}})
+        },
+      }
+      const ok = await exportAndCacheGlb({model, ...ctx})
+      expect(ok).toBe(false)
+      expect(mockExporterParse).not.toHaveBeenCalled()
+      expect(mockWriteGlbBytesToOPFS).not.toHaveBeenCalled()
+    })
+
     it('skips a Group whose only BatchedMesh child has no convertible instances', async () => {
       const model = {
         traverse: (fn) => {

--- a/src/loader/stepFormat.js
+++ b/src/loader/stepFormat.js
@@ -22,8 +22,10 @@ export const STORE_DETECT_PREFIX_BYTES = 65_536
 // the missing tail is "not in the index" (Arty STYLED_ITEM #36800 →
 // MANIFOLD_SOLID_BREP #1031384). The footer is required by ISO-10303-21;
 // its absence on a file that still has the magic is the truncated case.
-const PART21_MAGIC = 'ISO-10303-21'
-const PART21_END = 'END-ISO-10303-21'
+const PART21_MAGIC = asciiBytes('ISO-10303-21')
+// The footer keyword without its required `;` is still truncated — a
+// crash can land after the letters and before the terminator.
+const PART21_END = asciiBytes('END-ISO-10303-21;')
 const PART21_HEAD_SNIFF_BYTES = 64
 const PART21_TAIL_SNIFF_BYTES = 256
 
@@ -45,11 +47,11 @@ export function looksLikeTruncatedPart21(bytes) {
     return false
   }
   const headLen = Math.min(PART21_HEAD_SNIFF_BYTES, u8.byteLength)
-  if (!latin1(u8, 0, headLen).includes(PART21_MAGIC)) {
+  if (!containsBytes(u8, 0, headLen, PART21_MAGIC)) {
     return false
   }
   const tailStart = Math.max(0, u8.byteLength - PART21_TAIL_SNIFF_BYTES)
-  return !latin1(u8, tailStart, u8.byteLength).includes(PART21_END)
+  return !containsBytes(u8, tailStart, u8.byteLength, PART21_END)
 }
 
 
@@ -79,29 +81,52 @@ export async function looksLikeTruncatedPart21Blob(blob) {
     blob.slice(tailStart, blob.size).arrayBuffer(),
   ])
   const head = new Uint8Array(headBuf)
-  if (!latin1(head, 0, head.byteLength).includes(PART21_MAGIC)) {
+  if (!containsBytes(head, 0, head.byteLength, PART21_MAGIC)) {
     return false
   }
   const tail = new Uint8Array(tailBuf)
-  return !latin1(tail, 0, tail.byteLength).includes(PART21_END)
+  return !containsBytes(tail, 0, tail.byteLength, PART21_END)
 }
 
 
 /**
- * Decode a byte range as ISO-8859-1. Part-21 keywords are ASCII; we
- * must not UTF-8-decode a sniff that might cut a multi-byte sequence.
+ * ASCII needle as a Uint8Array. Keywords are 7-bit; TextEncoder would
+ * also work, but a hand table keeps this module free of encoder quirks
+ * in the sniff path.
  *
- * @param {Uint8Array} u8
- * @param {number} start
- * @param {number} end exclusive
- * @return {string}
+ * @param {string} s
+ * @return {Uint8Array}
  */
-function latin1(u8, start, end) {
-  let out = ''
-  for (let i = start; i < end; i++) {
-    out += String.fromCharCode(u8[i])
+function asciiBytes(s) {
+  const out = new Uint8Array(s.length)
+  for (let i = 0; i < s.length; i++) {
+    out[i] = s.charCodeAt(i)
   }
   return out
+}
+
+
+/**
+ * True when `needle` occurs in `haystack[start, end)`.
+ *
+ * @param {Uint8Array} haystack
+ * @param {number} start
+ * @param {number} end exclusive
+ * @param {Uint8Array} needle
+ * @return {boolean}
+ */
+function containsBytes(haystack, start, end, needle) {
+  const last = end - needle.byteLength
+  outer:
+  for (let i = start; i <= last; i++) {
+    for (let j = 0; j < needle.byteLength; j++) {
+      if (haystack[i + j] !== needle[j]) {
+        continue outer
+      }
+    }
+    return true
+  }
+  return false
 }
 
 

--- a/src/loader/stepFormat.js
+++ b/src/loader/stepFormat.js
@@ -14,6 +14,96 @@ import debug from '../utils/debug'
  */
 export const STORE_DETECT_PREFIX_BYTES = 65_536
 
+// Completeness sniff for a part-21 source already in OPFS. GitHub cache
+// HIT keys off the remote blob sha plus file existence, not local
+// completeness: a write killed after truncate(0) (OPFS.worker.js
+// writeFileToHandle) leaves a prefix under the correct sha, Conway
+// finalizes that prefix as a complete index, and every forward ref into
+// the missing tail is "not in the index" (Arty STYLED_ITEM #36800 →
+// MANIFOLD_SOLID_BREP #1031384). The footer is required by ISO-10303-21;
+// its absence on a file that still has the magic is the truncated case.
+const PART21_MAGIC = 'ISO-10303-21'
+const PART21_END = 'END-ISO-10303-21'
+const PART21_HEAD_SNIFF_BYTES = 64
+const PART21_TAIL_SNIFF_BYTES = 256
+
+
+/**
+ * True when `bytes` look like a part-21 file (IFC or STEP) whose DATA
+ * section was cut off before `END-ISO-10303-21`. Non-part-21 inputs
+ * (GLB, empty, random) return false — this is not a format detector.
+ *
+ * @param {ArrayBuffer|Uint8Array|null|undefined} bytes
+ * @return {boolean}
+ */
+export function looksLikeTruncatedPart21(bytes) {
+  if (bytes === null || bytes === undefined) {
+    return false
+  }
+  const u8 = bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes)
+  if (u8.byteLength === 0) {
+    return false
+  }
+  const headLen = Math.min(PART21_HEAD_SNIFF_BYTES, u8.byteLength)
+  if (!latin1(u8, 0, headLen).includes(PART21_MAGIC)) {
+    return false
+  }
+  const tailStart = Math.max(0, u8.byteLength - PART21_TAIL_SNIFF_BYTES)
+  return !latin1(u8, tailStart, u8.byteLength).includes(PART21_END)
+}
+
+
+/**
+ * Blob/File twin of {@link looksLikeTruncatedPart21}: sniffs only the
+ * first and last few hundred bytes so a 50MB OPFS hit does not have to
+ * be buffered to decide.
+ *
+ * A 0-byte File is always unusable as a model source (the truncate(0)
+ * then crash case) and is reported truncated regardless of magic.
+ *
+ * @param {Blob|null|undefined} blob
+ * @return {Promise<boolean>}
+ */
+export async function looksLikeTruncatedPart21Blob(blob) {
+  if (blob === null || blob === undefined ||
+      typeof blob.size !== 'number' || typeof blob.slice !== 'function') {
+    return false
+  }
+  if (blob.size === 0) {
+    return true
+  }
+  const headLen = Math.min(PART21_HEAD_SNIFF_BYTES, blob.size)
+  const tailStart = Math.max(0, blob.size - PART21_TAIL_SNIFF_BYTES)
+  const [headBuf, tailBuf] = await Promise.all([
+    blob.slice(0, headLen).arrayBuffer(),
+    blob.slice(tailStart, blob.size).arrayBuffer(),
+  ])
+  const head = new Uint8Array(headBuf)
+  if (!latin1(head, 0, head.byteLength).includes(PART21_MAGIC)) {
+    return false
+  }
+  const tail = new Uint8Array(tailBuf)
+  return !latin1(tail, 0, tail.byteLength).includes(PART21_END)
+}
+
+
+/**
+ * Decode a byte range as ISO-8859-1. Part-21 keywords are ASCII; we
+ * must not UTF-8-decode a sniff that might cut a multi-byte sequence.
+ *
+ * @param {Uint8Array} u8
+ * @param {number} start
+ * @param {number} end exclusive
+ * @return {string}
+ */
+function latin1(u8, start, end) {
+  let out = ''
+  for (let i = start; i < end; i++) {
+    out += String.fromCharCode(u8[i])
+  }
+  return out
+}
+
 
 /**
  * True when conway's `IfcApiModelPassthroughFactory.fromStore` will accept

--- a/src/loader/stepFormat.js
+++ b/src/loader/stepFormat.js
@@ -32,8 +32,10 @@ const PART21_TAIL_SNIFF_BYTES = 256
 
 /**
  * True when `bytes` look like a part-21 file (IFC or STEP) whose DATA
- * section was cut off before `END-ISO-10303-21`. Non-part-21 inputs
- * (GLB, empty, random) return false — this is not a format detector.
+ * section was cut off before a trailing `END-ISO-10303-21;`. The marker
+ * must be the last non-whitespace record, not a substring in DATA.
+ * Non-part-21 inputs (GLB, empty, random) return false — this is not a
+ * format detector.
  *
  * @param {ArrayBuffer|Uint8Array|null|undefined} bytes
  * @return {boolean}
@@ -51,7 +53,7 @@ export function looksLikeTruncatedPart21(bytes) {
     return false
   }
   const tailStart = Math.max(0, u8.byteLength - PART21_TAIL_SNIFF_BYTES)
-  return !containsBytes(u8, tailStart, u8.byteLength, PART21_END)
+  return !endsWithBytesIgnoringTrailingWs(u8, tailStart, u8.byteLength, PART21_END)
 }
 
 
@@ -85,7 +87,7 @@ export async function looksLikeTruncatedPart21Blob(blob) {
     return false
   }
   const tail = new Uint8Array(tailBuf)
-  return !containsBytes(tail, 0, tail.byteLength, PART21_END)
+  return !endsWithBytesIgnoringTrailingWs(tail, 0, tail.byteLength, PART21_END)
 }
 
 
@@ -127,6 +129,46 @@ function containsBytes(haystack, start, end, needle) {
     return true
   }
   return false
+}
+
+
+const WS_SP = 0x20
+const WS_HT = 0x09
+const WS_LF = 0x0a
+const WS_CR = 0x0d
+
+
+/**
+ * True when `haystack[start, end)`, ignoring trailing SP/HT/LF/CR, ends
+ * with `needle`. A DATA string or comment in the tail window that merely
+ * contains the footer must not count as a complete file.
+ *
+ * @param {Uint8Array} haystack
+ * @param {number} start
+ * @param {number} end exclusive
+ * @param {Uint8Array} needle
+ * @return {boolean}
+ */
+function endsWithBytesIgnoringTrailingWs(haystack, start, end, needle) {
+  let i = end - 1
+  while (i >= start) {
+    const c = haystack[i]
+    if (c !== WS_SP && c !== WS_HT && c !== WS_LF && c !== WS_CR) {
+      break
+    }
+    i--
+  }
+  const needleEnd = i + 1
+  const needleStart = needleEnd - needle.byteLength
+  if (needleStart < start) {
+    return false
+  }
+  for (let j = 0; j < needle.byteLength; j++) {
+    if (haystack[needleStart + j] !== needle[j]) {
+      return false
+    }
+  }
+  return true
 }
 
 

--- a/src/loader/stepFormat.test.js
+++ b/src/loader/stepFormat.test.js
@@ -174,10 +174,15 @@ describe('isConwayIfcFormat', () => {
 
     it('flags a part-21 prefix that never reached the footer', () => {
       // The Arty OPFS-poison case: magic is present, DATA starts, the
-      // tail solids (and END-ISO-10303-21) never landed on disk.
+      // tail solids (and END-ISO-10303-21;) never landed on disk.
       expect(looksLikeTruncatedPart21(bytes(
         `${MAGIC}FILE_SCHEMA(('AUTOMOTIVE_DESIGN'));\nENDSEC;\nDATA;\n` +
         `#36800=STYLED_ITEM('NAME_480',(#37527),#1031384);\n`))).toBe(true)
+    })
+
+    it('treats a footer keyword without its required semicolon as truncated', () => {
+      expect(looksLikeTruncatedPart21(bytes(
+        `${MAGIC}FILE_SCHEMA(('IFC4'));\nENDSEC;\nDATA;\nENDSEC;\nEND-ISO-10303-21\n`))).toBe(true)
     })
 
     it('ignores non-part-21 bytes, including empty', () => {

--- a/src/loader/stepFormat.test.js
+++ b/src/loader/stepFormat.test.js
@@ -1,4 +1,4 @@
-import {isConwayIfcFormat} from './stepFormat'
+import {isConwayIfcFormat, looksLikeTruncatedPart21, looksLikeTruncatedPart21Blob} from './stepFormat'
 
 
 const bytes = (text) => new TextEncoder().encode(text)
@@ -162,6 +162,37 @@ describe('isConwayIfcFormat', () => {
     it('ignores an entity whose name merely ends in FILE_SCHEMA', () => {
       expect(isConwayIfcFormat(part21(
         `FILE_SCHEMA(('AUTOMOTIVE_DESIGN'));\nNOT_FILE_SCHEMA(('IFC4'));`))).toBe(false)
+    })
+  })
+
+
+  describe('looksLikeTruncatedPart21', () => {
+    it('accepts a complete IFC or STEP file', () => {
+      expect(looksLikeTruncatedPart21(part21(`FILE_SCHEMA(('IFC4'));`))).toBe(false)
+      expect(looksLikeTruncatedPart21(part21(`FILE_SCHEMA(('AUTOMOTIVE_DESIGN'));`))).toBe(false)
+    })
+
+    it('flags a part-21 prefix that never reached the footer', () => {
+      // The Arty OPFS-poison case: magic is present, DATA starts, the
+      // tail solids (and END-ISO-10303-21) never landed on disk.
+      expect(looksLikeTruncatedPart21(bytes(
+        `${MAGIC}FILE_SCHEMA(('AUTOMOTIVE_DESIGN'));\nENDSEC;\nDATA;\n` +
+        `#36800=STYLED_ITEM('NAME_480',(#37527),#1031384);\n`))).toBe(true)
+    })
+
+    it('ignores non-part-21 bytes, including empty', () => {
+      expect(looksLikeTruncatedPart21(new Uint8Array(0))).toBe(false)
+      expect(looksLikeTruncatedPart21(NOT_TEXT)).toBe(false)
+      expect(looksLikeTruncatedPart21(null)).toBe(false)
+    })
+
+    it('the Blob helper flags a 0-byte file as truncated', async () => {
+      expect(await looksLikeTruncatedPart21Blob(new Blob([]))).toBe(true)
+    })
+
+    it('the Blob helper agrees with the byte helper on a complete file', async () => {
+      const complete = part21(`FILE_SCHEMA(('IFC4'));`)
+      expect(await looksLikeTruncatedPart21Blob(new Blob([complete]))).toBe(false)
     })
   })
 })

--- a/src/loader/stepFormat.test.js
+++ b/src/loader/stepFormat.test.js
@@ -185,6 +185,12 @@ describe('isConwayIfcFormat', () => {
         `${MAGIC}FILE_SCHEMA(('IFC4'));\nENDSEC;\nDATA;\nENDSEC;\nEND-ISO-10303-21\n`))).toBe(true)
     })
 
+    it('does not treat a footer string in DATA as a complete file', () => {
+      expect(looksLikeTruncatedPart21(bytes(
+        `${MAGIC}FILE_SCHEMA(('IFC4'));\nENDSEC;\nDATA;\n` +
+        `#1=IFCLABEL('END-ISO-10303-21; still more');\n`))).toBe(true)
+    })
+
     it('ignores non-part-21 bytes, including empty', () => {
       expect(looksLikeTruncatedPart21(new Uint8Array(0))).toBe(false)
       expect(looksLikeTruncatedPart21(NOT_TEXT)).toBe(false)


### PR DESCRIPTION
## Summary

GitHub OPFS HIT keys off remote sha + file existence, not local completeness. Two sticky poison cases:

1. **Truncated part-21 source.** A write killed after `truncate(0)` leaves a prefix under the correct sha. Conway finalizes that prefix as a complete index and every forward ref into the missing tail is \`not in the index\` (Arty \`STYLED_ITEM #36800\` → \`MANIFOLD_SOLID_BREP #1031384\`). Evict 0-byte files and part-21 files whose last 256 bytes lack \`END-ISO-10303-21\`, then re-fetch. GitHub-only — same shape as the LFS-pointer guard — because a re-fetch can repair it. Uploads are left alone (that copy is the only copy).

2. **Empty GLB artifact.** A failed extract can still return COMPLETE with 0 meshes, and the writer used to cache that scene. The next load is then a HIT of nothing. The writer now refuses to cache a scene with no POSITION vertices; the reader peeks the container JSON and evicts any artifact with no positioned primitives.

Existing empty/truncated OPFS junk is dropped on the next load of that URL.

Not related to conway#704 type-inherited materials (IFC-only). Arty is AP214.

## Test plan

- [x] \`looksLikeTruncatedPart21\` / Blob helper: complete file, prefix-only Arty-shaped DATA, non-part-21, 0-byte
- [x] \`sceneHasRenderableGeometry\` / \`cachedGlbHasRenderableGeometry\`: empty meshes, no POSITION, positioned primitive
- [x] Writer skips a 0-vertex traversed scene
- [x] Cover: truncated GitHub OPFS hit is evicted and re-fetched
- [x] Husky pre-commit (eslint + typecheck + 2879 Jest tests)
- [ ] Reload Arty from GitHub on a tab that still has the poisoned OPFS entries; expect a miss, a re-parse, and a render

@codex review